### PR TITLE
feat: `dev_wasm` process execution flow

### DIFF
--- a/src/dev_process_cache.erl
+++ b/src/dev_process_cache.erl
@@ -165,7 +165,7 @@ find_latest_output_test(Opts) ->
     Store = hb_opts:get(store, no_viable_store, Opts),
     ResetRes = hb_store:reset(Store),
     ?event({reset_store, {result, ResetRes}, {store, Store}}),
-    Proc1 = dev_process:test_process(),
+    Proc1 = dev_process:test_aos_process(),
     ProcID = hb_util:human_id(hb_converge:get(id, Proc1)),
     % Create messages for the slots, with only the middle slot having a
     % `/Process` field, while the top slot has a `/Deep/Process` field.

--- a/src/dev_test.erl
+++ b/src/dev_test.erl
@@ -1,5 +1,5 @@
 -module(dev_test).
--export([info/1, test_func/1, compute/3, init/3, restore/3]).
+-export([info/1, test_func/1, compute/3, init/3, restore/3, mul/2]).
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
 
@@ -60,6 +60,14 @@ restore(Msg, _Msg2, Opts) ->
                 ))
             }
     end.
+
+%% @doc Example implementation of an `imported` function for a WASM
+%% executor.
+mul(Msg1, Msg2) ->
+    %?event({test_pow_import_function, {msg1, Msg1}, {msg2, Msg2}}),
+    State = hb_converge:get(<<"State">>, Msg1, #{ hashpath => ignore }),
+    [Arg1, Arg2] = hb_converge:get(args, Msg2, #{ hashpath => ignore }),
+    {ok, #{ state => State, wasm_response => [Arg1 * Arg2] }}.
 
 %%% Tests
 

--- a/src/dev_test.erl
+++ b/src/dev_test.erl
@@ -64,7 +64,6 @@ restore(Msg, _Msg2, Opts) ->
 %% @doc Example implementation of an `imported` function for a WASM
 %% executor.
 mul(Msg1, Msg2) ->
-    %?event({test_pow_import_function, {msg1, Msg1}, {msg2, Msg2}}),
     State = hb_converge:get(<<"State">>, Msg1, #{ hashpath => ignore }),
     [Arg1, Arg2] = hb_converge:get(args, Msg2, #{ hashpath => ignore }),
     {ok, #{ state => State, wasm_response => [Arg1 * Arg2] }}.

--- a/src/dev_wasm.erl
+++ b/src/dev_wasm.erl
@@ -69,16 +69,16 @@ init(M1, _M2, Opts) ->
 %% pass.
 computed(M1, _M2, Opts) ->
     case hb_converge:get(pass, M1, Opts) of
-        1 ->
+        X when X == 1 orelse X == not_found ->
             % Extract the WASM port, func, params, and standard library
             % invokation from the message and apply them with the WASM executor.
             {ResType, Res, MsgAfterExecution} =
                 hb_beamr:call(
-                    M1,
                     hb_private:get(<<"WASM/Port">>, M1, Opts),
                     hb_converge:get(<<"WASM-Function">>, M1, Opts),
                     hb_converge:get(<<"WASM-Params">>, M1, Opts),
                     hb_private:get(<<"WASM/Invoke-stdlib">>, M1, Opts),
+                    M1,
                     Opts
                 ),
             {ok,
@@ -188,4 +188,4 @@ basic_execution_test() ->
     ?event({after_init, Msg1}),
     {ok, Res} = hb_converge:resolve(Msg1, <<"Computed">>, #{}),
     ?event({after_computed, Res}),
-    ?assertEqual(120.0, hb_converge:get(<<"Results/WASM/Output">>, Res)).
+    ?assertEqual([120.0], hb_converge:get(<<"Results/WASM/Output">>, Res)).

--- a/src/dev_wasm.erl
+++ b/src/dev_wasm.erl
@@ -210,6 +210,12 @@ basic_execution_test() ->
         test_run_wasm("test/test.wasm", <<"fac">>, [5.0], #{})
     ).
 
+basic_execution_64_test() ->
+    ?assertEqual(
+        {ok, [120.0]},
+        test_run_wasm("test/test-64.wasm", <<"fac">>, [5.0], #{})
+    ).
+
 imported_function_test() ->
     ?assertEqual(
         {ok, [32]},
@@ -219,13 +225,7 @@ imported_function_test() ->
             [2, 5],
             #{
                 <<"WASM/stdlib/my_lib">> =>
-                    #{
-                        device =>
-                            #{
-                                mul =>
-                                    fun hb_beamr:test_pow_import_function/2
-                            }
-                    }
+                    #{ device => <<"Test-Device/1.0">> }
             }
         )
     ).

--- a/src/dev_wasm.erl
+++ b/src/dev_wasm.erl
@@ -200,9 +200,9 @@ test_run_wasm(File, Func, Params, AdditionalMsg) ->
             )
         ),
     ?event({after_setup, Msg2}),
-    Res = hb_converge:resolve(Msg2, <<"Computed/Results/WASM/Output">>, #{}),
-    ?event({after_resolve, Res}),
-    Res.
+    {ok, StateRes} = hb_converge:resolve(Msg2, <<"Computed">>, #{}),
+    ?event({after_resolve, StateRes}),
+    hb_converge:resolve(StateRes, <<"Results/WASM/Output">>, #{}).
 
 basic_execution_test() ->
     ?assertEqual(

--- a/src/hb_beamr.erl
+++ b/src/hb_beamr.erl
@@ -123,9 +123,7 @@ monitor_call(Port, ImportFun, StateMsg, Opts) ->
             try
                 % Call the import function in a similar way to `hb_converge':
                 % Offer Msg1, Msg2, and Opts, but truncate the arguments to
-                % the import function's arity. Unlike `hb_converge', we expect
-                % a tuple response of two elements: the new state, and the
-                % WASM response.
+                % the import function's arity.
                 {ok, Msg3} =
                     apply(
                         ImportFun,
@@ -196,11 +194,12 @@ simple_wasm_test() ->
     ?assertEqual(120.0, Result).
 
 test_pow_import_function(Msg1, Msg2) ->
-    [ModName, FuncName] = hb_converge:get(path, Msg2, #{ hashpath => ignore }),
+    ?event(import1),
+    %?event({test_pow_import_function, {msg1, Msg1}, {msg2, Msg2}}),
+    State = hb_converge:get(<<"State">>, Msg1, #{ hashpath => ignore }),
     [Arg1, Arg2] = hb_converge:get(args, Msg2, #{ hashpath => ignore }),
-    ?assertEqual(<<"my_lib">>, ModName),
-    ?assertEqual(<<"mul">>, FuncName),
-    {ok, #{ state => Msg1, wasm_response => [Arg1 * Arg2] }}.
+    ?event(import2),
+    {ok, #{ state => State, wasm_response => [Arg1 * Arg2] }}.
 
 %% @doc Test that imported functions can be called from the WASM module.
 imported_function_test() ->

--- a/src/hb_beamr.erl
+++ b/src/hb_beamr.erl
@@ -53,8 +53,6 @@
 -export([start/1, call/3, call/4, call/5, call/6, stop/1]).
 %%% Utility API:
 -export([serialize/1, deserialize/2, stub/3]).
-%%% Test API:
--export([test_pow_import_function/2]).
 
 -include("src/include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -185,18 +183,12 @@ simple_wasm_test() ->
     {ok, [Result]} = call(Port, "fac", [5.0]),
     ?assertEqual(120.0, Result).
 
-test_pow_import_function(Msg1, Msg2) ->
-    %?event({test_pow_import_function, {msg1, Msg1}, {msg2, Msg2}}),
-    State = hb_converge:get(<<"State">>, Msg1, #{ hashpath => ignore }),
-    [Arg1, Arg2] = hb_converge:get(args, Msg2, #{ hashpath => ignore }),
-    {ok, #{ state => State, wasm_response => [Arg1 * Arg2] }}.
-
 %% @doc Test that imported functions can be called from the WASM module.
 imported_function_test() ->
     {ok, File} = file:read_file("test/pow_calculator.wasm"),
     {ok, Port, _Imports, _Exports} = start(File),
     {ok, [Result], _} =
-        call(Port, <<"pow">>, [2, 5], fun test_pow_import_function/2),
+        call(Port, <<"pow">>, [2, 5], fun dev_test:mul/2),
     ?assertEqual(32, Result).
 
 %% @doc Test that WASM Memory64 modules load and execute correctly.

--- a/src/hb_beamr.erl
+++ b/src/hb_beamr.erl
@@ -52,7 +52,6 @@
 -export([start/1, call/3, call/4, call/5, call/6, stop/1]).
 -export([serialize/1, deserialize/2, stub/3]).
 
-
 -include("src/include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -94,9 +93,11 @@ call(Port, FunctionName, Args, ImportFun) ->
     call(Port, FunctionName, Args, ImportFun, #{}).
 call(Port, FunctionName, Args, ImportFun, StateMsg) ->
     call(Port, FunctionName, Args, ImportFun, StateMsg, #{}).
+call(Port, FunctionName, Args, ImportFun, StateMsg, Opts)
+        when is_binary(FunctionName) ->
+    call(Port, binary_to_list(FunctionName), Args, ImportFun, StateMsg, Opts);
 call(Port, FunctionName, Args, ImportFun, StateMsg, Opts) ->
-    ?event({call_started, Port, FunctionName, Args, ImportFun}),
-    ?event({call, FunctionName, Args}),
+    ?event({call_started, Port, FunctionName, Args, ImportFun, StateMsg, Opts}),
     Port ! {self(), {command, term_to_binary({call, FunctionName, Args})}},
     ?event({waiting_for_call_result, self(), Port}),
     monitor_call(Port, ImportFun, StateMsg, Opts).

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -324,7 +324,11 @@ message_to_tx(RawM) when is_map(RawM) ->
     % Calculate which set of the remaining keys will be used as tags.
     {Tags, RawDataItems} =
         lists:partition(
-            fun({_Key, Value}) when byte_size(Value) =< ?MAX_TAG_VAL -> true;
+            fun({_Key, Value}) when is_binary(Value) ->
+                    case unicode:characters_to_binary(Value) of
+                        {error, _, _} -> false;
+                        _ -> byte_size(Value) =< ?MAX_TAG_VAL
+                    end;
                 (_) -> false
             end,
             [ 

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -54,7 +54,7 @@ config() ->
                 <<"Scheduler/1.0">> => dev_scheduler,
                 <<"Process/1.0">> => dev_process,
                 <<"VFS/1.0">> => dev_vfs,
-                <<"WASM64/1.0">> => dev_wasm,
+                <<"WASM-64/1.0">> => dev_wasm,
                 <<"Cron">> => dev_cron,
                 <<"Deduplicate">> => dev_dedup,
                 <<"JSON-Interface">> => dev_json_iface,


### PR DESCRIPTION
This PR implements the new WASM device with compatibility for execution inside a `dev_process` with Converge. It also uses Converge for import resolutions, such that these, too, generate hashpaths, can be executed remotely, etc. See commit log for full list of changes.