### PR TITLE
chore(repo): add simple githooks convention and enforce conventional commits

### DIFF
--- a/.githooks/_/install.sh
+++ b/.githooks/_/install.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+DIR="$(dirname "$0")/.."
+
+FLAG_FILE="$DIR/_/.setup"
+
+if [ ! -f "$FLAG_FILE" ]; then
+    echo "Linking Git Hooks 🐶..."
+    git config core.hooksPath "$DIR"
+    touch "$FLAG_FILE"
+fi

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Regex for Conventional Commits (Plus Git Vernacular for Merges and Reverts)
+CONVENTIONAL_COMMITS_REGEX="^((Merge[ a-z-]* branch.*)|(Revert*)|((build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.*\))?!?: .*))"
+
+# Get the commit message
+COMMIT_MSG=$(cat "$1")
+
+# Check if the commit message matches the Conventional Commits format
+if [[ ! $COMMIT_MSG =~ $CONVENTIONAL_COMMITS_REGEX ]]; then
+  echo "❌ Error: Commit message does not follow the Conventional Commits format."
+  echo ""
+  echo "Expected format: <type>(<scope>): <description>"
+  echo ""
+  echo "✅ Examples:"
+  echo "  feat(parser): add ability to parse arrays"
+  echo "  fix(login): handle edge case with empty passwords"
+  echo "  docs: update README with installation instructions"
+  echo ""
+  echo "Allowed types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test"
+  exit 1
+fi
+
+# If the commit message is valid, allow the commit
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,6 @@ rebar3.crashdump
 *~
 
 *.json
-!package.json
-!package-lock.json
 node_modules
 !.vscode/*
 
@@ -36,3 +34,5 @@ rebar.lock
 .DS_STORE
 TEST-data*
 test-cache/*
+
+.githooks/_/.setup

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ compile:
 WAMR_VERSION = 2.1.2
 WAMR_DIR = _build/wamr
 
+GITHOOKS_DIR = .githooks
+
 ifdef HB_DEBUG
 	WAMR_FLAGS = -DWAMR_ENABLE_LOG=1 -DWAMR_BUILD_DUMP_CALL_STACK=1 -DCMAKE_BUILD_TYPE=Debug
 else
@@ -26,6 +28,8 @@ else
     WAMR_BUILD_PLATFORM = linux
     WAMR_BUILD_TARGET = X86_64
 endif
+
+githooks: $(GITHOOKS_DIR)/_/setup
 
 wamr: $(WAMR_DIR)/lib/libvmlib.a
 
@@ -62,6 +66,9 @@ $(WAMR_DIR)/lib/libvmlib.a: $(WAMR_DIR)
 		-DWAMR_BUILD_INTERP=1 \
 		-DWAMR_BUILD_JIT=0
 	make -C $(WAMR_DIR)/lib
+
+$(GITHOOKS_DIR)/_/setup:
+	@sh ./$(GITHOOKS_DIR)/_/install.sh
 
 clean:
 	rebar3 clean

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Soon.
 
 <!-- toc -->
 
--   [Development](#development)
+- [Development](#development)
 
 <!-- tocstop -->
+
+## Development
+
+The repo uses githooks to help ensure repo-wide conventions. You can install these hooks by running `make githooks`, which will help ensure you're following these conventions:
+
+- All Commit Messages should follow [Conventional Commits Style](https://www.conventionalcommits.org/en/v1.0.0/).


### PR DESCRIPTION
This PR adds a zero-dependency simple convention for creating and installing git hooks. This convention establishes developer feedback loops, as part of normal git flow, great for early stage quality checks ie. at commit or push time.

Simply run `make githooks` to install any git supported hooks from the `.githooks` directory.

This PR also implements a `commit-msg` hook that ensures the commit message follows [Conventional Commits Style](https://www.conventionalcommits.org/en/v1.0.0/).