### PR TITLE
fix: fix most of dev_wasm test cases (fix incorrect key values)

### DIFF
--- a/src/hb_private.erl
+++ b/src/hb_private.erl
@@ -22,7 +22,11 @@
 
 %% @doc Return the `private' key from a message. If the key does not exist, an
 %% empty map is returned.
-from_message(Msg) when is_map(Msg) -> maps:get(priv, Msg, #{});
+from_message(Msg) when is_map(Msg) ->
+    case maps:is_key(<<"priv">>, Msg) of
+        true -> maps:get(<<"priv">>, Msg, #{});
+        false -> maps:get(priv, Msg, #{})
+    end;
 from_message(_NonMapMessage) -> #{}.
 
 %% @doc Helper for getting a value from the private element of a message. Uses


### PR DESCRIPTION
The current test run shows 6 passing tests. However, I have managed to lock the BEAM by:

```
imported_function_test_() ->
     % Manages to spoil everything. Looks like the beamr sends import request
     % but we never get it
     {timout, 10, imported_function_test()}.
```

E.g. the driver code successfully sends a request to the host machine to do the imported function call, but it appears like no one is listening to those. I am exploring the case deeper [as soon as it's also seems related to the issue I saw on another machine earlier]