### PR TITLE
feat: `dev_process` push with Converge and `hb_persistent` execution for `/Compute`

### DIFF
--- a/src/dev_json_iface.erl
+++ b/src/dev_json_iface.erl
@@ -151,7 +151,8 @@ results(M1, _M2, Opts) ->
                             M1,
                             #{
                                 <<"Results/Outbox">> => undefined,
-                                <<"Results/Body">> => <<"JSON error parsing WASM result output.">>
+                                <<"Results/Body">> =>
+                                    <<"JSON error parsing WASM result output.">>
                             },
                             Opts
                         )
@@ -183,7 +184,14 @@ preprocess_results(Msg, Proc, Opts) ->
             Msg
         ),
     maps:merge(
-        FilteredMsg,
+        maps:from_list(
+            lists:map(
+                fun({Key, Value}) ->
+                    {hb_converge:to_key(Key), Value}
+                end,
+                maps:to_list(FilteredMsg)
+            )
+        ),
         Tags#{
             <<"From-Process">> => hb_converge:get(id, Proc, Opts),
             <<"From-Image">> => hb_converge:get(<<"WASM-Image">>, Proc, Opts)

--- a/src/dev_json_iface.erl
+++ b/src/dev_json_iface.erl
@@ -207,7 +207,7 @@ generate_stack(File) ->
     test_init(),
     Wallet = hb:wallet(),
     Msg0 = dev_wasm:store_wasm_image(File),
-    Image = maps:get(<<"WASM-Image">>, Msg0),
+    Image = hb_converge:get(<<"Image">>, Msg0, #{}),
     Msg1 = Msg0#{
         device => <<"Stack/1.0">>,
         <<"Device-Stack">> =>
@@ -217,12 +217,26 @@ generate_stack(File) ->
                 <<"WASM-64/1.0">>,
                 <<"Multipass/1.0">>
             ],
+        <<"Input-Prefixes">> =>
+            [
+                <<"Process">>,
+                <<"Process">>,
+                <<"Process">>,
+                <<"Process">>
+            ],
+        <<"Output-Prefixes">> =>
+            [
+                <<"WASM">>,
+                <<"WASM">>,
+                <<"WASM">>,
+                <<"WASM">>
+            ],
         <<"Passes">> => 2,
         <<"Stack-Keys">> => [<<"Init">>, <<"Compute">>],
         <<"Process">> => 
             hb_message:sign(#{
                 <<"Type">> => <<"Process">>,
-                <<"WASM-Image">> => Image,
+                <<"Image">> => Image,
                 <<"Scheduler">> => hb:address(),
                 <<"Authority">> => hb:address()
             }, Wallet)

--- a/src/dev_json_iface.erl
+++ b/src/dev_json_iface.erl
@@ -185,7 +185,7 @@ preprocess_results(Msg, Proc, Opts) ->
     maps:merge(
         FilteredMsg,
         Tags#{
-            <<"From-Process">> => hb_util:id(Proc, signed),
+            <<"From-Process">> => hb_converge:get(id, Proc, Opts),
             <<"From-Image">> => hb_converge:get(<<"WASM-Image">>, Proc, Opts)
         }
     ).

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -147,8 +147,7 @@ do_compute(Msg1, Msg2, TargetSlot, Opts) ->
                     <<"Execution">>,
                     State,
                     ToProcess,
-                    Opts#{ cache_keys => CacheKeys },
-                    #{ spawn_worker => true }
+                    Opts#{ cache_keys => CacheKeys }
                 ),
             ?event({do_compute_result, {msg3, Msg3}}),
             do_compute(
@@ -586,7 +585,7 @@ persistent_process_test() ->
     },
     ?assertMatch(
         {ok, _},
-        hb_converge:resolve(Msg1, Msg2, #{})
+        hb_converge:resolve(Msg1, Msg2, #{ spawn_worker => true })
     ),
     T1 = hb:now(),
     ?assertMatch(

--- a/src/dev_process_worker.erl
+++ b/src/dev_process_worker.erl
@@ -4,32 +4,72 @@
 %%% to computation requests regarding a process as a singleton.
 -module(dev_process_worker).
 -export([server/3, stop/1, group/3]).
+-include_lib("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
 
 %% @doc Returns a group name for a request. The worker is responsible for all
 %% computation work on the same process on a single node, so we use the
 %% process ID as the group name.
-group(Msg1, _Msg2, Opts) ->
-    Proc = hb_converge:get(<<"Process">>, {as, dev_message, Msg1}, Opts),
-    hb_util:human_id(hb_converge:get(id, Proc, Opts#{ hashpath := ignore})).
+group(Msg1, undefined, Opts) ->
+    hb_persistent:default_grouper(Msg1, undefined, Opts);
+group(Msg1, Msg2, Opts) ->
+    case dev_message:get(path, Msg2, Opts) of
+        {ok, <<"Compute">>} ->
+            ID = process_to_group_name(Msg1, Opts),
+            ?event({id, ID}),
+            ID;
+        {_, OtherRes} ->
+            hb_persistent:default_grouper(Msg1, Msg2, Opts)
+    end.
+
+process_to_group_name(Msg1, Opts) ->
+    hb_util:human_id(
+        hb_converge:get(
+            id,
+            {as,
+                dev_message,
+                dev_process:ensure_process_key(Msg1, Opts)
+            },
+            Opts#{ hashpath => ignore}
+        )
+    ).
 
 %% @doc Spawn a new worker process. This is called after the end of the first
 %% execution of `hb_converge:resolve/3', so the state we are given is the
 %% already current.
-server(Msg1, _FirstMsg, Opts) ->
+server(GroupName, Msg1, Opts) ->
+    %hb_persistent:default_worker(GroupName, Msg1, Opts#{ static_worker => true }).
     receive
-        {resolve, Listener, Msg1, Msg2, ListenerOpts} ->
-            Res =
-                hb_converge:resolve(
-                    Msg1,
-                    Msg2,
-                    ListenerOpts#{ spawn_worker => false }
-                ),
-            Listener ! {resolved, self(), Msg1, Msg2, Res},
-            server(Msg1, Msg2, Opts);
-        stop -> ok
+        Req ->
+            ?event({req, Req}),
+            ok
     end.
 
 %% @doc Stop a worker process.
 stop(Worker) ->
     exit(Worker, normal).
 
+%%% Tests
+
+test_init() ->
+    application:ensure_all_started(hb),
+    ok.
+
+info_test() ->
+    test_init(),
+    M1 = dev_process:test_wasm_process(<<"test/aos-2-pure-xs.wasm">>),
+    Res = hb_converge:info(M1, #{}),
+    ?assertEqual(fun dev_process_worker:group/3, maps:get(grouper, Res)).
+
+grouper_test() ->
+    test_init(),
+    M1 = dev_process:test_aos_process(),
+    M2 = #{ path => <<"Compute">>, v => 1 },
+    M3 = #{ path => <<"Compute">>, v => 2 },
+    M4 = #{ path => <<"Not-Compute">>, v => 3 },
+    G1 = hb_persistent:group(M1, M2, #{}),
+    G2 = hb_persistent:group(M1, M3, #{}),
+    G3 = hb_persistent:group(M1, M4, #{}),
+    ?event({group_samples, {g1, G1}, {g2, G2}, {g3, G3}}),
+    ?assertEqual(G1, G2),
+    ?assertNotEqual(G1, G3).

--- a/src/dev_process_worker.erl
+++ b/src/dev_process_worker.erl
@@ -38,13 +38,8 @@ process_to_group_name(Msg1, Opts) ->
 %% execution of `hb_converge:resolve/3', so the state we are given is the
 %% already current.
 server(GroupName, Msg1, Opts) ->
-    %hb_persistent:default_worker(GroupName, Msg1, Opts#{ static_worker => true }).
-    ?event({waiting_for_work, GroupName}),
-    receive
-        Req ->
-            ?event({received_work, Req}),
-            ok
-    end.
+    ?event(worker_spawns, {proc_starting_default_resolver, GroupName}),
+    hb_persistent:default_worker(GroupName, Msg1, Opts#{ static_worker => true }).
 
 %% @doc Stop a worker process.
 stop(Worker) ->

--- a/src/dev_process_worker.erl
+++ b/src/dev_process_worker.erl
@@ -11,11 +11,10 @@
 %% computation work on the same process on a single node, so we use the
 %% process ID as the group name.
 group(Msg1, undefined, Opts) ->
-    ?event(compute_group_id_no_msg2),
-    process_to_group_name(Msg1, Opts);
+    hb_persistent:default_grouper(Msg1, undefined, Opts);
 group(Msg1, Msg2, Opts) ->
-    case dev_message:get(path, Msg2, Opts) of
-        {ok, <<"Compute">>} ->
+    case hb_path:hd(Msg2, Opts) of
+        <<"Compute">> ->
             ID = process_to_group_name(Msg1, Opts),
             ?event({compute_group_id, ID}),
             ID;

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -204,7 +204,7 @@ post_schedule(Msg1, Msg2, Opts) ->
             {ok,
                 #{
                     <<"Status">> => <<"OK">>,
-                    <<"Initial-Assignment">> => <<"0">>,
+                    <<"Assignment">> => <<"0">>,
                     <<"Process">> => ProcID
                 }
             };

--- a/src/dev_stack.erl
+++ b/src/dev_stack.erl
@@ -210,14 +210,14 @@ transform(Msg1, Key, Opts) ->
                                 hb_converge:get(
                                     [<<"Input-Prefixes">>, Key],
                                     {as, dev_message, Msg1},
-                                    <<"">>,
+                                    undefined,
                                     Opts
                                 ),
                             <<"Output-Prefix">> =>
                                 hb_converge:get(
                                     [<<"Output-Prefixes">>, Key],
                                     {as, dev_message, Msg1},
-                                    <<"">>,
+                                    undefined,
                                     Opts
                                 )
 						},
@@ -294,6 +294,7 @@ resolve_stack(Message1, Key, Message2, DevNum, Opts) ->
 	end.
 
 maybe_error(Message1, Key, Message2, DevNum, Info, Opts) ->
+    ?event(debug, {stack_error, {msg1, Message1}, {key, Key}, {msg2, Message2}, {dev_num, DevNum}, {info, Info}, {opts, Opts}}),
     case hb_opts:get(error_strategy, throw, Opts) of
         stop ->
 			{error, {stack_call_failed, Message1, Key, Message2, DevNum, Info}};
@@ -467,8 +468,8 @@ test_prefix_msg() ->
     Dev = #{
         prefix_set =>
             fun(M1, M2, Opts) ->
-                In = hb_converge:get(<<"Input-Prefix">>, M1, Opts),
-                Out = hb_converge:get(<<"Output-Prefix">>, M1, Opts),
+                In = input_prefix(M1, M2, Opts),
+                Out = output_prefix(M1, M2, Opts),
                 Key = hb_converge:get(<<"Key">>, M2, Opts),
                 Value = hb_converge:get(<<In/binary, "/", Key/binary>>, M2, Opts),
                 ?event(debug, {setting, {inp, In}, {outp, Out}, {key, Key}, {value, Value}}),

--- a/src/dev_test.erl
+++ b/src/dev_test.erl
@@ -53,11 +53,11 @@ restore(Msg, _Msg2, Opts) ->
         AlreadySeen ->
             ?event({restore_found, AlreadySeen}),
             {ok,
-                ?event(hb_private:set(
+                hb_private:set(
                     Msg,
                     #{ <<"Test-Key/Started-State">> => AlreadySeen },
                     Opts
-                ))
+                )
             }
     end.
 

--- a/src/dev_test.erl
+++ b/src/dev_test.erl
@@ -66,7 +66,7 @@ restore(Msg, _Msg2, Opts) ->
 mul(Msg1, Msg2) ->
     State = hb_converge:get(<<"State">>, Msg1, #{ hashpath => ignore }),
     [Arg1, Arg2] = hb_converge:get(args, Msg2, #{ hashpath => ignore }),
-    {ok, #{ state => State, wasm_response => [Arg1 * Arg2] }}.
+    {ok, #{ state => State, results => [Arg1 * Arg2] }}.
 
 %%% Tests
 

--- a/src/dev_wasi.erl
+++ b/src/dev_wasi.erl
@@ -256,6 +256,7 @@ generate_wasi_stack(File, Func, Params) ->
     Msg1 = Msg0#{
         device => <<"Stack/1.0">>,
         <<"Device-Stack">> => [<<"WASI/1.0">>, <<"WASM-64/1.0">>],
+        <<"Output-Prefixes">> => [<<"WASM">>, <<"WASM">>],
         <<"Stack-Keys">> => [<<"Init">>, <<"Compute">>],
         <<"WASM-Function">> => Func,
         <<"WASM-Params">> => Params

--- a/src/dev_wasi.erl
+++ b/src/dev_wasi.erl
@@ -127,7 +127,7 @@ path_open(Msg1, Msg2, Opts) ->
                     <<"vfs/", Path/binary>>,
                     FD
                 ),
-            wasm_response => [0, Index]
+            results => [0, Index]
         }
     }.
 
@@ -148,7 +148,7 @@ fd_write(S, Port, [_, _Ptr, 0, RetPtr], BytesWritten, _Opts) ->
         RetPtr,
         <<BytesWritten:64/little-unsigned-integer>>
     ),
-    {ok, #{ state => S, wasm_response => [0] }};
+    {ok, #{ state => S, results => [0] }};
 fd_write(S, Port, [FDnum, Ptr, Vecs, RetPtr], BytesWritten, Opts) ->
     FDNumStr = integer_to_binary(FDnum),
     FD = hb_converge:get(<<"File-Descriptors/", FDNumStr/binary>>, S, Opts),
@@ -199,7 +199,7 @@ fd_read(S, Port, [FD, _VecsPtr, 0, RetPtr], BytesRead, _Opts) ->
     ?event({{completed_read, FD, BytesRead}}),
     hb_beamr_io:write(Port, RetPtr,
         <<BytesRead:64/little-unsigned-integer>>),
-    {ok, #{ state => S, wasm_response => [0] }};
+    {ok, #{ state => S, results => [0] }};
 fd_read(S, Port, [FDNum, VecsPtr, NumVecs, RetPtr], BytesRead, Opts) ->
     ?event({fd_read, FDNum, VecsPtr, NumVecs, RetPtr}),
     % Parse the request
@@ -243,7 +243,7 @@ parse_iovec(Port, Ptr) ->
 clock_time_get(Msg1, _Msg2, Opts) ->
     ?event({clock_time_get, {returning, 1}}),
     State = hb_converge:get(<<"State">>, Msg1, Opts),
-    {ok, #{ state => State, wasm_response => [1] }}.
+    {ok, #{ state => State, results => [1] }}.
 
 %%% Tests
 

--- a/src/dev_wasm.erl
+++ b/src/dev_wasm.erl
@@ -49,7 +49,7 @@ init(M1, M2, Opts) ->
     InPrefix = dev_stack:input_prefix(M1, M2, Opts),
     % Where we should read/write our own state to.
     Prefix = dev_stack:prefix(M1, M2, Opts),
-    ?event(debug, {in_prefix, InPrefix}),
+    ?event({in_prefix, InPrefix}),
     ImageBin =
         case hb_converge:get(<<InPrefix/binary, "/Image">>, M1, Opts) of
             not_found ->

--- a/src/dev_wasm.erl
+++ b/src/dev_wasm.erl
@@ -53,7 +53,13 @@ init(M1, M2, Opts) ->
     ImageBin =
         case hb_converge:get(<<InPrefix/binary, "/Image">>, M1, Opts) of
             not_found ->
-                {error, <<"No viable image found in ", InPrefix/binary>>};
+                throw(
+                    {
+                        wasm_init_error,
+                        <<"No viable image found in ", InPrefix/binary, "/Image.">>,
+                        {msg1, M1}
+                    }
+                );
             ImageID when ?IS_ID(ImageID) ->
                 ?event({getting_wasm_image, ImageID}),
                 {ok, ImageMsg} = hb_cache:read(ImageID, Opts),

--- a/src/dev_wasm.erl
+++ b/src/dev_wasm.erl
@@ -96,7 +96,7 @@ init(M1, M2, Opts) ->
 %% @doc Take a BEAMR import call and resolve it using `hb_converge`.
 default_import_resolver(Msg1, Msg2, Opts) ->
     #{
-        port := Port,
+        instance := WASM,
         module := Module,
         func := Func,
         args := Args,
@@ -107,7 +107,7 @@ default_import_resolver(Msg1, Msg2, Opts) ->
         hb_converge:resolve(
             hb_private:set(
                 Msg1,
-                #{ <<Prefix/binary, "/Port">> => Port },
+                #{ <<Prefix/binary, "/Port">> => WASM },
                 Opts
             ),
             #{
@@ -276,7 +276,7 @@ init_test() ->
     ?event({after_init, Msg1}),
     Priv = hb_private:from_message(Msg1),
     ?assertMatch(
-        {ok, Port} when is_port(Port),
+        {ok, Port} when is_pid(Port),
         hb_converge:resolve(Priv, <<"WASM/Port">>, #{})
     ),
     ?assertMatch(
@@ -297,7 +297,7 @@ input_prefix_test() ->
     ?event({after_init, Msg2}),
     Priv = hb_private:from_message(Msg2),
     ?assertMatch(
-        {ok, Port} when is_port(Port),
+        {ok, Port} when is_pid(Port),
         hb_converge:resolve(Priv, <<"Port">>, #{})
     ),
     ?assertMatch(
@@ -321,7 +321,7 @@ process_prefixes_test() ->
     ?event({after_init, Msg3}),
     Priv = hb_private:from_message(Msg3),
     ?assertMatch(
-        {ok, Port} when is_port(Port),
+        {ok, Port} when is_pid(Port),
         hb_converge:resolve(Priv, <<"WASM/Port">>, #{})
     ),
     ?assertMatch(

--- a/src/dev_wasm.erl
+++ b/src/dev_wasm.erl
@@ -7,14 +7,14 @@
 %%%     M1/Init ->
 %%%         Assumes:
 %%%             M1/Process
-%%%             M1/Process/WASM-Image
+%%%             M1/[Prefix]/Image
 %%%         Generates:
 %%%             /priv/WASM/Port
 %%%             /priv/WASM/Import-Resolver
 %%%         Side-effects:
 %%%             Creates a WASM executor loaded in memory of the HyperBEAM node.
 %%% 
-%%%     M1/Computed ->
+%%%     M1/Compute ->
 %%%         Assumes:
 %%%             M1/priv/WASM/Port
 %%%             M1/priv/WASM/Import-Resolver
@@ -27,10 +27,15 @@
 %%%             /Results/WASM/Body
 %%%         Side-effects:
 %%%             Calls the WASM executor with the message and process.
+%%%     M1/WASM/State ->
+%%%         Assumes:
+%%%             M1/priv/WASM/Port
+%%%         Generates:
+%%%             Raw binary WASM state
 %%% '''
 -module(dev_wasm).
 -export([init/3, compute/3, import/3, terminate/3]).
--export([wasm_state/3]).
+-export([state/3]).
 %%% Test API:
 -export([store_wasm_image/1]).
 -include("include/hb.hrl").
@@ -38,25 +43,29 @@
 
 %% @doc Boot a WASM image on the image stated in the `Process/Image' field of
 %% the message.
-init(M1, _M2, Opts) ->
+init(M1, M2, Opts) ->
     ?event(running_init),
-    ImageID = 
-        case hb_converge:get(<<"WASM-Image">>, M1, Opts) of
+    % Where we should read initial parameters from.
+    InPrefix = dev_stack:input_prefix(M1, M2, Opts),
+    % Where we should read/write our own state to.
+    Prefix = dev_stack:prefix(M1, M2, Opts),
+    ?event(debug, {in_prefix, InPrefix}),
+    ImageBin =
+        case hb_converge:get(<<InPrefix/binary, "/Image">>, M1, Opts) of
             not_found ->
-                hb_converge:get(<<"Process/WASM-Image">>, M1, Opts);
-            X -> X
+                {error, <<"No viable image found in ", InPrefix/binary>>};
+            ImageID when ?IS_ID(ImageID) ->
+                ?event({getting_wasm_image, ImageID}),
+                {ok, ImageMsg} = hb_cache:read(ImageID, Opts),
+                hb_converge:get(<<"Body">>, ImageMsg, Opts);
+            Image when is_binary(Image) ->
+                ?event(wasm_image_message_directly_provided),
+                hb_converge:get(<<"Body">>, Image, Opts)
         end,
-    ?event({getting_wasm_image, ImageID}),
-    {ok, ImageMsg} =
-        hb_cache:read(
-            ImageID,
-            Opts
-        ),
     % Start the WASM executor.
-    {ok, Port, _ImportMap, _Exports} =
-        hb_beamr:start(hb_converge:get(<<"Body">>, ImageMsg, Opts)),
+    {ok, Port, _ImportMap, _Exports} = hb_beamr:start(ImageBin),
     % Apply the checkpoint if it is in the initial state.
-    case hb_converge:get(<<"WASM/State">>, M1, Opts) of
+    case hb_converge:get(<<Prefix/binary, "/State">>, {as, dev_message, M1}, Opts) of
         not_found -> do_nothing;
         Checkpoint ->
             ?event(wasm_checkpoint_found),
@@ -66,12 +75,13 @@ init(M1, _M2, Opts) ->
             ?event(wasm_deserialized)
     end,
     % Set the WASM port, handler, and standard library invokation function.
-    ?event({setting_wasm_port, Port}),
+    ?event({setting_wasm_port, Port, {prefix, Prefix}}),
     {ok,
         hb_private:set(M1,
             #{
-                <<"WASM/Port">> => Port,
-                <<"WASM/Import-Resolver">> => fun default_import_resolver/3
+                <<Prefix/binary, "/Port">> => Port,
+                <<Prefix/binary, "/Import-Resolver">> =>
+                    fun default_import_resolver/3
             },
             Opts
         )
@@ -86,12 +96,16 @@ default_import_resolver(Msg1, Msg2, Opts) ->
         args := Args,
         func_sig := Signature
     } = Msg2,
+    Prefix = dev_stack:prefix(Msg1, Msg2, Opts),
     {ok, Msg3} =
         hb_converge:resolve(
-            Msg1,
+            hb_private:set(
+                Msg1,
+                #{ <<Prefix/binary, "/Port">> => Port },
+                Opts
+            ),
             #{
                 path => import,
-                priv => #{ wasm => #{ port => Port } },
                 module => list_to_binary(Module),
                 func => list_to_binary(Func),
                 args => Args,
@@ -100,18 +114,18 @@ default_import_resolver(Msg1, Msg2, Opts) ->
             Opts
         ),
     NextState = hb_converge:get(state, Msg3, Opts),
-    Response = hb_converge:get(wasm_response, Msg3, Opts),
+    Response = hb_converge:get(results, Msg3, Opts),
     {ok, Response, NextState}.
 
 %% @doc Call the WASM executor with a message that has been prepared by a prior
 %% pass.
 compute(M1, M2, Opts) ->
     ?event(running_compute),
+    Prefix = dev_stack:prefix(M1, M2, Opts),
     case hb_converge:get(pass, M1, Opts) of
         X when X == 1 orelse X == not_found ->
             % Extract the WASM port, func, params, and standard library
             % invokation from the message and apply them with the WASM executor.
-            ?event({calling_wasm_executor, {msg1, M1}, {msg2, M2}}),
             WASMFunction =
                 case hb_converge:get(<<"Message/WASM-Function">>, M2, Opts) of
                     not_found ->
@@ -124,40 +138,52 @@ compute(M1, M2, Opts) ->
                         hb_converge:get(<<"WASM-Params">>, M1, Opts);
                     Params -> Params
                 end,
+            ?event(
+                {
+                    calling_wasm_executor,
+                    {prefix, Prefix},
+                    {m1, M1},
+                    {m2, M2},
+                    {priv, hb_private:from_message(M1)}
+                }
+            ),
             {ResType, Res, MsgAfterExecution} =
                 hb_beamr:call(
-                    hb_private:get(<<"WASM/Port">>, M1, Opts),
+                    hb_private:get(<<Prefix/binary, "/Port">>, M1, Opts),
                     WASMFunction,
                     WASMParams,
-                    hb_private:get(<<"WASM/Import-Resolver">>, M1, Opts),
+                    hb_private:get(<<Prefix/binary, "/Import-Resolver">>, M1, Opts),
                     M1,
                     Opts
                 ),
             {ok,
                 hb_converge:set(MsgAfterExecution,
                     #{
-                        <<"Results/WASM/Type">> => ResType,
-                        <<"Results/WASM/Output">> => Res
+                        <<"Results/", Prefix/binary, "/Type">> =>
+                            ResType,
+                        <<"Results/", Prefix/binary, "/Output">> => Res
                     }
                 )
             };
         _ -> {ok, M1}
     end.
 
-%% @doc Serialize the WASM state to a message.
-wasm_state(M1, _M2, Opts) ->
-    Port = hb_private:get(<<"priv/WASM/Port">>, M1, Opts),
+%% @doc Serialize the WASM state to a binary.
+state(M1, _M2, Opts) ->
+    Prefix = dev_stack:prefix(M1, _M2, Opts),
+    Port = hb_private:get(<<Prefix/binary, "/Port">>, M1, Opts),
     {ok, Serialized} = hb_beamr:serialize(Port),
     {ok, Serialized}.
 
 %% @doc Tear down the WASM executor.
 terminate(M1, _M2, Opts) ->
     ?event(terminate_called_on_dev_wasm),
-    Port = hb_private:get(<<"priv/WASM/Port">>, M1, Opts),
+    Prefix = dev_stack:prefix(M1, _M2, Opts),
+    Port = hb_private:get(<<Prefix/binary, "/Port">>, M1, Opts),
     hb_beamr:stop(Port),
     {ok, hb_private:set(M1,
         #{
-            <<"WASM/Port">> => undefined
+            <<Prefix/binary, "/Port">> => undefined
         },
         Opts
     )}.
@@ -172,8 +198,22 @@ import(Msg1, Msg2, Opts) ->
     % 1. Adjust the path to the stdlib.
     ModName = hb_converge:get(<<"Module">>, Msg2, Opts),
     FuncName = hb_converge:get(<<"Func">>, Msg2, Opts),
-    AdjustedPath = <<"WASM/stdlib/", ModName/binary, "/", FuncName/binary>>,
-    StatePath = << "WASM/stdlib/", ModName/binary, "/", "State">>,
+    Prefix = dev_stack:prefix(Msg1, Msg2, Opts),
+    AdjustedPath =
+        <<
+            Prefix/binary,
+            "/stdlib/",
+            ModName/binary,
+            "/",
+            FuncName/binary
+        >>,
+    StatePath =
+        <<
+            Prefix/binary,
+            "/stdlib/",
+            ModName/binary,
+            "/State"
+        >>,
     AdjustedMsg2 = Msg2#{ path => AdjustedPath },
     % 2. Add the current state to the message at the stdlib path.
     AdjustedMsg1 =
@@ -198,24 +238,24 @@ import(Msg1, Msg2, Opts) ->
 %% call details into the message.
 undefined_import_stub(Msg1, Msg2, Opts) ->
     ?event({unimplemented_dev_wasm_call, {msg1, Msg1}, {msg2, Msg2}}),
+    Prefix = dev_stack:prefix(Msg1, Msg2, Opts),
+    UndefinedCallsPath =
+        <<"State/Results/", Prefix/binary, "/Undefined-Calls">>,
     Msg3 = hb_converge:set(
         Msg1,
-        #{<<"State/Results/WASM/Undefined-Calls">> =>
-            [
-                Msg2
-            |
-                case hb_converge:get(
-                    <<"State/Results/WASM/Undefined-Calls">>,
-                    Msg1,
-                    Opts
-                ) of
-                    not_found -> [];
-                    X -> X
-                end
-            ]
+        #{
+            UndefinedCallsPath =>
+                [
+                    Msg2
+                |
+                    case hb_converge:get(UndefinedCallsPath, Msg1, Opts) of
+                        not_found -> [];
+                        X -> X
+                    end
+                ]
         }
     ),
-    {ok, #{ state => Msg3, wasm_response => [0] }}.
+    {ok, #{ state => Msg3, results => [0] }}.
 
 %%% Tests
 
@@ -223,36 +263,65 @@ init() ->
     application:ensure_all_started(hb),
     hb:init().
 
-store_wasm_image(Image) ->
-    {ok, Bin} = file:read_file(Image),
-    Msg = #{ <<"Body">> => Bin },
-    {ok, ID} = hb_cache:write(Msg, #{}),
-    #{
-        device => <<"WASM-64/1.0">>,
-        <<"WASM-Image">> => ID
-    }.
-
-test_run_wasm(File, Func, Params, AdditionalMsg) ->
+init_test() ->
     init(),
-    Msg0 = store_wasm_image(File),
-    {ok, Msg1} = hb_converge:resolve(Msg0, <<"Init">>, #{}),
+    Msg = store_wasm_image("test/test.wasm"),
+    {ok, Msg1} = hb_converge:resolve(Msg, <<"Init">>, #{}),
     ?event({after_init, Msg1}),
-    Msg2 =
-        maps:merge(
-            Msg1,
-            hb_converge:set(
-                #{
-                    <<"WASM-Function">> => Func,
-                    <<"WASM-Params">> => Params
-                },
-                AdditionalMsg,
-                #{ hashpath => ignore }
-            )
-        ),
-    ?event({after_setup, Msg2}),
-    {ok, StateRes} = hb_converge:resolve(Msg2, <<"Compute">>, #{}),
-    ?event({after_resolve, StateRes}),
-    hb_converge:resolve(StateRes, <<"Results/WASM/Output">>, #{}).
+    Priv = hb_private:from_message(Msg1),
+    ?assertMatch(
+        {ok, Port} when is_port(Port),
+        hb_converge:resolve(Priv, <<"WASM/Port">>, #{})
+    ),
+    ?assertMatch(
+        {ok, Fun} when is_function(Fun),
+        hb_converge:resolve(Priv, <<"WASM/Import-Resolver">>, #{})
+    ).
+
+input_prefix_test() ->
+    init(),
+    #{ image := ImageID } = store_wasm_image("test/test.wasm"),
+    Msg1 =
+        #{
+            <<"Device">> => <<"WASM-64/1.0">>,
+            <<"Input-Prefix">> => <<"Test-In">>,
+            <<"Test-In">> => #{ <<"Image">> => ImageID }
+        },
+    {ok, Msg2} = hb_converge:resolve(Msg1, <<"Init">>, #{}),
+    ?event({after_init, Msg2}),
+    Priv = hb_private:from_message(Msg2),
+    ?assertMatch(
+        {ok, Port} when is_port(Port),
+        hb_converge:resolve(Priv, <<"Port">>, #{})
+    ),
+    ?assertMatch(
+        {ok, Fun} when is_function(Fun),
+        hb_converge:resolve(Priv, <<"Import-Resolver">>, #{})
+    ).
+
+%% @doc Test that realistic prefixing for a `dev_process` works --
+%% including both inputs (from `Process/`) and outputs (to the 
+%% Device-Key) work
+process_prefixes_test() ->
+    init(),
+    Msg1 =
+        #{
+            <<"Device">> => <<"WASM-64/1.0">>,
+            <<"Output-Prefix">> => <<"WASM">>,
+            <<"Input-Prefix">> => <<"Process">>,
+            <<"Process">> => store_wasm_image("test/test.wasm")
+        },
+    {ok, Msg3} = hb_converge:resolve(Msg1, <<"Init">>, #{}),
+    ?event({after_init, Msg3}),
+    Priv = hb_private:from_message(Msg3),
+    ?assertMatch(
+        {ok, Port} when is_port(Port),
+        hb_converge:resolve(Priv, <<"WASM/Port">>, #{})
+    ),
+    ?assertMatch(
+        {ok, Fun} when is_function(Fun),
+        hb_converge:resolve(Priv, <<"WASM/Import-Resolver">>, #{})
+    ).
 
 basic_execution_test() ->
     ?assertEqual(
@@ -279,3 +348,60 @@ imported_function_test() ->
             }
         )
     ).
+
+% state_export_and_restore_test() ->
+%     init(),
+%     % Generate a WASM computation.
+%     Msg0 = store_wasm_image("test/test-64.wasm"),
+%     {ok, Msg1} = hb_converge:resolve(Msg0, <<"Init">>, #{}),
+%     Msg2 =
+%         maps:merge(
+%             Msg1,
+%             #{
+%                 <<"WASM-Function">> => <<"fac">>,
+%                 <<"WASM-Params">> => [5.0]
+%             }
+%         ),
+%     ?event({after_setup, Msg2}),
+%     % Compute a computation and export the state.
+%     {ok, StateRes} = hb_converge:resolve(Msg2, <<"Compute/State">>, #{}),
+%     ?event({state_res, StateRes}),
+%     % Restore the state without calling Init.
+%     NewMsg0 = maps:merge(Msg0, #{ <<"WASM/State">> => StateRes }),
+%     {ok, NewMsg1} = hb_converge:resolve(NewMsg0, <<"Compute">>, #{}),
+%     ?event({after_compute, NewMsg1}),
+%     hb_converge:resolve(NewMsg1, <<"Results/WASM/Output">>, #{}).
+
+%%% Test helpers
+
+store_wasm_image(Image) ->
+    {ok, Bin} = file:read_file(Image),
+    Msg = #{ <<"Body">> => Bin },
+    {ok, ID} = hb_cache:write(Msg, #{}),
+    #{
+        device => <<"WASM-64/1.0">>,
+        <<"Output-Prefix">> => <<"WASM">>,
+        image => ID
+    }.
+
+test_run_wasm(File, Func, Params, AdditionalMsg) ->
+    init(),
+    Msg0 = store_wasm_image(File),
+    {ok, Msg1} = hb_converge:resolve(Msg0, <<"Init">>, #{}),
+    ?event({after_init, Msg1}),
+    Msg2 =
+        maps:merge(
+            Msg1,
+            hb_converge:set(
+                #{
+                    <<"WASM-Function">> => Func,
+                    <<"WASM-Params">> => Params
+                },
+                AdditionalMsg,
+                #{ hashpath => ignore }
+            )
+        ),
+    ?event({after_setup, Msg2}),
+    {ok, StateRes} = hb_converge:resolve(Msg2, <<"Compute">>, #{}),
+    ?event({after_resolve, StateRes}),
+    hb_converge:resolve(StateRes, <<"Results/WASM/Output">>, #{}).

--- a/src/hb.erl
+++ b/src/hb.erl
@@ -1,11 +1,12 @@
-%%% @doc Hyperbeam is a decentralized node implementation implementing a protocol 
-%%% built on top of the Arweave protocol.
-%%% This protocol offers a computation layer for
-%%% executing arbitrary logic on top of data inside the Arweave network.
+%%% @doc Hyperbeam is a decentralized node implementating the Converge Protocol
+%%% on top of Arweave.
+%%% 
+%%% This protocol offers a computation layer for executing arbitrary logic on 
+%%% top of the network's data.
 %%% 
 %%% Arweave is built to offer a robust, permanent storage layer for static data
-%%% over time. One can see it essentially as a globally distributed key-value
-%%% store that allows users to lookup IDs to retrieve data at any point in time:
+%%% over time. It can be seen as a globally distributed key-value store that
+%%% allows users to lookup IDs to retrieve data at any point in time:
 %%% 
 %%% 	`Arweave(ID) => Message'
 %%% 
@@ -13,7 +14,7 @@
 %%% Allowing users to store and retrieve not only arbitrary bytes, but also to
 %%% perform execution of computation upon that data:
 %%% 
-%%% 	`Hyperbeam(Message0) => Message1'
+%%% 	`Hyperbeam(Message1, Message2) => Message3'
 %%% 
 %%% When Hyperbeam executes a message, it will return a new message containing
 %%% the result of that execution, as well as signed attestations of its
@@ -37,31 +38,30 @@
 %%% 
 %%% The core abstractions of the Hyperbeam node are broadly as follows:
 %%% 
-%%% 1. The `hb' module manages the node's configuration, environment variables,
-%%%    and debugging tools.
+%%% 1. The `hb' and `hb_opts' modules manage the node's configuration, 
+%%%    environment variables, and debugging tools.
 %%% 
 %%% 2. The `hb_http' and `hb_http_router' modules manage all HTTP-related
 %%%    functionality. `hb_http_router' handles turning received HTTP requests
 %%%    into messages and applying those messages with the appropriate devices.
 %%%    `hb_http' handles making requests and responding with messages. `cowboy'
-%%%    is used to implement the actual HTTP server.
+%%%    is used to implement the underlying HTTP server.
 %%% 
 %%% 3. `hb_converge' implements the computation logic of the node: A mechanism
 %%%    for resolving messages to other messages, via the application of logic
-%%%    implemented in devices. `hb_converge' also manages the loading of Erlang
+%%%    implemented in `devices'. `hb_converge' also manages the loading of Erlang
 %%%    modules for each device into the node's environment. There are many
 %%%    different default devices implemented in the hyperbeam node, using the
 %%%    namespace `dev_*'. Some of the critical components are:
 %%% 
-%%%    - `dev_meta': The device responsible for managing all requests to the
-%%%      node. This device takes a message and loads the appropriate devices to
-%%%      execute it. The `hb_http_router' uses this device to resolve incoming
-%%%      HTTP requests.
+%%%     - `dev_message': The default handler for all messages that do not 
+%%%      specify their own device. The message device is also used to resolve
+%%%      keys that are not implemented by the device specified in a message,
+%%%      unless otherwise signalled.
 %%% 
 %%%    - `dev_stack': The device responsible for creating and executing stacks
 %%%      of other devices on messages that request it. There are many uses for
-%%%      this device, one of which is the resolution of AO processes, which
-%%%      typically require it.
+%%%      this device, one of which is the resolution of AO processes.
 %%% 
 %%%    - `dev_p4': The device responsible for managing payments for the services
 %%%      provided by the node.
@@ -80,10 +80,6 @@
 %%% 
 %%% You can find documentation of a similar form to this note in each of the core
 %%% modules of the hyperbeam node.
-%%% This module implements the environment and configuration functionality
-%%% for the hyperbeam node. It manages all global components of the node,
-%%% including the node's wallet, address, configuration, and environment
-%%% variables.
 -module(hb).
 %%% Configuration and environment:
 -export([init/0, now/0, build/0]).

--- a/src/hb_beamr.erl
+++ b/src/hb_beamr.erl
@@ -88,7 +88,13 @@ start(WasmBinary) when is_binary(WasmBinary) ->
 %% @doc Stop a WASM executor context.
 stop(Port) when is_port(Port) ->
     ?event({stop_invoked_for_beamr, Port}),
-    port_close(Port),
+    case erlang:port_info(Port, id) of
+        undefined ->
+            ok;
+        _ ->
+            port_close(Port),
+            ok
+    end,
     ok.
 
 %% @doc Call a function in the WASM executor (see moduledoc for more details).

--- a/src/hb_beamr.erl
+++ b/src/hb_beamr.erl
@@ -13,7 +13,7 @@
 %%% Erlang manuals).
 %%% 
 %%% The core API is simple:
-%%%     ```
+%%% ```
 %%%     start(WasmBinary) -> {ok, Port, Imports, Exports}
 %%%         Where:
 %%%             WasmBinary is the WASM binary to load.
@@ -43,14 +43,15 @@
 %%%     deserialize(Port, Mem) -> ok
 %%%         Where:
 %%%             Port is the port to the LID.
-%%%             Mem is a binary output of a previous `serialize/1' call.'''
+%%%             Mem is a binary output of a previous `serialize/1' call.
+%%% '''
 %%% 
 %%% BEAMR was designed for use in the HyperBEAM project, but is suitable for
 %%% deployment in other Erlang applications that need to run WASM modules. PRs
 %%% are welcome.
 -module(hb_beamr).
 %%% Control API:
--export([start/1, call/3, call/4, call/5, call/6, stop/1]).
+-export([start/1, call/3, call/4, call/5, call/6, stop/1, wasm_send/2]).
 %%% Utility API:
 -export([serialize/1, deserialize/2, stub/3]).
 
@@ -68,33 +69,63 @@ load_driver() ->
 %% @doc Start a WASM executor context. Yields a port to the LID, and the
 %% imports and exports of the WASM module.
 start(WasmBinary) when is_binary(WasmBinary) ->
-    ok = load_driver(),
-    Port = open_port({spawn, "hb_beamr"}, []),
-    Port ! {self(), {command, term_to_binary({init, WasmBinary})}},
-    ?event({waiting_for_init_from, Port}),
+    Self = self(),
+    WASM = spawn(
+        fun() ->
+            ok = load_driver(),
+            Port = open_port({spawn, "hb_beamr"}, []),
+            Port ! {self(), {command, term_to_binary({init, WasmBinary})}},
+            ?event({waiting_for_init_from, Port}),
+            worker(Port, Self)
+        end
+    ),
     receive
         {execution_result, Imports, Exports} ->
             ?event(
                 {wasm_init_success,
                     {imports, Imports},
                     {exports, Exports}}),
-            {ok, Port, Imports, Exports};
+            {ok, WASM, Imports, Exports};
         {error, Error} ->
             ?event({wasm_init_error, Error}),
-            port_close(Port),
+            stop(WASM),
             {error, Error}
     end.
 
-%% @doc Stop a WASM executor context.
-stop(Port) when is_port(Port) ->
-    ?event({stop_invoked_for_beamr, Port}),
-    case erlang:port_info(Port, id) of
-        undefined ->
+%% @doc A worker process that is responsible for handling a WASM instance.
+%% It wraps the WASM port, handling inputs and outputs from the WASM module.
+%% The last sender to the port is always the recipient of its messages, so
+%% be careful to ensure that there is only one active sender to the port at 
+%% any time.
+worker(Port, Listener) ->
+    receive
+        stop ->
+            ?event({stop_invoked_for_beamr, self()}),
+            case erlang:port_info(Port, id) of
+                undefined ->
+                    ok;
+                _ ->
+                    port_close(Port),
+                    ok
+            end,
             ok;
-        _ ->
-            port_close(Port),
-            ok
-    end,
+        {wasm_send, NewListener, Message} ->
+            ?event({wasm_send, {listener, NewListener}, {message, Message}}),
+            Port ! {self(), Message},
+            worker(Port, NewListener);
+        WASMResult ->
+            ?event({wasm_result, {listener, Listener}, {result, WASMResult}}),
+            Listener ! WASMResult,
+            worker(Port, Listener)
+    end.
+
+wasm_send(WASM, Message) when is_pid(WASM) ->
+    WASM ! {wasm_send, self(), Message},
+    ok.
+
+%% @doc Stop a WASM executor context.
+stop(WASM) when is_pid(WASM) ->
+    WASM ! stop,
     ok.
 
 %% @doc Call a function in the WASM executor (see moduledoc for more details).
@@ -108,8 +139,8 @@ call(Port, FunctionName, Args, ImportFun, StateMsg) ->
 call(Port, FunctionName, Args, ImportFun, StateMsg, Opts)
         when is_binary(FunctionName) ->
     call(Port, binary_to_list(FunctionName), Args, ImportFun, StateMsg, Opts);
-call(Port, FunctionName, Args, ImportFun, StateMsg, Opts) 
-        when is_port(Port)
+call(WASM, FunctionName, Args, ImportFun, StateMsg, Opts) 
+        when is_pid(WASM)
         andalso is_list(FunctionName)
         andalso is_list(Args)
         andalso is_function(ImportFun)
@@ -118,17 +149,16 @@ call(Port, FunctionName, Args, ImportFun, StateMsg, Opts)
         true ->
             ?event(
                 {call_started,
-                    Port,
+                    WASM,
                     FunctionName,
                     Args,
                     ImportFun,
                     StateMsg,
                     Opts}),
-            Port !
-                {self(),
-                    {command, term_to_binary({call, FunctionName, Args})}},
-            ?event({waiting_for_call_result, self(), Port}),
-            monitor_call(Port, ImportFun, StateMsg, Opts);
+            wasm_send(WASM,
+                {command, term_to_binary({call, FunctionName, Args})}),
+            ?event({waiting_for_call_result, self(), WASM}),
+            monitor_call(WASM, ImportFun, StateMsg, Opts);
         false ->
             {error, {invalid_args, Args}}
     end.
@@ -140,7 +170,7 @@ stub(Msg1, _Msg2, _Opts) ->
 
 %% @doc Synchonously monitor the WASM executor for a call result and any
 %% imports that need to be handled.
-monitor_call(Port, ImportFun, StateMsg, Opts) ->
+monitor_call(WASM, ImportFun, StateMsg, Opts) ->
     receive
         {execution_result, Result} ->
             ?event({call_result, Result}),
@@ -148,10 +178,10 @@ monitor_call(Port, ImportFun, StateMsg, Opts) ->
         {import, Module, Func, Args, Signature} ->
             ?event({import_called, Module, Func, Args, Signature}),
             try
-                {ok, Response, StateMsg2} =
+                {ok, Res, StateMsg2} =
                     ImportFun(StateMsg,
                         #{
-                            port => Port,
+                            instance => WASM,
                             module => Module,
                             func => Func,
                             args => Args,
@@ -159,14 +189,14 @@ monitor_call(Port, ImportFun, StateMsg, Opts) ->
                         },
                         Opts
                     ),
-                ?event({import_returned, Module, Func, {args, Args}, {response, Response}}),
-                dispatch_response(Port, Response),
-                monitor_call(Port, ImportFun, StateMsg2, Opts)
+                ?event({import_ret, Module, Func, {args, Args}, {params, Res}}),
+                dispatch_response(WASM, Res),
+                monitor_call(WASM, ImportFun, StateMsg2, Opts)
             catch
                 Err:Reason:Stack ->
                     % Signal the WASM executor to stop.
                     ?event({import_error, Err, Reason, Stack}),
-                    stop(Port),
+                    stop(WASM),
                     % The driver is going to send us an error message, so we 
                     % need to clear it from the mailbox, even if we already 
                     % know that the import failed.
@@ -182,19 +212,15 @@ monitor_call(Port, ImportFun, StateMsg, Opts) ->
     end.
 
 %% @doc Check the type of an import response and dispatch it to a Beamr port.
-dispatch_response(Port, Term) when is_port(Port) ->
+dispatch_response(WASM, Term) when is_pid(WASM) ->
 	case is_valid_arg_list(Term) of
 		true ->
-			Port !
-				{self(),
-					{
-						command,
-						term_to_binary({import_response, Term})
-					}};
+			wasm_send(WASM,
+				{command, term_to_binary({import_response, Term})});
 		false ->
 			throw({error, {invalid_response, Term}})
 	end;
-dispatch_response(_Port, Term) ->
+dispatch_response(_WASM, Term) ->
 	throw({error, {invalid_response, Term}}).
 
 %% @doc Check that a list of arguments is valid for a WASM function call.
@@ -204,17 +230,17 @@ is_valid_arg_list(_) ->
     false.
 
 %% @doc Serialize the WASM state to a binary.
-serialize(Port) when is_port(Port) ->
+serialize(WASM) when is_pid(WASM) ->
     ?event(starting_serialize),
-    {ok, Size} = hb_beamr_io:size(Port),
-    {ok, Mem} = hb_beamr_io:read(Port, 0, Size),
+    {ok, Size} = hb_beamr_io:size(WASM),
+    {ok, Mem} = hb_beamr_io:read(WASM, 0, Size),
     ?event({finished_serialize, byte_size(Mem)}),
     {ok, Mem}.
 
 %% @doc Deserialize a WASM state from a binary.
-deserialize(Port, Bin) when is_port(Port) andalso is_binary(Bin) ->
+deserialize(WASM, Bin) when is_pid(WASM) andalso is_binary(Bin) ->
     ?event(starting_deserialize),
-    Res = hb_beamr_io:write(Port, 0, Bin),
+    Res = hb_beamr_io:write(WASM, 0, Bin),
     ?event({finished_deserialize, Res}),
     ok.
 
@@ -226,16 +252,16 @@ driver_loads_test() ->
 %% @doc Test standalone `hb_beamr' correctly after loading a WASM module.
 simple_wasm_test() ->
     {ok, File} = file:read_file("test/test.wasm"),
-    {ok, Port, _Imports, _Exports} = start(File),
-    {ok, [Result]} = call(Port, "fac", [5.0]),
+    {ok, WASM, _Imports, _Exports} = start(File),
+    {ok, [Result]} = call(WASM, "fac", [5.0]),
     ?assertEqual(120.0, Result).
 
 %% @doc Test that imported functions can be called from the WASM module.
 imported_function_test() ->
     {ok, File} = file:read_file("test/pow_calculator.wasm"),
-    {ok, Port, _Imports, _Exports} = start(File),
+    {ok, WASM, _Imports, _Exports} = start(File),
     {ok, [Result], _} =
-        call(Port, <<"pow">>, [2, 5],
+        call(WASM, <<"pow">>, [2, 5],
             fun(Msg1, #{ args := [Arg1, Arg2] }, _Opts) ->
                 {ok, [Arg1 * Arg2], Msg1}
             end),
@@ -244,6 +270,26 @@ imported_function_test() ->
 %% @doc Test that WASM Memory64 modules load and execute correctly.
 wasm64_test() ->
     {ok, File} = file:read_file("test/test-64.wasm"),
-    {ok, Port, _ImportMap, _Exports} = start(File),
-    {ok, [Result]} = call(Port, "fac", [5.0]),
+    {ok, WASM, _ImportMap, _Exports} = start(File),
+    {ok, [Result]} = call(WASM, "fac", [5.0]),
     ?assertEqual(120.0, Result).
+
+%% @doc Ensure that processes outside of the initial one can interact with
+%% the WASM executor.
+multiclient_test() ->
+    Self = self(),
+    ExecPID = spawn(fun() ->
+        receive {wasm, WASM} ->
+            {ok, [Result]} = call(WASM, "fac", [5.0]),
+            Self ! {result, Result}
+        end
+    end),
+    _StartPID = spawn(fun() ->
+        {ok, File} = file:read_file("test/test.wasm"),
+        {ok, WASM, _ImportMap, _Exports} = start(File),
+        ExecPID ! {wasm, WASM}
+    end),
+    receive
+        {result, Result} ->
+            ?assertEqual(120.0, Result)
+    end.

--- a/src/hb_converge.erl
+++ b/src/hb_converge.erl
@@ -669,7 +669,14 @@ device_set(Msg, Key, Value, Opts) ->
             {applying_path, #{ path => set, Key => Value }}
         }
     ),
-	Res = hb_util:ok(resolve(Msg, #{ path => set, Key => Value }, Opts), Opts),
+	Res = hb_util:ok(
+        resolve(
+            Msg,
+            #{ path => set, Key => Value },
+            Opts#{ spawn_worker => false }
+        ),
+        Opts#{ spawn_worker => false }
+    ),
 	?event(
         converge_internal,
         {device_set_result, Res}
@@ -683,7 +690,7 @@ remove(Msg, Key, Opts) ->
         resolve(
             Msg,
             #{ path => remove, item => Key },
-            Opts#{ topic => converge_internal }
+            Opts#{ topic => converge_internal, spawn_worker => false }
         ),
         Opts
     ).

--- a/src/hb_converge.erl
+++ b/src/hb_converge.erl
@@ -324,6 +324,7 @@ resolve_stage(4, Msg1, Msg2, ExecName, Opts) ->
                 % If the device cannot be loaded, we alert the caller.
 				handle_error(
                     ExecName,
+                    Msg2,
 					loading_device,
 					{Class, Exception, Stacktrace},
 					Opts
@@ -391,6 +392,7 @@ resolve_stage(5, Func, Msg1, Msg2, ExecName, Opts) ->
                 % indicated by caller's `#Opts`.
                 handle_error(
                     ExecName,
+                    Msg2,
                     device_call,
                     {ExecClass, ExecException, ExecStacktrace},
                     Opts
@@ -426,7 +428,7 @@ resolve_stage(8, Msg1, Msg2, Res, ExecName, Opts) ->
     ?event(converge_core, {stage, 8, ExecName}, Opts),
     % Notify processes that requested the resolution while we were executing and
     % unregister ourselves from the group.
-    hb_persistent:unregister_notify(ExecName, Res, Opts),
+    hb_persistent:unregister_notify(ExecName, Msg2, Res, Opts),
     resolve_stage(9, Msg1, Msg2, Res, ExecName, Opts);
 resolve_stage(9, _Msg1, Msg2, {ok, Msg3}, ExecName, Opts) ->
     ?event(converge_core, {stage, 9, ExecName}, Opts),
@@ -670,9 +672,9 @@ remove(Msg, Key, Opts) ->
     ).
 
 %% @doc Handle an error in a device call.
-handle_error(ExecGroup, Whence, {Class, Exception, Stacktrace}, Opts) ->
+handle_error(ExecGroup, Msg2, Whence, {Class, Exception, Stacktrace}, Opts) ->
     Error = {error, Whence, {Class, Exception, Stacktrace}},
-    hb_persistent:unregister_notify(ExecGroup, Error, Opts),
+    hb_persistent:unregister_notify(ExecGroup, Msg2, Error, Opts),
     ?event(converge_core, {handle_error, Error, {opts, Opts}}),
     case maps:get(error_strategy, Opts, throw) of
         throw -> erlang:raise(Class, Exception, Stacktrace);

--- a/src/hb_converge.erl
+++ b/src/hb_converge.erl
@@ -366,7 +366,7 @@ resolve_stage(5, Func, Msg1, Msg2, ExecName, Opts) ->
                     {exec_name, ExecName},
                     {msg1, Msg1},
                     {msg2, Msg2},
-                    {msg_res, MsgRes},
+                    {msg3, MsgRes},
                     {opts, Opts}
                 },
                 Opts

--- a/src/hb_converge.erl
+++ b/src/hb_converge.erl
@@ -165,7 +165,17 @@ resolve_stage(0, Msg1, Msg2, Opts) ->
             ?event({cache_hit, {msg1, Msg1}, {msg2, Msg2}, {msg3, Msg3}}),
             {ok, Msg3};
         not_found ->
-            resolve_stage(1, Msg1, Msg2, Opts)
+            case ?IS_ID(Msg1) of
+                false ->
+                    resolve_stage(1, Msg1, Msg2, Opts);
+                true ->
+                    case hb_cache:read(Msg1, Opts) of
+                        {ok, FullMsg1} ->
+                            resolve_stage(1, FullMsg1, Msg2, Opts);
+                        not_found ->
+                            error_not_found(Msg1, Msg2, Opts)
+                    end
+            end
     end;
 resolve_stage(1, Msg1, Msg2, Opts) ->
     ?event(converge_core, {stage, 1, validation_check}, Opts),

--- a/src/hb_converge.erl
+++ b/src/hb_converge.erl
@@ -335,11 +335,19 @@ resolve_stage(5, Func, Msg1, Msg2, ExecName, Opts) ->
 	% Execution.
 	% First, determine the arguments to pass to the function.
 	% While calculating the arguments we unset the add_key option.
-	UserOpts = maps:remove(add_key, Opts),
+	UserOpts1 = maps:remove(add_key, Opts),
+    % Unless the user has explicitly requested recursive spawning, we
+    % unset the spawn_worker option so that we do not spawn a new worker
+    % for every resulting execution.
+    UserOpts2 =
+        case maps:get(spawn_worker, UserOpts1, false) of
+            recursive -> UserOpts1;
+            _ -> maps:remove(spawn_worker, UserOpts1)
+        end,
 	Args =
 		case maps:get(add_key, Opts, false) of
-			false -> [Msg1, Msg2, UserOpts];
-			Key -> [Key, Msg1, Msg2, UserOpts]
+			false -> [Msg1, Msg2, UserOpts1];
+			Key -> [Key, Msg1, Msg2, UserOpts1]
 		end,
     % Try to execute the function.
     Res = 

--- a/src/hb_converge.erl
+++ b/src/hb_converge.erl
@@ -66,8 +66,20 @@
 %%%                    interacting with messages.
 %%% 
 %%%     info/default_mod : A different device module that should be used to
-%%%                        handle all keys that are not explicitly implemented
-%%%                        by the device. Defaults to the `dev_message` device.'''
+%%%                    handle all keys that are not explicitly implemented
+%%%                    by the device. Defaults to the `dev_message` device.
+%%% 
+%%%     info/grouper : A function that returns the concurrency 'group' name for
+%%%                    an execution. Executions with the same group name will
+%%%                    be executed by sending a message to the associated process
+%%%                    and waiting for a response. This allows you to control 
+%%%                    concurrency of execution and to allow executions to share
+%%%                    in-memory state as applicable. Default: A derivation of
+%%%                    Msg1+Msg2. This means that concurrent calls for the same
+%%%                    output will lead to only a single execution.
+%%% 
+%%%     info/worker : A function that should be run as the 'server' loop of
+%%%                   the executor for interactions using the device.
 %%% 
 %%% The HyperBEAM resolver also takes a number of runtime options that change
 %%% the way that the environment operates:

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -414,14 +414,14 @@ message_to_tx(RawM) when is_map(RawM) ->
     Res = try ar_bundles:reset_ids(ar_bundles:normalize(TXWithData))
     catch
         _:Error ->
-            ?event(debug, {{reset_ids_error, Error}, {tx_without_data, TX}}),
-            ?event(debug, {prepared_tx_before_ids,
+            ?event({{reset_ids_error, Error}, {tx_without_data, TX}}),
+            ?event({prepared_tx_before_ids,
                 {tags, {explicit, TXWithData#tx.tags}},
                 {data, TXWithData#tx.data}
             }),
             throw(Error)
     end,
-    %?event(debug, {result, {explicit, Res}}),
+    %?event({result, {explicit, Res}}),
     Res;
 message_to_tx(Other) ->
     ?event({unexpected_message_form, {explicit, Other}}),

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -93,7 +93,7 @@ config() ->
         cache_results => false,
         stack_print_prefixes => ["hb", "dev", "ar"],
         debug_print_trace => short, % `short` | `false`. Has performance impact.
-        short_trace_len => 2
+        short_trace_len => 8
     }.
 
 %% @doc Get an option from the global options, optionally overriding with a

--- a/src/hb_persistent.erl
+++ b/src/hb_persistent.erl
@@ -21,15 +21,7 @@ start() -> pg:start(pg).
 %% @doc Register the process to lead an execution if none is found, otherwise
 %% signal that we should await resolution.
 find_or_register(Msg1, Msg2, Opts) ->
-    case hb_opts:get(spawn_worker, false, Opts) of
-        true -> ?event(worker_spawns, {calculating_group_name, {msg1, Msg1}, {msg2, Msg2}});
-        _ -> ok
-    end,
     GroupName = group(Msg1, Msg2, Opts),
-    case is_binary(GroupName) of
-        true -> ?event(worker_spawns, {calculated_group_name, GroupName, {msg1, Msg1}, {msg2, Msg2}, Opts});
-        _ -> ok
-    end,
     find_or_register(GroupName, Msg1, Msg2, Opts).
 find_or_register(GroupName, Msg1, Msg2, Opts) ->
     Self = self(),
@@ -77,15 +69,10 @@ find_execution(Groupname, _Opts) ->
 group(Msg1, Msg2, Opts) ->
     Grouper =
         maps:get(grouper, hb_converge:info(Msg1, Opts), fun default_grouper/3),
-    Name = apply(
+    apply(
         Grouper,
         hb_converge:truncate_args(Grouper, [Msg1, Msg2, Opts])
-    ),
-    case hb_opts:get(spawn_worker, false, Opts) of
-        true -> ?event(worker_spawns, {name, Name, Grouper});
-        _ -> ok
-    end,
-    Name.
+    ).
 
 %% @doc Register for performing a Converge resolution.
 register_groupname(Groupname, _Opts) ->

--- a/src/hb_persistent.erl
+++ b/src/hb_persistent.erl
@@ -9,9 +9,9 @@
 %%% manager.
 
 -module(hb_persistent).
--export([find_or_register/3, unregister_notify/3, await/4, start_worker/2]).
-%-export([find/2, find/3]).
-%-export([notify/4, register/2, register/3, unregister/2, unregister/3]).
+-export([find_or_register/3, unregister_notify/4, await/4]).
+-export([find/2, find/3, group/3, start_worker/2, forward_work/2]).
+-export([default_grouper/3, default_worker/3]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -35,9 +35,7 @@ find_or_register(GroupName, Msg1, Msg2, Opts) ->
                 converge_core,
                 {
                     register_resolver,
-                    {group, GroupName},
-                    {msg1, Msg1},
-                    {msg2, Msg2}
+                    {group, GroupName}
                 },
                 Opts
             ),
@@ -46,16 +44,16 @@ find_or_register(GroupName, Msg1, Msg2, Opts) ->
     end.
 
 %% @doc Unregister as the leader for an execution and notify waiting processes.
-unregister_notify(GroupName, Msg3, Opts) ->
-    ?event(
-        {unregister_notify,
-            {group, GroupName},
-            {msg3, Msg3},
-            {opts, Opts}
-        }
-    ),
+unregister_notify(GroupName, Msg2, Msg3, Opts) ->
+    % ?event(
+    %     {unregister_notify,
+    %         {group, GroupName},
+    %         {msg3, Msg3},
+    %         {opts, Opts}
+    %     }
+    % ),
     unregister_groupname(GroupName, Opts),
-    notify(GroupName, Msg3, Opts).
+    notify(GroupName, Msg2, Msg3, Opts).
 
 %% @doc Find a process that is already managing a specific Converge resolution.
 find(Msg1, Opts) -> find(Msg1, undefined, Opts).
@@ -76,7 +74,8 @@ find_execution(Groupname, _Opts) ->
 %% @doc Calculate the group name for a Msg1 and Msg2 pair. Uses the Msg1's
 %% `group' function if it is found in the `info', otherwise uses the default.
 group(Msg1, Msg2, Opts) ->
-    Grouper = maps:get(group, hb_converge:info(Msg1, Opts), fun default_group/2),
+    Grouper =
+        maps:get(grouper, hb_converge:info(Msg1, Opts), fun default_grouper/3),
     apply(
         Grouper,
         hb_converge:truncate_args(Grouper, [Msg1, Msg2, Opts])
@@ -84,6 +83,7 @@ group(Msg1, Msg2, Opts) ->
 
 %% @doc Register for performing a Converge resolution.
 register_groupname(Groupname, _Opts) ->
+    ?event({registering_as, Groupname}),
     pg:join(Groupname, self()).
 
 %% @doc Unregister for being the leader on a Converge resolution.
@@ -91,7 +91,7 @@ unregister(Msg1, Msg2, Opts) ->
     start(),
     unregister_groupname(group(Msg1, Msg2, Opts), Opts).
 unregister_groupname(Groupname, _Opts) ->
-    ?event({unregister_resolver, {group, Groupname}}),
+    ?event({unregister_resolver, {explicit, Groupname}}),
     pg:leave(Groupname, self()).
 
 %% @doc If there was already an Erlang process handling this execution,
@@ -102,9 +102,10 @@ await(Worker, Msg1, Msg2, Opts) ->
     % Register with the process.
     GroupName = group(Msg1, Msg2, Opts),
     Worker ! {resolve, self(), GroupName, Msg2, Opts},
-    ?event(
+    ?event(worker,
         {await_resolution,
             {group, GroupName},
+            {worker, Worker},
             {msg1, Msg1},
             {msg2, Msg2},
             {opts, Opts}
@@ -112,9 +113,9 @@ await(Worker, Msg1, Msg2, Opts) ->
     ),
     % Wait for the result.
     receive
-        {resolved, Worker, GroupName, Msg2, Msg3} ->
-            ?event(
-                {finished_await,
+        {resolved, _, GroupName, Msg2, Msg3} ->
+            ?event(worker,
+                {resolved_await,
                     {group, GroupName},
                     {msg2, Msg2},
                     {msg3, Msg3}
@@ -127,15 +128,6 @@ await(Worker, Msg1, Msg2, Opts) ->
 %% of this execution. Comes in two forms:
 %% 1. Notify on group name alone.
 %% 2. Notify on group name and Msg2.
-notify(GroupName, Msg3, Opts) ->
-    receive
-        {resolve, Listener, GroupName, Msg2, _ListenerOpts} ->
-            send_response(Listener, GroupName, Msg2, Msg3),
-            notify(GroupName, Msg3, Opts)
-    after 0 ->
-        ?event(finished_notify),
-        ok
-    end.
 notify(GroupName, Msg2, Msg3, Opts) ->
     receive
         {resolve, Listener, GroupName, Msg2, _ListenerOpts} ->
@@ -146,14 +138,49 @@ notify(GroupName, Msg2, Msg3, Opts) ->
         ok
     end.
 
+%% @doc Forward requests to a newly delegated execution process.
+forward_work(NewPID, _Opts) ->
+    Gather =
+        fun Gather() ->
+            receive
+                Req = {resolve, _, _, _, _} -> [Req | Gather()]
+            after 0 -> []
+            end
+        end,
+    ToForward = Gather(),
+    lists:foreach(
+        fun(Req) ->
+            NewPID ! Req
+        end,
+        ToForward
+    ),
+    case length(ToForward) > 0 of
+        true ->
+            ?event(
+                worker,
+                {fwded, {requests, length(ToForward)}, {pid, NewPID}}
+            );
+        false -> ok
+    end,
+    ok.
+
 %% @doc Helper function that wraps responding with a new Msg3.
 send_response(Listener, GroupName, Msg2, Msg3) ->
-    ?event({send_response, {group, GroupName}, {msg2, Msg2}, {msg3, Msg3}}),
+    ?event(worker,
+        {send_response,
+            {listener, Listener},
+            {group, GroupName}
+        }
+    ),
     Listener ! {resolved, self(), GroupName, Msg2, Msg3}.
 
 %% @doc Start a worker process that will hold a message in memory for
 %% future executions.
+start_worker(NotMsg, _) when not is_map(NotMsg) -> not_started;
 start_worker(Msg, Opts) ->
+    start_worker(group(Msg, undefined, Opts), Msg, Opts).
+start_worker(GroupName, Msg, Opts) ->
+    start(),
     WorkerPID = spawn(
         fun() ->
             % If the device's info contains a `worker` function we
@@ -162,33 +189,90 @@ start_worker(Msg, Opts) ->
                 maps:get(
                     worker,
                     hb_converge:info(Msg, Opts),
-                    fun default_worker/2
+                    Def = fun default_worker/3
                 ),
+            ?event(worker,
+                {new_worker,
+                    {group, GroupName},
+                    {default_server, WorkerFun == Def},
+                    {default_group,
+                        default_grouper(Msg, undefined, Opts) == GroupName
+                    }
+                }
+            ),
             % Call the worker function, unsetting the option
             % to avoid recursive spawns.
+            register_groupname(GroupName, Opts),
             apply(
                 WorkerFun,
                 hb_converge:truncate_args(
                     WorkerFun,
-                    [Msg, Opts#{ spawn_worker := false }])
+                    [
+                        GroupName,
+                        Msg,
+                        maps:merge(Opts, #{
+                            is_worker => true,
+                            spawn_worker => false,
+                            allow_infinite => true
+                        })
+                    ]
+                )
             )
         end
     ),
-    ?MODULE:register(Msg, WorkerPID).
+    WorkerPID.
 
 %% @doc A server function for handling persistent executions. 
-default_worker(Msg1, Opts) ->
-    Timeout = hb_opts:get(worker_timeout, infinity, Opts),
-    GroupName = default_group(Msg1),
+default_worker(GroupName, Msg1, Opts) ->
+    Timeout = hb_opts:get(worker_timeout, 10000, Opts),
+    ?event(worker,
+        {
+            default_worker_waiting_for_req,
+            {group, GroupName},
+            {msg1, Msg1},
+            {opts, Opts}
+        }
+    ),
     receive
-        {resolve, Listener, GroupName, Msg2, _ListenerOpts} ->
-            Msg3 = hb_converge:resolve(Msg1, Msg2, Opts),
-            send_response(Listener, GroupName, Msg2, Msg3),
-            notify(Msg1, Msg2, Msg3, Opts),
-            % In this (default) worker implementation we do not advance the
-            % process to monitor resolution of `Msg3`, staying instead with
-            % Msg1 indefinitely.
-            default_worker(Msg1, Opts)
+        {resolve, Listener, GroupName, Msg2, ListenerOpts} ->
+            ?event(worker,
+                {work_received,
+                    {listener, Listener},
+                    {group, GroupName}
+                }
+            ),
+            Res =
+                hb_converge:resolve(
+                    Msg1,
+                    Msg2,
+                    maps:merge(ListenerOpts, Opts)
+                ),
+            send_response(Listener, GroupName, Msg2, Res),
+            notify(GroupName, Msg2, Res, Opts),
+            case hb_opts:get(static_worker, false, Opts) of
+                true ->
+                    % Reregister for the existing group name.
+                    register_groupname(GroupName, Opts),
+                    default_worker(GroupName, Msg1, Opts);
+                false ->
+                    % Register for the new (Msg1) group.
+                    case Res of
+                        {ok, Msg3} ->
+                            NewGroupName = group(Msg3, undefined, Opts),
+                            register_groupname(NewGroupName, Opts),
+                            default_worker(NewGroupName, Msg3, Opts);
+                        _ ->
+                            % If the result is not ok, we should either ignore
+                            % the error and stay on the existing group,
+                            % or throw it.
+                            case hb_opts:get(error_strategy, ignore, Opts) of
+                                ignore ->
+                                    register_groupname(GroupName, Opts),
+                                    default_worker(GroupName, Msg1, Opts);
+                                throw -> throw(Res)
+                            end
+                    end
+            end
     after Timeout ->
         % We have hit the in-memory persistence timeout. Check whether the
         % device has shutdown procedures (for example, writing in-memory
@@ -198,9 +282,7 @@ default_worker(Msg1, Opts) ->
     end.
 
 %% @doc Create a group name from a Msg1 and Msg2 pair as a tuple.
-default_group(Msg1) ->
-    default_group(Msg1, undefined).
-default_group(Msg1, Msg2) ->
+default_grouper(Msg1, Msg2, _Opts) ->
     %?event({calculating_default_group_name, {msg1, Msg1}, {msg2, Msg2}}),
     % Use Erlang's `phash2` to hash the result of the Grouper function.
     % `phash2` is relatively fast and ensures that the group name is short for
@@ -211,52 +293,124 @@ default_group(Msg1, Msg2) ->
 
 %%% Tests
 
-%% @doc Test merging and returning a value with a persistent worker.
-merged_execution_test() ->
-    Device =
-        #{
-            info =>
-                fun() ->
+test_device() -> test_device(#{}).
+test_device(Base) ->
+    #{
+        info =>
+            fun() ->
+                maps:merge(
                     #{
-                        group => fun(Msg) -> Msg end
-                    }
-                end,
-            slow_key =>
-                fun(_, #{ wait := Wait }) ->
-                    receive after Wait ->
-                        {ok,
-                            #{
-                                waited => Wait,
-                                pid => self(),
-                                random_bytes =>
-                                    hb_util:encode(crypto:strong_rand_bytes(4))
-                            }
+                        grouper =>
+                            fun(M1, _M2, _Opts) ->
+                                erlang:phash2(M1)
+                            end
+                    },
+                    Base
+                )
+            end,
+        slow_key =>
+            fun(_, #{ wait := Wait }) ->
+                ?event({slow_key_wait_started, Wait}),
+                receive after Wait ->
+                    {ok,
+                        #{
+                            waited => Wait,
+                            pid => self(),
+                            random_bytes =>
+                                hb_util:encode(crypto:strong_rand_bytes(4))
                         }
-                    end
+                    }
                 end
-        },
-    TestTime = 200,
-    Msg1 = #{ device => Device },
-    Msg2 = #{ path => [slow_key], wait => TestTime },
+            end,
+        self =>
+            fun(M1, #{ wait := Wait }) ->
+                ?event({self_waiting, {wait, Wait}}),
+                receive after Wait ->
+                    ?event({self_returning, M1, {wait, Wait}}),
+                    {ok, M1}
+                end
+            end
+    }.
+
+spawn_test_client(Msg1, Msg2) ->
+    spawn_test_client(Msg1, Msg2, #{}).
+spawn_test_client(Msg1, Msg2, Opts) ->
+    Ref = make_ref(),
     TestParent = self(),
-    ParalellTestFun =
-        fun(Ref) ->
-            ?event({starting_test_worker, {time, TestTime}}),
-            Res = hb_converge:resolve(Msg1, Msg2, #{}),
-            ?event({test_worker_got_result, {time, TestTime}, {result, Res}}),
-            TestParent ! {result, Ref, Res}
-        end,
-    GatherResult = fun(Ref) -> receive {result, Ref, Res} -> Res end end,
+    spawn_link(fun() ->
+        ?event({new_concurrent_test_resolver, Ref, {executing, Msg2}}),
+        Res = hb_converge:resolve(Msg1, Msg2, Opts),
+        ?event({test_worker_got_result, Ref, {result, Res}}),
+        TestParent ! {result, Ref, Res}
+    end),
+    Ref.
+
+wait_for_test_result(Ref) ->
+    receive {result, Ref, Res} -> Res end.
+
+%% @doc Test merging and returning a value with a persistent worker.
+deduplicated_execution_test() ->
+    TestTime = 200,
+    Msg1 = #{ device => test_device() },
+    Msg2 = #{ path => [slow_key], wait => TestTime },
     T0 = hb:now(),
-    Ref1 = make_ref(),
-    Ref2 = make_ref(),
-    spawn_link(fun() -> ParalellTestFun(Ref1) end),
+    Ref1 = spawn_test_client(Msg1, Msg2),
     receive after 100 -> ok end,
-    spawn_link(fun() -> ParalellTestFun(Ref2) end),
-    Res1 = GatherResult(Ref1),
-    Res2 = GatherResult(Ref2),
+    Ref2 = spawn_test_client(Msg1, Msg2),
+    Res1 = wait_for_test_result(Ref1),
+    Res2 = wait_for_test_result(Ref2),
     T1 = hb:now(),
     % Check the result is the same.
     ?assertEqual(Res1, Res2),
     % Check the time it took is less than the sum of the two test times.
     ?assert(T1 - T0 < (2*TestTime)).
+
+%% @doc Test spawning a default persistent worker.
+persistent_worker_test() ->
+    TestTime = 200,
+    Msg1 = #{ device => test_device() },
+    link(start_worker(Msg1, #{ static_worker => true })),
+    receive after 10 -> ok end,
+    Msg2 = #{ path => [slow_key], wait => TestTime },
+    Msg3 = #{ path => [slow_key], wait => trunc(TestTime*1.1) },
+    Msg4 = #{ path => [slow_key], wait => trunc(TestTime*1.2) },
+    T0 = hb:now(),
+    Ref1 = spawn_test_client(Msg1, Msg2),
+    Ref2 = spawn_test_client(Msg1, Msg3),
+    Ref3 = spawn_test_client(Msg1, Msg4),
+    Res1 = wait_for_test_result(Ref1),
+    Res2 = wait_for_test_result(Ref2),
+    Res3 = wait_for_test_result(Ref3),
+    T1 = hb:now(),
+    ?assertNotEqual(Res1, Res2),
+    ?assertNotEqual(Res2, Res3),
+    ?assert(T1 - T0 >= (3*TestTime)).
+
+spawn_after_execution_test() ->
+    ?event(<<"">>),
+    TestTime = 500,
+    Msg1 = #{ device => test_device() },
+    Msg2 = #{ path => [self], wait => TestTime },
+    Msg3 = #{ path => [slow_key], wait => trunc(TestTime*1.1) },
+    Msg4 = #{ path => [slow_key], wait => trunc(TestTime*1.2) },
+    T0 = hb:now(),
+    Ref1 =
+        spawn_test_client(
+            Msg1,
+            Msg2,
+            #{
+                spawn_worker => true,
+                static_worker => true,
+                hashpath => ignore
+            }
+        ),
+    receive after 10 -> ok end,
+    Ref2 = spawn_test_client(Msg1, Msg3),
+    Ref3 = spawn_test_client(Msg1, Msg4),
+    Res1 = wait_for_test_result(Ref1),
+    Res2 = wait_for_test_result(Ref2),
+    Res3 = wait_for_test_result(Ref3),
+    T1 = hb:now(),
+    ?assertNotEqual(Res1, Res2),
+    ?assertNotEqual(Res2, Res3),
+    ?assert(T1 - T0 >= (3*TestTime)).

--- a/src/hb_persistent.erl
+++ b/src/hb_persistent.erl
@@ -176,9 +176,10 @@ send_response(Listener, GroupName, Msg2, Msg3) ->
 
 %% @doc Start a worker process that will hold a message in memory for
 %% future executions.
-start_worker(NotMsg, _) when not is_map(NotMsg) -> not_started;
+
 start_worker(Msg, Opts) ->
     start_worker(group(Msg, undefined, Opts), Msg, Opts).
+start_worker(_, NotMsg, _) when not is_map(NotMsg) -> not_started;
 start_worker(GroupName, Msg, Opts) ->
     start(),
     WorkerPID = spawn(

--- a/src/hb_private.erl
+++ b/src/hb_private.erl
@@ -28,9 +28,9 @@ from_message(Msg) -> maps:get(priv, Msg, #{}).
 %% Converge resolve under-the-hood, removing the private specifier from the
 %% path if it exists.
 get(Key, Msg, Opts) ->
-    get(Key, Msg, undefined, Opts).
+    get(Key, Msg, not_found, Opts).
 get(InputPath, Msg, Default, Opts) ->
-    Path = remove_private_specifier(InputPath),
+    Path = hb_path:term_to_path(remove_private_specifier(InputPath)),
     ?event({get_private, {in, InputPath}, {out, Path}}),
     % Resolve the path against the private element of the message.
     Resolve =

--- a/src/hb_private.erl
+++ b/src/hb_private.erl
@@ -95,7 +95,7 @@ set_private_test() ->
 
 get_private_key_test() ->
     M1 = #{a => 1, priv => #{b => 2}},
-    ?assertEqual(undefined, get(a, M1, #{})),
+    ?assertEqual(not_found, get(a, M1, #{})),
     {ok, [a]} = hb_converge:resolve(M1, <<"Keys">>, #{}),
     ?assertEqual(2, get(b, M1, #{})),
     {error, not_found} = hb_converge:resolve(M1, <<"priv/a">>, #{}),

--- a/src/hb_sup.erl
+++ b/src/hb_sup.erl
@@ -19,11 +19,8 @@ init([]) ->
     SupFlags = #{strategy => one_for_all,
                 intensity => 0,
                 period => 1},
-
     RocksDBOptions = hb_opts:get(local_store),
     ChildSpecs = [
         #{id => hb_store_rocksdb, start => {hb_store_rocksdb, start_link, [RocksDBOptions]}}
     ],
     {ok, {SupFlags, ChildSpecs}}.
-
-%% internal functions

--- a/src/hb_util.erl
+++ b/src/hb_util.erl
@@ -253,8 +253,10 @@ debug_fmt(Tuple, Indent) when is_tuple(Tuple) ->
     format_tuple(Tuple, Indent);
 debug_fmt(Str = [X | _], Indent) when is_integer(X) andalso X >= 32 andalso X < 127 ->
     format_indented("~s", [Str], Indent);
+debug_fmt(X, Indent) when is_binary(X) ->
+    format_indented("~s", [format_binary(X)], Indent);
 debug_fmt(X, Indent) ->
-    format_indented("~120p", [X], Indent).
+    format_indented("~80p", [X], Indent).
 
 %% @doc Helper function to format tuples with arity greater than 2.
 format_tuple(Tuple, Indent) ->

--- a/src/hb_util.erl
+++ b/src/hb_util.erl
@@ -208,7 +208,7 @@ debug_print(X, Mod, Func, LineNum) ->
         [
             TSDiff, self(),
             format_debug_trace(Mod, Func, LineNum),
-            lists:flatten(debug_fmt(X, 0))
+            debug_fmt(X, 0)
         ]),
     X.
 
@@ -218,7 +218,7 @@ format_debug_trace(Mod, Func, Line) ->
         short ->
             format_trace_short(get_trace());
         false ->
-            lists:flatten(io_lib:format("~p:~w ~p", [Mod, Line, Func]))
+            io_lib:format("~p:~w ~p", [Mod, Line, Func])
     end.
 
 %% @doc Convert a term to a string for debugging print purposes.


### PR DESCRIPTION
Also adds support for multiple clients of the WASM port using a wrapper process.

See full commit log for details.

Tests:
```
sam@Sams-MacBook-Pro hyperbeam % rebar3 eunit
===> Verifying dependencies...
make: Nothing to be done for `wamr'.
===> Analyzing applications...
===> Compiling hb
Post-compile hooks executed
===> Performing EUnit tests...
======================== EUnit ========================
file "hb.app"
  application 'hb'
    module 'ar_bundles'
      ar_bundles: test_no_tags...[0.109 s] ok
      ar_bundles: test_with_tags...[0.163 s] ok
      ar_bundles: test_bundle_with_zero_length_tag...ok
      ar_bundles: test_unsigned_data_item_id...ok
      ar_bundles: test_unsigned_data_item_normalization...ok
      ar_bundles: test_empty_bundle...[0.003 s] ok
      ar_bundles: test_bundle_with_one_item...ok
      ar_bundles: test_bundle_with_two_items...ok
      ar_bundles: test_recursive_bundle...[0.092 s] ok
      ar_bundles: test_bundle_map...[0.213 s] ok
      ar_bundles: test_basic_member_id...[0.166 s] ok
      ar_bundles: test_deep_member...[0.167 s] ok
      ar_bundles: test_extremely_large_bundle...[1.196 s] ok
      ar_bundles: test_serialize_deserialize_deep_signed_bundle...[0.860 s] ok
      [done in 3.156 s]
    module 'ar_deep_hash'
    module 'ar_timestamp'
    module 'ar_tx'
    module 'ar_wallet'
    module 'dev_cron'
    module 'dev_cu'
    module 'dev_dedup'
    dev_json_iface: basic_aos_call_test (module 'dev_json_iface')...[2.044 s] ok
    module 'dev_lookup'
    module 'dev_message'
      dev_message: get_keys_mod_test...ok
      dev_message: is_private_mod_test...ok
      dev_message: keys_from_device_test...ok
      dev_message: case_insensitive_get_test...ok
      dev_message: private_keys_are_filtered_test...ok
      dev_message: cannot_get_private_keys_test...ok
      dev_message: key_from_device_test...ok
      dev_message: remove_test...ok
      dev_message: set_conflicting_keys_test...ok
      [done in 0.027 s]
    module 'dev_meta'
    module 'dev_monitor'
    module 'dev_mu'
    dev_multipass: basic_multipass_test (module 'dev_multipass')...[0.001 s] ok
    module 'dev_p4'
    module 'dev_poda'
    module 'dev_process'
      dev_process: schedule_on_process_test...[0.133 s] ok
      dev_process: get_scheduler_slot_test...[0.064 s] ok
      dev_process: recursive_path_resolution_test...[0.037 s] ok
      dev_process: test_device_compute_test...[0.235 s] ok
      dev_process: wasm_compute_test...[0.230 s] ok
      dev_process: -aos_compute_test_/0-fun-2-...[3.774 s] ok
      dev_process: now_results_test...[2.082 s] ok
      dev_process: -full_push_test_/0-fun-1-...[11.473 s] ok
      dev_process: persistent_process_test...[2.419 s] ok
      [done in 20.474 s]
    module 'dev_process_cache'
      hb_store: -generate_test_suite/1-fun-1- (RocksDB: write and read process outputs)...[1.318 s] ok
      hb_store: -generate_test_suite/1-fun-1- (RocksDB: find latest output (with path))...[0.107 s] ok
      hb_store: -generate_test_suite/1-fun-1- (FS: write and read process outputs)...[0.889 s] ok
      hb_store: -generate_test_suite/1-fun-1- (FS: find latest output (with path))...[0.035 s] ok
      [done in 2.531 s]
    module 'dev_process_worker'
      dev_process_worker: info_test...[0.009 s] ok
      dev_process_worker: grouper_test...[0.023 s] ok
      [done in 0.038 s]
    module 'dev_scheduler'
      dev_scheduler: status_test...[0.001 s] ok
      dev_scheduler: register_new_process_test...[0.531 s] ok
      dev_scheduler: schedule_message_and_get_slot_test...[0.048 s] ok
      dev_scheduler: benchmark_test...
        Scheduled 320 messages through Converge in 4000 ms (80.00 msg/s)
[3.996 s] ok
      dev_scheduler: get_schedule_test...[0.073 s] ok
      [done in 4.665 s]
    module 'dev_scheduler_cache'
    module 'dev_scheduler_interface'
    module 'dev_scheduler_registry'
      dev_scheduler_registry: find_non_existent_process_test...ok
      dev_scheduler_registry: create_and_find_process_test...[0.006 s] ok
      dev_scheduler_registry: create_multiple_processes_test...[0.007 s] ok
      dev_scheduler_registry: get_all_processes_test...ok
      [done in 0.025 s]
    module 'dev_scheduler_server'
      dev_scheduler_server: new_proc_test...[0.257 s] ok
      dev_scheduler_server: benchmark_test...
        Scheduled 196 messages in 2500 ms (78.40 msg/s)
[2.987 s] ok
      [done in 3.251 s]
    module 'dev_stack'
      dev_stack: transform_internal_call_device_test...[0.004 s] ok
      dev_stack: transform_external_call_device_test...[0.003 s] ok
      dev_stack: example_device_for_stack_test...ok
      dev_stack: simple_stack_execute_test...[0.006 s] ok
      dev_stack: many_devices_test...[0.026 s] ok
      dev_stack: no_prefix_test...[0.012 s] ok
      dev_stack: output_prefix_test...[0.011 s] ok
      dev_stack: all_prefixes_test...[0.013 s] ok
      dev_stack: reinvocation_test...[0.013 s] ok
      dev_stack: skip_test...[0.003 s] ok
      dev_stack: pass_test...[0.009 s] ok
      [done in 0.133 s]
    module 'dev_test'
      dev_test: device_with_function_key_module_test...ok
      dev_test: compute_test...[0.005 s] ok
      dev_test: restore_test...ok
      [done in 0.014 s]
    module 'dev_wasi'
      dev_wasi: vfs_is_serializable_test...[0.013 s] ok
      dev_wasi: wasi_stack_is_serializable_test...[0.016 s] ok
      dev_wasi: basic_aos_exec_test...[1.531 s] ok
      [done in 1.569 s]
    module 'dev_wasm'
      dev_wasm: init_test...[0.004 s] ok
      dev_wasm: input_prefix_test...[0.005 s] ok
      dev_wasm: process_prefixes_test...[0.004 s] ok
      dev_wasm: basic_execution_test...[0.006 s] ok
      dev_wasm: basic_execution_64_test...[0.006 s] ok
      dev_wasm: imported_function_test...[0.046 s] ok
      [done in 0.089 s]
    module 'hb'
    module 'hb_app'
    module 'hb_beamr'
      hb_beamr: driver_loads_test...ok
      hb_beamr: simple_wasm_test...ok
      hb_beamr: imported_function_test...ok
      hb_beamr: wasm64_test...ok
      hb_beamr: multiclient_test...ok
      [done in 0.015 s]
    module 'hb_beamr_io'
      hb_beamr_io: write_test...ok
      hb_beamr_io: read_test...ok
      hb_beamr_io: malloc_test...ok
      hb_beamr_io: string_write_and_read_test...ok
      [done in 0.012 s]
    module 'hb_cache'
      hb_store: -generate_test_suite/1-fun-1- (RocksDB: store simple unsigned item)...[0.001 s] ok
      hb_store: -generate_test_suite/1-fun-1- (RocksDB: deeply nested item)...[0.804 s] ok
      hb_store: -generate_test_suite/1-fun-1- (RocksDB: message with list)...ok
      hb_store: -generate_test_suite/1-fun-1- (FS: store simple unsigned item)...[0.001 s] ok
      hb_store: -generate_test_suite/1-fun-1- (FS: deeply nested item)...[1.101 s] ok
      hb_store: -generate_test_suite/1-fun-1- (FS: message with list)...[0.001 s] ok
      [done in 2.134 s]
    module 'hb_client'
    module 'hb_converge'
      hb_converge: resolve_simple_test...ok
      hb_converge: resolve_key_twice_test...ok
      hb_converge: resolve_from_multiple_keys_test...ok
      hb_converge: resolve_path_element_test...ok
      hb_converge: key_to_binary_test...ok
      hb_converge: resolve_binary_key_test...ok
      hb_converge: key_from_id_device_with_args_test...ok
      hb_converge: device_with_handler_function_test...ok
      hb_converge: device_with_default_handler_function_test...ok
      hb_converge: basic_get_test...ok
      hb_converge: recursive_get_test...ok
      hb_converge: basic_set_test...ok
      hb_converge: get_with_device_test...ok
      hb_converge: get_as_with_device_test...[0.001 s] ok
      hb_converge: set_with_device_test...[0.001 s] ok
      hb_converge: deep_set_test...[0.002 s] ok
      hb_converge: deep_set_new_messages_test...ok
      hb_converge: deep_set_with_device_test...[0.003 s] ok
      hb_converge: device_exports_test...ok
      hb_converge: device_excludes_test...ok
      hb_converge: denormalized_device_key_test...ok
      hb_converge: list_transform_test...ok
      [done in 0.073 s]
    hb_crypto: sha256_chain_test (module 'hb_crypto')...ok
    module 'hb_http'
    module 'hb_http_message'
    module 'hb_http_router'
    module 'hb_http_signature'
      hb_http_signature: trim_ws_test...ok
      hb_http_signature: sign_test...[0.011 s] ok
      hb_http_signature: verify_test...[0.012 s] ok
      hb_http_signature: join_signature_base_test...ok
      hb_http_signature: signature_components_line_test...ok
      hb_http_signature: signature_params_line_test...ok
      hb_http_signature: extract_field_msg_access_test...ok
      hb_http_signature: extract_field_bs_test...ok
      hb_http_signature: extract_field_sf_test...ok
      hb_http_signature: extract_field_error_conflicting_params_test...ok
      hb_http_signature: extract_field_error_field_not_found_test...ok
      hb_http_signature: extract_field_error_not_sf_dictionary_test...ok
      hb_http_signature: extract_field_error_sf_dictionary_key_not_found_test...ok
      hb_http_signature: derive_component_test...ok
      hb_http_signature: derive_component_error_req_param_on_request_target_test...ok
      hb_http_signature: derive_component_error_query_param_no_name_test...ok
      hb_http_signature: derive_component_error_status_req_target_test...ok
      [done in 0.074 s]
    module 'hb_http_structured_fields'
    module 'hb_logger'
    module 'hb_message'
      hb_message: basic_map_to_tx_test...ok
      hb_message: default_tx_keys_removed_test...ok
      hb_message: minimization_test...ok
      hb_message: single_layer_message_to_tx_test...ok
      hb_message: single_layer_tx_to_message_test...ok
      hb_message: match_test...ok
      hb_message: structured_field_atom_parsing_test...ok
      hb_message: structured_field_decimal_parsing_test...ok
      hb_message: binary_to_binary_test...ok
      hb_message: message_with_large_keys_test...ok
      hb_message: nested_message_with_large_keys_and_data_test...ok
      hb_message: simple_nested_message_test...ok
      hb_message: nested_message_with_large_data_test...[0.001 s] ok
      hb_message: deeply_nested_message_with_data_test...[0.001 s] ok
      hb_message: nested_structured_fields_test...ok
      hb_message: nested_message_with_large_keys_test...ok
      hb_message: signed_tx_to_message_and_back_test...[0.012 s] ok
      hb_message: signed_deep_tx_serialize_and_deserialize_test...[0.012 s] ok
      hb_message: calculate_unsigned_message_id_test...ok
      hb_message: sign_serialize_deserialize_verify_test...[0.011 s] ok
      hb_message: unsigned_id_test...ok
      hb_message: list_encoding_test...ok
      hb_message: message_with_simple_list_test...ok
      hb_message: empty_string_in_tag_test...ok
      [done in 0.109 s]
    module 'hb_metrics_collector'
    module 'hb_opts'
      hb_opts: global_get_test...ok
      hb_opts: local_get_test...ok
      hb_opts: local_preference_test...ok
      hb_opts: global_preference_test...ok
      [done in 0.012 s]
    module 'hb_path'
      hb_path: push_hashpath_test...ok
      hb_path: push_multiple_hashpaths_test...ok
      hb_path: verify_hashpath_test...ok
      hb_path: pop_from_message_test...ok
      hb_path: pop_from_path_list_test...ok
      hb_path: hd_test...ok
      hb_path: tl_test...ok
      [done in 0.021 s]
    module 'hb_persistent'
      hb_persistent: deduplicated_execution_test...[0.201 s] ok
      hb_persistent: persistent_worker_test...[0.677 s] ok
      hb_persistent: spawn_after_execution_test...[1.655 s] ok
      [done in 2.542 s]
    module 'hb_private'
      hb_private: set_private_test...[0.001 s] ok
      hb_private: get_private_key_test...ok
      [done in 0.007 s]
    module 'hb_process_monitor'
    module 'hb_router'
    module 'hb_store'
      hb_store: -generate_test_suite/1-fun-1- (RocksDB: simple path resolution)...[0.001 s] ok
      hb_store: -generate_test_suite/1-fun-1- (RocksDB: resursive path resolution)...[0.001 s] ok
      hb_store: -generate_test_suite/1-fun-1- (RocksDB: hierarchical path resolution)...ok
      hb_store: -generate_test_suite/1-fun-1- (FS: simple path resolution)...[0.003 s] ok
      hb_store: -generate_test_suite/1-fun-1- (FS: resursive path resolution)...[0.001 s] ok
      hb_store: -generate_test_suite/1-fun-1- (FS: hierarchical path resolution)...[0.001 s] ok
      [done in 0.267 s]
    module 'hb_store_fs'
    module 'hb_store_remote_node'
    module 'hb_store_rocksdb'
      hb_store_rocksdb: -write_read_test_/0-fun-5- (can read/write data)...ok
      hb_store_rocksdb: -write_read_test_/0-fun-3- (returns not_found for non existing keys)...ok
      hb_store_rocksdb: -write_read_test_/0-fun-1- (follows links)...ok
      hb_store_rocksdb: -api_test_/0-fun-27- (list/2 lists keys under given path)...[0.001 s] ok
      hb_store_rocksdb: -api_test_/0-fun-25- (list/2 resolves given path before listing)...ok
      hb_store_rocksdb: -api_test_/0-fun-23- (list/2 when database is empty)...ok
      hb_store_rocksdb: -api_test_/0-fun-21- (make_link/3 creates a link to actual data)...ok
      hb_store_rocksdb: -api_test_/0-fun-19- (make_group/2 creates a group)...[0.001 s] ok
      hb_store_rocksdb: -api_test_/0-fun-17- (make_link/3 does not create links if keys are same)...ok
      hb_store_rocksdb: -api_test_/0-fun-15- (reset cleans up the database)...[0.076 s] ok
      hb_store_rocksdb: -api_test_/0-fun-13- (type/2 can identify simple items)...ok
      hb_store_rocksdb: -api_test_/0-fun-11- (type/2 returns not_found for non existing keys)...ok
      hb_store_rocksdb: -api_test_/0-fun-9- (type/2 treats links as simple items)...[0.001 s] ok
      hb_store_rocksdb: -api_test_/0-fun-7- (type/2 treats groups as composite items)...ok
      hb_store_rocksdb: -api_test_/0-fun-5- (resolve/2 resolutions for computed folder)...ok
      hb_store_rocksdb: -api_test_/0-fun-1- (resolving interlinked item paths)...ok
      [done in 1.211 s]
    module 'hb_sup'
    module 'hb_test'
    module 'hb_util'
    module 'rsa_pss'
    module 'sec'
    module 'sec_helpers'
    module 'sec_tee'
    module 'sec_tpm'
    [done in 44.525 s]
  [done in 44.526 s]
=======================================================
  All 191 tests passed.
```