### PR TITLE
Start Http Codec

### DIFF
--- a/src/hb_codec_http.erl
+++ b/src/hb_codec_http.erl
@@ -194,14 +194,14 @@ find_header(Headers, Name) ->
 find_header(Headers, Name, Opts) when is_list(Headers) ->
     Matcher = case lists:member(strict, Opts) of
         true -> fun ({N, _Value}) -> N =:= Name end;
-        _ -> fun ({N, _Value}) -> hb_util:to_lower(N) =:= hb_util:to_lower(N) end
+        _ -> fun ({N, _Value}) -> hb_util:to_lower(N) =:= hb_util:to_lower(Name) end
     end,
     case lists:filter(Matcher, Headers) of
-        [] -> undefined;
-        Headers -> case lists:member(global, Opts) of
-            true -> Headers;
+        [] -> {undefined, undefined};
+        Found -> case lists:member(global, Opts) of
+            true -> Found;
             _ ->
-                [First | _] = Headers,
+                [First | _] = Found,
                 First
         end
     end.

--- a/src/hb_codec_http.erl
+++ b/src/hb_codec_http.erl
@@ -42,46 +42,198 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--define(MAX_HEADER_LENGTH, 256).
+% The max header length is 4KB
+-define(MAX_HEADER_LENGTH, 4096).
 
 %%% @doc Convert an HTTP Message into a TABM.
 %%% Any HTTP Structured Field is encoded into it's equivalent TABM encoding.
-%%% TODO: special rules for Signature and Signature-Input headers
-%% Recursively encode the multipart body into TABM
+from(#{ headers := Headers, body := Body }) when is_map(Headers) ->
+    from(#{ headers => maps:to_list(Headers), body => Body });
 from(#{ headers := Headers, body := Body }) ->
-    ContentType = lists:keyfind(<<"Content-Type">>, 1, Headers),
-    {item, _, Params} = hb_http_structured_fields:item(ContentType),
-    _Parts = case lists:keyfind(<<"boundary">>, 1, Params) of
-        false -> [Body];
+    % First, parse all headers and add as key-value pairs to the TABM
+    TABM0 = from_headers(#{}, Headers),
+    % Next, we need to potentially parse the body and add to the TABM
+    % potentially as additional key-binary value pairs, or as sub-TABMs
+    ContentType = case lists:keyfind(<<"Content-Type">>, 1, Headers) of
+        false -> <<"application/octet-stream">>;
+        {_, CT} -> CT
+    end,
+    TABM1 = from_body(TABM0, ContentType, Body),
+    TABM1.
+
+from_headers(TABM, Headers) -> from_headers(TABM, Headers, Headers).
+from_headers(TABM, [], _) -> TABM;
+from_headers(TABM, [{Name, Value} | Rest], Headers) ->
+    TABM1 = case Name of
+        % Handled as part of "Signature" so simply skip it
+        <<"Signature-Input">> -> TABM;
+        <<"signature-input">> -> TABM;
+
+        <<"Signature">> ->
+            {ok, SigInput} = get_signature_input(Headers),
+            from_signature(TABM, Value, SigInput);
+        <<"signature">> ->
+            {ok, SigInput} = get_signature_input(Headers),
+            from_signature(TABM, Value, SigInput);
+
+        % Decode the header as normal
+        N -> from_pair(TABM, {N, Value})
+    end,
+    from_headers(TABM1, Rest, Headers).
+
+%%% @doc attempt to parse the value as a structured field
+%%% First as an SF Item,
+%%% then an SF Dictionary,
+%%% then an SF List.
+%%%
+%%% If parsing is successful, convert the SF structure into
+%%% a TAB structure
+from_pair(TABM, {Name, Value}) when is_binary(Value) ->
+    case catch hb_http_structured_fields:parse_item(Value) of
+        {'EXIT', _} ->
+            case catch hb_http_structured_fields:parse_dictionary(Value) of
+                {'EXIT', _} ->
+                    case catch hb_http_structured_fields:parse_list(Value) of
+                        {'EXIT', _} -> {not_ok, undefined};
+                        % [item()]
+                        List ->
+                            ?no_prod("Is this proper way to TABM encode a list?"),
+                            BareValues = lists:map(
+                                fun
+                                    ({item, BareItem, []}) -> decode_sf_bare_item(BareItem);
+                                    % Re-encode to preserve original binary
+                                    (Item) -> hb_http_structured_fields:item(Item)
+                                end,
+                                List
+                            ),
+                            TopLevelFields = maps:from_list(hb_codec_converge:to_tab(Name, BareValues)),
+                            maps:merge(TABM, TopLevelFields)
+                    end;
+                % [{binary(), item()}]
+                DictList ->
+                    TABM_Pairs = lists:foldl(
+                        fun ({MapKey, Item}, Acc) ->
+                            Pairs = sf_item_to_tab(MapKey, Item),
+                            Pairs ++ Acc
+                        end,
+                        [],
+                        DictList
+                    ),
+                    SubTABM = maps:from_list(TABM_Pairs),
+                    maps:put(Name, SubTABM, TABM)
+            end;
+        Item ->
+            TopLevelFields = maps:from_list(sf_item_to_tab(Name, Item)),
+            maps:merge(TABM, TopLevelFields)
+    end.
+
+sf_item_to_tab(Key, Item = {item, _BareItem, _Params}) -> 
+    case Item of
+        {item, BareItem, []} ->
+            hb_codec_converge:to_tab(Key, decode_sf_bare_item(BareItem));
+        {item, _, _} ->
+            ?no_prod("How do we handle SF Params?"),
+            % Re-encode to preserve original binary
+            hb_codec_converge:to_tab(Key, hb_http_structured_fields:item(Item))
+    end.
+
+decode_sf_bare_item (BareItem) ->
+    case BareItem of
+        I when is_integer(I) -> I;
+        B when is_boolean(B) -> B;
+        D = {decimal, _} -> list_to_float(hb_http_structured_fields:bare_item(D));
+        {string, S} -> S;
+        {token, T} -> binary_to_existing_atom(T);
+        {binary, B} -> B
+    end.
+
+from_signature(TABM, RawSig, RawSigInput) ->
+    SfSigs = hb_http_structured_fields:dictionary(RawSig),
+    SfInputs = hb_http_structured_fields:dictionary(RawSigInput),
+    % Build a TABM for Signatures by gathering each Signature
+    % with its corresponding Inputs.
+    % 
+    % Inputs are merged as fields on the Signature Map
+    Signatures = maps:fold(
+        fun (SigName, {item, {_, Sig}, _}, TABM_Sigs) ->
+            {list, SfInputItems, SfInputParams} = lists:keyfind(SigName, 1, SfInputs),
+            % [<<"foo">>, <<"bar">>]
+            Inputs = lists:map(fun({item, {_, Input}, _}) -> Input end, SfInputItems),
+            InputFields = maps:from_list(hb_codec_converge:to_tab(<<"inputs">>, Inputs)),
+
+            % Signature parameters are converted into top-level keys on the signature TABM
+            Params = lists:foldl(
+                fun({PName, PValue}, PAcc) ->
+                    ParamFields = maps:from_list(hb_codec_converge:to_tab(PName, PValue)),
+                    maps:merge(PAcc, ParamFields)
+                end,
+                #{ <<"signature">> => Sig },
+                SfInputParams    
+            ),
+
+            TABM_Sig = maps:merge(Params, InputFields),
+            % #{ [SigName/binary] => #{ <<"signature">> => <<>>, <<"inputs">> => , ... } }
+            maps:put(SigName, TABM_Sig, TABM_Sigs)
+        end,
+        #{},
+        SfSigs
+    ),
+    % Finally place the Signatures as a top-level TABM on the parent TABM
+    maps:put(<<"Signatures">>, Signatures, TABM).
+
+get_signature_input(Headers) ->
+    case lists:keyfind(<<"Signature-Input">>, 1, Headers) of
+        false -> case lists:keyfind(<<"signature-input">>, 1, Headers) of
+            false -> signature_input_not_found;
+            {_, V} -> {ok, V}
+        end;
+        {_, V} -> {ok, V}
+    end.
+
+from_body(TABM, _ContentType, <<>>) -> TABM;
+from_body(TABM, ContentType, Body) ->
+    {item, {_, _BodyType}, Params} = hb_http_structured_fields:item(ContentType),
+    case lists:keyfind(<<"boundary">>, 1, Params) of
+        % The body is not a multipart, so just set as is to the Body key on the TABM
+        false -> maps:put(<<"Body">>, Body, TABM);
+        % We need to manually parse the multipart body into key/values on the TABM
         {_, Boundary} ->
             % The first part will always be empty (since the boundary is always placed first
             % in the body
-            [_, P] = binary:split(Body, <<"--", Boundary/binary>>),
+            [_ | Parts] = binary:split(Body, <<"--", Boundary/binary>>),
             % The last part MIGHT be "--" for the terminating boundary.
             %
             % So we need to check and potentially trim off the last
             % element
-            _TrimmedParts = case lists:last(P) of
-                <<"--">> ->
-                    lists:sublist(P, length(P) - 1);
-                _ -> P
-            end
-    end,
+            TParts = case lists:last(Parts) of
+                <<"--">> -> lists:sublist(Parts, length(Parts) - 1);
+                _ -> Parts
+            end,
+            % Finally, for each body part, we need to parse it into its
+            % own HTTP Message, then recursively convert into a TABM
+            TABM1 = lists:foldl(
+                fun (Part, Acc) -> append_body_part(Acc, Part) end,
+                TParts,
+                TABM
+            ),
+            TABM1
+    end.
 
-    % TODO: WIP NOT DONE
-    % Take each part and convert into a HB message
-    %   - headers become fields
-    %       - maybe parse as structured fields?
-    %   - parts become fields (recursively parsed)
-    %       - "inline" part becomes top level "body" field
-    %   - "Signature" & "Signature-Input" are parsed as SF dictionaries and become "Signatures" on HB message
-
+append_body_part(TABM, Part) ->
+    % TODO
+    % - extract headers block by splitting on "\n\n" then grabbing HEAD
+    % - extract individual headers by splitting on "\n"
+    % - parse each header, splitting on FIRST ": " -> {Name, Value}
+    % - take body block and use as the body
+    % - recursively call from(Http)
+    % - Set as key on TABM as Content-Disposition: form-data; name="..." OR as <<"body">> key if "inline"
+    % FIN
     not_implemented.
 
 %%% @doc Convert a TABM into an HTTP Message. The HTTP Message is a simple Erlang Map
 %%% that can translated to a given web server Response API
 to(Bin) when is_binary(Bin) -> Bin;
-to(TABM) ->
+to(TABM) when is_map(TABM) ->
     % PublicMsg = hb_private:reset(TABM),
     % MinimizedMsg = hb_message:minimize(PublicMsg),
     % NormalizedMsg = hb_message:normalize_keys(MinimizedMsg),
@@ -158,7 +310,7 @@ signatures_to_http(Http, Signatures) when is_map(Signatures) ->
     signatures_to_http(Http, maps:to_list(Signatures));
 signatures_to_http(Http, Signatures) when is_list(Signatures) ->
     {SfSigInputs, SfSigs} = lists:foldl(
-        fun ({SigName, SignatureMap = #{ inputs := Inputs, signature := Signature }}, {SfSigInputs, SfSigs}) ->
+        fun ({SigName, SignatureMap = #{ <<"inputs">> := Inputs, <<"signature">> := Signature }}, {SfSigInputs, SfSigs}) ->
             NextSigInput = hb_http_signature:sf_signature_params(Inputs, SignatureMap),
             NextSig = hb_http_signature:sf_signature(Signature),
             NextName = hb_converge:key_to_binary(SigName),
@@ -196,10 +348,11 @@ field_to_http(Http, {Name, MapOrList}, Opts) when is_map(MapOrList) orelse is_li
     MaybeEncoded = case Mapper(MapOrList) of
         {ok, Sf} ->
             % Check the size of the encoded value, and signal to store
-            % the as a Structured Field encoded dictionary in the header
+            % as a Structured Field in the header
             %
-            % Otherwise, we will need to convert the Map into its own HTTP message
-            % and append as a part of the body in the parent multi-part msg
+            % Otherwise, in the case of a Map, we will need to convert the Map into
+            % its own HTTP message. For a list, we can still use the Structured field encoding.
+            % In both cases, the value is appended as a part of the parent's multi-part body
             EncodedSf = iolist_to_binary(Parser(Sf)),
             Fits = byte_size(EncodedSf) =< ?MAX_HEADER_LENGTH,
             {Fits, EncodedSf};
@@ -208,16 +361,16 @@ field_to_http(Http, {Name, MapOrList}, Opts) when is_map(MapOrList) orelse is_li
     ?no_prod("What should the name be?"),
     NormalizedName = hb_converge:key_to_binary(Name),
     case MaybeEncoded of
-        {true, Bin} ->
-            field_to_http(Http, {NormalizedName, Bin}, Opts);
+        {true, EncodedSfDict} ->
+            field_to_http(Http, {NormalizedName, EncodedSfDict}, Opts);
         % Encode the map as a sub part, to be appended to the body
         {false, _} when is_map(MapOrList) ->
             SubHttp = to(MapOrList),
             EncodedHttpMap = encode_http_msg(SubHttp),
             field_to_http(Http, {Name, EncodedHttpMap}, maps:put(where, body, Opts));
         % Encode the SF list as a sub part, to be appended to the body
-        {false, Bin} when is_list(MapOrList) ->
-            field_to_http(Http, {NormalizedName, Bin}, maps:put(where, body, Opts));
+        {false, EncodedSfList} when is_list(MapOrList) ->
+            field_to_http(Http, {NormalizedName, EncodedSfList}, maps:put(where, body, Opts));
         undefined when is_list(MapOrList) ->
             ?no_prod("how do we encode a list in HTTP message if it cannot be encoded as a structured field?"),
             not_implemented

--- a/src/hb_codec_http.erl
+++ b/src/hb_codec_http.erl
@@ -1,7 +1,8 @@
 
-%%% @doc Maps the native HyperBEAM Message to an "HTTP" message.
-%%% Every HyperBEAM Message is mapped to an HTTP multipart message.
-%%% The HTTP Message data structure has the following shape:
+%%% @doc A codec for the that marshals TABM encoded messages to and from the
+%%% "HTTP" message structure.
+%%% 
+%%% The HTTP Message is an Erlang Map with the following shape:
 %%% #{ 
 %%%     headers => [
 %%%         {<<"Example-Header">>, <<"Value">>}
@@ -9,10 +10,12 @@
 %%%     body: <<"Some body">>
 %%% }
 %%% 
+%%% Every HTTP message is an HTTP multipart message.
+%%% See https://datatracker.ietf.org/doc/html/rfc7578
+%%%
+%%% For each TABM Key:
 %%% 
-%%% For each HyperBEAM Message Key:
-%%% 
-%%% The Key will be ignored if:
+%%% The TABM Key will be ignored if:
 %%% - The field is private (according to hb_private:is_private/1)
 %%% - The field is one of ?REGEN_KEYS
 %%%
@@ -41,21 +44,71 @@
 
 -define(MAX_HEADER_LENGTH, 256).
 
-to(Msg) ->
-    PublicMsg = hb_private:reset(Msg),
-    MinimizedMsg = hb_message:minimize(PublicMsg),
-    NormalizedMsg = hb_message:normalize_keys(MinimizedMsg),
-    Http = lists:foldl(
+%%% @doc Convert an HTTP Message into a TABM.
+%%% Any HTTP Structured Field is encoded into it's equivalent TABM encoding.
+%%% TODO: special rules for Signature and Signature-Input headers
+%% Recursively encode the multipart body into TABM
+from(#{ headers := Headers, body := Body }) ->
+    ContentType = lists:keyfind(<<"Content-Type">>, 1, Headers),
+    {item, _, Params} = hb_http_structured_fields:item(ContentType),
+    _Parts = case lists:keyfind(<<"boundary">>, 1, Params) of
+        false -> [Body];
+        {_, Boundary} ->
+            % The first part will always be empty (since the boundary is always placed first
+            % in the body
+            [_, P] = binary:split(Body, <<"--", Boundary/binary>>),
+            % The last part MIGHT be "--" for the terminating boundary.
+            %
+            % So we need to check and potentially trim off the last
+            % element
+            _TrimmedParts = case lists:last(P) of
+                <<"--">> ->
+                    lists:sublist(P, length(P) - 1);
+                _ -> P
+            end
+    end,
+
+    % TODO: WIP NOT DONE
+    % Take each part and convert into a HB message
+    %   - headers become fields
+    %       - maybe parse as structured fields?
+    %   - parts become fields (recursively parsed)
+    %       - "inline" part becomes top level "body" field
+    %   - "Signature" & "Signature-Input" are parsed as SF dictionaries and become "Signatures" on HB message
+
+    not_implemented.
+
+%%% @doc Convert a TABM into an HTTP Message. The HTTP Message is a simple Erlang Map
+%%% that can translated to a given web server Response API
+to(Bin) when is_binary(Bin) -> Bin;
+to(TABM) ->
+    % PublicMsg = hb_private:reset(TABM),
+    % MinimizedMsg = hb_message:minimize(PublicMsg),
+    % NormalizedMsg = hb_message:normalize_keys(MinimizedMsg),
+    Http = maps:fold(
         fun
-            ({<<"signatures">>, Signatures}, Http) -> signatures_to_http(Http, Signatures);
-            ({<<"body">>, Body}, Http) -> body_to_http(Http, Body);
-            ({Name, Value}, Http) -> field_to_http(Http, {Name, Value}, #{})
+            % Signatures (note abbr. & case-insensitivity) are mapped according to RFC-9421
+            (<<"signatures">>, Signatures, Http) -> signatures_to_http(Http, Signatures);
+            (<<"sigs">>, Signatures, Http) -> signatures_to_http(Http, Signatures);
+            (<<"sig">>, Signature, Http) -> signatures_to_http(Http, [Signature]);
+            (<<"Signatures">>, Signatures, Http) -> signatures_to_http(Http, Signatures);
+            (<<"Sigs">>, Signatures, Http) -> signatures_to_http(Http, Signatures);
+            (<<"Sig">>, Signature, Http) -> signatures_to_http(Http, [Signature]);
+
+            % Body (note case-insensitivity) is mapped into a multipart according to RFC-7578
+            (<<"body">>, Body, Http) -> body_to_http(Http, Body);
+            (<<"Body">>, Body, Http) -> body_to_http(Http, Body);
+
+            % All other values are encoded as an HTTP Structured Fields.
+            % non-map/list is encoded as an HTTP Structured Field Item
+            (Name, Value, Http) when not (is_map(Value) orelse is_list(Value)) ->
+                {ok, Item} = hb_http_structured_fields:to_item(Value),
+                field_to_http(Http, {Name, iolist_to_binary(hb_http_structured_fields:item(Item))}, #{});
+            % Further mapping of lists and maps delegated to field_to_http
+            (Name, Value, Http) -> field_to_http(Http, {Name, Value}, #{})
         end,
-        #{
-            headers => [],
-            body => #{}
-        },
-        maps:to_list(NormalizedMsg)    
+        #{ headers => [], body => #{} },
+        TABM
     ),
     Body = maps:get(body, Http),
     NewHttp = case maps:size(Body) of
@@ -63,18 +116,14 @@ to(Msg) ->
         _ ->
             ?no_prod("What should the Boundary be?"),
             Boundary = base64:encode(crypto:strong_rand_bytes(8)),
-            % Transform body into a binary, delimiting each part,
-            % with the Boundary
-            Bin = maps:fold(
+            % Transform body into a binary, delimiting each part with the Boundary
+            BodyBin = maps:fold(
                 fun (_, BodyPart, Acc) ->
                     <<Acc/binary, "--", Boundary/binary, "\n", BodyPart/binary, "\n">>
                 end,
                 <<>>,
                 Body
             ),
-            % TODO: I _think_ this is needed, according to spec
-            % End the body with a final terminating Boundary
-            EncodedBody = <<Bin/binary, "--", Boundary/binary, "--">>,
             #{ 
                 headers => [
                     {
@@ -83,7 +132,9 @@ to(Msg) ->
 					}
                     | maps:get(headers, Http)
                 ],
-                body => EncodedBody
+                % TODO: I _think_ this is needed, according to the spec
+                % End the body with a final terminating Boundary
+                body => <<BodyBin/binary, "--", Boundary/binary, "--">>
             }
     end,
     NewHttp.
@@ -101,7 +152,7 @@ encode_http_msg (#{ headers := SubHeaders, body := SubBody }) ->
     % Content-Type: image/png
     % 
     % <body>
-    <<EncodedHeaders/binary, <<"\n\n">>, SubBody/binary>>.
+    <<EncodedHeaders/binary, "\n\n", SubBody/binary>>.
 
 signatures_to_http(Http, Signatures) when is_map(Signatures) ->
     signatures_to_http(Http, maps:to_list(Signatures));
@@ -135,51 +186,52 @@ body_to_http(Http, Body) when is_binary(Body) ->
     Disposition = <<"Content-Disposition: inline">>,
     field_to_http(Http, {<<"body">>, Body}, #{ disposition => Disposition, where => body }).
 
+field_to_http(Http, {Name, {<<"List">>, Value}}, Opts) ->
+    field_to_http(Http, {Name, Value}, Opts);
 field_to_http(Http, {Name, MapOrList}, Opts) when is_map(MapOrList) orelse is_list(MapOrList) ->
     {Mapper, Parser} = case MapOrList of
         Map when is_map(Map) -> {fun hb_http_structured_fields:to_dictionary/1, fun hb_http_structured_fields:dictionary/1};
         List when is_list(List) -> {fun hb_http_structured_fields:to_list/1, fun hb_http_structured_fields:list/1}
     end,
-    MaybeBin = case Mapper(MapOrList) of
+    MaybeEncoded = case Mapper(MapOrList) of
         {ok, Sf} ->
-            % Check the size of the encoded dictionary, and signal to store
-            % the map as an Structured Field encoded dictionary in the header
+            % Check the size of the encoded value, and signal to store
+            % the as a Structured Field encoded dictionary in the header
             %
             % Otherwise, we will need to convert the Map into its own HTTP message
             % and append as a part of the body in the parent multi-part msg
-            EncodedSf = Parser(Sf),
-            case byte_size(EncodedSf) of
-                Fits when Fits =< ?MAX_HEADER_LENGTH -> EncodedSf;
-                _ -> undefined
-            end;
+            EncodedSf = iolist_to_binary(Parser(Sf)),
+            Fits = byte_size(EncodedSf) =< ?MAX_HEADER_LENGTH,
+            {Fits, EncodedSf};
         _ -> undefined
     end,
     ?no_prod("What should the name be?"),
     NormalizedName = hb_converge:key_to_binary(Name),
-    case MaybeBin of
-        Bin when is_binary(Bin) ->
+    case MaybeEncoded of
+        {true, Bin} ->
             field_to_http(Http, {NormalizedName, Bin}, Opts);
-        undefined when is_map(MapOrList) ->
+        % Encode the map as a sub part, to be appended to the body
+        {false, _} when is_map(MapOrList) ->
             SubHttp = to(MapOrList),
             EncodedHttpMap = encode_http_msg(SubHttp),
-            % Append to the serialized field to the parent body, as a part
-            field_to_http(Http, {Name, EncodedHttpMap}, Opts);
+            field_to_http(Http, {Name, EncodedHttpMap}, maps:put(where, body, Opts));
+        % Encode the SF list as a sub part, to be appended to the body
+        {false, Bin} when is_list(MapOrList) ->
+            field_to_http(Http, {NormalizedName, Bin}, maps:put(where, body, Opts));
         undefined when is_list(MapOrList) ->
-            ?no_prod("how do we further encode a list?"),
+            ?no_prod("how do we encode a list in HTTP message if it cannot be encoded as a structured field?"),
             not_implemented
     end;
-% field_to_http(Http, {Name, List}, Opts) when is_list(List) ->
-%     {not_implemented, List};
-field_to_http(Http, {Name, Value}, Opts) ->
-    NormalizedName = hb_converge:key_to_binary(Name),
-    NormalizedValue = hb_converge:key_to_binary(Value),
 
-    % Depending on the size of the value, we may need to force
-    % the value to be encoded into the body.
-    %
-    % Otherwise, we place the value according to Opts,
-    % defaulting to header
-    DefaultWhere = case byte_size(NormalizedValue) of
+field_to_http(Http, {Name, Value}, Opts) when is_binary(Value) ->
+    NormalizedName = hb_converge:key_to_binary(Name),
+
+    % The default location where the value is encoded within the HTTP
+    % message depends on its size.
+    % 
+    % So we check whether the size of the value is within the threshold
+    % to encode as a header, and other default to encoding in the body
+    DefaultWhere = case byte_size(Value) of
         Fits when Fits =< ?MAX_HEADER_LENGTH -> headers;
         _ -> maps:get(where, Opts, headers)
     end,
@@ -187,7 +239,7 @@ field_to_http(Http, {Name, Value}, Opts) ->
     case maps:get(where, Opts, DefaultWhere) of
         headers ->
             Headers = maps:get(headers, Http),
-            NewHeaders = lists:append(Headers, [{NormalizedName, NormalizedValue}]),
+            NewHeaders = lists:append(Headers, [{NormalizedName, Value}]),
             maps:put(headers, NewHeaders, Http);
         % Append the value as a part of the multipart body
         %
@@ -198,52 +250,23 @@ field_to_http(Http, {Name, Value}, Opts) ->
         body ->
             Body = maps:get(body, Http),
             Disposition = maps:get(disposition, Opts, <<"Content-Disposition: form-data; name=", NormalizedName/binary>>),
-            BodyPart = <<Disposition/binary, "\n\n", NormalizedValue/binary>>,
+            BodyPart = <<Disposition/binary, "\n\n", Value/binary>>,
             NewBody = maps:put(NormalizedName, BodyPart, Body),
             maps:put(body, NewBody, Http)
     end.
 
-from(#{ headers := Headers, body := Body }) ->
-    ContentType = lists:keyfind(<<"Content-Type">>, 1, Headers),
-    {item, _, Params} = hb_http_structured_fields:item(ContentType),
-    _Parts = case lists:keyfind(<<"boundary">>, 1, Params) of
-        false -> [Body];
-        {_, Boundary} ->
-            % The first part will always be empty (since the boundary is always placed first
-            % in the body
-            [_, P] = binary:split(Body, <<"--", Boundary/binary>>),
-            % The last part MIGHT be "--" for the terminating boundary.
-            %
-            % So we need to check and potentially trim off the last
-            % element
-            _TrimmedParts = case lists:last(P) of
-                <<"--">> ->
-                    lists:sublist(P, length(P) - 1);
-                _ -> P
-            end
-    end,
-    % TODO: WIP NOT DONE
-    % Take each part and convert into a HB message
-    %   - headers become fields
-    %       - maybe parse as structured fields?
-    %   - parts become fields (recursively parsed)
-    %       - "inline" part becomes top level "body" field
-    %   - "Signature" & "Signature-Input" are parsed as SF dictionaries and become "Signatures" on HB message
-
-    not_implemented.
-
 %%% Tests
 
-simple_message_to_http_test() ->
-    Msg = #{ a => 1, b => 2, priv_c => 3, id => <<"regen_ignore">> },
-    Http = hb_codec_http:to(Msg),
+simple_message_to_test() ->
+    Http = hb_codec_http:to(Msg = #{ a => 1, b => <<"foo">> }),
+    erlang:display({foooo, Http}),
     ?assertEqual(
-        #{ headers => [{<<"a">>, <<"1">>}, {<<"b">>, <<"2">>}], body => <<>> },
+        #{ headers => [{<<"a">>, <<"1">>}, {<<"b">>, <<"\"foo\"">>}], body => <<>> },
         Http
     ),
     ok.
 
-simple_body_message_to_http_test() ->
+simple_body_message_to_test() ->
     Html = <<"<html><body>Hello</body></html>">>,
     _Msg = #{ "Content-Type" => <<"text/html">>, body => Html },
     %Http = hb_codec_http:to(Msg),

--- a/src/hb_http_structured_fields.erl
+++ b/src/hb_http_structured_fields.erl
@@ -1,7 +1,7 @@
 -module(hb_http_structured_fields).
 
--export([parse_dictionary/1, parse_item/1, parse_list/1]).
--export([dictionary/1, item/1, list/1]).
+-export([parse_dictionary/1, parse_item/1, parse_list/1, parse_bare_item/1]).
+-export([dictionary/1, item/1, list/1, bare_item/1]).
 -export([to_dictionary/1, to_list/1, to_item/1, to_item/2]).
 
 -include_lib("eunit/include/eunit.hrl").


### PR DESCRIPTION
This PR implements the start of the `http` codec. This passes the `hb_message` codec testsuite EXCEPT for signature test cases:

```
{"signed item to message and back test", fun signed_message_encode_decode_verify_test/1},
{"signed item to tx and back test", fun signed_tx_encode_decode_verify_test/1},
{"signed deep serialize and deserialize test", fun signed_deep_tx_serialize_and_deserialize_test/1},
```

As mentioned, signature is still not working, and what I am focusing on now, but wanted to get this PR up since the changes were getting to be pretty dense.

I'll also need to write a test ensuring a `body` key will be properly encoded as the `inline` Content-Disposition in the Http multi-part response.