### PR TITLE
impl process restore from snapshot

### DIFF
--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -572,8 +572,8 @@ test_device_compute_test() ->
     ?assertMatch(
         {ok, <<"TEST TEXT 2">>},
         hb_converge:resolve(
-            <<"Schedule/Assignments/1/Message/Test-Label">>,
             Msg1,
+            <<"Schedule/Assignments/1/Message/Test-Label">>,
             #{ hashpath => ignore }
         )
     ),

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -176,7 +176,7 @@ do_compute(Msg1, Msg2, TargetSlot, Opts) ->
                     % MemoryPath = hb_path:hashpath(Proc,
                     %     PathIn = [<<"Slot">>, integer_to_binary(CurrentSlot), <<"Memory">>]),
                     % {ok, _} = hb_cache:write_binary(MemoryPath, Memory, Opts),
-                    % ?event(debug, 
+                    % ?event(
                     %     {stored, 
                     %         {msg3, Msg3}, 
                     %         {path, PathIn},

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -196,12 +196,12 @@ do_compute(ProcID, Msg1, Msg2, TargetSlot, Opts) ->
                             ?event(debug,
                                 {got_snapshot, 
                                     {snapshot, Snapshot},
-                                    {storing_as_slot, CurrentSlot + 1}
+                                    {storing_as_slot, CurrentSlot}
                                 }
                             ),
                             dev_process_cache:write(
                                 ProcID,
-                                CurrentSlot + 1,
+                                CurrentSlot,
                                 Snapshot,
                                 Opts
                             );

--- a/src/dev_process_cache.erl
+++ b/src/dev_process_cache.erl
@@ -30,7 +30,7 @@ write(ProcID, Slot, Msg, Opts) ->
             Opts
         ),
     ?event({linking_id, {proc_id, ProcID}, {id, ID}, {path, MsgIDPath}}),
-    ok = hb_cache:link(Root, MsgIDPath, Opts),
+    hb_cache:link(Root, MsgIDPath, Opts),
     % Return the slot number path.
     {ok, SlotNumPath}.
 
@@ -129,10 +129,18 @@ first_with_path(ProcID, RequiredPath, [Slot | Rest], Opts, Store) ->
 %%% Tests
 
 process_cache_suite_test_() ->
-    hb_store:generate_test_suite([
-        {"write and read process outputs", fun test_write_and_read_output/1}
-        %{"find latest output (with path)", fun find_latest_output_test/1}
-    ]).
+    hb_store:generate_test_suite(
+        [
+            {"write and read process outputs", fun test_write_and_read_output/1},
+            {"find latest output (with path)", fun find_latest_outputs/1}
+        ],
+        [
+            {Name, Opts}
+        ||
+            {Name, Opts} <- hb_store:test_stores(),
+                Name =/= hb_store_rocksdb % Disable rocksdb for now
+        ]
+    ).
 
 %% @doc Test for writing multiple computed outputs, then getting them by
 %% their slot number and by their signed and unsigned IDs.
@@ -159,44 +167,43 @@ test_write_and_read_output(Opts) ->
         read(ProcID, hb_util:human_id(hb_converge:get(unsigned_id, Item2)), Opts),
     ?assert(hb_message:match(Item2, ReadItem2ByID)).
 
-% Disabled: This functionality is no longer needed?
-% %% @doc Test for retrieving the latest computed output for a process.
-% find_latest_output_test(Opts) ->
-%     % Create test environment.
-%     Store = hb_opts:get(store, no_viable_store, Opts),
-%     ResetRes = hb_store:reset(Store),
-%     ?event({reset_store, {result, ResetRes}, {store, Store}}),
-%     Proc1 = dev_process:test_aos_process(),
-%     ProcID = hb_util:human_id(hb_converge:get(id, Proc1)),
-%     % Create messages for the slots, with only the middle slot having a
-%     % `/Process` field, while the top slot has a `/Deep/Process` field.
-%     Msg0 = #{ <<"Results">> => #{ <<"Result-Number">> => 0 } },
-%     Msg1 =
-%         #{ 
-%             <<"Results">> => #{ <<"Result-Number">> => 1 }, 
-%             <<"Process">> => Proc1 
-%         },
-%     Msg2 =
-%         #{ 
-%             <<"Results">> => #{ <<"Result-Number">> => 2 }, 
-%             <<"Deep">> => #{ <<"Process">> => Proc1 } 
-%         },
-%     % Write the messages to the cache.
-%     {ok, _} = write(ProcID, 0, Msg0, Opts),
-%     {ok, _} = write(ProcID, 1, Msg1, Opts),
-%     {ok, _} = write(ProcID, 2, Msg2, Opts),
-%     ?event(wrote_items),
-%     % Read the messages with various qualifiers.
-%     {ok, 2, ReadMsg2} = latest(ProcID, Opts),
-%     ?event({read_latest, ReadMsg2}),
-%     ?assert(hb_message:match(Msg2, ReadMsg2)),
-%     ?event(read_latest_slot_without_qualifiers),
-%     {ok, 1, ReadMsg1Required} = latest(ProcID, <<"Process">>, Opts),
-%     ?event({read_latest_with_process, ReadMsg1Required}),
-%     ?assert(hb_message:match(Msg1, ReadMsg1Required)),
-%     ?event(read_latest_slot_with_shallow_key),
-%     {ok, 2, ReadMsg2Required} = latest(ProcID, <<"Deep/Process">>, Opts),
-%     ?assert(hb_message:match(Msg2, ReadMsg2Required)),
-%     ?event(read_latest_slot_with_deep_key),
-%     {ok, 1, ReadMsg1} = latest(ProcID, <<"">>, 1, Opts),
-%     ?assert(hb_message:match(Msg1, ReadMsg1)).
+%% @doc Test for retrieving the latest computed output for a process.
+find_latest_outputs(Opts) ->
+    % Create test environment.
+    Store = hb_opts:get(store, no_viable_store, Opts),
+    ResetRes = hb_store:reset(Store),
+    ?event({reset_store, {result, ResetRes}, {store, Store}}),
+    Proc1 = dev_process:test_aos_process(),
+    ProcID = hb_util:human_id(hb_converge:get(id, Proc1)),
+    % Create messages for the slots, with only the middle slot having a
+    % `/Process` field, while the top slot has a `/Deep/Process` field.
+    Msg0 = #{ <<"Results">> => #{ <<"Result-Number">> => 0 } },
+    Msg1 =
+        #{ 
+            <<"Results">> => #{ <<"Result-Number">> => 1 }, 
+            <<"Process">> => Proc1 
+        },
+    Msg2 =
+        #{ 
+            <<"Results">> => #{ <<"Result-Number">> => 2 }, 
+            <<"Deep">> => #{ <<"Process">> => Proc1 } 
+        },
+    % Write the messages to the cache.
+    {ok, _} = write(ProcID, 0, Msg0, Opts),
+    {ok, _} = write(ProcID, 1, Msg1, Opts),
+    {ok, _} = write(ProcID, 2, Msg2, Opts),
+    ?event(wrote_items),
+    % Read the messages with various qualifiers.
+    {ok, 2, ReadMsg2} = latest(ProcID, Opts),
+    ?event({read_latest, ReadMsg2}),
+    ?assert(hb_message:match(Msg2, ReadMsg2)),
+    ?event(read_latest_slot_without_qualifiers),
+    {ok, 1, ReadMsg1Required} = latest(ProcID, <<"Process">>, Opts),
+    ?event({read_latest_with_process, ReadMsg1Required}),
+    ?assert(hb_message:match(Msg1, ReadMsg1Required)),
+    ?event(read_latest_slot_with_shallow_key),
+    {ok, 2, ReadMsg2Required} = latest(ProcID, <<"Deep/Process">>, Opts),
+    ?assert(hb_message:match(Msg2, ReadMsg2Required)),
+    ?event(read_latest_slot_with_deep_key),
+    {ok, 1, ReadMsg1} = latest(ProcID, <<"">>, 1, Opts),
+    ?assert(hb_message:match(Msg1, ReadMsg1)).

--- a/src/dev_process_cache.erl
+++ b/src/dev_process_cache.erl
@@ -21,7 +21,7 @@ write(ProcID, Slot, Msg, Opts) ->
     {ok, Root} = hb_cache:write(Msg, Opts),
     % Link the item to the path in the store by slot number.
     SlotNumPath = path(ProcID, Slot, Opts),
-    ok = hb_cache:link(Root, SlotNumPath, Opts),
+    hb_cache:link(Root, SlotNumPath, Opts),
     % Link the item to the message ID path in the store.
     MsgIDPath =
         path(

--- a/src/dev_stack.erl
+++ b/src/dev_stack.erl
@@ -204,6 +204,7 @@ transform(Msg1, Key, Opts) ->
                         Msg1,
 						#{
 							<<"Device">> => DevMsg,
+                            <<"Device-Key">> => Key,
                             <<"Input-Prefix">> =>
                                 hb_converge:get(
                                     [<<"Input-Prefixes">>, Key],
@@ -276,6 +277,7 @@ resolve_fold(Message1, Message2, Opts) ->
                             undefined,
                             Opts
                         ),
+                    <<"Device-Key">> => unset,
                     <<"Device-Stack-Previous">> => unset,
                     <<"Pass">> => StartingPassValue
                 },
@@ -338,7 +340,7 @@ resolve_map(Message1, Message2, Opts) ->
             {as, dev_message, Message1},
             Opts#{ hashpath => ignore }
         ),
-    {ok,
+    Res = {ok,
         maps:filtermap(
             fun(Key, _Dev) ->
                 {ok, OrigWithDev} = transform(Message1, Key, Opts),
@@ -347,9 +349,11 @@ resolve_map(Message1, Message2, Opts) ->
                     _ -> false
                 end
             end,
-            maps:without([hashpath], DevKeys)
+            maps:without(?CONVERGE_KEYS, hb_converge:ensure_message(DevKeys))
         )
-    }.
+    },
+    ?event(debug, {map_res, Res}),
+    Res.
 
 %% @doc Helper to increment the pass number.
 increment_pass(Message, Opts) ->

--- a/src/dev_stack.erl
+++ b/src/dev_stack.erl
@@ -338,7 +338,7 @@ resolve_map(Message1, Message2, Opts) ->
         hb_converge:get(
             <<"Device-Stack">>,
             {as, dev_message, Message1},
-            Opts#{ hashpath => ignore }
+            Opts
         ),
     Res = {ok,
         maps:filtermap(
@@ -352,7 +352,7 @@ resolve_map(Message1, Message2, Opts) ->
             maps:without(?CONVERGE_KEYS, hb_converge:ensure_message(DevKeys))
         )
     },
-    ?event(debug, {map_res, Res}),
+    ?event(debug, {map_res, Res}, Opts),
     Res.
 
 %% @doc Helper to increment the pass number.

--- a/src/dev_stack.erl
+++ b/src/dev_stack.erl
@@ -352,7 +352,6 @@ resolve_map(Message1, Message2, Opts) ->
             maps:without(?CONVERGE_KEYS, hb_converge:ensure_message(DevKeys))
         )
     },
-    ?event(debug, {map_res, Res}, Opts),
     Res.
 
 %% @doc Helper to increment the pass number.

--- a/src/dev_test.erl
+++ b/src/dev_test.erl
@@ -1,5 +1,5 @@
 -module(dev_test).
--export([info/1, test_func/1, compute/3, init/3, restore/3, mul/2]).
+-export([info/1, test_func/1, compute/3, init/3, restore/3, snapshot/3, mul/2]).
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
 
@@ -67,6 +67,10 @@ mul(Msg1, Msg2) ->
     State = hb_converge:get(<<"State">>, Msg1, #{ hashpath => ignore }),
     [Arg1, Arg2] = hb_converge:get(args, Msg2, #{ hashpath => ignore }),
     {ok, #{ state => State, results => [Arg1 * Arg2] }}.
+
+%% @doc Do nothing when asked to snapshot.
+snapshot(_Msg1, _Msg2, _Opts) ->
+    {ok, #{}}.
 
 %%% Tests
 

--- a/src/dev_wasm.erl
+++ b/src/dev_wasm.erl
@@ -195,7 +195,7 @@ normalize(RawM1, M2, Opts) ->
                         not_found -> [];
                         Key -> [Key]
                     end,
-                ?event(debug,
+                ?event(snapshot,
                     {no_instance_attempting_to_get_snapshot,
                         {msg1, RawM1}, {device_key, DeviceKey}
                     }
@@ -209,21 +209,20 @@ normalize(RawM1, M2, Opts) ->
                 case Memory of
                     not_found -> throw({error, no_wasm_instance_or_});
                     State ->
-                        ?event(debug, {state_found, {state, State}}),
                         {ok, M1} = init(RawM1, State, Opts),
                         Res = hb_beamr:deserialize(instance(M1, M2, Opts), State),
-                        ?event(debug, {wasm_deserialized, {result, Res}}),
+                        ?event(snapshot, {wasm_deserialized, {result, Res}}),
                         M1
                 end;
             _ ->
-                ?event(debug, wasm_instance_found_not_deserializing),
+                ?event(wasm_instance_found_not_deserializing),
                 RawM1
         end,
     dev_message:set(M3, #{ <<"Snapshot">> => unset }, Opts).
 
 %% @doc Serialize the WASM state to a binary.
 snapshot(M1, M2, Opts) ->
-    ?event(debug, generating_snapshot),
+    ?event(snapshot, generating_snapshot),
     Instance = instance(M1, M2, Opts),
     {ok, Serialized} = hb_beamr:serialize(Instance),
     {ok,

--- a/src/dev_wasm.erl
+++ b/src/dev_wasm.erl
@@ -186,7 +186,7 @@ compute(RawM1, M2, Opts) ->
 %% @doc Normalize the message to have an open WASM instance, but no literal
 %% `State' key. Ensure that we do not change the hashpath during this process.
 normalize(RawM1, M2, Opts) ->
-    ?event(debug, {normalize_raw_m1, RawM1}),
+    ?event({normalize_raw_m1, RawM1}),
     M3 = 
         case instance(RawM1, M2, Opts) of
             not_found ->
@@ -196,7 +196,7 @@ normalize(RawM1, M2, Opts) ->
                         Key -> [Key]
                     end,
                 ?event(debug,
-                    {no_wasm_instance_or_state,
+                    {no_instance_attempting_to_get_snapshot,
                         {msg1, RawM1}, {device_key, DeviceKey}
                     }
                 ),
@@ -207,7 +207,7 @@ normalize(RawM1, M2, Opts) ->
                         Opts
                     ),
                 case Memory of
-                    not_found -> throw({error, no_wasm_instance_or_state});
+                    not_found -> throw({error, no_wasm_instance_or_});
                     State ->
                         ?event(debug, {state_found, {state, State}}),
                         {ok, M1} = init(RawM1, State, Opts),
@@ -216,20 +216,19 @@ normalize(RawM1, M2, Opts) ->
                         M1
                 end;
             _ ->
-                ?event(debug, {wasm_instance_found, {msg1, RawM1}}),
+                ?event(debug, wasm_instance_found_not_deserializing),
                 RawM1
         end,
     dev_message:set(M3, #{ <<"Snapshot">> => unset }, Opts).
 
 %% @doc Serialize the WASM state to a binary.
 snapshot(M1, M2, Opts) ->
-    ?event(debug, asked_to_get_snapshot),
+    ?event(debug, generating_snapshot),
     Instance = instance(M1, M2, Opts),
     {ok, Serialized} = hb_beamr:serialize(Instance),
     {ok,
         #{
-            body => Serialized,
-            <<"Cache-Control">> => [<<"store">>]
+            body => Serialized
         }
     }.
 

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -78,7 +78,7 @@ write_message(Msg, Store, Opts) when is_map(Msg) ->
     % Precalculate the hashpath of the message.
     MsgHashpath = hb_path:hashpath(Msg, Opts),
     MsgHashpathAlg = hb_path:hashpath_alg(Msg),
-    ?event(debug, {storing_msg_with_hashpath, MsgHashpath}),
+    ?event({storing_msg_with_hashpath, MsgHashpath}),
     % Get the ID of the unsigned message.
     {ok, UnsignedID} = dev_message:unsigned_id(Msg),
     % Write the keys of the message into the graph of hashpaths, generating a map of

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -155,7 +155,7 @@ write_message(Msg, Store, Opts) when is_map(Msg) ->
 %% ID1/Compute/Results/2 -> Hashpath1/Compute/Results/2
 %% ID1/Compute/Results/3 -> Hashpath1/Compute/Results/3
 write_link_tree(RootPath, PathMap, Store, Opts) ->
-    ?event({write_link_tree, {root, RootPath}, {pathmap, PathMap}, {store, Store}}),
+    ?event({write_link_tree, {root, RootPath}, {store, Store}}),
     maps:map(
         fun(Key, Path) when is_map(Path) ->
             % The key is a map of subkeys and paths, so we adjust our root ID to
@@ -239,7 +239,6 @@ store_read(Path, Store, Opts) ->
                             Subpaths
                         )
                     ),
-                    ?event({explicit, FlatMap}),
                     {ok, FlatMap};
                 _ -> not_found
             end

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -215,7 +215,6 @@ store_read(Path, Store, Opts) ->
                         no_viable_store ->
                             {ok, Binary};
                         {ok, Type} ->
-                            ?event(debug, {decoding, {key, Key}, {type, Type}, {binary, Binary}}),
                             {ok, hb_codec_converge:decode_value(Type, Binary)}
                     end;
                 _ ->

--- a/src/hb_cache_control.erl
+++ b/src/hb_cache_control.erl
@@ -330,11 +330,11 @@ cache_message_result_test() ->
                 cache_control => [<<"always">>]
             }
         ),
-    ?event(debug, {res1, Res}),
-    ?event(debug, reading_from_cache),
+    ?event({res1, Res}),
+    ?event(reading_from_cache),
     {ok, Res2} = hb_converge:resolve(Msg1, Msg2, #{ cache_control => [<<"only-if-cached">>] }),
-    ?event(debug, reading_from_cache_again),
+    ?event(reading_from_cache_again),
     {ok, Res3} = hb_converge:resolve(Msg1, Msg2, #{ cache_control => [<<"only-if-cached">>] }),
-    ?event(debug, {res2, Res2}),
-    ?event(debug, {res3, Res3}),
+    ?event({res2, Res2}),
+    ?event({res3, Res3}),
     ?assertEqual(Res2, Res3).

--- a/src/hb_converge.erl
+++ b/src/hb_converge.erl
@@ -411,7 +411,7 @@ resolve_stage(7, Msg1, Msg2, {ok, Msg3}, ExecName, Opts) when is_map(Msg3) ->
     resolve_stage(8, Msg1, Msg2,
         case hb_opts:get(hashpath, update, Opts#{ only => local }) of
             update ->
-                ?event(debug, {setting_hashpath_msg3, {msg1, Msg1}, {msg2, Msg2}, {opts, Opts}}),
+                ?event({setting_hashpath_msg3, {msg1, Msg1}, {msg2, Msg2}, {opts, Opts}}),
                 {ok,
                     Msg3#{ hashpath => hb_path:hashpath(Msg1, Msg2, Opts) }
                 };

--- a/src/hb_converge.erl
+++ b/src/hb_converge.erl
@@ -402,10 +402,12 @@ resolve_stage(7, Msg1, Msg2, {ok, Msg3}, ExecName, Opts) when is_map(Msg3) ->
             update ->
                 ?event({setting_hashpath_msg3, {msg1, Msg1}, {msg2, Msg2}, {opts, Opts}}),
                 {ok,
-                    Msg3#{ hashpath => hb_path:hashpath(Msg1, Msg2, Opts) }
+                    maps:without(?REGEN_KEYS,
+                        Msg3#{ hashpath => hb_path:hashpath(Msg1, Msg2, Opts) }
+                    )
                 };
             ignore ->
-                {ok, maps:without([hashpath], Msg3)}
+                {ok, maps:without([hashpath] ++ ?REGEN_KEYS, Msg3)}
         end,
         ExecName,
         Opts
@@ -413,7 +415,10 @@ resolve_stage(7, Msg1, Msg2, {ok, Msg3}, ExecName, Opts) when is_map(Msg3) ->
 resolve_stage(7, Msg1, Msg2, {Status, Msg3}, ExecName, Opts) when is_map(Msg3) ->
     ?event(converge_core, {stage, 7, ExecName, abnormal_status_reset_hashpath}, Opts),
     % Skip cryptographic linking and reset the hashpath if the result is abnormal.
-    resolve_stage(8, Msg1, Msg2, {Status, maps:without([hashpath], Msg3)}, ExecName, Opts);
+    resolve_stage(
+        8, Msg1, Msg2,
+        {Status, maps:without([hashpath] ++ ?REGEN_KEYS, Msg3)},
+        ExecName, Opts);
 resolve_stage(7, Msg1, Msg2, Res, ExecName, Opts) ->
     ?event(converge_core, {stage, 7, ExecName, non_map_result_skipping_hash_path}, Opts),
     % Skip cryptographic linking and continue if we don't have a map that can have

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -23,7 +23,7 @@ config() ->
         %% Scheduling mode: Determines when the SU should inform the recipient
         %% that an assignment has been scheduled for a message.
         %% Options: aggressive(!), local_confirmation, remote_confirmation
-        scheduling_mode => local_confirmation,
+        scheduling_mode => aggressive,
         %% Compute mode: Determines whether the CU should attempt to execute
         %% more messages on a process after it has returned a result.
         %% Options: aggressive, lazy

--- a/src/hb_path.erl
+++ b/src/hb_path.erl
@@ -87,16 +87,16 @@ hashpath(Msg1, Opts) when is_map(Msg1) ->
                 _A:_B:_ST -> throw({badarg, {unsupported_type, Msg1}})
             end
     end.
-hashpath(Msg1, Msgs, Opts) when is_list(Msgs) ->
-    HashpathAlg = hashpath_alg(Msg1),
-    lists:foldl(
-        fun(Msg, Acc) ->
-            ?event({generating_hashpath, {current, Acc}, {msg, Msg}}),
-            hashpath(Acc, hashpath(Msg, Opts), HashpathAlg, Opts)
-        end,
-        hashpath(Msg1, Opts),
-        Msgs
-    );
+% hashpath(Msg1, Msgs, Opts) when is_list(Msgs) ->
+%     HashpathAlg = hashpath_alg(Msg1),
+%     lists:foldl(
+%         fun(Msg, Acc) ->
+%             ?event({generating_hashpath, {current, Acc}, {msg, Msg}}),
+%             hashpath(Acc, hashpath(Msg, Opts), HashpathAlg, Opts)
+%         end,
+%         hashpath(Msg1, Opts),
+%         Msgs
+%     );
 hashpath(Msg1, Msg2ID, Opts) when is_map(Msg1) ->
     Msg1Hashpath = hashpath(Msg1, Opts),
     HashpathAlg = hashpath_alg(Msg1),

--- a/src/hb_path.erl
+++ b/src/hb_path.erl
@@ -76,7 +76,8 @@ data_id(Bin, _Opts) when is_binary(Bin) ->
 hashpath(Bin, _Opts) when is_binary(Bin) ->
     % Default hashpath for a binary message is its SHA2-256 hash.
     hb_util:human_id(hb_crypto:sha256(Bin));
-hashpath(Msg1, Opts) when is_map(Msg1) ->
+hashpath(RawMsg1, Opts) ->
+    Msg1 = hb_converge:ensure_message(RawMsg1),
     case dev_message:get(hashpath, Msg1) of
         {ok, ignore} ->
             throw({hashpath_set_to_ignore, {msg1, Msg1}, {opts, Opts}});

--- a/src/hb_path.erl
+++ b/src/hb_path.erl
@@ -91,7 +91,7 @@ hashpath(Msg1, Msgs, Opts) when is_list(Msgs) ->
     HashpathAlg = hashpath_alg(Msg1),
     lists:foldl(
         fun(Msg, Acc) ->
-            ?event(debug, {generating_hashpath, {current, Acc}, {msg, Msg}}),
+            ?event({generating_hashpath, {current, Acc}, {msg, Msg}}),
             hashpath(Acc, hashpath(Msg, Opts), HashpathAlg, Opts)
         end,
         hashpath(Msg1, Opts),
@@ -105,7 +105,7 @@ hashpath(Msg1, Msg2, Opts) ->
     throw({hashpath_not_viable, Msg1, Msg2, Opts}).
 hashpath(Msg1, Msg2, HashpathAlg, Opts) when is_map(Msg2) ->
     {ok, Msg2WithoutMeta} = dev_message:remove(Msg2, #{ items => ?CONVERGE_KEYS }),
-    ?event(debug, {generating_msg2_hashpath_with_keys, maps:keys(Msg2WithoutMeta)}),
+    ?event({generating_msg2_hashpath_with_keys, maps:keys(Msg2WithoutMeta)}),
     case {map_size(Msg2WithoutMeta), hd(Msg2, Opts)} of
         {0, Key} when Key =/= undefined ->
             hashpath(Msg1, to_binary(Key), HashpathAlg, Opts);
@@ -133,7 +133,7 @@ hashpath(Msg1Hashpath, Msg2ID, HashpathAlg, _Opts) ->
                 HumanNewBase = hb_util:human_id(NativeNewBase),
                 << HumanNewBase/binary, "/", Msg2ID/binary >>
         end,
-    ?event(debug, {generated_hashpath, HP, {msg1hp, Msg1Hashpath}, {msg2id, Msg2ID}}),
+    ?event({generated_hashpath, HP, {msg1hp, Msg1Hashpath}, {msg2id, Msg2ID}}),
     HP.
 
 %%% @doc Get the hashpath function for a message from its HashPath-Alg.

--- a/src/hb_private.erl
+++ b/src/hb_private.erl
@@ -38,7 +38,7 @@ get(InputPath, Msg, Default, Opts) ->
         hb_converge:resolve(
             from_message(Msg),
             #{ path => Path },
-            converge_opts(Opts)
+            priv_converge_opts(Opts)
         ),
     case Resolve of
         {error, _} -> Default;
@@ -49,11 +49,11 @@ get(InputPath, Msg, Default, Opts) ->
 set(Msg, InputPath, Value, Opts) ->
     Path = remove_private_specifier(InputPath),
     Priv = from_message(Msg),
-    NewPriv = hb_converge:set(Priv, Path, Value, converge_opts(Opts)),
+    NewPriv = hb_converge:set(Priv, Path, Value, priv_converge_opts(Opts)),
     set(Msg, NewPriv, Opts).
 set(Msg, PrivMap, Opts) ->
     CurrentPriv = from_message(Msg),
-    NewPriv = hb_converge:set(CurrentPriv, PrivMap, converge_opts(Opts)),
+    NewPriv = hb_converge:set(CurrentPriv, PrivMap, priv_converge_opts(Opts)),
     set_priv(Msg, NewPriv).
 
 %% @doc Helper function for setting the complete private element of a message.
@@ -76,8 +76,8 @@ remove_private_specifier(InputPath) ->
 
 %% @doc The opts map that should be used when resolving paths against the
 %% private element of a message.
-converge_opts(Opts) ->
-    Opts#{ hashpath => ignore, cache_control => false }.
+priv_converge_opts(Opts) ->
+    Opts#{ hashpath => ignore, cache_control => [<<"no-cache">>, <<"no-store">>] }.
 
 %% @doc Unset all of the private keys in a message.
 reset(Msg) ->

--- a/src/hb_store.erl
+++ b/src/hb_store.erl
@@ -5,7 +5,7 @@
 -export([type/2, read/2, write/3, list/2]).
 -export([path/1, path/2, add_path/2, add_path/3, join/1]).
 -export([make_group/2, make_link/3, resolve/2]).
--export([generate_test_suite/1, test_stores/0]).
+-export([generate_test_suite/1, generate_test_suite/2, test_stores/0]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -188,6 +188,8 @@ test_stores() ->
     ].
 
 generate_test_suite(Suite) ->
+    generate_test_suite(Suite, test_stores()).
+generate_test_suite(Suite, Stores) ->
     lists:map(
         fun(Store = {Mod, _Opts}) ->
             {foreach,
@@ -201,7 +203,7 @@ generate_test_suite(Suite) ->
                 ]
             }
         end,
-        test_stores()
+        Stores
     ).
 
 %%% Tests

--- a/src/hb_util.erl
+++ b/src/hb_util.erl
@@ -68,7 +68,7 @@ short_id(Bin) when is_binary(Bin) andalso byte_size(Bin) == 32 ->
 short_id(Bin) when is_binary(Bin) andalso byte_size(Bin) == 43 ->
     << FirstTag:5/binary, _:33/binary, LastTag:5/binary >> = Bin,
     << FirstTag/binary, "..", LastTag/binary >>;
-short_id(Bin) when byte_size(Bin) > 43 ->
+short_id(Bin) when byte_size(Bin) > 43 andalso byte_size(Bin) < 100 ->
     case binary:split(Bin, <<"/">>, [trim_all, global]) of
         [First, Second] when byte_size(Second) == 43 ->
             FirstEnc = short_id(First),


### PR DESCRIPTION
This version stores snapshot data in the 'old' way, where multipart paths are used, rather than hashpaths. Works fine for now, but later we can neaten it up.

Also includes:
- Mapping across `dev_stack`s
- Various improvements (timeouts on tests, etc).

*Horrendous* performance at the moment, caused by excessive repeated ID generations. Shooting to close the gap on BETA-1/2 goals first, then we can look at those. Will be an easy fix when we have a moment for it.

All 337 tests passing.