### PR TITLE
feat(hb_store): switch local_store to hb_store_rocksdb

### DIFF
--- a/src/ar_bundles.erl
+++ b/src/ar_bundles.erl
@@ -944,9 +944,23 @@ ar_bundles_test_() ->
         {timeout, 30, fun test_bundle_map/0},
         {timeout, 30, fun test_basic_member_id/0},
         {timeout, 30, fun test_deep_member/0},
-        {timeout, 30, fun test_serialize_deserialize_deep_signed_bundle/0},
         {timeout, 30, fun test_extremely_large_bundle/0}
     ].
+
+ar_bundles_with_hb_store_test_() ->
+    {foreach,
+        fun() ->
+            Opts = hb_opts:get(local_store),
+            hb_store:start(Opts)
+        end,
+        fun(_) ->
+            Opts = hb_opts:get(local_store),
+            hb_store:stop(Opts)
+        end,
+        [
+            {timeout, 30, fun test_serialize_deserialize_deep_signed_bundle/0}
+        ]
+    }.
 
 test_no_tags() ->
     {Priv, Pub} = ar_wallet:new(),

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -100,7 +100,7 @@ config() ->
         client_error_strategy => throw,
         % Dev options
         local_store =>
-            [{hb_store_fs, #{ prefix => "TEST-data" }}],
+            [{hb_store_rocksdb, #{ prefix => "TEST-data" }}],
         mode => debug,
         debug_stack_depth => 40,
         debug_print_map_line_threshold => 30,

--- a/src/hb_store_rocksdb.erl
+++ b/src/hb_store_rocksdb.erl
@@ -53,7 +53,7 @@ start_link(Opts) ->
 
 % -spec start(#{dir := term()}) -> ignore | {ok, pid()}.
 start(Opts) ->
-    start_link(Opts).
+    start_link([{hb_store_rocksdb, Opts}]).
 
 -spec stop(any()) -> ok.
 stop(_Opts) ->
@@ -211,7 +211,6 @@ add_path(_Opts, Path1, Path2) ->
 %%% Gen server callbacks
 %%%=============================================================================
 init(Dir) ->
-    logger:error("Starting the process"),
     {ok, DBHandle, [DefaultH, MetaH]} = open_rockdb(Dir),
     State = #{
         db_handle => DBHandle,


### PR DESCRIPTION
tests seem to work well on my machine:

```
rebar3 eunit
===> Verifying dependencies...
make: Nothing to be done for `wamr'.
===> Analyzing applications...
===> Compiling hb
Post-compile hooks executed
===> Performing EUnit tests...
======================== EUnit ========================
file "hb.app"
  application 'hb'
    module 'ar_bundles'
      ar_bundles: test_no_tags...[0.496 s] ok
      ar_bundles: test_with_tags...[0.155 s] ok
      ar_bundles: test_unsigned_data_item_id...ok
      ar_bundles: test_unsigned_data_item_normalization...ok
      ar_bundles: test_empty_bundle...[0.010 s] ok
      ar_bundles: test_bundle_with_one_item...[0.001 s] ok
      ar_bundles: test_bundle_with_two_items...[0.001 s] ok
      ar_bundles: test_recursive_bundle...[2.559 s] ok
      ar_bundles: test_bundle_map...[1.175 s] ok
      ar_bundles: test_basic_member_id...[0.262 s] ok
      ar_bundles: test_deep_member...[0.491 s] ok
      ar_bundles: test_extremely_large_bundle...[2.990 s] ok
      ar_bundles: test_serialize_deserialize_deep_signed_bundle...[0.655 s] ok
      [done in 9.272 s]
    module 'ar_deep_hash'
    module 'ar_timestamp'
    module 'ar_tx'
    module 'ar_wallet'
    module 'dev_cron'
    module 'dev_cu'
    module 'dev_dedup'
    module 'dev_json_iface'
    module 'dev_lookup'
    module 'dev_message'
      dev_message: get_keys_mod_test...ok
      dev_message: is_private_mod_test...[0.003 s] ok
      dev_message: keys_from_device_test...[0.005 s] ok
      dev_message: case_insensitive_get_test...ok
      dev_message: private_keys_are_filtered_test...[0.006 s] ok
      dev_message: cannot_get_private_keys_test...[0.003 s] ok
      dev_message: key_from_device_test...[0.003 s] ok
      dev_message: remove_test...[0.016 s] ok
      dev_message: set_conflicting_keys_test...[0.009 s] ok
      [done in 0.072 s]
    module 'dev_meta'
    module 'dev_monitor'
    module 'dev_mu'
    module 'dev_multipass'
    module 'dev_p4'
    module 'dev_poda'
    module 'dev_process'
    module 'dev_scheduler'
      dev_scheduler: status_test...=INFO REPORT==== 11-Dec-2024::09:29:28.684724 ===
    alarm_handler: {set,{system_memory_high_watermark,[]}}
=INFO REPORT==== 11-Dec-2024::09:29:28.691677 ===
    alarm_handler: {set,{{disk_almost_full,"/System/Volumes/Data"},[]}}
=INFO REPORT==== 11-Dec-2024::09:29:28.691783 ===
    alarm_handler: {set,{{disk_almost_full,"/Volumes/Joplin 3.1.23"},[]}}
[1.379 s] ok
      dev_scheduler: register_new_process_test...[0.743 s] ok
      dev_scheduler: schedule_message_and_get_slot_test...[0.227 s] ok
      dev_scheduler: get_schedule_test...[0.246 s] ok
      [done in 2.607 s]
    module 'dev_scheduler_interface'
    module 'dev_scheduler_registry'
      dev_scheduler_registry: find_non_existent_process_test...ok
      dev_scheduler_registry: create_and_find_process_test...[0.001 s] ok
      dev_scheduler_registry: create_multiple_processes_test...[0.001 s] ok
      dev_scheduler_registry: get_all_processes_test...ok
      [done in 0.014 s]
    dev_scheduler_server: new_proc_test (module 'dev_scheduler_server')...[0.630 s] ok
    module 'dev_stack'
      dev_stack: transform_internal_call_device_test...[0.010 s] ok
      dev_stack: transform_external_call_device_test...[0.029 s] ok
      dev_stack: example_device_for_stack_test...[0.005 s] ok
      dev_stack: simple_stack_execute_test...[0.042 s] ok
      dev_stack: many_devices_test...[0.107 s] ok
      dev_stack: reinvocation_test...[0.077 s] ok
      dev_stack: skip_test...[0.021 s] ok
      [done in 0.312 s]
    dev_test: device_with_function_key_module_test (module 'dev_test')...[0.003 s] ok
    module 'dev_vfs'
    module 'dev_wasm'
    module 'hb'
    module 'hb_app'
    module 'hb_beamr'
      hb_beamr: nif_loads_test...ok
      hb_beamr: simple_wasm_test...[0.008 s] ok
      hb_beamr: simple_wasm_calling_test...[0.022 s] ok
      hb_beamr: imported_functions_are_called_test...[0.011 s] ok
      hb_beamr: wasm64_test...[0.003 s] ok
      hb_beamr: aos64_standalone_wex_test...[2.860 s] ok
      hb_beamr: test_checkpoint_and_resume...[3.472 s] ok
      [done in 6.397 s]
    module 'hb_beamr_io'
    module 'hb_cache'
      hb_cache: -create_store_test/1-fun-8- (simple_path_resolution_test [backend: hb_store_rocksdb])...[0.001 s] ok
      hb_cache: -create_store_test/1-fun-7- (resursive_path_resolution_test [backend: hb_store_rocksdb])...[0.002 s] ok
      hb_cache: -create_store_test/1-fun-6- (hierarchical_path_resolution_test [backend: hb_store_rocksdb])...[0.002 s] ok
      hb_cache: -create_store_test/1-fun-5- (store_simple_unsigned_item_test [backend: hb_store_rocksdb])...[0.004 s] ok
      hb_cache: -create_store_test/1-fun-4- (simple_signed_item_test [backend: hb_store_rocksdb])...[0.310 s] ok
      hb_cache: -create_store_test/1-fun-3- (deeply_nested_item_test [backend: hb_store_rocksdb])...[0.060 s] ok
      hb_cache: -create_store_test/1-fun-2- (write_and_read_output_test [backend: hb_store_rocksdb])...[0.084 s] ok
      hb_cache: -create_store_test/1-fun-1- (latest_output_retrieval_test [backend: hb_store_rocksdb])...[0.071 s] ok
      hb_cache: -create_store_test/1-fun-8- (simple_path_resolution_test [backend: hb_store_fs])...[0.005 s] ok
      hb_cache: -create_store_test/1-fun-7- (resursive_path_resolution_test [backend: hb_store_fs])...[0.005 s] ok
      hb_cache: -create_store_test/1-fun-6- (hierarchical_path_resolution_test [backend: hb_store_fs])...[0.005 s] ok
      hb_cache: -create_store_test/1-fun-5- (store_simple_unsigned_item_test [backend: hb_store_fs])...[0.006 s] ok
      hb_cache: -create_store_test/1-fun-4- (simple_signed_item_test [backend: hb_store_fs])...[0.032 s] ok
      hb_cache: -create_store_test/1-fun-3- (deeply_nested_item_test [backend: hb_store_fs])...[0.057 s] ok
      hb_cache: -create_store_test/1-fun-2- (write_and_read_output_test [backend: hb_store_fs])...[0.068 s] ok
      hb_cache: -create_store_test/1-fun-1- (latest_output_retrieval_test [backend: hb_store_fs])...[0.086 s] ok
      [done in 3.587 s]
    module 'hb_client'
    module 'hb_converge'
      hb_converge: key_from_id_device_test...[0.003 s] ok
      hb_converge: keys_from_id_device_test...[0.003 s] ok
      hb_converge: path_test...[0.006 s] ok
      hb_converge: key_to_binary_test...ok
      hb_converge: resolve_binary_key_test...[0.006 s] ok
      hb_converge: key_from_id_device_with_args_test...[0.008 s] ok
      hb_converge: device_with_handler_function_test...[0.003 s] ok
      hb_converge: device_with_default_handler_function_test...[0.005 s] ok
      hb_converge: basic_get_test...[0.007 s] ok
      hb_converge: basic_set_test...[0.029 s] ok
      hb_converge: get_with_device_test...[0.007 s] ok
      hb_converge: get_as_with_device_test...[0.026 s] ok
      hb_converge: set_with_device_test...[0.042 s] ok
      hb_converge: deep_set_test...[0.057 s] ok
      hb_converge: deep_set_with_device_test...[0.050 s] ok
      hb_converge: device_exports_test...[0.002 s] ok
      hb_converge: denormalized_device_key_test...[0.011 s] ok
      [done in 0.316 s]
    hb_crypto: sha256_chain_test (module 'hb_crypto')...ok
    module 'hb_http'
    module 'hb_http_router'
    module 'hb_http_signature'
      hb_http_signature: trim_ws_test...ok
      hb_http_signature: sign_test...ok
      hb_http_signature: signature_base_test...ok
      hb_http_signature: signature_components_line_test...ok
      hb_http_signature: signature_params_line_test...ok
      hb_http_signature: extract_field_msg_access_test...ok
      hb_http_signature: extract_field_bs_test...ok
      hb_http_signature: extract_field_sf_test...ok
      hb_http_signature: extract_field_error_conflicting_params_test...ok
      hb_http_signature: extract_field_error_field_not_found_test...ok
      hb_http_signature: extract_field_error_not_sf_dictionary_test...ok
      hb_http_signature: extract_field_error_sf_dictionary_key_not_found_test...ok
      hb_http_signature: derive_component_test...ok
      hb_http_signature: derive_component_error_req_param_on_request_target_test...ok
      hb_http_signature: derive_component_error_query_param_no_name_test...ok
      hb_http_signature: derive_component_error_status_req_target_test...ok
      [done in 0.048 s]
    module 'hb_http_structured_fields'
    module 'hb_logger'
    module 'hb_message'
      hb_message: basic_map_to_tx_test...ok
      hb_message: default_tx_keys_removed_test...ok
      hb_message: minimization_test...ok
      hb_message: single_layer_message_to_tx_test...ok
      hb_message: single_layer_tx_to_message_test...ok
      hb_message: match_test...[0.001 s] ok
      hb_message: structured_field_atom_parsing_test...ok
      hb_message: structured_field_decimal_parsing_test...ok
      hb_message: binary_to_binary_test...ok
      hb_message: message_with_large_keys_test...[0.001 s] ok
      hb_message: nested_message_with_large_keys_and_data_test...[0.001 s] ok
      hb_message: simple_nested_message_test...[0.002 s] ok
      hb_message: nested_message_with_large_data_test...[0.006 s] ok
      hb_message: deeply_nested_message_with_data_test...[0.006 s] ok
      hb_message: nested_structured_fields_test...[0.001 s] ok
      hb_message: nested_message_with_large_keys_test...[0.002 s] ok
      hb_message: signed_tx_to_message_and_back_test...[0.019 s] ok
      hb_message: signed_deep_tx_serialize_and_deserialize_test...[0.022 s] ok
      hb_message: calculate_unsigned_message_id_test...[0.004 s] ok
      hb_message: sign_serialize_deserialize_verify_test...[0.018 s] ok
      hb_message: unsigned_id_test...[0.004 s] ok
      [done in 0.152 s]
    module 'hb_metrics_collector'
    module 'hb_opts'
      hb_opts: global_get_test...[0.001 s] ok
      hb_opts: local_get_test...ok
      hb_opts: local_preference_test...ok
      hb_opts: global_preference_test...[0.001 s] ok
      [done in 0.014 s]
    module 'hb_path'
      hb_path: push_hashpath_test...[0.002 s] ok
      hb_path: push_multiple_hashpaths_test...[0.003 s] ok
      hb_path: verify_hashpath_test...[0.005 s] ok
      hb_path: pop_from_message_test...[0.001 s] ok
      hb_path: pop_from_path_list_test...ok
      hb_path: hd_test...ok
      hb_path: tl_test...[0.001 s] ok
      [done in 0.033 s]
    module 'hb_private'
      hb_private: set_private_test...ok
      hb_private: get_private_key_test...[0.010 s] ok
      [done in 0.017 s]
    module 'hb_process'
    module 'hb_process_monitor'
    module 'hb_router'
    module 'hb_store'
    module 'hb_store_fs'
    module 'hb_store_remote_node'
    module 'hb_store_rocksdb'
      hb_store_rocksdb: -write_read_test_/0-fun-5- (can read/write data)...ok
      hb_store_rocksdb: -write_read_test_/0-fun-3- (returns not_found for non existing keys)...ok
      hb_store_rocksdb: -write_read_test_/0-fun-1- (follows links)...[0.001 s] ok
      hb_store_rocksdb: -api_test_/0-fun-25- (list/2 lists keys under given path)...ok
      hb_store_rocksdb: -api_test_/0-fun-23- (list/2 resolves given path before listing)...ok
      hb_store_rocksdb: -api_test_/0-fun-21- (make_link/3 creates a link to actual data)...ok
      hb_store_rocksdb: -api_test_/0-fun-19- (make_group/2 creates a group)...ok
      hb_store_rocksdb: -api_test_/0-fun-17- (make_link/3 does not create links if keys are same)...ok
      hb_store_rocksdb: -api_test_/0-fun-15- (reset cleans up the database)...[0.314 s] ok
      hb_store_rocksdb: -api_test_/0-fun-13- (type/2 can identify simple items)...ok
      hb_store_rocksdb: -api_test_/0-fun-11- (type/2 returns not_found for non existing keys)...ok
      hb_store_rocksdb: -api_test_/0-fun-9- (type/2 treats links as simple items)...ok
      hb_store_rocksdb: -api_test_/0-fun-7- (type/2 treats groups as composite items)...ok
      hb_store_rocksdb: -api_test_/0-fun-5- (resolve/2 resolutions for computed folder)...[0.001 s] ok
      hb_store_rocksdb: -api_test_/0-fun-1- (resolving interlinked item paths)...[0.001 s] ok
      [done in 5.010 s]
    module 'hb_sup'
    module 'hb_test'
    module 'hb_util'
    module 'rsa_pss'
    module 'sec'
    module 'sec_helpers'
    module 'sec_tee'
    module 'sec_tpm'
    [done in 28.809 s]
  [done in 28.812 s]
=======================================================
  All 145 tests passed.
[os_mon] memory supervisor port (memsup): Erlang has closed
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed                                                                                                                                       30.90s
```