### PR TITLE
feat(metrics): introduce Erlnag VM metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Soon.
 
+<!-- toc -->
+
+-   [Development](#development)
+
+<!-- tocstop -->
+
 ## Development
 
 Environment Setup TBD
@@ -10,8 +16,8 @@ This repo uses `npm` and `node` to install and execute top level, repo-wide, too
 at the root to install those dependencies. This will set up git hooks that will help ensure you're following some of the
 guidelines outlined in this document:
 
-- All Erlang files are formatted using [`erlfmt`](https://github.com/WhatsApp/erlfmt)
-- All Commit Messages follow our [Conventional Commits Config](https://www.conventionalcommits.org/en/v1.0.0/)
-- All Markdown files should contain a Table of Contents
+-   All Erlang files are formatted using [`erlfmt`](https://github.com/WhatsApp/erlfmt)
+-   All Commit Messages follow our [Conventional Commits Config](https://www.conventionalcommits.org/en/v1.0.0/)
+-   All Markdown files should contain a Table of Contents
 
 Once you've install the top level tooling, each of these conventions are enforced, via git a commit hook, automatically.

--- a/docs/gathering-metrics-locally.md
+++ b/docs/gathering-metrics-locally.md
@@ -1,0 +1,8 @@
+## Bring up grafana/Prometheus locally
+
+```
+cd ./metrics
+docker-compose up -d
+```
+
+Grafana will be available under http://localhost:3000 (admin/admin) Prometheus http://localhost:9000

--- a/metrics/docker-compose.yml
+++ b/metrics/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"  # Exposing Prometheus on port 9090
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    volumes:
+      - ./grafana/provisioning/dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml  # Mount provisioning file
+      - ./grafana/provisioning/dashboards:/var/lib/grafana/dashboards     # Mount dashboards folder
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin  # Default admin password, change for production
+    ports:
+      - "3000:3000"  # Exposes Grafana on port 3000
+    depends_on:
+      - prometheus   # Ensures Prometheus starts before Grafana
+

--- a/metrics/grafana/provisioning/dashboards.yaml
+++ b/metrics/grafana/provisioning/dashboards.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: 'default'                      # Name of the provider
+    orgId: 1                             # Grafana organization ID
+    folder: ''                           # Leave empty to add to the default folder
+    type: file                           # Type of provider (file-based)
+    disableDeletion: false               # Allow dashboard deletion
+    updateIntervalSeconds: 10            # How often Grafana checks for updates
+    options:
+      path: /var/lib/grafana/dashboards  # Path inside the container where dashboards are located

--- a/metrics/grafana/provisioning/datasources/datasources.yaml
+++ b/metrics/grafana/provisioning/datasources/datasources.yaml
@@ -1,0 +1,12 @@
+# grafana/provisioning/datasources/datasources.yaml
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy                 # Use 'proxy' if Grafana should query Prometheus on behalf of the client
+    url: http://prometheus:9090    # Prometheus URL (use service name if both in docker-compose)
+    isDefault: true                # Set as the default data source
+    editable: true                 # Allow the data source to be edited via Grafana UI
+    jsonData:
+      httpMethod: POST             # Use POST requests for queries

--- a/metrics/prometheus.yml
+++ b/metrics/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s  # Scrape targets 15s
+
+scrape_configs:
+  - job_name: 'local'
+    static_configs:
+      - targets: ['host.docker.internal:8734']

--- a/rebar.config
+++ b/rebar.config
@@ -2,58 +2,60 @@
 {plugins, [pc]}.
 
 {project_plugins, [
-    {erlfmt, {git, "https://github.com/TillaTheHun0/erlfmt", {branch, "main"}}}
+	{erlfmt, {git, "https://github.com/TillaTheHun0/erlfmt", {branch, "main"}}}
 ]}.
 {erlfmt, [
-    write,
-    {print_width, 120}
+	write,
+	{print_width, 120}
 ]}.
 
 {pre_hooks, [
-    {compile, "make -C \"${REBAR_ROOT_DIR}\" wamr"}
+	{compile, "make -C \"${REBAR_ROOT_DIR}\" wamr"}
 ]}.
 
 {port_env, [
-    {"(linux|darwin|solaris)", "CFLAGS",
-        "$CFLAGS -I${REBAR_ROOT_DIR}/_build/wamr/core/iwasm/include -I/usr/local/lib/erlang/usr/include/"},
-    {"(linux|darwin|solaris)", "LDFLAGS", "$LDFLAGS -L${REBAR_ROOT_DIR}/_build/wamr/lib -lvmlib -lei"},
-    {"(linux|darwin|solaris)", "LDLIBS", "-lei"}
+	{"(linux|darwin|solaris)", "CFLAGS",
+		"$CFLAGS -I${REBAR_ROOT_DIR}/_build/wamr/core/iwasm/include -I/usr/local/lib/erlang/usr/include/"},
+	{"(linux|darwin|solaris)", "LDFLAGS", "$LDFLAGS -L${REBAR_ROOT_DIR}/_build/wamr/lib -lvmlib -lei"},
+	{"(linux|darwin|solaris)", "LDLIBS", "-lei"}
 ]}.
 
 {post_hooks, [
-    {"(linux|darwin|solaris)", clean, "rm -rf \"${REBAR_ROOT_DIR}/_build\" \"${REBAR_ROOT_DIR}/priv\""},
-    {"(linux|darwin|solaris)", compile, "echo 'Post-compile hooks executed'"}
+	{"(linux|darwin|solaris)", clean, "rm -rf \"${REBAR_ROOT_DIR}/_build\" \"${REBAR_ROOT_DIR}/priv\""},
+	{"(linux|darwin|solaris)", compile, "echo 'Post-compile hooks executed'"}
 ]}.
 
 {provider_hooks, [
-    {post, [
-        {compile, {pc, compile}},
-        {clean, {pc, clean}}
-    ]}
+	{post, [
+		{compile, {pc, compile}},
+		{clean, {pc, clean}}
+	]}
 ]}.
 
 {port_specs, [
-    {"./priv/hb_beamr.so", ["./c_src/hb_beamr.c"]}
+	{"./priv/hb_beamr.so", ["./c_src/hb_beamr.c"]}
 ]}.
 
 {deps, [
-    {b64fast, {git, "https://github.com/ArweaveTeam/b64fast.git", {ref, "58f0502e49bf73b29d95c6d02460d1fb8d2a5273"}}},
-    {jiffy, {git, "https://github.com/ArweaveTeam/jiffy.git", {ref, "74c956defa9116c85d76f77c3e9b5bd6de7bd39a"}}},
-    {cowboy, {git, "https://github.com/ninenines/cowboy", {tag, "2.12.0"}}}
+	{b64fast, {git, "https://github.com/ArweaveTeam/b64fast.git", {ref, "58f0502e49bf73b29d95c6d02460d1fb8d2a5273"}}},
+	{jiffy, {git, "https://github.com/ArweaveTeam/jiffy.git", {ref, "74c956defa9116c85d76f77c3e9b5bd6de7bd39a"}}},
+	{cowboy, {git, "https://github.com/ninenines/cowboy", {tag, "2.12.0"}}},
+	{prometheus, "4.11.0"},
+	{prometheus_cowboy, "0.1.8"}
 ]}.
 
 {shell, [
-    {apps, [hb]}
+	{apps, [hb]}
 ]}.
 
 {eunit, [
-    {apps, [hb]}
+	{apps, [hb]}
 ]}.
 
 {eunit_opts, [verbose]}.
 
 {relx, [
-    {release, {'hb', "0.0.1"}, [hb, jiffy, cowboy, gun, b64fast]},
-    {include_erts, true},
-    {extended_start_script, true}
+	{release, {'hb', "0.0.1"}, [hb, jiffy, cowboy, gun, b64fast]},
+	{include_erts, true},
+	{extended_start_script, true}
 ]}.

--- a/src/hb.app.src
+++ b/src/hb.app.src
@@ -1,17 +1,21 @@
-{application, hb,
- [{description, "HyperBEAM: An Erlang implementation of a permaweb supercomputer."},
-  {vsn, "0.0.1"},
-  {registered, []},
-  {mod, {hb_app, []}},
-  {applications,
-   [kernel,
-    stdlib,
-    inets,
-    ssl,
-    debugger
-   ]},
-  {env,[]},
-  {modules, []},
-  {licenses, ["BSL-1.1"]},
-  {links, []}
- ]}.
+{application, hb, [
+	{description, "HyperBEAM: An Erlang implementation of a permaweb supercomputer."},
+	{vsn, "0.0.1"},
+	{registered, []},
+	{mod, {hb_app, []}},
+	{applications, [
+		kernel,
+		stdlib,
+		inets,
+		ssl,
+		debugger,
+		cowboy,
+		prometheus,
+		prometheus_cowboy,
+		os_mon
+	]},
+	{env, []},
+	{modules, []},
+	{licenses, ["BSL-1.1"]},
+	{links, []}
+]}.

--- a/src/hb_http_router.erl
+++ b/src/hb_http_router.erl
@@ -3,71 +3,81 @@
 -include("include/hb.hrl").
 
 start() ->
-    hb_http:start(),
-    application:ensure_all_started(cowboy),
-    Dispatcher =
+	hb_http:start(),
+	Dispatcher =
 		cowboy_router:compile(
 			[
-				{'_', 
-					[
-						{
-							'_',
-							?MODULE,
-							% The default state/opts for executions from the 
-							% HTTP API. This would be the appropriate place 
-							% to add components (a differently scoped store,
-							% a different wallet, etc.) to execution for 
-							% remote clients.
-							#{
-								store => hb_opts:get(store),
-								wallet => hb_opts:get(wallet),
-								error_strategy => hb_opts:get(client_error_strategy)
-							}
+				% {HostMatch, list({PathMatch, Handler, InitialState})}
+				{'_', [
+					{
+						"/metrics/[:registry]",
+						prometheus_cowboy2_handler,
+						#{}
+					},
+					{
+						'_',
+						?MODULE,
+						% The default state/opts for executions from the
+						% HTTP API. This would be the appropriate place
+						% to add components (a differently scoped store,
+						% a different wallet, etc.) to execution for
+						% remote clients.
+						#{
+							store => hb_opts:get(store),
+							wallet => hb_opts:get(wallet),
+							error_strategy => hb_opts:get(client_error_strategy)
 						}
-					]
-				}
+					}
+				]}
 			]
 		),
-    cowboy:start_clear(
-        ?MODULE,
-        [{port, hb_opts:get(http_port)}],
-        #{env => #{dispatch => Dispatcher}}
-    ).
+
+	cowboy:start_clear(
+		?MODULE,
+		[{port, hb_opts:get(http_port)}],
+
+		#{
+			env => #{dispatch => Dispatcher},
+			metrics_callback => fun prometheus_cowboy2_instrumenter:observe/1,
+			stream_handlers => [cowboy_metrics_h, cowboy_stream_h]
+		}
+	).
 
 init(Req, State) ->
-    Path = cowboy_req:path(Req),
-    ?event({http_called_with_path, Path}),
+	Path = cowboy_req:path(Req),
+	?event({http_called_with_path, Path}),
 	% Note: We pass the state twice in the call below: Once for the device
 	% to optionally have it if useful, and once for the hb_pam module
 	% itself. This lets us send execution environment parameters as well as
 	% the request itself to the device.
-    case hb_pam:resolve(dev_meta, execute, [hb_http:req_to_tx(Req), State], State) of
-        {ok, ResultingMessage} when is_record(ResultingMessage, tx) or is_map(ResultingMessage) ->
-            % If the device returns a message (either normalized or not),
-            % we normalize and serialize it, returning it to the client.
-            % If the message contains a `Status` tag, we use it as the HTTP
-            % status code, otherwise we default to 200.
-            NormMessage = ar_bundles:normalize(ResultingMessage),
-            Signed =
-                case ar_bundles:is_signed(NormMessage) of
-                    true -> NormMessage;
-                    false -> ar_bundles:sign_item(NormMessage, hb:wallet())
-                end,
-            hb_http:reply(
-                Req,
-                hb_http:tx_to_status(Signed),
-                Signed
-            );
-        no_match ->
-            % If the device returns no_match, we return a 404.
-            ?event({could_not_match_path_to_device, Path}),
-            hb_http:reply(Req,
-				#tx {
+	case hb_pam:resolve(dev_meta, execute, [hb_http:req_to_tx(Req), State], State) of
+		{ok, ResultingMessage} when is_record(ResultingMessage, tx) or is_map(ResultingMessage) ->
+			% If the device returns a message (either normalized or not),
+			% we normalize and serialize it, returning it to the client.
+			% If the message contains a `Status` tag, we use it as the HTTP
+			% status code, otherwise we default to 200.
+			NormMessage = ar_bundles:normalize(ResultingMessage),
+			Signed =
+				case ar_bundles:is_signed(NormMessage) of
+					true -> NormMessage;
+					false -> ar_bundles:sign_item(NormMessage, hb:wallet())
+				end,
+			hb_http:reply(
+				Req,
+				hb_http:tx_to_status(Signed),
+				Signed
+			);
+		no_match ->
+			% If the device returns no_match, we return a 404.
+			?event({could_not_match_path_to_device, Path}),
+			hb_http:reply(
+				Req,
+				#tx{
 					tags = [{<<"Status">>, <<"500">>}],
 					data = <<"No matching device found.">>
 				}
 			)
-    end.
+	end.
 
 allowed_methods(Req, State) ->
 	{[<<"GET">>, <<"POST">>, <<"DELETE">>], Req, State}.

--- a/src/hb_metrics_collector.erl
+++ b/src/hb_metrics_collector.erl
@@ -1,0 +1,62 @@
+-module(hb_metrics_collector).
+
+-export(
+	[
+		deregister_cleanup/1,
+		collect_mf/2,
+		collect_metrics/2
+	]
+).
+-behaviour(prometheus_collector).
+%%====================================================================
+%% Collector API
+%%====================================================================
+deregister_cleanup(_) -> ok.
+
+collect_mf(_Registry, Callback) ->
+	{Uptime, _} = erlang:statistics(wall_clock),
+	Callback(
+		create_gauge(
+			process_uptime_seconds,
+			"The number of seconds the Erlang process has been up.",
+			Uptime
+		)
+	),
+
+	SystemLoad = cpu_sup:avg5(),
+
+	Callback(
+		create_gauge(
+			system_load,
+			"The load values are proportional to how long"
+			" time a runnable Unix process has to spend in the run queue"
+			" before it is scheduled. Accordingly, higher values mean"
+			" more system load",
+			SystemLoad
+		)
+	),
+
+	ok.
+collect_metrics(system_load, SystemLoad) ->
+	%% Return the gauge metric with no labels
+	prometheus_model_helpers:gauge_metrics(
+		[
+			{[], SystemLoad}
+		]
+	);
+collect_metrics(process_uptime_seconds, Uptime) ->
+	%% Convert the uptime from milliseconds to seconds
+	UptimeSeconds = Uptime / 1000,
+
+	%% Return the gauge metric with no labels
+	prometheus_model_helpers:gauge_metrics(
+		[
+			{[], UptimeSeconds}
+		]
+	).
+
+%%====================================================================
+%% Private Parts
+%%====================================================================
+create_gauge(Name, Help, Data) ->
+	prometheus_model_helpers:create_mf(Name, Help, gauge, ?MODULE, Data).


### PR DESCRIPTION
- use prometheus and prometheus_cowboy libraries to expose node metrics via /metrics endpoint;
- introduce custom `ao_metrics_collector` that allows collecting application-specific metrics (Load average and Uptime);
- introduce docker-compose setup that allows bringing up local infrastructure for Prometheus and Grafana (+ dashboard defined in JSON) on local machines