### PR TITLE
feat: key normalization and hsig API

### DIFF
--- a/c_src/hb_beamr.c
+++ b/c_src/hb_beamr.c
@@ -53,7 +53,7 @@ static ErlDrvTermData atom_import;
 static ErlDrvTermData atom_execution_result;
 
 #ifndef HB_DEBUG
-#define HB_DEBUG 0
+#define HB_DEBUG 1
 #endif
 
 #define DRV_DEBUG(format, ...) beamr_print(HB_DEBUG, __FILE__, __LINE__, format, ##__VA_ARGS__)
@@ -166,6 +166,7 @@ ei_term* decode_list(char* buff, int* index) {
     }
     DRV_DEBUG("Decoded header. Arity: %d", arity);
 
+    DRV_PRINT("alloc1 - alloc %d (%d * %d)", sizeof(ei_term) * arity, sizeof(ei_term), arity);
     ei_term* res = driver_alloc(sizeof(ei_term) * arity);
 
     if(type == ERL_LIST_EXT) {
@@ -179,6 +180,7 @@ ei_term* decode_list(char* buff, int* index) {
     }
     else if(type == ERL_STRING_EXT) {
         //DRV_DEBUG("Decoding list encoded as string");
+        DRV_PRINT("alloc2 %d", arity * sizeof(char) + 1);
         unsigned char* str = driver_alloc(arity * sizeof(char) + 1);
         ei_decode_string(buff, index, str);
         for(int i = 0; i < arity; i++) {
@@ -186,6 +188,7 @@ ei_term* decode_list(char* buff, int* index) {
             res[i].value.i_val = (long) str[i];
             DRV_DEBUG("Decoded term %d: %d", i, res[i].value.i_val);
         }
+        DRV_PRINT("alloc2 - free");
         driver_free(str);
     }
     else {
@@ -193,6 +196,7 @@ ei_term* decode_list(char* buff, int* index) {
         return NULL;
     }
 
+    DRV_PRINT("res %x", *res);
     return res;
 }
 
@@ -300,9 +304,11 @@ long get_memory_size(Proc* proc) {
 void send_error(Proc* proc, const char* message_fmt, ...) {
     va_list args;
     va_start(args, message_fmt);
+    DRV_PRINT("alloc3 %d", 256);
     char* message = driver_alloc(256);
     vsnprintf(message, 256, message_fmt, args);
     DRV_DEBUG("Sending error message: %s", message);
+    DRV_PRINT("alloc4 %d", sizeof(ErlDrvTermData) * 7);
     ErlDrvTermData* msg = driver_alloc(sizeof(ErlDrvTermData) * 7);
     int msg_index = 0;
     msg[msg_index++] = ERL_DRV_ATOM;
@@ -315,7 +321,9 @@ void send_error(Proc* proc, const char* message_fmt, ...) {
 
     int msg_res = erl_drv_output_term(proc->port_term, msg, msg_index);
     DRV_DEBUG("Sent error message. Res: %d", msg_res);
+    DRV_PRINT("alloc3 - free");
     driver_free(message);
+    DRV_PRINT("alloc4 - free");
     driver_free(msg);
     va_end(args);
 }
@@ -328,6 +336,7 @@ wasm_trap_t* generic_import_handler(void* env, const wasm_val_vec_t* args, wasm_
     DRV_DEBUG("Import name: %s.%s [%s]", import_hook->module_name, import_hook->field_name, import_hook->signature);
 
     // Initialize the message object
+    DRV_PRINT("alloc5 %d", sizeof(ErlDrvTermData) * ((2+(2*3)) + ((args->size + 1) * 2) + ((results->size + 1) * 2) + 2));
     ErlDrvTermData* msg = driver_alloc(sizeof(ErlDrvTermData) * ((2+(2*3)) + ((args->size + 1) * 2) + ((results->size + 1) * 2) + 2));
     int msg_index = 0;
     msg[msg_index++] = ERL_DRV_ATOM;
@@ -357,6 +366,7 @@ wasm_trap_t* generic_import_handler(void* env, const wasm_val_vec_t* args, wasm_
     msg[msg_index++] = 5;
 
     // Initialize the result vector and set the required result types
+    DRV_PRINT("alloc6 %d", sizeof(ImportResponse));
     proc->current_import = driver_alloc(sizeof(ImportResponse));
 
     // Create and initialize a is_running and condition variable for the response
@@ -367,6 +377,7 @@ wasm_trap_t* generic_import_handler(void* env, const wasm_val_vec_t* args, wasm_
     DRV_DEBUG("Sending %d terms...", msg_index);
     // Send the message to the caller process
     int msg_res = erl_drv_output_term(proc->port_term, msg, msg_index);
+    DRV_PRINT("alloc5 - free");
     driver_free(msg);
     // Wait for the response (we set this directly after the message was sent
     // so we have the lock, before Erlang sends us data back)
@@ -380,6 +391,7 @@ wasm_trap_t* generic_import_handler(void* env, const wasm_val_vec_t* args, wasm_
         wasm_name_t message;
         wasm_name_new_from_string_nt(&message, proc->current_import->error_message);
         wasm_trap_t* trap = wasm_trap_new(proc->store, &message);
+        DRV_PRINT("alloc6 - free");
         // TODO: check where the error_message is allocated
         driver_free(proc->current_import->error_message);
         driver_free(proc->current_import);
@@ -405,8 +417,10 @@ wasm_trap_t* generic_import_handler(void* env, const wasm_val_vec_t* args, wasm_
     erl_drv_cond_destroy(proc->current_import->cond);
     erl_drv_mutex_destroy(proc->current_import->response_ready);
     if (proc->current_import->result_terms) {
+        DRV_PRINT("alloc1 - free2");
         driver_free(proc->current_import->result_terms);
     }
+    DRV_PRINT("alloc6 - free");
     driver_free(proc->current_import);
 
     proc->current_import = NULL;
@@ -464,6 +478,7 @@ static void async_init(void* raw) {
 
     // Create Erlang lists for imports
     //DRV_DEBUG("Exports size: %d", exports.size);
+    DRV_PRINT("alloc7 %d", sizeof(ErlDrvTermData) * (2 + (13 * imports.size) + (11 * exports.size)));
     ErlDrvTermData* init_msg = driver_alloc(sizeof(ErlDrvTermData) * (2 + (13 * imports.size) + (11 * exports.size)));
     //DRV_DEBUG("Allocated init message");
     int msg_i = 0;
@@ -480,6 +495,7 @@ static void async_init(void* raw) {
 
         //DRV_DEBUG("Import: %s.%s", module_name->data, name->data);
 
+    DRV_PRINT("alloc8 %d", 256);
         char* type_str = driver_alloc(256);
         // TODO: What happpens here?
         if(!get_function_sig(type, type_str)) {
@@ -502,6 +518,7 @@ static void async_init(void* raw) {
         init_msg[msg_i++] = 4;
 
         DRV_DEBUG("Creating callback for %s.%s [%s]", module_name->data, name->data, type_str);
+        DRV_PRINT("alloc9 %d", sizeof(ImportHook));
         ImportHook* hook = driver_alloc(sizeof(ImportHook));
         hook->module_name = module_name->data;
         hook->field_name = name->data;
@@ -544,6 +561,7 @@ static void async_init(void* raw) {
         const wasm_externtype_t* type = wasm_exporttype_type(export);
         char* kind_str = (char*) wasm_externtype_to_kind_string(type);
 
+        DRV_PRINT("alloc10 %d", 256);
         char* type_str = driver_alloc(256);
         get_function_sig(type, type_str);
         DRV_DEBUG("Export: %s [%s] -> %s", name->data, kind_str, type_str);
@@ -643,6 +661,7 @@ static void async_call(void* raw) {
 
     // Send the results back to Erlang
     DRV_DEBUG("Results size: %d", results.size);
+    DRV_PRINT("alloc11 %d", sizeof(ErlDrvTermData) * (7 + (results.size * 2)));
     ErlDrvTermData* msg = driver_alloc(sizeof(ErlDrvTermData) * (7 + (results.size * 2)));
     DRV_DEBUG("Allocated msg");
     int msg_index = 0;
@@ -679,11 +698,15 @@ static void async_call(void* raw) {
     msg[msg_index++] = 2;
     DRV_DEBUG("Sending %d terms", msg_index);
     int response_msg_res = erl_drv_output_term(proc->port_term, msg, msg_index);
+    DRV_PRINT("alloc11 - free");
     driver_free(msg);
 
     DRV_DEBUG("Msg: %d", response_msg_res);
 
+    DRV_PRINT("alloc1 - free1");
+    DRV_PRINT("free current_args: %p", proc->current_args);
     driver_free(proc->current_args);
+    DRV_PRINT("alloc15 - free %s", proc->current_function);
     driver_free(proc->current_function);
 
     wasm_val_vec_delete(&results);
@@ -713,6 +736,7 @@ static ErlDrvData wasm_driver_start(ErlDrvPort port, char *buff) {
     DRV_DEBUG("info.dirty_scheduler_support: %d", info.dirty_scheduler_support);
     DRV_DEBUG("info.erts_version: %s", info.erts_version);
     DRV_DEBUG("info.otp_release: %s", info.otp_release);
+    DRV_PRINT("alloc12 %d", sizeof(Proc));
     Proc* proc = driver_alloc(sizeof(Proc));
     proc->port = port;
     DRV_DEBUG("Port: %p", proc->port);
@@ -789,9 +813,11 @@ static void wasm_driver_output(ErlDrvData raw, char *buff, ErlDrvSizeT bufflen) 
         int size, type;
         ei_get_type(buff, &index, &type, &size);
         //DRV_DEBUG("WASM binary size: %d bytes. Type: %c", size, type);
+        DRV_PRINT("alloc13 %d", size);
         void* wasm_binary = driver_alloc(size);
         long size_l = (long)size;
         ei_decode_binary(buff, &index, wasm_binary, &size_l);
+        DRV_PRINT("alloc14 %d", sizeof(LoadWasmReq));
         LoadWasmReq* mod_bin = driver_alloc(sizeof(LoadWasmReq));
         mod_bin->proc = proc;
         mod_bin->binary = wasm_binary;
@@ -806,6 +832,7 @@ static void wasm_driver_output(ErlDrvData raw, char *buff, ErlDrvSizeT bufflen) 
         // Extract the function name and the args from the Erlang term and generate the wasm_val_vec_t
         char* function_name = driver_alloc(MAXATOMLEN);
         ei_decode_string(buff, &index, function_name);
+        DRV_PRINT("alloc15 %d %s", MAXATOMLEN, function_name);
         //DRV_DEBUG("Function name: %s", function_name);
         proc->current_function = function_name;
 
@@ -813,6 +840,7 @@ static void wasm_driver_output(ErlDrvData raw, char *buff, ErlDrvSizeT bufflen) 
         proc->current_args = decode_list(buff, &index);
 
         driver_async(proc->port, NULL, async_call, proc, NULL);
+        //        driver_free(proc->current_args);
     } else if (strcmp(command, "import_response") == 0) {
         // Handle import response
         // TODO: We should probably start a mutex on the current_import object here.
@@ -857,10 +885,12 @@ static void wasm_driver_output(ErlDrvData raw, char *buff, ErlDrvSizeT bufflen) 
         memcpy(memory_data + ptr, wasm_binary, size_bytes);
         DRV_DEBUG("Write complete");
 
+        DRV_PRINT("alloc16 %d", sizeof(ErlDrvTermData) * 2);
         ErlDrvTermData* msg = driver_alloc(sizeof(ErlDrvTermData) * 2);
         msg[0] = ERL_DRV_ATOM;
         msg[1] = atom_ok;
         erl_drv_output_term(proc->port_term, msg, 2);
+        DRV_PRINT("alloc16 - free");
         driver_free(msg);
     }
     else if (strcmp(command, "read") == 0) {
@@ -881,11 +911,13 @@ static void wasm_driver_output(ErlDrvData raw, char *buff, ErlDrvSizeT bufflen) 
         byte_t* memory_data = wasm_memory_data(get_memory(proc));
         DRV_DEBUG("Memory location to read from: %p", memory_data + ptr);
         
+        DRV_PRINT("alloc17 %d", size_l);
         char* out_binary = driver_alloc(size_l);
         memcpy(out_binary, memory_data + ptr, size_l);
 
         DRV_DEBUG("Read complete. Binary: %p", out_binary);
 
+        DRV_PRINT("alloc18 %d", sizeof(ErlDrvTermData) * 7);
         ErlDrvTermData* msg = driver_alloc(sizeof(ErlDrvTermData) * 7);
         int msg_index = 0;
         msg[msg_index++] = ERL_DRV_ATOM;
@@ -898,7 +930,9 @@ static void wasm_driver_output(ErlDrvData raw, char *buff, ErlDrvSizeT bufflen) 
         
         int msg_res = erl_drv_output_term(proc->port_term, msg, msg_index);
         DRV_DEBUG("Read response sent: %d", msg_res);
+        DRV_PRINT("alloc17 - free");
         driver_free(out_binary);
+        DRV_PRINT("alloc18 - free");
         driver_free(msg);
     }
     else if (strcmp(command, "size") == 0) {
@@ -906,6 +940,7 @@ static void wasm_driver_output(ErlDrvData raw, char *buff, ErlDrvSizeT bufflen) 
         long size = get_memory_size(proc);
         DRV_DEBUG("Size: %ld", size);
 
+        DRV_PRINT("alloc19 %d", sizeof(ErlDrvTermData) * 6);
         ErlDrvTermData* msg = driver_alloc(sizeof(ErlDrvTermData) * 6);
         int msg_index = 0;
         msg[msg_index++] = ERL_DRV_ATOM;

--- a/src/ar_bundles.erl
+++ b/src/ar_bundles.erl
@@ -694,7 +694,7 @@ maybe_unbundle(Item) ->
     Format = lists:keyfind(<<"bundle-format">>, 1, Item#tx.tags),
     Version = lists:keyfind(<<"bundle-version">>, 1, Item#tx.tags),
     case {Format, Version} of
-        {{<<"bundle-format">>, <<"Binary">>}, {<<"bundle-version">>, <<"2.0.0">>}} ->
+        {{<<"bundle-format">>, <<"binary">>}, {<<"bundle-version">>, <<"2.0.0">>}} ->
             maybe_map_to_list(maybe_unbundle_map(Item));
         _ ->
             Item

--- a/src/ar_bundles.erl
+++ b/src/ar_bundles.erl
@@ -1023,7 +1023,7 @@ assert_data_item(KeyType, Owner, Target, Anchor, Tags, Data, DataItem) ->
 test_empty_bundle() ->
     Bundle = serialize([]),
     BundleItem = deserialize(Bundle),
-    ?assertEqual([], BundleItem#tx.data).
+    ?assertEqual(#{}, BundleItem#tx.data).
 
 test_bundle_with_one_item() ->
     Item = new_item(
@@ -1034,7 +1034,7 @@ test_bundle_with_one_item() ->
     ),
     Bundle = serialize([Item]),
     BundleItem = deserialize(Bundle),
-    ?assertEqual(ItemData, (erlang:hd(BundleItem#tx.data))#tx.data).
+    ?assertEqual(ItemData, (maps:get(<<"1">>, BundleItem#tx.data))#tx.data).
 
 test_bundle_with_two_items() ->
     Item1 = new_item(
@@ -1051,8 +1051,8 @@ test_bundle_with_two_items() ->
     ),
     Bundle = serialize([Item1, Item2]),
     BundleItem = deserialize(Bundle),
-    ?assertEqual(ItemData1, (erlang:hd(BundleItem#tx.data))#tx.data),
-    ?assertEqual(ItemData2, (erlang:hd(tl(BundleItem#tx.data)))#tx.data).
+    ?assertEqual(ItemData1, (maps:get(<<"1">>, BundleItem#tx.data))#tx.data),
+    ?assertEqual(ItemData2, (maps:get(<<"2">>, BundleItem#tx.data))#tx.data).
 
 test_recursive_bundle() ->
     W = ar_wallet:new(),
@@ -1073,9 +1073,9 @@ test_recursive_bundle() ->
     }, W),
     Bundle = serialize([Item3]),
     BundleItem = deserialize(Bundle),
-    [UnbundledItem3] = BundleItem#tx.data,
-    [UnbundledItem2] = UnbundledItem3#tx.data,
-    [UnbundledItem1] = UnbundledItem2#tx.data,
+    #{<<"1">> := UnbundledItem3} = BundleItem#tx.data,
+    #{<<"1">> := UnbundledItem2} = UnbundledItem3#tx.data,
+    #{<<"1">> := UnbundledItem1} = UnbundledItem2#tx.data,
     ?assert(verify_item(UnbundledItem1)),
     % TODO: Verify bundled lists...
     ?assertEqual(Item1#tx.data, UnbundledItem1#tx.data).

--- a/src/ar_bundles.erl
+++ b/src/ar_bundles.erl
@@ -793,7 +793,7 @@ item_to_json_struct(
     }
 ) ->
     % Set "From" if From-Process is Tag or set with "Owner" address
-    ?event(debug, {invoked_item_to_json_struct, {tags, Tags}, {owner, Owner}, {data, Data}}),
+    ?event({invoked_item_to_json_struct, {tags, Tags}, {owner, Owner}, {data, Data}}),
     From =
         case lists:filter(fun({Name, _}) -> Name =:= <<"From-Process">> end, Tags) of
             [{_, FromProcess}] -> FromProcess;

--- a/src/ar_bundles.erl
+++ b/src/ar_bundles.erl
@@ -15,12 +15,12 @@
 %%% @doc Module for creating, signing, and verifying Arweave data items and bundles.
 
 -define(BUNDLE_TAGS, [
-    {<<"Bundle-Format">>, <<"Binary">>},
-    {<<"Bundle-Version">>, <<"2.0.0">>}
+    {<<"bundle-format">>, <<"binary">>},
+    {<<"bundle-version">>, <<"2.0.0">>}
 ]).
 
 -define(LIST_TAGS, [
-    {<<"Map-Format">>, <<"List">>}
+    {<<"map-format">>, <<"list">>}
 ]).
 
 % How many bytes of a binary to print with `print/1'.
@@ -87,7 +87,7 @@ format(Item, Indent) ->
     format_line("INCORRECT ITEM: ~p", [Item], Indent).
 
 format_data(Item, Indent) when is_binary(Item#tx.data) ->
-    case lists:keyfind(<<"Bundle-Format">>, 1, Item#tx.tags) of
+    case lists:keyfind(<<"bundle-format">>, 1, Item#tx.tags) of
         {_, _} ->
             format_data(deserialize(serialize(Item)), Indent);
         false ->
@@ -248,11 +248,11 @@ verify_item(DataItem) ->
     ValidID andalso ValidSignature andalso ValidTags.
 
 type(Item) when is_record(Item, tx) ->
-    lists:keyfind(<<"Bundle-Map">>, 1, Item#tx.tags),
-    case lists:keyfind(<<"Bundle-Map">>, 1, Item#tx.tags) of
-        {<<"Bundle-Map">>, _} ->
-            case lists:keyfind(<<"Map-Format">>, 1, Item#tx.tags) of
-                {<<"Map-Format">>, <<"List">>} -> list;
+    lists:keyfind(<<"bundle-map">>, 1, Item#tx.tags),
+    case lists:keyfind(<<"bundle-map">>, 1, Item#tx.tags) of
+        {<<"bundle-map">>, _} ->
+            case lists:keyfind(<<"map-format">>, 1, Item#tx.tags) of
+                {<<"map-format">>, <<"list">>} -> list;
                 _ -> map
             end;
         _ ->
@@ -525,11 +525,11 @@ add_list_tags(Tags) ->
 add_manifest_tags(Tags, ManifestID) ->
     lists:filter(
         fun
-            ({<<"Bundle-Map">>, _}) -> false;
+            ({<<"bundle-map">>, _}) -> false;
             (_) -> true
         end,
         Tags
-    ) ++ [{<<"Bundle-Map">>, hb_util:encode(ManifestID)}].
+    ) ++ [{<<"bundle-map">>, hb_util:encode(ManifestID)}].
 
 finalize_bundle_data(Processed) ->
     Length = <<(length(Processed)):256/integer>>,
@@ -562,8 +562,8 @@ new_manifest(Index) ->
     TX = normalize(#tx{
         format = ans104,
         tags = [
-            {<<"Data-Protocol">>, <<"Bundle-Map">>},
-            {<<"Variant">>, <<"0.0.1">>}
+            {<<"data-protocol">>, <<"bundle-map">>},
+            {<<"variant">>, <<"0.0.1">>}
         ],
         data = jiffy:encode(Index)
     }),
@@ -691,18 +691,18 @@ deserialize(Bin, json) ->
     end.
 
 maybe_unbundle(Item) ->
-    Format = lists:keyfind(<<"Bundle-Format">>, 1, Item#tx.tags),
-    Version = lists:keyfind(<<"Bundle-Version">>, 1, Item#tx.tags),
+    Format = lists:keyfind(<<"bundle-format">>, 1, Item#tx.tags),
+    Version = lists:keyfind(<<"bundle-version">>, 1, Item#tx.tags),
     case {Format, Version} of
-        {{<<"Bundle-Format">>, <<"Binary">>}, {<<"Bundle-Version">>, <<"2.0.0">>}} ->
+        {{<<"bundle-format">>, <<"Binary">>}, {<<"bundle-version">>, <<"2.0.0">>}} ->
             maybe_map_to_list(maybe_unbundle_map(Item));
         _ ->
             Item
     end.
 
 maybe_map_to_list(Item) ->
-    case lists:keyfind(<<"Map-Format">>, 1, Item#tx.tags) of
-        {<<"Map-Format">>, <<"List">>} ->
+    case lists:keyfind(<<"map-format">>, 1, Item#tx.tags) of
+        {<<"map-format">>, <<"List">>} ->
             unbundle_list(Item);
         _ ->
             Item
@@ -720,8 +720,8 @@ unbundle_list(Item) ->
     }.
 
 maybe_unbundle_map(Bundle) ->
-    case lists:keyfind(<<"Bundle-Map">>, 1, Bundle#tx.tags) of
-        {<<"Bundle-Map">>, MapTXID} ->
+    case lists:keyfind(<<"bundle-map">>, 1, Bundle#tx.tags) of
+        {<<"bundle-map">>, MapTXID} ->
             case unbundle(Bundle) of
                 detached -> Bundle#tx { data = detached };
                 Items ->
@@ -793,6 +793,7 @@ item_to_json_struct(
     }
 ) ->
     % Set "From" if From-Process is Tag or set with "Owner" address
+    ?event(debug, {invoked_item_to_json_struct, {tags, Tags}, {owner, Owner}, {data, Data}}),
     From =
         case lists:filter(fun({Name, _}) -> Name =:= <<"From-Process">> end, Tags) of
             [{_, FromProcess}] -> FromProcess;

--- a/src/ar_http.erl
+++ b/src/ar_http.erl
@@ -103,7 +103,7 @@ init(Opts) ->
 		{help, "The total amount of bytes posted via HTTP, per remote endpoint"},
 		{labels, [route]}
 	]),
-    ?event(debug, started),
+    ?event(started),
 	{ok, #state{ opts = Opts }}.
 
 handle_call({get_connection, Args}, From,

--- a/src/ar_http.erl
+++ b/src/ar_http.erl
@@ -400,8 +400,8 @@ await_response(Args, Opts) ->
                                 Opts
                             );
 						false ->
-							log(err, http_fetched_too_much_data, Args,
-									<<"Fetched too much data">>, Opts),
+							?event(error, {http_fetched_too_much_data, Args,
+									<<"Fetched too much data">>, Opts}),
 							{error, too_much_data}
 					end
 			end;

--- a/src/ar_rate_limiter.erl
+++ b/src/ar_rate_limiter.erl
@@ -87,7 +87,7 @@ handle_cast({throttle, Peer, Path, From}, State) ->
 			%% Try to approach but not hit the limit.
 			case N2 + 1 > max(1, HalfLimit * 80 / 100) of
 				true ->
-					?event(debug,
+					?event(
                         {approaching_peer_rpm_limit,
                             {peer, Peer},
                             {path, Path},

--- a/src/dev_cron.erl
+++ b/src/dev_cron.erl
@@ -12,8 +12,8 @@
 }).
 
 init(State = #{ process := ProcM }, Params) ->
-    case lists:keyfind(<<"Time">>, 1, Params) of
-        {<<"Time">>, CronTime} ->
+    case lists:keyfind(<<"time">>, 1, Params) of
+        {<<"time">>, CronTime} ->
             MilliSecs = parse_time(CronTime),
             %% TODO: What's the most sensible way to initialize the last_run?
             %% Current behavior: Timer starts after _first_ message.
@@ -57,8 +57,8 @@ execute(_, S) ->
 
 timestamp(M) ->
     % TODO: Process this properly
-    case lists:keyfind(<<"Timestamp">>, 1, M#tx.tags) of
-        {<<"Timestamp">>, TSBin} ->
+    case lists:keyfind(<<"timestamp">>, 1, M#tx.tags) of
+        {<<"timestamp">>, TSBin} ->
             list_to_integer(binary_to_list(TSBin));
         false ->
             0
@@ -67,8 +67,8 @@ timestamp(M) ->
 create_cron(_State, CronTime) ->
     #tx{
         tags = [
-            {<<"Action">>, <<"Cron">>},
-            {<<"Timestamp">>, list_to_binary(integer_to_list(CronTime))}
+            {<<"action">>, <<"Cron">>},
+            {<<"timestamp">>, list_to_binary(integer_to_list(CronTime))}
         ]
     }.
 

--- a/src/dev_cron.erl
+++ b/src/dev_cron.erl
@@ -67,8 +67,8 @@ timestamp(M) ->
 create_cron(_State, CronTime) ->
     #tx{
         tags = [
-            {<<"action">>, <<"Cron">>},
-            {<<"timestamp">>, list_to_binary(integer_to_list(CronTime))}
+            {<<"Action">>, <<"Cron">>},
+            {<<"Timestamp">>, list_to_binary(integer_to_list(CronTime))}
         ]
     }.
 

--- a/src/dev_cu.erl
+++ b/src/dev_cu.erl
@@ -25,15 +25,15 @@ execute(CarrierMsg, S) ->
     Wallet = hb:wallet(),
     {ok, Results} =
         case MaybeBundle of
-            #tx{data = #{ <<"Message">> := _Msg, <<"Assignment">> := Assignment }} ->
+            #tx{data = #{ <<"message">> := _Msg, <<"assignment">> := Assignment }} ->
                 % TODO: Execute without needing to call the SU unnecessarily.
-                {_, ProcID} = lists:keyfind(<<"Process">>, 1, Assignment#tx.tags),
+                {_, ProcID} = lists:keyfind(<<"process">>, 1, Assignment#tx.tags),
                 ?event({dev_cu_computing_from_full_assignment, {process, ProcID}, {slot, hb_util:id(Assignment, signed)}}),
                 hb_process:result(ProcID, hb_util:id(Assignment, signed), Store, Wallet);
             _ ->
-                case lists:keyfind(<<"Process">>, 1, CarrierMsg#tx.tags) of
+                case lists:keyfind(<<"process">>, 1, CarrierMsg#tx.tags) of
                     {_, Process} ->
-                        {_, Slot} = lists:keyfind(<<"Slot">>, 1, CarrierMsg#tx.tags),
+                        {_, Slot} = lists:keyfind(<<"slot">>, 1, CarrierMsg#tx.tags),
                         ?event({dev_cu_computing_from_slot_ref, {process, Process}, {slot, Slot}}),
                         hb_process:result(Process, Slot, Store, Wallet);
                     false ->
@@ -41,7 +41,7 @@ execute(CarrierMsg, S) ->
                 end
         end,
     {ResType, ModState = #{ results := _ModResults }} =
-        case lists:keyfind(<<"Attest-To">>, 1, CarrierMsg#tx.tags) of
+        case lists:keyfind(<<"attest-to">>, 1, CarrierMsg#tx.tags) of
             {_, RawAttestTo} ->
                 AttestTo = hb_util:decode(RawAttestTo),
                 ?event({attest_to_only_message, RawAttestTo}),
@@ -52,7 +52,7 @@ execute(CarrierMsg, S) ->
                             S#{
                                 results =>
                                     #tx {
-                                        tags = [{<<"Status">>, <<"404">>}],
+                                        tags = [{<<"status">>, <<"404">>}],
                                         data = <<"Requested message to attest to not in results bundle.">>
                                     }
                             }
@@ -63,8 +63,8 @@ execute(CarrierMsg, S) ->
                             results => ar_bundles:sign_item(
                                 #tx {
                                     tags = [
-                                        {<<"Status">>, <<"200">>},
-                                        {<<"Attestation-For">>, RawAttestTo}
+                                        {<<"status">>, <<"200">>},
+                                        {<<"attestation-for">>, RawAttestTo}
                                     ],
                                     data = <<>>
                                 },

--- a/src/dev_cu.erl
+++ b/src/dev_cu.erl
@@ -52,7 +52,7 @@ execute(CarrierMsg, S) ->
                             S#{
                                 results =>
                                     #tx {
-                                        tags = [{<<"status">>, <<"404">>}],
+                                        tags = [{<<"status-code">>, 404}],
                                         data = <<"Requested message to attest to not in results bundle.">>
                                     }
                             }
@@ -63,7 +63,7 @@ execute(CarrierMsg, S) ->
                             results => ar_bundles:sign_item(
                                 #tx {
                                     tags = [
-                                        {<<"status">>, <<"200">>},
+                                        {<<"status-code">>, 200},
                                         {<<"attestation-for">>, RawAttestTo}
                                     ],
                                     data = <<>>

--- a/src/dev_dedup.erl
+++ b/src/dev_dedup.erl
@@ -47,6 +47,7 @@ handle(Key, M1, M2, Opts) ->
 %%% Tests
 
 dedup_test() ->
+    hb:init(),
     % Create a stack with a dedup device and 2 devices that will append to a
     % `Result` key.
 	Msg = #{
@@ -60,11 +61,15 @@ dedup_test() ->
 		<<"result">> => <<"INIT">>
 	},
     % Send the same message twice, with the same binary.
-    {ok, Msg2} = hb_converge:resolve(Msg, #{ path => append, bin => <<"_">> }, #{}),
-    {ok, Msg3} = hb_converge:resolve(Msg2, #{ path => append, bin => <<"_">> }, #{}),
+    {ok, Msg2} = hb_converge:resolve(Msg,
+        #{ <<"path">> => <<"append">>, <<"bin">> => <<"_">> }, #{}),
+    {ok, Msg3} = hb_converge:resolve(Msg2,
+        #{ <<"path">> => <<"append">>, <<"bin">> => <<"_">> }, #{}),
     % Send the same message twice, with another binary.
-    {ok, Msg4} = hb_converge:resolve(Msg3, #{ path => append, bin => <<"/">> }, #{}),
-    {ok, Msg5} = hb_converge:resolve(Msg4, #{ path => append, bin => <<"/">> }, #{}),
+    {ok, Msg4} = hb_converge:resolve(Msg3,
+        #{ <<"path">> => <<"append">>, <<"bin">> => <<"/">> }, #{}),
+    {ok, Msg5} = hb_converge:resolve(Msg4,
+        #{ <<"path">> => <<"append">>, <<"bin">> => <<"/">> }, #{}),
     % Ensure that downstream devices have only seen each message once.
     ?assertMatch(
 		#{ <<"result">> := <<"INIT+D2_+D3_+D2/+D3/">> },
@@ -89,11 +94,11 @@ dedup_with_multipass_test() ->
         <<"passes">> => 2
 	},
     % Send the same message twice, with the same binary.
-    {ok, Msg2} = hb_converge:resolve(Msg, #{ path => append, bin => <<"_">> }, #{}),
-    {ok, Msg3} = hb_converge:resolve(Msg2, #{ path => append, bin => <<"_">> }, #{}),
+    {ok, Msg2} = hb_converge:resolve(Msg, #{ <<"path">> => <<"append">>, <<"bin">> => <<"_">> }, #{}),
+    {ok, Msg3} = hb_converge:resolve(Msg2, #{ <<"path">> => <<"append">>, <<"bin">> => <<"_">> }, #{}),
     % Send the same message twice, with another binary.
-    {ok, Msg4} = hb_converge:resolve(Msg3, #{ path => append, bin => <<"/">> }, #{}),
-    {ok, Msg5} = hb_converge:resolve(Msg4, #{ path => append, bin => <<"/">> }, #{}),
+    {ok, Msg4} = hb_converge:resolve(Msg3, #{ <<"path">> => <<"append">>, <<"bin">> => <<"/">> }, #{}),
+    {ok, Msg5} = hb_converge:resolve(Msg4, #{ <<"path">> => <<"append">>, <<"bin">> => <<"/">> }, #{}),
     % Ensure that downstream devices have only seen each message once.
     ?assertMatch(
 		#{ result := <<"INIT+D2_+D3_+D2_+D3_+D2/+D3/+D2/+D3/">> },

--- a/src/dev_dedup.erl
+++ b/src/dev_dedup.erl
@@ -15,9 +15,9 @@ info(M1) ->
 
 %% @doc Forward the keys function to the message device, handle all others
 %% with deduplication. We only act on the first pass.
-handle(keys, M1, _M2, _Opts) ->
+handle(<<"keys">>, M1, _M2, _Opts) ->
     dev_message:keys(M1);
-handle(set, M1, M2, Opts) ->
+handle(<<"set">>, M1, M2, Opts) ->
     dev_message:set(M1, M2, Opts);
 handle(Key, M1, M2, Opts) ->
     ?event({dedup_handle, {key, Key}, {msg1, M1}, {msg2, M2}}),

--- a/src/dev_dedup.erl
+++ b/src/dev_dedup.erl
@@ -21,10 +21,10 @@ handle(set, M1, M2, Opts) ->
     dev_message:set(M1, M2, Opts);
 handle(Key, M1, M2, Opts) ->
     ?event({dedup_handle, {key, Key}, {msg1, M1}, {msg2, M2}}),
-    case hb_converge:get(<<"Pass">>, {as, dev_message, M1}, 1, Opts) of
+    case hb_converge:get(<<"pass">>, {as, dev_message, M1}, 1, Opts) of
         1 ->
             Msg2ID = hb_converge:get(<<"id">>, M2, Opts),
-            Dedup = hb_converge:get(<<"Dedup">>, {as, dev_message, M1}, [], Opts),
+            Dedup = hb_converge:get(<<"dedup">>, {as, dev_message, M1}, [], Opts),
             ?event({dedup_checking, {existing, Dedup}}),
             case lists:member(Msg2ID, Dedup) of
                 true ->
@@ -34,7 +34,7 @@ handle(Key, M1, M2, Opts) ->
                     ?event({not_seen, Msg2ID}),
                     M3 = hb_converge:set(
                         M1,
-                        #{ <<"Dedup">> => [Msg2ID|Dedup] }
+                        #{ <<"dedup">> => [Msg2ID|Dedup] }
                     ),
                     ?event({dedup_updated, M3}),
                     {ok, M3}
@@ -50,14 +50,14 @@ dedup_test() ->
     % Create a stack with a dedup device and 2 devices that will append to a
     % `Result` key.
 	Msg = #{
-		device => <<"Stack/1.0">>,
-		<<"Device-Stack">> =>
+		<<"device">> => <<"Stack/1.0">>,
+		<<"device-stack">> =>
 			#{
 				<<"1">> => <<"Dedup/1.0">>,
 				<<"2">> => dev_stack:generate_append_device(<<"+D2">>),
 				<<"3">> => dev_stack:generate_append_device(<<"+D3">>)
 			},
-		result => <<"INIT">>
+		<<"result">> => <<"INIT">>
 	},
     % Send the same message twice, with the same binary.
     {ok, Msg2} = hb_converge:resolve(Msg, #{ path => append, bin => <<"_">> }, #{}),
@@ -67,7 +67,7 @@ dedup_test() ->
     {ok, Msg5} = hb_converge:resolve(Msg4, #{ path => append, bin => <<"/">> }, #{}),
     % Ensure that downstream devices have only seen each message once.
     ?assertMatch(
-		#{ result := <<"INIT+D2_+D3_+D2/+D3/">> },
+		#{ <<"result">> := <<"INIT+D2_+D3_+D2/+D3/">> },
 		Msg5
 	).
 
@@ -77,16 +77,16 @@ dedup_with_multipass_test() ->
     % an additional pass. We want to ensure that Multipass is not hindered by
     % the dedup device.
 	Msg = #{
-		device => <<"Stack/1.0">>,
-		<<"Device-Stack">> =>
+		<<"device">> => <<"Stack/1.0">>,
+		<<"device-stack">> =>
 			#{
 				<<"1">> => <<"Dedup/1.0">>,
 				<<"2">> => dev_stack:generate_append_device(<<"+D2">>),
 				<<"3">> => dev_stack:generate_append_device(<<"+D3">>),
                 <<"4">> => <<"Multipass/1.0">>
 			},
-		result => <<"INIT">>,
-        <<"Passes">> => 2
+		<<"result">> => <<"INIT">>,
+        <<"passes">> => 2
 	},
     % Send the same message twice, with the same binary.
     {ok, Msg2} = hb_converge:resolve(Msg, #{ path => append, bin => <<"_">> }, #{}),

--- a/src/dev_dedup.erl
+++ b/src/dev_dedup.erl
@@ -101,6 +101,6 @@ dedup_with_multipass_test() ->
     {ok, Msg5} = hb_converge:resolve(Msg4, #{ <<"path">> => <<"append">>, <<"bin">> => <<"/">> }, #{}),
     % Ensure that downstream devices have only seen each message once.
     ?assertMatch(
-		#{ result := <<"INIT+D2_+D3_+D2_+D3_+D2/+D3/+D2/+D3/">> },
+		#{ <<"result">> := <<"INIT+D2_+D3_+D2_+D3_+D2/+D3/+D2/+D3/">> },
 		Msg5
 	).

--- a/src/dev_json_iface.erl
+++ b/src/dev_json_iface.erl
@@ -104,7 +104,7 @@ results(M1, _M2, Opts) ->
     Instance = hb_private:get(<<"priv/WASM/Instance">>, M1, Opts),
     Type = hb_converge:get(<<"Results/WASM/Type">>, M1, Opts),
     Proc = hb_converge:get(<<"Process">>, M1, Opts),
-    case hb_converge:to_key(Type) of
+    case hb_converge:normalize_key(Type) of
         error ->
             {error,
                 hb_converge:set(
@@ -139,7 +139,7 @@ results(M1, _M2, Opts) ->
                                                 Messages
                                             )
                                     ]),
-                                <<"Results/Data">> => Data
+                                <<"Results/data">> => Data
                             },
                             Opts
                         ),
@@ -187,7 +187,7 @@ preprocess_results(Msg, Proc, Opts) ->
         maps:from_list(
             lists:map(
                 fun({Key, Value}) ->
-                    {hb_converge:to_key(Key), Value}
+                    {hb_converge:normalize_key(Key), Value}
                 end,
                 maps:to_list(FilteredMsg)
             )
@@ -256,7 +256,7 @@ basic_aos_call_test() ->
             generate_aos_msg(ProcID, <<"return 1+1">>),
             #{}
         ),
-    Data = hb_converge:get(<<"Results/Data">>, Msg3, #{}),
+    Data = hb_converge:get(<<"Results/data">>, Msg3, #{}),
     ?assertEqual(<<"2">>, Data).
 
 aos_stack_benchmark_test_() ->

--- a/src/dev_lookup.erl
+++ b/src/dev_lookup.erl
@@ -8,6 +8,6 @@ read(#tx { tags = Tags }) ->
     % Note: Use the local store -- do not attempt to reach remotely.
     % hb_cache:read should return {ok, Val} or an error tuple, so we can return
     % the value directly.
-    {<<"Subpath">>, Subpath} = lists:keyfind(<<"Subpath">>, 1, Tags),
+    {<<"subpath">>, Subpath} = lists:keyfind(<<"subpath">>, 1, Tags),
     ?event({looking_up_for_remote_peer, Subpath}),
     hb_cache:read_message(hb_store:scope(hb_opts:get(store), local), Subpath).

--- a/src/dev_messenger.erl
+++ b/src/dev_messenger.erl
@@ -30,7 +30,7 @@
 %%%                 response message received from the remote HTTP server to
 %%%                 its own output message.
 %%% Messenger-Keys: A list of the keys for which the messenger device should
-%%%                 be active. Default: [<<"Push">>].
+%%%                 be active. Default: [<<"push">>].
 %%%         Report: Determines whether the results of the message pushing 
 %%%                 should be reported in the resulting output, and if set,
 %%%                 to which subpath.
@@ -44,13 +44,13 @@
 push(M1, M2, Opts) ->
     Prefix =
         hb_converge:get(
-            <<"Input-Prefix">>,
+            <<"input-prefix">>,
             {as, dev_message, M1},
             <<>>,
             Opts
         ),
     ShouldReport =
-        hb_converge:get(<< Prefix/binary, "/Report">>, M1, false, Opts),
+        hb_converge:get(<< Prefix/binary, "/report">>, M1, false, Opts),
     case ShouldReport of
         false ->
             % We do not need to report our progress, so we can spawn a new
@@ -68,13 +68,13 @@ push(M1, M2, Opts) ->
     end.
 
 dispatch(Msg1, Msg2, Opts) ->
-    case hb_converge:get(<<"Target">>, Msg2, Opts) of
+    case hb_converge:get(<<"target">>, Msg2, Opts) of
         not_found ->
             ?event({uploading_to_arweave_as_no_target_set, Msg2}),
             hb_client:upload(Msg2);
         Target = << "http", _/binary >> ->
             ?event({posting_to_http, Target, Msg2}),
-            M1Allowed = hb_converge:get(<<"Allow-URLs">>, Msg1, Opts),
+            M1Allowed = hb_converge:get(<<"allow-urls">>, Msg1, Opts),
             OptsAllowed = hb_opts:get(allow_urls, false, Opts),
             case {M1Allowed, OptsAllowed} of
                 {A1, A2} when (not A1) or (A2 == false) ->
@@ -99,7 +99,7 @@ dispatch(Msg1, Msg2, Opts) ->
                     ?event({sending_to_http, Target, Msg2}),
                     case Admissable of
                         true ->
-                            case hb_converge:get(<<"Method">>, Msg2, Opts) of
+                            case hb_converge:get(<<"method">>, Msg2, Opts) of
                                 <<"POST">> -> hb_http:post(Target, Msg2);
                                 _ -> hb_http:get(Target, Msg2)
                             end;
@@ -111,11 +111,11 @@ dispatch(Msg1, Msg2, Opts) ->
                 {pushing_to_target, Target, hb_path:from_message(hashpath, Msg1)}
             ),
             {ok, Downstream} = hb_converge:resolve(
-                #{ path => <<Target, "/Push">> },
+                #{ path => <<Target, "/push">> },
                 Opts
             ),
             #{
-                <<"Target">> => Target,
-                <<"Resulted-In">> => Downstream
+                <<"target">> => Target,
+                <<"resulted-in">> => Downstream
             }
     end.

--- a/src/dev_messenger.erl
+++ b/src/dev_messenger.erl
@@ -111,7 +111,7 @@ dispatch(Msg1, Msg2, Opts) ->
                 {pushing_to_target, Target, hb_path:from_message(hashpath, Msg1)}
             ),
             {ok, Downstream} = hb_converge:resolve(
-                #{ path => <<Target, "/push">> },
+                #{ <<"path">> => <<Target, "/push">> },
                 Opts
             ),
             #{

--- a/src/dev_messenger.erl
+++ b/src/dev_messenger.erl
@@ -22,7 +22,7 @@
 %%%                 `Value` time period, pushing the resulting messages as
 %%%                 in other modes. Default: Not set.
 %%% 
-%%%    Allow-URLs:  Whether messages for which the `Target` is a centralized
+%%%    allow-URLs:  Whether messages for which the `Target` is a centralized
 %%%                 web location (a fully-qualified IP/FDQN address) should be
 %%%                 honored (`True`) or ignored (`False`) by the messenger. 
 %%%                 If set to `True`, the device will relay messages as given

--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -10,9 +10,9 @@
 %% with a `Meta` key are routed to the `handle_meta/2` function, while all
 %% other messages are routed to the `handle_converge/2` function.
 handle(NodeMsg, RawRequest) ->
-    ?event(debug, #{ request => RawRequest }),
+    ?event(RawRequest),
     NormRequest = hb_singleton:from(RawRequest),
-    ?event(debug, {processing_messages, NormRequest}),
+    ?event({processing_messages, NormRequest}),
     case is_meta_request(NormRequest) of
         true -> handle_meta(NormRequest, NodeMsg);
         false -> handle_converge(NormRequest, NodeMsg)
@@ -61,7 +61,7 @@ handle_converge(Request, NodeMsg) ->
                         NodeMsg#{ force_message => true }
                     )
                 ),
-            ?event(debug, {res, Res}),
+            ?event({res, Res}),
             % Apply the post-processor to the result.
             embed_status(
                 resolve_processor(

--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -56,7 +56,7 @@ handle_converge(Request, NodeMsg) ->
             % Resolve the request message.
             {ok, Res} =
                 embed_status(
-                    hb_converge:resolve(
+                    hb_converge:resolve_many(
                         PreProcMsg,
                         NodeMsg#{ force_message => true }
                     )

--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -20,7 +20,7 @@ handle(NodeMsg, RawRequest) ->
 
 %% @doc Handle a potential list of messages, checking if the first message
 %% has a path of `Meta`.
-is_meta_request([PrimaryMsg | _]) -> hb_path:hd(PrimaryMsg, #{}) == <<"Meta">>;
+is_meta_request([PrimaryMsg | _]) -> hb_path:hd(PrimaryMsg, #{}) == <<"meta">>;
 is_meta_request(_) -> false.
 
 %% @doc Get/set the node message based on the request method. If the request

--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -87,4 +87,4 @@ resolve_processor(Processor, Request, NodeMsg) ->
 
 %% @doc Wrap the result of a device call in a status.
 embed_status({Status, Res}) ->
-    {ok, Res#{ <<"Status-Code">> => hb_http:status_code(Status) }}.
+    {ok, Res#{ <<"status-code">> => hb_http:status_code(Status) }}.

--- a/src/dev_mu.erl
+++ b/src/dev_mu.erl
@@ -46,7 +46,7 @@ push(CarrierMsg, State) ->
             ),
             % TODO: Implement trace waiting.
             ResTX = ar_bundles:sign_item(
-                #tx{ tags = [{<<"Status">>, <<"200">>}]},
+                #tx{ tags = [{<<"status">>, <<"200">>}]},
                 hb:wallet()),
             {ok, #{ results => ResTX }}
         %false ->
@@ -110,9 +110,9 @@ push_messages(attest, Assignments, #{ logger := Logger }) ->
 handle_push_result(Results, Opts = #{ depth := Depth }) ->
     % Second pass: We have the results, so we can fork the messages/spawns/...
     Res = #result{
-        messages = maps:get(<<"/Outbox">>, Results, #{}),
-        assignments = maps:get(<<"/Assignment">>, Results, #{}),
-        spawns = maps:get(<<"/Spawn">>, Results, #{})
+        messages = maps:get(<<"/outbox">>, Results, #{}),
+        assignments = maps:get(<<"/assignment">>, Results, #{}),
+        spawns = maps:get(<<"/spawn">>, Results, #{})
     },
     ?event({push_recursing,
         {depth, Depth},

--- a/src/dev_mu.erl
+++ b/src/dev_mu.erl
@@ -46,7 +46,7 @@ push(CarrierMsg, State) ->
             ),
             % TODO: Implement trace waiting.
             ResTX = ar_bundles:sign_item(
-                #tx{ tags = [{<<"status">>, <<"200">>}]},
+                #tx{ tags = [{<<"status-code">>, <<"200">>}]},
                 hb:wallet()),
             {ok, #{ results => ResTX }}
         %false ->

--- a/src/dev_multipass.erl
+++ b/src/dev_multipass.erl
@@ -17,8 +17,8 @@ handle(keys, M1, _M2, _Opts) ->
 handle(set, M1, M2, Opts) ->
     dev_message:set(M1, M2, Opts);
 handle(_Key, M1, _M2, Opts) ->
-    Passes = hb_converge:get(<<"Passes">>, {as, dev_message, M1}, 1, Opts),
-    Pass = hb_converge:get(<<"Pass">>, {as, dev_message, M1}, 1, Opts),
+    Passes = hb_converge:get(<<"passes">>, {as, dev_message, M1}, 1, Opts),
+    Pass = hb_converge:get(<<"pass">>, {as, dev_message, M1}, 1, Opts),
     case Pass < Passes of
         true -> {pass, M1};
         false -> {ok, M1}
@@ -30,9 +30,9 @@ basic_multipass_test() ->
     Msg1 =
         #{
             <<"device">> => <<"Multipass/1.0">>,
-            <<"Passes">> => 2,
-            <<"Pass">> => 1
+            <<"passes">> => 2,
+            <<"pass">> => 1
         },
-    Msg2 = Msg1#{ <<"Pass">> => 2 },
+    Msg2 = Msg1#{ <<"pass">> => 2 },
     ?assertMatch({pass, _}, hb_converge:resolve(Msg1, <<"Compute">>, #{})),
     ?assertMatch({ok, _}, hb_converge:resolve(Msg2, <<"Compute">>, #{})).

--- a/src/dev_multipass.erl
+++ b/src/dev_multipass.erl
@@ -3,6 +3,7 @@
 %%% execution passes to be completed in sequence across devices.
 -module(dev_multipass).
 -export([info/1]).
+-include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 info(_M1) ->
@@ -12,9 +13,9 @@ info(_M1) ->
 
 %% @doc Forward the keys function to the message device, handle all others
 %% with deduplication. We only act on the first pass.
-handle(keys, M1, _M2, _Opts) ->
+handle(<<"keys">>, M1, _M2, _Opts) ->
     dev_message:keys(M1);
-handle(set, M1, M2, Opts) ->
+handle(<<"set">>, M1, M2, Opts) ->
     dev_message:set(M1, M2, Opts);
 handle(_Key, M1, _M2, Opts) ->
     Passes = hb_converge:get(<<"passes">>, {as, dev_message, M1}, 1, Opts),
@@ -35,4 +36,5 @@ basic_multipass_test() ->
         },
     Msg2 = Msg1#{ <<"pass">> => 2 },
     ?assertMatch({pass, _}, hb_converge:resolve(Msg1, <<"Compute">>, #{})),
+    ?event(alive),
     ?assertMatch({ok, _}, hb_converge:resolve(Msg2, <<"Compute">>, #{})).

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -70,21 +70,21 @@ info(_Msg1) ->
 
 %% @doc Wraps functions in the Scheduler device.
 schedule(Msg1, Msg2, Opts) ->
-    run_as(<<"Scheduler">>, Msg1, Msg2, Opts).
+    run_as(<<"scheduler">>, Msg1, Msg2, Opts).
 
 slot(Msg1, Msg2, Opts) ->
     ?event({slot_called, {msg1, Msg1}, {msg2, Msg2}, {opts, Opts}}),
-    run_as(<<"Scheduler">>, Msg1, Msg2, Opts).
+    run_as(<<"scheduler">>, Msg1, Msg2, Opts).
 
 next(Msg1, _Msg2, Opts) ->
-    run_as(<<"Scheduler">>, Msg1, next, Opts).
+    run_as(<<"scheduler">>, Msg1, next, Opts).
 
 snapshot(RawMsg1, _Msg2, Opts) ->
     Msg1 = ensure_process_key(RawMsg1, Opts),
     {ok, SnapshotMsg} = run_as(
         <<"Execution">>,
         Msg1,
-        #{ path => <<"Snapshot">>, <<"Mode">> => <<"Map">> },
+        #{ <<"path">> => <<"Snapshot">>, <<"mode">> => <<"Map">> },
         Opts#{ cache_control => [] }
     ),
     ProcID = hb_converge:get(<<"id">>, Msg1, Opts),
@@ -93,10 +93,10 @@ snapshot(RawMsg1, _Msg2, Opts) ->
         hb_private:set(
             hb_converge:set(
                 SnapshotMsg,
-                #{ <<"Cache-Control">> => [<<"store">>] },
+                #{ <<"cache-control">> => [<<"store">>] },
                 Opts
             ),
-            #{ <<"priv/Additional-Hashpaths">> =>
+            #{ <<"priv/additional-hashpaths">> =>
                     [
                         hb_path:to_binary([ProcID, <<"Snapshot">>, Slot])
                     ]
@@ -113,14 +113,14 @@ snapshot(RawMsg1, _Msg2, Opts) ->
 init(Msg1, _Msg2, Opts) ->
     ?event({init_called, {msg1, Msg1}, {opts, Opts}}),
     {ok, Initialized} =
-        run_as(<<"Execution">>, Msg1, #{ path => init }, Opts),
+        run_as(<<"execution">>, Msg1, #{ <<"path">> => init }, Opts),
     {
         ok,
         hb_converge:set(
             Initialized,
             #{
-                <<"Initialized">> => <<"True">>,
-                <<"Current-Slot">> => -1
+                <<"initialized">> => <<"true">>,
+                <<"current-slot">> => -1
             },
             Opts
         )
@@ -138,7 +138,7 @@ compute(Msg1, Msg2, Opts) ->
         ),
     {ok, Normalized} = 
         run_as(
-            <<"Execution">>,
+            <<"execution">>,
             Loaded,
             normalize,
             Opts
@@ -157,7 +157,7 @@ compute(Msg1, Msg2, Opts) ->
 %% we reach the target slot that the user has requested.
 do_compute(ProcID, Msg1, Msg2, TargetSlot, Opts) ->
     ?event({do_compute_called, {target_slot, TargetSlot}, {msg1, Msg1}}),
-    case hb_converge:get(<<"Current-Slot">>, Msg1, Opts) of
+    case hb_converge:get(<<"current-slot">>, Msg1, Opts) of
         CurrentSlot when CurrentSlot > TargetSlot ->
             throw({error, {already_calculated_slot, TargetSlot}});
         CurrentSlot when CurrentSlot == TargetSlot ->
@@ -166,7 +166,7 @@ do_compute(ProcID, Msg1, Msg2, TargetSlot, Opts) ->
             {ok, as_process(Msg1, Opts)};
         CurrentSlot ->
             % Get the next input from the scheduler device.
-            {ok, #{ <<"Message">> := ToProcess, <<"State">> := State }} =
+            {ok, #{ <<"message">> := ToProcess, <<"state">> := State }} =
                 next(Msg1, Msg2, Opts),
             ?event(process_compute,
                 {
@@ -177,7 +177,7 @@ do_compute(ProcID, Msg1, Msg2, TargetSlot, Opts) ->
             ),
             {ok, Msg3} =
                 run_as(
-                    <<"Execution">>,
+                    <<"execution">>,
                     State,
                     ToProcess,
                     Opts
@@ -215,7 +215,7 @@ do_compute(ProcID, Msg1, Msg2, TargetSlot, Opts) ->
                 ProcID,
                 hb_converge:set(
                     Msg3,
-                    #{ <<"Current-Slot">> => CurrentSlot + 1 },
+                    #{ <<"current-slot">> => CurrentSlot + 1 },
                     Opts
                 ),
                 Msg2,
@@ -227,12 +227,12 @@ do_compute(ProcID, Msg1, Msg2, TargetSlot, Opts) ->
 %% @doc Returns the `/Results' key of the latest computed message.
 now(RawMsg1, _Msg2, Opts) ->
     Msg1 = ensure_process_key(RawMsg1, Opts),
-    {ok, CurrentSlot} = hb_converge:resolve(Msg1, #{ path => <<"Slot/Current-Slot">> }, Opts),
-    ProcessID = hb_converge:get(<<"Process/id">>, Msg1, Opts),
+    {ok, CurrentSlot} = hb_converge:resolve(Msg1, #{ <<"path">> => <<"slot/current-slot">> }, Opts),
+    ProcessID = hb_converge:get(<<"process/id">>, Msg1, Opts),
     ?event({now_called, {process, ProcessID}, {slot, CurrentSlot}}),
     hb_converge:resolve(
         Msg1,
-        #{ path => <<"Compute/Results">>, <<"Slot">> => CurrentSlot },
+        #{ <<"path">> => <<"compute/results">>, <<"slot">> => CurrentSlot },
         Opts
     ).
 
@@ -243,7 +243,7 @@ push(Msg1, Msg2, Opts) ->
     PushMsgSlot = hb_converge:get(<<"Slot">>, Msg2, Opts),
     {ok, Outbox} = hb_converge:resolve(
         Msg1,
-        #{ path => <<"Compute/Results/Outbox">>, <<"Slot">> => PushMsgSlot },
+        #{ <<"path">> => <<"compute/results/outbox">>, <<"slot">> => PushMsgSlot },
         Opts#{ spawn_worker => true }
     ),
     case ?IS_EMPTY_MESSAGE(Outbox) of
@@ -252,7 +252,7 @@ push(Msg1, Msg2, Opts) ->
         false ->
             {ok, maps:map(
                 fun(Key, MsgToPush) ->
-                    case hb_converge:get(<<"Target">>, MsgToPush, Opts) of
+                    case hb_converge:get(<<"target">>, MsgToPush, Opts) of
                         not_found ->
                             ?event({skip_no_target, {key, Key}, MsgToPush}),
                             {ok, <<"No Target. Did not push.">>};
@@ -266,9 +266,9 @@ push(Msg1, Msg2, Opts) ->
                             {ok, NextSlotOnProc} = hb_converge:resolve(
                                 Msg1,
                                 #{
-                                    method => <<"POST">>,
-                                    path => <<"Schedule/Slot">>,
-                                    <<"Message">> =>
+                                    <<"method">> => <<"POST">>,
+                                    <<"path">> => <<"schedule/slot">>,
+                                    <<"message">> =>
                                         PushedMsg = hb_message:sign(
                                             MsgToPush,
                                             Wallet
@@ -284,14 +284,14 @@ push(Msg1, Msg2, Opts) ->
                                 }),
                             {ok, Downstream} = hb_converge:resolve(
                                 Msg1,
-                                #{ path => <<"Push">>, <<"Slot">> => NextSlotOnProc },
+                                #{ <<"path">> => <<"push">>, <<"slot">> => NextSlotOnProc },
                                 Opts
                             ),
                             #{
                                 <<"id">> => PushedMsgID,
-                                <<"Target">> => Target,
-                                <<"Slot">> => NextSlotOnProc,
-                                <<"Resulted-In">> => Downstream
+                                <<"target">> => Target,
+                                <<"slot">> => NextSlotOnProc,
+                                <<"resulted-in">> => Downstream
                             }
                     end
                 end,
@@ -303,15 +303,15 @@ push(Msg1, Msg2, Opts) ->
 %% up-to-date.
 ensure_loaded(Msg1, Msg2, Opts) ->
     % Get the nonce we are currently on and the inbound nonce.
-    TargetSlot = hb_converge:get(<<"Slot">>, Msg2, undefined, Opts),
+    TargetSlot = hb_converge:get(<<"slot">>, Msg2, undefined, Opts),
     ProcID = 
-        case hb_converge:get(<<"Process/id">>, {as, dev_message, Msg1}, Opts) of
+        case hb_converge:get(<<"process/id">>, {as, dev_message, Msg1}, Opts) of
             not_found ->
                 hb_converge:get(<<"id">>, Msg1, Opts);
             P -> P
         end,
-    case hb_converge:get(<<"Initialized">>, Msg1, <<"False">>, Opts) of
-        <<"False">> ->
+    case hb_converge:get(<<"initialized">>, Msg1, <<"false">>, Opts) of
+        <<"false">> ->
             % Try to load the latest complete state from disk.
             LoadRes =
                 dev_process_cache:latest(
@@ -333,9 +333,9 @@ ensure_loaded(Msg1, Msg2, Opts) ->
                         hb_converge:set(
                             Msg1,
                             #{
-                                <<"Initialized">> => <<"True">>,
-                                <<"Current-Slot">> => LoadedSlot,
-                                <<"Snapshot">> => SnapshotMsg
+                                <<"initialized">> => <<"true">>,
+                                <<"current-slot">> => LoadedSlot,
+                                <<"snapshot">> => SnapshotMsg
                             },
                             Opts#{ hashpath => ignore }
                         )
@@ -358,7 +358,7 @@ ensure_loaded(Msg1, Msg2, Opts) ->
 %% the device found at `Key'. After execution, the device is swapped back
 %% to the original device if the device is the same as we left it.
 run_as(Key, Msg1, Msg2, Opts) ->
-    BaseDevice = hb_converge:get(<<"Device">>, {as, dev_message, Msg1}, Opts),
+    BaseDevice = hb_converge:get(<<"device">>, {as, dev_message, Msg1}, Opts),
     %?event({running_as, {key, Key}, {msg1, Msg1}, {msg2, Msg2}, {opts, Opts}}),
     {ok, PreparedMsg} =
         dev_message:set(
@@ -366,18 +366,18 @@ run_as(Key, Msg1, Msg2, Opts) ->
             #{
                 device => 
                     DeviceSet = hb_converge:get(
-                        << Key/binary, "-Device">>,
+                        << Key/binary, "-device">>,
                         {as, dev_message, Msg1},
                         Opts
                     ),
-                <<"Input-Prefix">> =>
-                    case hb_converge:get(<<"Input-Prefix">>, Msg1, Opts) of
-                        not_found -> <<"Process">>;
+                <<"input-prefix">> =>
+                    case hb_converge:get(<<"input-prefix">>, Msg1, Opts) of
+                        not_found -> <<"process">>;
                         Prefix -> Prefix
                     end,
-                <<"Output-Prefixes">> =>
+                <<"output-prefixes">> =>
                     hb_converge:get(
-                        <<Key/binary, "-Output-Prefixes">>,
+                        <<Key/binary, "-output-prefixes">>,
                         {as, dev_message, Msg1}, undefined, Opts)
             },
             Opts
@@ -390,8 +390,8 @@ run_as(Key, Msg1, Msg2, Opts) ->
             Opts
         ),
     case BaseResult of
-        #{ device := DeviceSet } ->
-            {ok, hb_converge:set(BaseResult, #{ device => BaseDevice })};
+        #{ <<"device">> := DeviceSet } ->
+            {ok, hb_converge:set(BaseResult, #{ <<"device">> => BaseDevice })};
         _ ->
             ?event({returning_base_result, BaseResult}),
             {ok, BaseResult}
@@ -401,15 +401,15 @@ run_as(Key, Msg1, Msg2, Opts) ->
 %% In situations where the key that is `run_as` returns a message with a 
 %% transformed device, this is useful.
 as_process(Msg1, Opts) ->
-    {ok, Proc} = dev_message:set(Msg1, #{ device => <<"Process/1.0">> }, Opts),
+    {ok, Proc} = dev_message:set(Msg1, #{ <<"device">> => <<"Process/1.0">> }, Opts),
     Proc.
 
 %% @doc Helper function to store a copy of the `process` key in the message.
 ensure_process_key(Msg1, Opts) ->
-    case hb_converge:get(<<"Process">>, {as, dev_message, Msg1}, Opts) of
+    case hb_converge:get(<<"process">>, {as, dev_message, Msg1}, Opts) of
         not_found ->
             hb_converge:set(
-                Msg1, #{ <<"Process">> => Msg1 }, Opts#{ hashpath => ignore });
+                Msg1, #{ <<"process">> => Msg1 }, Opts#{ hashpath => ignore });
         _ -> Msg1
     end.
 
@@ -425,19 +425,19 @@ test_base_process() ->
     Wallet = hb:wallet(),
     Address = hb_util:human_id(ar_wallet:to_address(Wallet)),
     #{
-        device => <<"Process/1.0">>,
-        <<"Scheduler-Device">> => <<"Scheduler/1.0">>,
-        <<"Scheduler-Location">> => Address,
-        <<"Type">> => <<"Process">>,
-        <<"Test-Random-Seed">> => rand:uniform(1337)
+        <<"device">> => <<"Process/1.0">>,
+        <<"scheduler-device">> => <<"Scheduler/1.0">>,
+        <<"scheduler-location">> => Address,
+        <<"type">> => <<"Process">>,
+        <<"test-random-seed">> => rand:uniform(1337)
     }.
 
 test_wasm_process(WASMImage) ->
     #{ image := WASMImageID } = dev_wasm:cache_wasm_image(WASMImage),
     maps:merge(test_base_process(), #{
-        <<"Execution-Device">> => <<"Stack/1.0">>,
-        <<"Device-Stack">> => [<<"WASM-64/1.0">>],
-        <<"Image">> => WASMImageID
+        <<"execution-device">> => <<"Stack/1.0">>,
+        <<"device-stack">> => [<<"WASM-64/1.0">>],
+        <<"image">> => WASMImageID
     }).
 
 %% @doc Generate a process message with a random number, and the 
@@ -446,24 +446,24 @@ test_aos_process() ->
     Wallet = hb:wallet(),
     WASMProc = test_wasm_process(<<"test/aos-2-pure-xs.wasm">>),
     hb_message:sign(maps:merge(WASMProc, #{
-        <<"Device-Stack">> =>
+        <<"device-stack">> =>
             [
                 <<"WASI/1.0">>,
                 <<"JSON-Iface/1.0">>,
                 <<"WASM-64/1.0">>,
                 <<"Multipass/1.0">>
             ],
-        <<"Output-Prefix">> => <<"WASM">>,
-        <<"Passes">> => 2,
-        <<"Stack-Keys">> =>
+        <<"output-prefix">> => <<"WASM">>,
+        <<"passes">> => 2,
+        <<"stack-keys">> =>
             [
-                <<"Init">>,
-                <<"Compute">>,
-                <<"Snapshot">>,
-                <<"Normalize">>
+                <<"init">>,
+                <<"compute">>,
+                <<"snapshot">>,
+                <<"normalize">>
             ],
-        <<"Scheduler">> => hb:address(),
-        <<"Authority">> => hb:address()
+        <<"scheduler">> => hb:address(),
+        <<"authority">> => hb:address()
     }), Wallet).
 
 %% @doc Generate a device that has a stack of two `dev_test's for 
@@ -471,8 +471,8 @@ test_aos_process() ->
 %% `Already-Seen' elements for each assigned slot.
 dev_test_process() ->
     maps:merge(test_base_process(), #{
-        <<"Execution-Device">> => <<"Stack/1.0">>,
-        <<"Device-Stack">> => [<<"Test-Device/1.0">>, <<"Test-Device/1.0">>]
+        <<"execution-device">> => <<"Stack/1.0">>,
+        <<"device-stack">> => [<<"Test-Device/1.0">>, <<"Test-Device/1.0">>]
     }).
 
 schedule_test_message(Msg1, Text) ->
@@ -484,8 +484,8 @@ schedule_test_message(Msg1, Text, MsgBase) ->
         <<"Method">> => <<"POST">>,
         <<"Message">> =>
             MsgBase#{
-                <<"Type">> => <<"Message">>,
-                <<"Test-Label">> => Text
+                <<"type">> => <<"Message">>,
+                <<"test-label">> => Text
             }
     }, Wallet),
     {ok, _} = hb_converge:resolve(Msg1, Msg2, #{}).
@@ -494,9 +494,9 @@ schedule_aos_call(Msg1, Code) ->
     Wallet = hb:wallet(),
     ProcID = hb_converge:get(id, Msg1, #{}),
     Msg2 = hb_message:sign(#{
-        <<"Action">> => <<"Eval">>,
-        data => Code,
-        target => ProcID
+        <<"action">> => <<"Eval">>,
+        <<"data">> => Code,
+        <<"target">> => ProcID
     }, Wallet),
     schedule_test_message(Msg1, <<"TEST MSG">>, Msg2).
 
@@ -506,9 +506,9 @@ schedule_wasm_call(Msg1, FuncName, Params) ->
         <<"Method">> => <<"POST">>,
         <<"Message">> =>
             #{
-                <<"Type">> => <<"Message">>,
-                <<"WASM-Function">> => FuncName,
-                <<"WASM-Params">> => Params
+                <<"type">> => <<"Message">>,
+                <<"wasm-function">> => FuncName,
+                <<"wasm-params">> => Params
             }
     },
     ?assertMatch({ok, _}, hb_converge:resolve(Msg1, Msg2, #{})).
@@ -521,8 +521,8 @@ schedule_on_process_test() ->
     ?event(messages_scheduled),
     {ok, SchedulerRes} =
         hb_converge:resolve(Msg1, #{
-            <<"Method">> => <<"GET">>,
-            path => <<"Schedule">>
+            <<"method">> => <<"GET">>,
+            <<"path">> => <<"Schedule">>
         }, #{}),
     ?assertMatch(
         <<"TEST TEXT 1">>,
@@ -539,8 +539,8 @@ get_scheduler_slot_test() ->
     schedule_test_message(Msg1, <<"TEST TEXT 1">>),
     schedule_test_message(Msg1, <<"TEST TEXT 2">>),
     Msg2 = #{
-        path => <<"Slot">>,
-        <<"Method">> => <<"GET">>
+        <<"path">> => <<"Slot">>,
+        <<"method">> => <<"GET">>
     },
     ?assertMatch(
         {ok, #{ <<"Current-Slot">> := CurrentSlot }} when CurrentSlot > 0,
@@ -554,8 +554,8 @@ recursive_path_resolution_test() ->
     CurrentSlot =
         hb_converge:resolve(
             Msg1,
-            #{ path => <<"Slot/Current-Slot">> },
-            #{ hashpath => ignore }
+            #{ <<"path">> => <<"slot/current-slot">> },
+            #{ <<"hashpath">> => ignore }
         ),
     ?event({resolved_current_slot, CurrentSlot}),
     ?assertMatch(
@@ -574,14 +574,14 @@ test_device_compute_test() ->
         hb_converge:resolve(
             Msg1,
             <<"Schedule/Assignments/1/Message/Test-Label">>,
-            #{ hashpath => ignore }
+            #{ <<"hashpath">> => ignore }
         )
     ),
-    Msg2 = #{ path => <<"Compute">>, <<"Slot">> => 1 },
+    Msg2 = #{ <<"path">> => <<"Compute">>, <<"slot">> => 1 },
     {ok, Msg3} = hb_converge:resolve(Msg1, Msg2, #{}),
     ?event({computed_message, {msg3, Msg3}}),
-    ?assertEqual(1, hb_converge:get(<<"Results/Assignment-Slot">>, Msg3, #{})),
-    ?assertEqual([1,1,0,0], hb_converge:get(<<"Already-Seen">>, Msg3, #{})).
+    ?assertEqual(1, hb_converge:get(<<"results/assignment-slot">>, Msg3, #{})),
+    ?assertEqual([1,1,0,0], hb_converge:get(<<"already-seen">>, Msg3, #{})).
 
 wasm_compute_test() ->
     init(),
@@ -591,19 +591,19 @@ wasm_compute_test() ->
     {ok, Msg3} = 
         hb_converge:resolve(
             Msg1,
-            #{ path => <<"Compute">>, <<"Slot">> => 0 },
-            #{ hashpath => ignore }
+            #{ <<"path">> => <<"Compute">>, <<"slot">> => 0 },
+            #{ <<"hashpath">> => ignore }
         ),
     ?event({computed_message, {msg3, Msg3}}),
-    ?assertEqual([120.0], hb_converge:get(<<"Results/Output">>, Msg3, #{})),
+    ?assertEqual([120.0], hb_converge:get(<<"results/output">>, Msg3, #{})),
     {ok, Msg4} = 
         hb_converge:resolve(
             Msg1,
-            #{ path => <<"Compute">>, <<"Slot">> => 1 },
-            #{ hashpath => ignore }
+            #{ <<"path">> => <<"Compute">>, <<"slot">> => 1 },
+            #{ <<"hashpath">> => ignore }
         ),
     ?event({computed_message, {msg4, Msg4}}),
-    ?assertEqual([720.0], hb_converge:get(<<"Results/Output">>, Msg4, #{})).
+    ?assertEqual([720.0], hb_converge:get(<<"results/output">>, Msg4, #{})).
 
 aos_compute_test_() ->
     {timeout, 30, fun() ->
@@ -611,16 +611,16 @@ aos_compute_test_() ->
         Msg1 = test_aos_process(),
         schedule_aos_call(Msg1, <<"return 1+1">>),
         schedule_aos_call(Msg1, <<"return 2+2">>),
-        Msg2 = #{ path => <<"Compute">>, <<"Slot">> => 0 },
+        Msg2 = #{ <<"path">> => <<"compute">>, <<"slot">> => 0 },
         {ok, Msg3} = hb_converge:resolve(Msg1, Msg2, #{}),
-        {ok, Res} = hb_converge:resolve(Msg3, <<"Results">>, #{}),
+        {ok, Res} = hb_converge:resolve(Msg3, <<"results">>, #{}),
         ?event({computed_message, {msg3, Res}}),
         {ok, Data} = hb_converge:resolve(Res, <<"data">>, #{}),
         ?event({computed_data, Data}),
         ?assertEqual(<<"2">>, Data),
-        Msg4 = #{ path => <<"Compute">>, <<"Slot">> => 1 },
+        Msg4 = #{ <<"path">> => <<"compute">>, <<"slot">> => 1 },
         {ok, Msg5} = hb_converge:resolve(Msg1, Msg4, #{}),
-        ?assertEqual(<<"4">>, hb_converge:get(<<"Results/data">>, Msg5, #{})),
+        ?assertEqual(<<"4">>, hb_converge:get(<<"results/data">>, Msg5, #{})),
         {ok, Msg5}
     end}.
 
@@ -642,17 +642,17 @@ do_test_restore() ->
     {ok, _} =
         hb_converge:resolve(
             Msg1,
-            #{ path => <<"Compute">>, <<"Slot">> => 1 },
+            #{ <<"path">> => <<"compute">>, <<"slot">> => 1 },
             Opts
         ),
     {ok, ResultB} =
         hb_converge:resolve(
             Msg1,
-            #{ path => <<"Compute">>, <<"Slot">> => 2 },
+            #{ <<"path">> => <<"compute">>, <<"slot">> => 2 },
             Opts
         ),
     ?event({result_b, ResultB}),
-    ?assertEqual(<<"1337">>, hb_converge:get(<<"Results/data">>, ResultB, #{})).
+    ?assertEqual(<<"1337">>, hb_converge:get(<<"results/data">>, ResultB, #{})).
 
 now_results_test() ->
     {timeout, 30, fun() ->
@@ -660,7 +660,7 @@ now_results_test() ->
         Msg1 = test_aos_process(),
         schedule_aos_call(Msg1, <<"return 1+1">>),
         schedule_aos_call(Msg1, <<"return 2+2">>),
-        ?assertEqual({ok, <<"4">>}, hb_converge:resolve(Msg1, <<"Now/data">>, #{}))
+        ?assertEqual({ok, <<"4">>}, hb_converge:resolve(Msg1, <<"now/data">>, #{}))
     end}.
 
 full_push_test_() ->
@@ -672,16 +672,16 @@ full_push_test_() ->
         {ok, Msg2} = schedule_aos_call(Msg1, Script),
         ?event({init_sched_result, Msg2}),
         {ok, StartingMsgSlot} =
-            hb_converge:resolve(Msg2, #{ path => <<"Slot">> }, #{}),
+            hb_converge:resolve(Msg2, #{ <<"path">> => <<"slot">> }, #{}),
         Msg3 =
             #{
-                path => <<"Push">>,
-                <<"Slot">> => StartingMsgSlot
+                <<"path">> => <<"push">>,
+                <<"slot">> => StartingMsgSlot
             },
         {ok, _} = hb_converge:resolve(Msg1, Msg3, #{}),
         ?assertEqual(
             {ok, <<"Done.">>},
-            hb_converge:resolve(Msg1, <<"Now/data">>, #{})
+            hb_converge:resolve(Msg1, <<"now/data">>, #{})
         )
     end}.
 
@@ -694,8 +694,8 @@ persistent_process_test() ->
         schedule_aos_call(Msg1, <<"return X">>),
         T0 = hb:now(),
         FirstSlotMsg2 = #{
-            path => <<"Compute">>,
-            <<"Slot">> => 0
+            <<"path">> => <<"compute">>,
+            <<"slot">> => 0
         },
         ?assertMatch(
             {ok, _},
@@ -703,8 +703,8 @@ persistent_process_test() ->
         ),
         T1 = hb:now(),
         ThirdSlotMsg2 = #{
-            path => <<"Compute">>,
-            <<"Slot">> => 2
+            <<"path">> => <<"compute">>,
+            <<"slot">> => 2
         },
         Res = hb_converge:resolve(Msg1, ThirdSlotMsg2, #{}),
         ?event({computed_message, {msg3, Res}}),
@@ -728,8 +728,8 @@ simple_wasm_persistent_worker_benchmark_test() ->
     {ok, Initialized} = 
         hb_converge:resolve(
             Msg1,
-            #{ path => <<"Compute">>, <<"Slot">> => 1 },
-            #{ spawn_worker => true }
+            #{ <<"path">> => <<"compute">>, <<"slot">> => 1 },
+            #{ <<"spawn_worker">> => true }
         ),
     Iterations = hb:benchmark(
         fun(Iteration) ->
@@ -742,7 +742,7 @@ simple_wasm_persistent_worker_benchmark_test() ->
                 {ok, _},
                 hb_converge:resolve(
                     Initialized,
-                    #{ path => <<"Compute">>, <<"Slot">> => Iteration + 1 },
+                    #{ <<"path">> => <<"compute">>, <<"slot">> => Iteration + 1 },
                     #{}
                 )
             )
@@ -764,8 +764,8 @@ aos_persistent_worker_benchmark_test_() ->
         Msg1 = test_aos_process(),
         schedule_aos_call(Msg1, <<"X=1337">>),
         FirstSlotMsg2 = #{
-            path => <<"Compute">>,
-            <<"Slot">> => 0
+            <<"path">> => <<"compute">>,
+            <<"slot">> => 0
         },
         ?assertMatch(
             {ok, _},
@@ -781,7 +781,7 @@ aos_persistent_worker_benchmark_test_() ->
                     {ok, _},
                     hb_converge:resolve(
                         Msg1,
-                        #{ path => <<"Compute">>, <<"Slot">> => Iteration },
+                        #{ <<"path">> => <<"compute">>, <<"slot">> => Iteration },
                         #{}
                     )
                 )

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -351,7 +351,7 @@ ensure_loaded(Msg1, Msg2, Opts) ->
                     ),
                     init(Msg1, Msg2, Opts)
             end;
-        <<"True">> -> {ok, Msg1}
+        <<"true">> -> {ok, Msg1}
     end.
 
 %% @doc Run a message against Msg1, with the device being swapped out for
@@ -453,7 +453,7 @@ test_aos_process() ->
                 <<"WASM-64/1.0">>,
                 <<"Multipass/1.0">>
             ],
-        <<"output-prefix">> => <<"WASM">>,
+        <<"output-prefix">> => <<"wasm">>,
         <<"passes">> => 2,
         <<"stack-keys">> =>
             [

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -84,11 +84,11 @@ snapshot(RawMsg1, _Msg2, Opts) ->
     {ok, SnapshotMsg} = run_as(
         <<"Execution">>,
         Msg1,
-        #{ <<"path">> => <<"Snapshot">>, <<"mode">> => <<"Map">> },
+        #{ <<"path">> => <<"snapshot">>, <<"mode">> => <<"Map">> },
         Opts#{ cache_control => [] }
     ),
     ProcID = hb_converge:get(<<"id">>, Msg1, Opts),
-    Slot = hb_converge:get(<<"Current-Slot">>, Msg1, Opts),
+    Slot = hb_converge:get(<<"current-slot">>, Msg1, Opts),
     {ok,
         hb_private:set(
             hb_converge:set(
@@ -143,13 +143,13 @@ compute(Msg1, Msg2, Opts) ->
             normalize,
             Opts
         ),
-    ProcID = hb_converge:get(<<"Process/id">>, Loaded, Opts),
+    ProcID = hb_converge:get(<<"process/id">>, Loaded, Opts),
     ?event({compute_called, {msg1, Msg1}, {msg2, Msg2}, {opts, Opts}}),
     do_compute(
         ProcID,
         Normalized,
         Msg2,
-        hb_converge:get(<<"Slot">>, Msg2, Opts),
+        hb_converge:get(<<"slot">>, Msg2, Opts),
         Opts
     ).
 
@@ -364,7 +364,7 @@ run_as(Key, Msg1, Msg2, Opts) ->
         dev_message:set(
             ensure_process_key(Msg1, Opts),
             #{
-                device => 
+                <<"device">> => 
                     DeviceSet = hb_converge:get(
                         << Key/binary, "-device">>,
                         {as, dev_message, Msg1},
@@ -433,7 +433,7 @@ test_base_process() ->
     }.
 
 test_wasm_process(WASMImage) ->
-    #{ image := WASMImageID } = dev_wasm:cache_wasm_image(WASMImage),
+    #{ <<"image">> := WASMImageID } = dev_wasm:cache_wasm_image(WASMImage),
     maps:merge(test_base_process(), #{
         <<"execution-device">> => <<"Stack/1.0">>,
         <<"device-stack">> => [<<"WASM-64/1.0">>],
@@ -480,9 +480,9 @@ schedule_test_message(Msg1, Text) ->
 schedule_test_message(Msg1, Text, MsgBase) ->
     Wallet = hb:wallet(),
     Msg2 = hb_message:sign(#{
-        path => <<"Schedule">>,
-        <<"Method">> => <<"POST">>,
-        <<"Message">> =>
+        <<"path">> => <<"schedule">>,
+        <<"method">> => <<"POST">>,
+        <<"message">> =>
             MsgBase#{
                 <<"type">> => <<"Message">>,
                 <<"test-label">> => Text
@@ -492,7 +492,7 @@ schedule_test_message(Msg1, Text, MsgBase) ->
 
 schedule_aos_call(Msg1, Code) ->
     Wallet = hb:wallet(),
-    ProcID = hb_converge:get(id, Msg1, #{}),
+    ProcID = hb_converge:get(<<"id">>, Msg1, #{}),
     Msg2 = hb_message:sign(#{
         <<"action">> => <<"Eval">>,
         <<"data">> => Code,
@@ -502,9 +502,9 @@ schedule_aos_call(Msg1, Code) ->
 
 schedule_wasm_call(Msg1, FuncName, Params) ->
     Msg2 = #{
-        path => <<"Schedule">>,
-        <<"Method">> => <<"POST">>,
-        <<"Message">> =>
+        <<"path">> => <<"schedule">>,
+        <<"method">> => <<"POST">>,
+        <<"message">> =>
             #{
                 <<"type">> => <<"Message">>,
                 <<"wasm-function">> => FuncName,
@@ -522,7 +522,7 @@ schedule_on_process_test() ->
     {ok, SchedulerRes} =
         hb_converge:resolve(Msg1, #{
             <<"method">> => <<"GET">>,
-            <<"path">> => <<"Schedule">>
+            <<"path">> => <<"schedule">>
         }, #{}),
     ?assertMatch(
         <<"TEST TEXT 1">>,
@@ -543,7 +543,7 @@ get_scheduler_slot_test() ->
         <<"method">> => <<"GET">>
     },
     ?assertMatch(
-        {ok, #{ <<"Current-Slot">> := CurrentSlot }} when CurrentSlot > 0,
+        {ok, #{ <<"current-slot">> := CurrentSlot }} when CurrentSlot > 0,
         hb_converge:resolve(Msg1, Msg2, #{})
     ).
 
@@ -573,11 +573,11 @@ test_device_compute_test() ->
         {ok, <<"TEST TEXT 2">>},
         hb_converge:resolve(
             Msg1,
-            <<"Schedule/Assignments/1/Message/Test-Label">>,
+            <<"schedule/assignments/1/message/test-label">>,
             #{ <<"hashpath">> => ignore }
         )
     ),
-    Msg2 = #{ <<"path">> => <<"Compute">>, <<"slot">> => 1 },
+    Msg2 = #{ <<"path">> => <<"compute">>, <<"slot">> => 1 },
     {ok, Msg3} = hb_converge:resolve(Msg1, Msg2, #{}),
     ?event({computed_message, {msg3, Msg3}}),
     ?assertEqual(1, hb_converge:get(<<"results/assignment-slot">>, Msg3, #{})),
@@ -591,7 +591,7 @@ wasm_compute_test() ->
     {ok, Msg3} = 
         hb_converge:resolve(
             Msg1,
-            #{ <<"path">> => <<"Compute">>, <<"slot">> => 0 },
+            #{ <<"path">> => <<"compute">>, <<"slot">> => 0 },
             #{ <<"hashpath">> => ignore }
         ),
     ?event({computed_message, {msg3, Msg3}}),
@@ -599,7 +599,7 @@ wasm_compute_test() ->
     {ok, Msg4} = 
         hb_converge:resolve(
             Msg1,
-            #{ <<"path">> => <<"Compute">>, <<"slot">> => 1 },
+            #{ <<"path">> => <<"compute">>, <<"slot">> => 1 },
             #{ <<"hashpath">> => ignore }
         ),
     ?event({computed_message, {msg4, Msg4}}),

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -615,12 +615,12 @@ aos_compute_test_() ->
         {ok, Msg3} = hb_converge:resolve(Msg1, Msg2, #{}),
         {ok, Res} = hb_converge:resolve(Msg3, <<"Results">>, #{}),
         ?event({computed_message, {msg3, Res}}),
-        {ok, Data} = hb_converge:resolve(Res, <<"Data">>, #{}),
+        {ok, Data} = hb_converge:resolve(Res, <<"data">>, #{}),
         ?event({computed_data, Data}),
         ?assertEqual(<<"2">>, Data),
         Msg4 = #{ path => <<"Compute">>, <<"Slot">> => 1 },
         {ok, Msg5} = hb_converge:resolve(Msg1, Msg4, #{}),
-        ?assertEqual(<<"4">>, hb_converge:get(<<"Results/Data">>, Msg5, #{})),
+        ?assertEqual(<<"4">>, hb_converge:get(<<"Results/data">>, Msg5, #{})),
         {ok, Msg5}
     end}.
 
@@ -652,7 +652,7 @@ do_test_restore() ->
             Opts
         ),
     ?event({result_b, ResultB}),
-    ?assertEqual(<<"1337">>, hb_converge:get(<<"Results/Data">>, ResultB, #{})).
+    ?assertEqual(<<"1337">>, hb_converge:get(<<"Results/data">>, ResultB, #{})).
 
 now_results_test() ->
     {timeout, 30, fun() ->
@@ -660,7 +660,7 @@ now_results_test() ->
         Msg1 = test_aos_process(),
         schedule_aos_call(Msg1, <<"return 1+1">>),
         schedule_aos_call(Msg1, <<"return 2+2">>),
-        ?assertEqual({ok, <<"4">>}, hb_converge:resolve(Msg1, <<"Now/Data">>, #{}))
+        ?assertEqual({ok, <<"4">>}, hb_converge:resolve(Msg1, <<"Now/data">>, #{}))
     end}.
 
 full_push_test_() ->
@@ -681,7 +681,7 @@ full_push_test_() ->
         {ok, _} = hb_converge:resolve(Msg1, Msg3, #{}),
         ?assertEqual(
             {ok, <<"Done.">>},
-            hb_converge:resolve(Msg1, <<"Now/Data">>, #{})
+            hb_converge:resolve(Msg1, <<"Now/data">>, #{})
         )
     end}.
 

--- a/src/dev_process_cache.erl
+++ b/src/dev_process_cache.erl
@@ -42,13 +42,13 @@ path(ProcID, Ref, PathSuffix, Opts) ->
     hb_store:path(
         Store,
         [
-            <<"Computed">>,
+            <<"computed">>,
             hb_util:human_id(ProcID)
         ] ++
         case Ref of
-            Int when is_integer(Int) -> ["Slot", integer_to_binary(Int)];
+            Int when is_integer(Int) -> ["slot", integer_to_binary(Int)];
             root -> [];
-            slot_root -> ["Slot"];
+            slot_root -> ["slot"];
             _ -> [Ref]
         end ++ PathSuffix
     ).
@@ -68,7 +68,7 @@ latest(ProcID, RawRequiredPath, Limit, Opts) ->
             _ ->
                 hb_path:term_to_path_parts(
                     RawRequiredPath,
-                    Opts#{ atom_keys => false }
+                    Opts
                 )
         end,
     Path = path(ProcID, slot_root, Opts),

--- a/src/dev_process_worker.erl
+++ b/src/dev_process_worker.erl
@@ -13,7 +13,7 @@
 group(Msg1, undefined, Opts) ->
     hb_persistent:default_grouper(Msg1, undefined, Opts);
 group(Msg1, Msg2, Opts) ->
-    case hb_path:matches(<<"Compute">>, hb_path:hd(Msg2, Opts)) of
+    case hb_path:matches(<<"compute">>, hb_path:hd(Msg2, Opts)) of
         true ->
             process_to_group_name(Msg1, Opts);
         _ ->
@@ -23,7 +23,7 @@ group(Msg1, Msg2, Opts) ->
 process_to_group_name(Msg1, Opts) ->
     hb_util:human_id(
         hb_converge:get(
-            <<"Process/id">>,
+            <<"process/id">>,
             {as,
                 dev_message,
                 dev_process:ensure_process_key(Msg1, Opts)
@@ -57,9 +57,9 @@ info_test() ->
 grouper_test() ->
     test_init(),
     M1 = dev_process:test_aos_process(),
-    M2 = #{ path => <<"Compute">>, v => 1 },
-    M3 = #{ path => <<"Compute">>, v => 2 },
-    M4 = #{ path => <<"Not-Compute">>, v => 3 },
+    M2 = #{ <<"path">> => <<"compute">>, <<"v">> => 1 },
+    M3 = #{ <<"path">> => <<"compute">>, <<"v">> => 2 },
+    M4 = #{ <<"path">> => <<"not-compute">>, <<"v">> => 3 },
     G1 = hb_persistent:group(M1, M2, #{}),
     G2 = hb_persistent:group(M1, M3, #{}),
     G3 = hb_persistent:group(M1, M4, #{}),

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -33,7 +33,7 @@
 
 %% @doc Device function that returns all known routes.
 routes(M1, M2, Opts) ->
-    ?event(debug, {routes_msg, M1, M2}),
+    ?event({routes_msg, M1, M2}),
     Routes = hb_opts:get(routes, [], Opts),
     case hb_converge:get(method, M2, Opts) of
         <<"POST">> ->
@@ -333,7 +333,7 @@ get_routes_test() ->
         }
     ),
     Res = hb_client:routes(Node),
-    ?event(debug, {get_routes_test, Res}),
+    ?event({get_routes_test, Res}),
     {ok, RecvdRoutes} = Res,
     ?assert(hb_message:match(Routes, RecvdRoutes)).
 
@@ -357,10 +357,10 @@ add_route_test() ->
             <<"priority">> => 15
         }
     ),
-    ?event(debug, {add_route_test, Res}),
+    ?event({add_route_test, Res}),
     ?assertEqual({ok, <<"Route added.">>}, Res),
     Res2 = hb_client:routes(Node),
-    ?event(debug, {new_routes, Res2}),
+    ?event({new_routes, Res2}),
     {ok, RecvdRoutes} = Res2,
     ?assert(hb_message:match(Routes ++ [NewRoute], RecvdRoutes)).
 

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -47,7 +47,7 @@ routes(M1, M2, Opts) ->
                 ),
             case IsTrusted of
                 true ->
-                    Priority = hb_converge:get(<<"Priority">>, M2, Opts),
+                    Priority = hb_converge:get(<<"priority">>, M2, Opts),
                     NewRoutes =
                         lists:sort(fun(X, Y) -> X > Y end, [Priority|Routes]),
                     hb_http_server:set_opts(Opts#{ routes => NewRoutes }),
@@ -76,23 +76,23 @@ find_route(Msg, Opts) -> find_route(undefined, Msg, Opts).
 find_route(_, Msg, Opts) ->
     Routes = hb_opts:get(routes, [], Opts),
     R = match_routes(Msg, Routes, Opts),
-    case (R =/= no_matches) andalso hb_converge:get(<<"Node">>, R, Opts) of
+    case (R =/= no_matches) andalso hb_converge:get(<<"node">>, R, Opts) of
         false -> no_matches;
         Node when is_binary(Node) -> {ok, Node};
         not_found ->
-            Nodes = hb_converge:get(<<"Peers">>, R, Opts),
-            case hb_converge:get(<<"Strategy">>, R, Opts) of
+            Nodes = hb_converge:get(<<"peers">>, R, Opts),
+            case hb_converge:get(<<"strategy">>, R, Opts) of
                 not_found -> {ok, Nodes};
                 Strategy ->
-                    ChooseN = hb_converge:get(<<"Choose">>, R, 1, Opts),
+                    ChooseN = hb_converge:get(<<"choose">>, R, 1, Opts),
                     Hashpath = hb_path:from_message(hashpath, R),
                     Chosen = choose(ChooseN, Strategy, Hashpath, Nodes, Opts),
                     case Chosen of
                         [X] when is_map(X) ->
-                            {ok, hb_converge:get(<<"Host">>, X, Opts)};
+                            {ok, hb_converge:get(<<"host">>, X, Opts)};
                         [X] -> {ok, X};
                         _ ->
-                            {ok, hb_converge:set(<<"Peers">>, Chosen, Opts)}
+                            {ok, hb_converge:set(<<"peers">>, Chosen, Opts)}
                     end
             end
     end.
@@ -110,7 +110,7 @@ match_routes(ToMatch, Routes, [XKey|Keys], Opts) ->
     XM = hb_converge:get(XKey, Routes, Opts),
     Template =
         hb_converge:get(
-            <<"Template">>,
+            <<"template">>,
             XM,
             #{},
             Opts#{ hashpath => ignore }
@@ -265,25 +265,25 @@ unique_nodes(Simulation) ->
 route_template_message_matches_test() ->
     Routes = [
         #{
-            <<"Template">> => #{ <<"Other-Key">> => <<"Other-Value">> },
-            <<"Node">> => <<"incorrect">>
+            <<"template">> => #{ <<"other-key">> => <<"other-value">> },
+            <<"node">> => <<"incorrect">>
         },
         #{
-            <<"Template">> => #{ <<"Special-Key">> => <<"Special-Value">> },
-            <<"Node">> => <<"correct">>
+            <<"template">> => #{ <<"special-key">> => <<"special-value">> },
+            <<"node">> => <<"correct">>
         }
     ],
     ?assertEqual(
         {ok, <<"correct">>},
         find_route(
-            #{ path => <<"/">>, <<"Special-Key">> => <<"Special-Value">> },
+            #{ path => <<"/">>, <<"special-key">> => <<"special-value">> },
             #{ routes => Routes }
         )
     ),
     ?assertEqual(
         no_matches,
         find_route(
-            #{ path => <<"/">>, <<"Special-Key">> => <<"Special-Value2">> },
+            #{ path => <<"/">>, <<"special-key">> => <<"special-value2">> },
             #{ routes => Routes }
         )
     ),
@@ -291,32 +291,32 @@ route_template_message_matches_test() ->
         {ok, <<"fallback">>},
         find_route(
             #{ path => <<"/">> },
-            #{ routes => Routes ++ [#{ <<"Node">> => <<"fallback">> }] }
+            #{ routes => Routes ++ [#{ <<"node">> => <<"fallback">> }] }
         )
     ).
 
 route_regex_matches_test() ->
     Routes = [
         #{
-            <<"Template">> => <<"/.*/Compute">>,
-            <<"Node">> => <<"incorrect">>
+            <<"template">> => <<"/.*/compute">>,
+            <<"node">> => <<"incorrect">>
         },
         #{
-            <<"Template">> => <<"/.*/Schedule">>,
-            <<"Node">> => <<"correct">>
+            <<"template">> => <<"/.*/schedule">>,
+            <<"node">> => <<"correct">>
         }
     ],
     ?assertEqual(
         {ok, <<"correct">>},
-        find_route(#{ path => <<"/abc/Schedule">> }, #{ routes => Routes })
+        find_route(#{ path => <<"/abc/schedule">> }, #{ routes => Routes })
     ),
     ?assertEqual(
         {ok, <<"correct">>},
-        find_route(#{ path => <<"/a/b/c/Schedule">> }, #{ routes => Routes })
+        find_route(#{ path => <<"/a/b/c/schedule">> }, #{ routes => Routes })
     ),
     ?assertEqual(
         no_matches,
-        find_route(#{ path => <<"/a/b/c/BadKey">> }, #{ routes => Routes })
+        find_route(#{ path => <<"/a/b/c/bad-key">> }, #{ routes => Routes })
     ).
 
 get_routes_test() ->
@@ -325,9 +325,9 @@ get_routes_test() ->
             force_signed => false,
             routes => Routes = [
                 #{
-                    <<"Template">> => <<"*">>,
-                    <<"Node">> => <<"our_node">>,
-                    <<"Priority">> => 10
+                    <<"template">> => <<"*">>,
+                    <<"node">> => <<"our_node">>,
+                    <<"priority">> => 10
                 }
             ]
         }
@@ -343,18 +343,18 @@ add_route_test() ->
             force_signed => false,
             routes => Routes = [
                 #{
-                    <<"Template">> => <<"/Some/Path">>,
-                    <<"Node">> => <<"old">>,
-                    <<"Priority">> => 10
+                    <<"template">> => <<"/some/path">>,
+                    <<"node">> => <<"old">>,
+                    <<"priority">> => 10
                 }
             ]
         }
     ),
     Res = hb_client:add_route(Node,
         NewRoute = #{
-            <<"Template">> => <<"/Some/New/Path">>,
-            <<"Node">> => <<"new">>,
-            <<"Priority">> => 15
+            <<"template">> => <<"/some/new/path">>,
+            <<"node">> => <<"new">>,
+            <<"priority">> => 15
         }
     ),
     ?event(debug, {add_route_test, Res}),
@@ -369,9 +369,9 @@ add_route_test() ->
 generate_nodes(N) ->
     [
         #{
-            <<"Host">> =>
+            <<"host">> =>
                 <<"http://localhost:", (integer_to_binary(Port))/binary>>,
-            <<"Wallet">> => hb_util:encode(crypto:strong_rand_bytes(32))
+            <<"wallet">> => hb_util:encode(crypto:strong_rand_bytes(32))
         }
     ||
         Port <- lists:seq(1, N)

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -276,21 +276,21 @@ route_template_message_matches_test() ->
     ?assertEqual(
         {ok, <<"correct">>},
         find_route(
-            #{ path => <<"/">>, <<"special-key">> => <<"special-value">> },
+            #{ <<"path">> => <<"/">>, <<"special-key">> => <<"special-value">> },
             #{ routes => Routes }
         )
     ),
     ?assertEqual(
         no_matches,
         find_route(
-            #{ path => <<"/">>, <<"special-key">> => <<"special-value2">> },
+            #{ <<"path">> => <<"/">>, <<"special-key">> => <<"special-value2">> },
             #{ routes => Routes }
         )
     ),
     ?assertEqual(
         {ok, <<"fallback">>},
         find_route(
-            #{ path => <<"/">> },
+            #{ <<"path">> => <<"/">> },
             #{ routes => Routes ++ [#{ <<"node">> => <<"fallback">> }] }
         )
     ).
@@ -308,15 +308,15 @@ route_regex_matches_test() ->
     ],
     ?assertEqual(
         {ok, <<"correct">>},
-        find_route(#{ path => <<"/abc/schedule">> }, #{ routes => Routes })
+        find_route(#{ <<"path">> => <<"/abc/schedule">> }, #{ routes => Routes })
     ),
     ?assertEqual(
         {ok, <<"correct">>},
-        find_route(#{ path => <<"/a/b/c/schedule">> }, #{ routes => Routes })
+        find_route(#{ <<"path">> => <<"/a/b/c/schedule">> }, #{ routes => Routes })
     ),
     ?assertEqual(
         no_matches,
-        find_route(#{ path => <<"/a/b/c/bad-key">> }, #{ routes => Routes })
+        find_route(#{ <<"path">> => <<"/a/b/c/bad-key">> }, #{ routes => Routes })
     ).
 
 get_routes_test() ->

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -122,7 +122,7 @@ next(Msg1, Msg2, Opts) ->
         false ->
             {error,
                 #{
-                    <<"status">> => <<"Service Unavailable">>,
+                    <<"status">> => 503,
                     <<"body">> => <<"No assignment found for next slot.">>
                 }
             }
@@ -187,14 +187,14 @@ post_schedule(Msg1, Msg2, Opts) ->
         {false, _, _} ->
             {ok,
                 #{
-                    <<"status">> => <<"Failed">>,
+                    <<"status">> => 500,
                     <<"body">> => <<"Scheduler location does not match wallet address.">>
                 }
             };
         {true, false, _} ->
             {ok,
                 #{
-                    <<"status">> => <<"Failed">>,
+                    <<"status">> => 400,
                     <<"body">> => <<"Data item is not valid.">>
                 }
             };
@@ -211,7 +211,7 @@ post_schedule(Msg1, Msg2, Opts) ->
             ),
             {ok,
                 #{
-                    <<"status">> => <<"OK">>,
+                    <<"status">> => 200,
                     <<"assignment">> => <<"0">>,
                     <<"process">> => ProcID
                 }

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -437,7 +437,7 @@ test_process() ->
         device => ?MODULE,
         process => #{
             <<"device-stack">> =>
-                [<<"Cron/1.0">>, <<"Wasm/1.0">>, <<"Poda/1.0">>],
+                [<<"Cron/1.0">>, <<"WASM-64/1.0">>, <<"PODA/1.0">>],
             <<"image">> => <<"wasm-image-id">>,
             <<"type">> => <<"process">>,
             <<"scheduler-location">> => Address,
@@ -465,7 +465,7 @@ register_new_process_test() ->
             Msg1,
             #{
                 <<"method">> => <<"POST">>,
-                <<"path">> => <<"Schedule">>,
+                <<"path">> => <<"schedule">>,
                 <<"message">> => Proc
             },
             #{}
@@ -484,7 +484,7 @@ schedule_message_and_get_slot_test() ->
     Proc = hb_converge:get(<<"process">>, Msg1, #{ hashpath => ignore }),
     ProcID = hb_util:id(Proc),
     Msg2 = #{
-        <<"path">> => <<"Schedule">>,
+        <<"path">> => <<"schedule">>,
         <<"method">> => <<"POST">>,
         <<"message">> =>
             #{
@@ -495,13 +495,13 @@ schedule_message_and_get_slot_test() ->
     ?assertMatch({ok, _}, hb_converge:resolve(Msg1, Msg2, #{})),
     ?assertMatch({ok, _}, hb_converge:resolve(Msg1, Msg2, #{})),
     Msg3 = #{
-        <<"path">> => <<"Slot">>,
+        <<"path">> => <<"slot">>,
         <<"method">> => <<"GET">>,
         <<"process">> => ProcID
     },
     ?event({pg, dev_scheduler_registry:get_processes()}),
     ?event({getting_schedule, {msg, Msg3}}),
-    ?assertMatch({ok, #{ <<"Current-Slot">> := CurrentSlot }}
+    ?assertMatch({ok, #{ <<"current-slot">> := CurrentSlot }}
             when CurrentSlot > 0,
         hb_converge:resolve(Msg1, Msg3, #{})).
 
@@ -515,7 +515,7 @@ benchmark_test() ->
     Iterations = hb:benchmark(
         fun(X) ->
             MsgX = #{
-                <<"path">> => <<"Schedule">>,
+                <<"path">> => <<"schedule">>,
                 <<"method">> => <<"POST">>,
                 <<"message">> =>
                     #{
@@ -529,7 +529,7 @@ benchmark_test() ->
     ),
     ?event(benchmark, {scheduled, Iterations}),
     Msg3 = #{
-        <<"path">> => <<"Slot">>,
+        <<"path">> => <<"slot">>,
         <<"method">> => <<"GET">>,
         <<"process">> => ProcID
     },
@@ -546,7 +546,7 @@ get_schedule_test() ->
     start(),
     Msg1 = test_process(),
     Msg2 = #{
-        <<"path">> => <<"Schedule">>,
+        <<"path">> => <<"schedule">>,
         <<"method">> => <<"POST">>,
         <<"message">> =>
             #{
@@ -555,7 +555,7 @@ get_schedule_test() ->
             }
     },
     Msg3 = #{
-        <<"path">> => <<"Schedule">>,
+        <<"path">> => <<"schedule">>,
         <<"method">> => <<"POST">>,
         <<"message">> =>
             #{
@@ -569,7 +569,7 @@ get_schedule_test() ->
         {ok, _},
         hb_converge:resolve(Msg1, #{
             <<"method">> => <<"GET">>,
-            <<"path">> => <<"Schedule">>
+            <<"path">> => <<"schedule">>
         },
         #{})
     ).

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -63,11 +63,11 @@ next(Msg1, Msg2, Opts) ->
     ?event({scheduler_next_called, {msg1, Msg1}, {msg2, Msg2}, {opts, Opts}}),
     Schedule =
         hb_private:get(
-            <<"priv/Scheduler/Assignments">>,
+            <<"priv/scheduler/assignments">>,
             Msg1,
             Opts
         ),
-    LastProcessed = hb_converge:get(<<"Current-Slot">>, Msg1, Opts),
+    LastProcessed = hb_converge:get(<<"current-slot">>, Msg1, Opts),
     ?event({local_schedule_cache, {schedule, Schedule}}),
     Assignments =
         case Schedule of
@@ -77,9 +77,9 @@ next(Msg1, Msg2, Opts) ->
                     hb_converge:resolve(
                         Msg1,
                         #{
-                            <<"Method">> => <<"GET">>,
-                            path => <<"Schedule/Assignments">>,
-                            <<"From">> => LastProcessed
+                            <<"method">> => <<"GET">>,
+                            <<"path">> => <<"schedule/assignments">>,
+                            <<"from">> => LastProcessed
                         },
                         Opts
                     ),
@@ -112,18 +112,18 @@ next(Msg1, Msg2, Opts) ->
             NextState =
                 hb_private:set(
                     Msg1,
-                    <<"Schedule/Assignments">>,
+                    <<"schedule/assignments">>,
                     hb_converge:remove(FilteredAssignments, Slot),
                     Opts
                 ),
             ?event(
                 {next_returning, {slot, Slot}, {message, NextMessage}}),
-            {ok, #{ <<"Message">> => NextMessage, <<"State">> => NextState }};
+            {ok, #{ <<"message">> => NextMessage, <<"state">> => NextState }};
         false ->
             {error,
                 #{
-                    <<"Status">> => <<"Service Unavailable">>,
-                    <<"Body">> => <<"No assignment found for next slot.">>
+                    <<"status">> => <<"Service Unavailable">>,
+                    <<"body">> => <<"No assignment found for next slot.">>
                 }
             }
     end.
@@ -134,13 +134,13 @@ status(_M1, _M2, _Opts) ->
     Wallet = dev_scheduler_registry:get_wallet(),
     {ok,
         #{
-            <<"Address">> => hb_util:id(ar_wallet:to_address(Wallet)),
-            <<"Processes">> =>
+            <<"address">> => hb_util:id(ar_wallet:to_address(Wallet)),
+            <<"processes">> =>
                 lists:map(
                     fun hb_util:id/1,
                     dev_scheduler_registry:get_processes()
                 ),
-            <<"Cache-Control">> => <<"no-store">>
+            <<"cache-control">> => <<"no-store">>
         }
     }.
 
@@ -148,7 +148,7 @@ status(_M1, _M2, _Opts) ->
 %% scheduling a new message.
 schedule(Msg1, Msg2, Opts) ->
     ?event({resolving_schedule_request, {msg2, Msg2}, {state_msg, Msg1}}),
-    case hb_converge:get(<<"Method">>, Msg2, <<"GET">>, Opts) of
+    case hb_converge:get(<<"method">>, Msg2, <<"GET">>, Opts) of
         <<"POST">> -> post_schedule(Msg1, Msg2, Opts);
         <<"GET">> -> get_schedule(Msg1, Msg2, Opts)
     end.
@@ -161,15 +161,15 @@ append(Msg1, Msg2, Opts) ->
 %% @doc Schedules a new message on the SU.
 post_schedule(Msg1, Msg2, Opts) ->
     ?event(scheduling_message),
-    ToSched = hb_converge:get(message, Msg2, Opts#{ hashpath => ignore }),
-    ToSchedID = hb_converge:get(id, ToSched),
-    Proc = hb_converge:get(process, Msg1, Opts#{ hashpath => ignore }),
+    ToSched = hb_converge:get(<<"message">>, Msg2, Opts#{ hashpath => ignore }),
+    ToSchedID = hb_converge:get(<<"id">>, ToSched),
+    Proc = hb_converge:get(<<"process">>, Msg1, Opts#{ hashpath => ignore }),
     ?no_prod("Once we have GQL, get the scheduler location record. "
         "For now, we'll just use the address of the wallet."),
     SchedulerLocation =
-        hb_converge:get(<<"Process/Scheduler-Location">>,
+        hb_converge:get(<<"process/scheduler-location">>,
             Msg1, Opts#{ hashpath => ignore }),
-    ProcID = hb_converge:get(id, Proc),
+    ProcID = hb_converge:get(<<"id">>, Proc),
     PID = dev_scheduler_registry:find(ProcID, true),
     #{ wallet := Wallet } = dev_scheduler_server:info(PID),
     WalletAddress = hb_util:id(ar_wallet:to_address(Wallet)),
@@ -187,15 +187,15 @@ post_schedule(Msg1, Msg2, Opts) ->
         {false, _, _} ->
             {ok,
                 #{
-                    <<"Status">> => <<"Failed">>,
-                    <<"Body">> => <<"Scheduler location does not match wallet address.">>
+                    <<"status">> => <<"Failed">>,
+                    <<"body">> => <<"Scheduler location does not match wallet address.">>
                 }
             };
         {true, false, _} ->
             {ok,
                 #{
-                    <<"Status">> => <<"Failed">>,
-                    <<"Body">> => <<"Data item is not valid.">>
+                    <<"status">> => <<"Failed">>,
+                    <<"body">> => <<"Data item is not valid.">>
                 }
             };
         {true, true, <<"Process">>} ->
@@ -211,9 +211,9 @@ post_schedule(Msg1, Msg2, Opts) ->
             ),
             {ok,
                 #{
-                    <<"Status">> => <<"OK">>,
-                    <<"Assignment">> => <<"0">>,
-                    <<"Process">> => ProcID
+                    <<"status">> => <<"OK">>,
+                    <<"assignment">> => <<"0">>,
+                    <<"process">> => ProcID
                 }
             };
         {true, true, _} ->
@@ -234,7 +234,7 @@ slot(M1, _M2, Opts) ->
         {as, dev_message, M1},
         Opts#{ hashpath => ignore }
     ),
-    ProcID = hb_converge:get(id, Proc),
+    ProcID = hb_converge:get(<<"id">>, Proc),
     ?event({getting_current_slot, {proc_id, ProcID}, {process, Proc}}),
     {Timestamp, Hash, Height} = ar_timestamp:get(),
     #{ current := CurrentSlot, wallet := Wallet } =
@@ -242,13 +242,13 @@ slot(M1, _M2, Opts) ->
             dev_scheduler_registry:find(ProcID)
         ),
     {ok, #{
-        <<"Process">> => ProcID,
-        <<"Current-Slot">> => CurrentSlot,
-        <<"Timestamp">> => Timestamp,
-        <<"Block-Height">> => Height,
-        <<"Block-Hash">> => Hash,
-        <<"Cache-Control">> => <<"no-store">>,
-        <<"Wallet-Address">> => hb_util:human_id(ar_wallet:to_address(Wallet))
+        <<"process">> => ProcID,
+        <<"current-slot">> => CurrentSlot,
+        <<"timestamp">> => Timestamp,
+        <<"block-height">> => Height,
+        <<"block-hash">> => Hash,
+        <<"cache-control">> => <<"no-store">>,
+        <<"wallet-address">> => hb_util:human_id(ar_wallet:to_address(Wallet))
     }}.
 
 get_schedule(Msg1, Msg2, Opts) ->
@@ -257,15 +257,15 @@ get_schedule(Msg1, Msg2, Opts) ->
         {as, dev_message, Msg1},
         Opts#{ hashpath => ignore }
     ),
-    ProcID = hb_converge:get(id, Proc),
+    ProcID = hb_converge:get(<<"id">>, Proc),
     From =
-        case hb_converge:get(from, Msg2, not_found, Opts) of
+        case hb_converge:get(<<"from">>, Msg2, not_found, Opts) of
             not_found -> 0;
             X when X < 0 -> 0;
             FromRes -> FromRes
         end,
     To =
-        case hb_converge:get(to, Msg2, not_found, Opts) of
+        case hb_converge:get(<<"to">>, Msg2, not_found, Opts) of
             not_found ->
                 ?event({getting_current_slot, {proc_id, ProcID}}),
                 maps:get(current,
@@ -296,13 +296,13 @@ gen_schedule(ProcID, From, To, Opts) ->
     ),
     ?event({got_assignments, length(Assignments), {more, More}}),
     Bundle = #{
-        <<"Type">> => <<"Schedule">>,
-        <<"Process">> => ProcID,
-        <<"Continues">> => atom_to_binary(More, utf8),
-        <<"Timestamp">> => list_to_binary(integer_to_list(Timestamp)),
-        <<"Block-Height">> => list_to_binary(integer_to_list(Height)),
-        <<"Block-Hash">> => Hash,
-        <<"Assignments">> => assignment_bundle(Assignments, Opts)
+        <<"type">> => <<"schedule">>,
+        <<"process">> => ProcID,
+        <<"continues">> => atom_to_binary(More, utf8),
+        <<"timestamp">> => list_to_binary(integer_to_list(Timestamp)),
+        <<"block-height">> => list_to_binary(integer_to_list(Height)),
+        <<"block-hash">> => Hash,
+        <<"assignments">> => assignment_bundle(Assignments, Opts)
     },
     ?event(assignments_bundle_outbound),
     Signed = hb_message:sign(Bundle, hb:wallet()),
@@ -341,9 +341,9 @@ assignment_bundle(Assignments, Opts) ->
 assignment_bundle([], Bundle, _Opts) ->
     Bundle;
 assignment_bundle([Assignment | Assignments], Bundle, Opts) ->
-    Slot = hb_converge:get(<<"Slot">>, Assignment, Opts#{ hashpath => ignore }),
+    Slot = hb_converge:get(<<"slot">>, Assignment, Opts#{ hashpath => ignore }),
     MessageID =
-        hb_converge:get(<<"Message">>, Assignment, Opts#{ hashpath => ignore }),
+        hb_converge:get(<<"message">>, Assignment, Opts#{ hashpath => ignore }),
     {ok, Message} = hb_cache:read(MessageID, Opts),
     ?event(
         {adding_assignment_to_bundle,
@@ -359,9 +359,9 @@ assignment_bundle([Assignment | Assignments], Bundle, Opts) ->
             Slot =>
                 hb_message:sign(
                     #{
-                        path => <<"Compute">>,
-                        <<"Assignment">> => Assignment,
-                        <<"Message">> => Message
+                        <<"path">> => <<"compute">>,
+                        <<"assignment">> => Assignment,
+                        <<"message">> => Message
                     },
                     hb:wallet()
                 )
@@ -386,9 +386,9 @@ update_schedule(M1, M2, Opts) ->
     Proc = hb_converge:get(process, M1, Opts),
     ProcID = hb_util:id(Proc),
     CurrentSlot =
-        hb_converge:get(<<"Current-Slot">>, M1, Opts, 0),
+        hb_converge:get(<<"current-slot">>, M1, Opts, 0),
     ToSlot =
-        hb_converge:get(<<"Slot">>, M2, Opts, undefined),
+        hb_converge:get(<<"slot">>, M2, Opts, undefined),
     ?event({updating_schedule_current, CurrentSlot, to, ToSlot}),
     Assignments =
         hb_client:get_assignments(
@@ -399,7 +399,7 @@ update_schedule(M1, M2, Opts) ->
     ?event({got_assignments_from_su,
         [
             {
-                element(2, lists:keyfind(<<"Assignment">>, 1, A#tx.tags)),
+                element(2, lists:keyfind(<<"assignment">>, 1, A#tx.tags)),
                 hb_util:id(A, signed),
                 hb_util:id(A, unsigned)
             }
@@ -436,19 +436,20 @@ test_process() ->
     #{
         device => ?MODULE,
         process => #{
-            <<"Device-Stack">> => [dev_cron, dev_wasm, dev_poda],
-            <<"Image">> => <<"wasm-image-id">>,
-            <<"Type">> => <<"Process">>,
-            <<"Scheduler-Location">> => Address,
-            <<"Test-Random-Seed">> => rand:uniform(1337)
+            <<"device-stack">> =>
+                [<<"Cron/1.0">>, <<"Wasm/1.0">>, <<"Poda/1.0">>],
+            <<"image">> => <<"wasm-image-id">>,
+            <<"type">> => <<"process">>,
+            <<"scheduler-location">> => Address,
+            <<"test-random-seed">> => rand:uniform(1337)
         }
     }.
 
 status_test() ->
     start(),
     ?assertMatch(
-        #{<<"Processes">> := Processes,
-            <<"Address">> := Address}
+        #{<<"processes">> := Processes,
+            <<"address">> := Address}
             when is_list(Processes) and is_binary(Address),
         hb_converge:get(status, test_process())
     ).
@@ -463,9 +464,9 @@ register_new_process_test() ->
         hb_converge:resolve(
             Msg1,
             #{
-                <<"Method">> => <<"POST">>,
-                path => <<"Schedule">>,
-                <<"Message">> => Proc
+                <<"method">> => <<"POST">>,
+                <<"path">> => <<"Schedule">>,
+                <<"message">> => Proc
             },
             #{}
         )
@@ -473,30 +474,30 @@ register_new_process_test() ->
     ?assert(
         lists:member(
             ProcID,
-            hb_converge:get(processes, hb_converge:get(status, Msg1))
+            hb_converge:get(<<"processes">>, hb_converge:get(status, Msg1))
         )
     ).
 
 schedule_message_and_get_slot_test() ->
     start(),
     Msg1 = test_process(),
-    Proc = hb_converge:get(process, Msg1, #{ hashpath => ignore }),
+    Proc = hb_converge:get(<<"process">>, Msg1, #{ hashpath => ignore }),
     ProcID = hb_util:id(Proc),
     Msg2 = #{
-        path => <<"Schedule">>,
-        <<"Method">> => <<"POST">>,
-        <<"Message">> =>
+        <<"path">> => <<"Schedule">>,
+        <<"method">> => <<"POST">>,
+        <<"message">> =>
             #{
-                <<"Type">> => <<"Message">>,
-                <<"Test-Key">> => <<"true">>
+                <<"type">> => <<"Message">>,
+                <<"test-key">> => <<"true">>
             }
     },
     ?assertMatch({ok, _}, hb_converge:resolve(Msg1, Msg2, #{})),
     ?assertMatch({ok, _}, hb_converge:resolve(Msg1, Msg2, #{})),
     Msg3 = #{
-        path => <<"Slot">>,
-        <<"Method">> => <<"GET">>,
-        <<"Process">> => ProcID
+        <<"path">> => <<"Slot">>,
+        <<"method">> => <<"GET">>,
+        <<"process">> => ProcID
     },
     ?event({pg, dev_scheduler_registry:get_processes()}),
     ?event({getting_schedule, {msg, Msg3}}),
@@ -508,18 +509,18 @@ benchmark_test() ->
     start(),
     BenchTime = 4,
     Msg1 = test_process(),
-    Proc = hb_converge:get(process, Msg1, #{ hashpath => ignore }),
+    Proc = hb_converge:get(<<"process">>, Msg1, #{ hashpath => ignore }),
     ProcID = hb_util:id(Proc),
     ?event({benchmark_start, ?MODULE}),
     Iterations = hb:benchmark(
         fun(X) ->
             MsgX = #{
-                path => <<"Schedule">>,
-                <<"Method">> => <<"POST">>,
-                <<"Message">> =>
+                <<"path">> => <<"Schedule">>,
+                <<"method">> => <<"POST">>,
+                <<"message">> =>
                     #{
-                        <<"Type">> => <<"Message">>,
-                        <<"Test-Val">> => X
+                        <<"type">> => <<"Message">>,
+                        <<"test-val">> => X
                     }
             },
             ?assertMatch({ok, _}, hb_converge:resolve(Msg1, MsgX, #{}))
@@ -528,11 +529,11 @@ benchmark_test() ->
     ),
     ?event(benchmark, {scheduled, Iterations}),
     Msg3 = #{
-        path => <<"Slot">>,
-        <<"Method">> => <<"GET">>,
-        <<"Process">> => ProcID
+        <<"path">> => <<"Slot">>,
+        <<"method">> => <<"GET">>,
+        <<"process">> => ProcID
     },
-    ?assertMatch({ok, #{ <<"Current-Slot">> := CurrentSlot }}
+    ?assertMatch({ok, #{ <<"current-slot">> := CurrentSlot }}
             when CurrentSlot == Iterations - 1,
         hb_converge:resolve(Msg1, Msg3, #{})),
     hb_util:eunit_print(
@@ -545,21 +546,21 @@ get_schedule_test() ->
     start(),
     Msg1 = test_process(),
     Msg2 = #{
-        path => <<"Schedule">>,
-        <<"Method">> => <<"POST">>,
-        <<"Message">> =>
+        <<"path">> => <<"Schedule">>,
+        <<"method">> => <<"POST">>,
+        <<"message">> =>
             #{
-                <<"Type">> => <<"Message">>,
-                <<"Test-Key">> => <<"Test-Val">>
+                <<"type">> => <<"Message">>,
+                <<"test-key">> => <<"Test-Val">>
             }
     },
     Msg3 = #{
-        path => <<"Schedule">>,
-        <<"Method">> => <<"POST">>,
-        <<"Message">> =>
+        <<"path">> => <<"Schedule">>,
+        <<"method">> => <<"POST">>,
+        <<"message">> =>
             #{
-                <<"Type">> => <<"Message">>,
-                <<"Test-Key">> => <<"Test-Val-2">>
+                <<"type">> => <<"Message">>,
+                <<"test-key">> => <<"Test-Val-2">>
             }
     },
     ?assertMatch({ok, _}, hb_converge:resolve(Msg1, Msg2, #{})),
@@ -567,8 +568,8 @@ get_schedule_test() ->
     ?assertMatch(
         {ok, _},
         hb_converge:resolve(Msg1, #{
-            <<"Method">> => <<"GET">>,
-            path => <<"Schedule">>
+            <<"method">> => <<"GET">>,
+            <<"path">> => <<"Schedule">>
         },
         #{})
     ).

--- a/src/dev_scheduler_cache.erl
+++ b/src/dev_scheduler_cache.erl
@@ -28,7 +28,7 @@ write(Assignment, Opts) ->
             [
                 <<"assignments">>,
                 hb_util:human_id(ProcID),
-                hb_converge:key_to_binary(Slot)
+                hb_converge:normalize_key(Slot)
             ]
         )
     ),

--- a/src/dev_scheduler_cache.erl
+++ b/src/dev_scheduler_cache.erl
@@ -8,8 +8,8 @@
 write(Assignment, Opts) ->
     Store = hb_opts:get(store, no_viable_store, Opts),
     % Write the message into the main cache
-    ProcID = hb_converge:get(<<"Process">>, Assignment),
-    Slot = hb_converge:get(<<"Slot">>, Assignment),
+    ProcID = hb_converge:get(<<"process">>, Assignment),
+    Slot = hb_converge:get(<<"slot">>, Assignment),
     ?event(
         {writing_assignment,
             {proc_id, ProcID},

--- a/src/dev_scheduler_interface.erl
+++ b/src/dev_scheduler_interface.erl
@@ -82,7 +82,7 @@ schedule(CarrierM) ->
                 #tx{
                     tags =
                         [
-                            {<<"status">>, <<"OK">>},
+                            {<<"status">>, 200},
                             {<<"initial-assignment">>, <<"0">>},
                             {<<"process">>, hb_util:id(M, signed)}
                         ],

--- a/src/dev_scheduler_interface.erl
+++ b/src/dev_scheduler_interface.erl
@@ -10,12 +10,12 @@ handle(M) ->
     (choose_handler(M))(M).
 
 choose_handler(M) ->
-    Method = hb_converge:get(<<"Method">>, M),
-    Action = hb_converge:get(<<"Action">>, M),
+    Method = hb_converge:get(<<"method">>, M),
+    Action = hb_converge:get(<<"action">>, M),
     case {Method, Action} of
-        {{_, <<"GET">>}, {_, <<"Info">>}} -> fun info/1;
-        {{_, <<"GET">>}, {_, <<"Slot">>}} -> fun current_slot/1;
-        {{_, <<"GET">>}, {_, <<"Schedule">>}} -> fun current_schedule/1;
+        {{_, <<"GET">>}, {_, <<"info">>}} -> fun info/1;
+        {{_, <<"GET">>}, {_, <<"slot">>}} -> fun current_slot/1;
+        {{_, <<"GET">>}, {_, <<"schedule">>}} -> fun current_schedule/1;
         {{_, <<"POST">>}, _} -> fun schedule/1
     end.
 
@@ -23,8 +23,8 @@ info(M) ->
     Wallet = dev_scheduler_registry:get_wallet(),
     {ok,
         #{
-            <<"Unit">> => <<"Scheduler">>,
-            <<"Address">> => hb_util:id(ar_wallet:to_address(Wallet)),
+            <<"unit">> => <<"scheduler">>,
+            <<"address">> => hb_util:id(ar_wallet:to_address(Wallet)),
             <<"data">> =>
                 jiffy:encode(
                     lists:map(
@@ -36,29 +36,29 @@ info(M) ->
     }.
 
 current_slot(M) ->
-    {_, ProcID} = lists:keyfind(<<"Process">>, 1, M#tx.tags),
+    {_, ProcID} = lists:keyfind(<<"process">>, 1, M#tx.tags),
     {Timestamp, Hash, Height} = ar_timestamp:get(),
     {ok, #tx{
         tags = [
-            {<<"Process">>, ProcID},
-            {<<"Current-Slot">>,
+            {<<"process">>, ProcID},
+            {<<"current-slot">>,
                 dev_scheduler_server:get_current_slot(
                     dev_scheduler_registry:find(ProcID)
                 )
             },
-            {<<"Timestamp">>, Timestamp},
-            {<<"Block-Height">>, Height},
-            {<<"Block-Hash">>, Hash}
+            {<<"timestamp">>, Timestamp},
+            {<<"block-height">>, Height},
+            {<<"block-hash">>, Hash}
         ]
     }}.
 
 current_schedule(M) ->
-    {_, ProcID} = lists:keyfind(<<"Process">>, 1, M#tx.tags),
+    {_, ProcID} = lists:keyfind(<<"process">>, 1, M#tx.tags),
     send_schedule(
         hb_opts:get(store),
         ProcID,
-        lists:keyfind(<<"From">>, 1, M#tx.tags),
-        lists:keyfind(<<"To">>, 1, M#tx.tags)
+        lists:keyfind(<<"from">>, 1, M#tx.tags),
+        lists:keyfind(<<"to">>, 1, M#tx.tags)
     ).
 
 schedule(CarrierM) ->
@@ -67,24 +67,24 @@ schedule(CarrierM) ->
     %ar_bundles:print(M),
     Store = hb_opts:get(store),
     ?no_prod("SU does not validate item before writing into stream."),
-    case {ar_bundles:verify_item(M), lists:keyfind(<<"Type">>, 1, M#tx.tags)} of
+    case {ar_bundles:verify_item(M), lists:keyfind(<<"type">>, 1, M#tx.tags)} of
         % {false, _} ->
         %     {ok,
         %         #tx{
-        %             tags = [{<<"Status">>, <<"Failed">>}],
+        %             tags = [{<<"status">>, <<"failed">>}],
         %             data = <<"Data item is not valid.">>
         %         }
         %     };
-        {_, {<<"Type">>, <<"Process">>}} ->
+        {_, {<<"type">>, <<"process">>}} ->
             hb_cache:write(Store, M),
             hb_client:upload(M),
             {ok,
                 #tx{
                     tags =
                         [
-                            {<<"Status">>, <<"OK">>},
-                            {<<"Initial-Assignment">>, <<"0">>},
-                            {<<"Process">>, hb_util:id(M, signed)}
+                            {<<"status">>, <<"OK">>},
+                            {<<"initial-assignment">>, <<"0">>},
+                            {<<"process">>, hb_util:id(M, signed)}
                         ],
                     data = []
                 }
@@ -92,7 +92,7 @@ schedule(CarrierM) ->
         {_, _} ->
             % If the process-id is not specified, use the target of the message as the process-id
             AOProcID =
-                case lists:keyfind(<<"Process">>, 1, M#tx.tags) of
+                case lists:keyfind(<<"process">>, 1, M#tx.tags) of
                     false -> binary_to_list(hb_util:id(M#tx.target));
                     {_, ProcessID} -> ProcessID
                 end,
@@ -105,11 +105,11 @@ send_schedule(Store, ProcID, false, To) ->
     send_schedule(Store, ProcID, 0, To);
 send_schedule(Store, ProcID, From, false) ->
     send_schedule(Store, ProcID, From, dev_scheduler_server:get_current_slot(dev_scheduler_registry:find(ProcID)));
-send_schedule(Store, ProcID, {<<"From">>, From}, To) ->
+send_schedule(Store, ProcID, {<<"from">>, From}, To) ->
     send_schedule(Store, ProcID, binary_to_integer(From), To);
-send_schedule(Store, ProcID, From, {<<"To">>, To}) when byte_size(To) == 43 ->
+send_schedule(Store, ProcID, From, {<<"to">>, To}) when byte_size(To) == 43 ->
     send_schedule(Store, ProcID, From, To);
-send_schedule(Store, ProcID, From, {<<"To">>, To}) ->
+send_schedule(Store, ProcID, From, {<<"to">>, To}) ->
     send_schedule(Store, ProcID, From, binary_to_integer(To));
 send_schedule(Store, ProcID, From, To) ->
     {Timestamp, Height, Hash} = ar_timestamp:get(),
@@ -122,26 +122,26 @@ send_schedule(Store, ProcID, From, To) ->
     Bundle = #tx{
         tags =
             [
-                {<<"Type">>, <<"Schedule">>},
-                {<<"Process">>, ProcID},
-                {<<"Continues">>, atom_to_binary(More, utf8)},
-                {<<"Timestamp">>, list_to_binary(integer_to_list(Timestamp))},
-                {<<"Block-Height">>, list_to_binary(integer_to_list(Height))},
-                {<<"Block-Hash">>, Hash}
+                {<<"type">>, <<"schedule">>},
+                {<<"process">>, ProcID},
+                {<<"continues">>, atom_to_binary(More, utf8)},
+                {<<"timestamp">>, list_to_binary(integer_to_list(Timestamp))},
+                {<<"block-height">>, list_to_binary(integer_to_list(Height))},
+                {<<"block-hash">>, Hash}
             ] ++
                 case Assignments of
                     [] ->
                         [];
                     _ ->
                         {_, FromSlot} = lists:keyfind(
-                            <<"Slot">>, 1, (hd(Assignments))#tx.tags
+                            <<"slot">>, 1, (hd(Assignments))#tx.tags
                         ),
                         {_, ToSlot} = lists:keyfind(
-                            <<"Slot">>, 1, (lists:last(Assignments))#tx.tags
+                            <<"slot">>, 1, (lists:last(Assignments))#tx.tags
                         ),
                         [
-                            {<<"From">>, FromSlot},
-                            {<<"To">>, ToSlot}
+                            {<<"from">>, FromSlot},
+                            {<<"to">>, ToSlot}
                         ]
                 end,
         data = assignments_to_bundle(Store, Assignments)
@@ -156,8 +156,8 @@ assignments_to_bundle(Store, Assignments) ->
 assignments_to_bundle(_, [], Bundle) ->
     Bundle;
 assignments_to_bundle(Store, [Assignment | Assignments], Bundle) ->
-    {_, Slot} = lists:keyfind(<<"Slot">>, 1, Assignment#tx.tags),
-    {_, MessageID} = lists:keyfind(<<"Message">>, 1, Assignment#tx.tags),
+    {_, Slot} = lists:keyfind(<<"slot">>, 1, Assignment#tx.tags),
+    {_, MessageID} = lists:keyfind(<<"message">>, 1, Assignment#tx.tags),
     {ok, Message} = hb_cache:read_message(Store, MessageID),
     ?event({adding_assignment_to_bundle, Slot, {requested, MessageID}, hb_util:id(Assignment, signed), hb_util:id(Assignment, unsigned)}),
     assignments_to_bundle(
@@ -168,12 +168,12 @@ assignments_to_bundle(Store, [Assignment | Assignments], Bundle) ->
                 ar_bundles:sign_item(
                     #tx{
                         tags = [
-                            {<<"Assignment">>, Slot},
-                            {<<"Message">>, MessageID}
+                            {<<"assignment">>, Slot},
+                            {<<"message">>, MessageID}
                         ],
                         data = #{
-                            <<"Assignment">> => Assignment,
-                            <<"Message">> => Message
+                            <<"assignment">> => Assignment,
+                            <<"message">> => Message
                         }
                     },
                     hb:wallet()

--- a/src/dev_scheduler_interface.erl
+++ b/src/dev_scheduler_interface.erl
@@ -25,7 +25,7 @@ info(M) ->
         #{
             <<"Unit">> => <<"Scheduler">>,
             <<"Address">> => hb_util:id(ar_wallet:to_address(Wallet)),
-            <<"Data">> =>
+            <<"data">> =>
                 jiffy:encode(
                     lists:map(
                         fun hb_util:id/1,

--- a/src/dev_scheduler_server.erl
+++ b/src/dev_scheduler_server.erl
@@ -175,18 +175,18 @@ next_hashchain(HashChain, Message) ->
 new_proc_test() ->
     Wallet = ar_wallet:new(),
     SignedItem = hb_message:sign(
-        #{ <<"Data">> => <<"test">>, <<"Random-Key">> => rand:uniform(10000) },
+        #{ <<"data">> => <<"test">>, <<"Random-Key">> => rand:uniform(10000) },
         Wallet
     ),
     SignedItem2 = hb_message:sign(
-        #{ <<"Data">> => <<"test2">> },
+        #{ <<"data">> => <<"test2">> },
         Wallet
     ),
     SignedItem3 = hb_message:sign(
         #{
-            <<"Data">> => <<"test2">>,
+            <<"data">> => <<"test2">>,
             <<"Deep-Key">> =>
-                #{ <<"Data">> => <<"test3">> }
+                #{ <<"data">> => <<"test3">> }
         },
         Wallet
     ),
@@ -203,7 +203,7 @@ benchmark_test() ->
     BenchTime = 1,
     Wallet = ar_wallet:new(),
     SignedItem = hb_message:sign(
-        #{ <<"Data">> => <<"test">>, <<"Random-Key">> => rand:uniform(10000) },
+        #{ <<"data">> => <<"test">>, <<"Random-Key">> => rand:uniform(10000) },
         Wallet
     ),
     dev_scheduler_registry:find(ID = hb_converge:get(id, SignedItem), true),

--- a/src/dev_scheduler_server.erl
+++ b/src/dev_scheduler_server.erl
@@ -54,7 +54,7 @@ slot_from_cache(ProcID, Opts) ->
             {
                 AssignmentNum,
                 hb_converge:get(
-                    <<"Hash-Chain">>, Assignment, #{ hashpath => ignore })
+                    <<"hash-chain">>, Assignment, #{ hashpath => ignore })
             }
     end.
 
@@ -113,18 +113,18 @@ do_assign(State, Message, ReplyPID) ->
         fun() ->
             {Timestamp, Height, Hash} = ar_timestamp:get(),
             Assignment = hb_message:sign(#{
-                <<"Data-Protocol">> => <<"ao">>,
-                <<"Variant">> => <<"ao.TN.2">>,
-                <<"Process">> => hb_util:id(maps:get(id, State)),
-                <<"Epoch">> => <<"0">>,
-                <<"Slot">> => NextSlot,
-                <<"Message">> => hb_converge:get(id, Message),
-                <<"Block-Height">> => Height,
-                <<"Block-Hash">> => Hash,
-                <<"Block-Timestamp">> => Timestamp,
+                <<"data-protocol">> => <<"ao">>,
+                <<"variant">> => <<"ao.TN.2">>,
+                <<"process">> => hb_util:id(maps:get(id, State)),
+                <<"epoch">> => <<"0">>,
+                <<"slot">> => NextSlot,
+                <<"message">> => hb_converge:get(id, Message),
+                <<"block-height">> => Height,
+                <<"block-hash">> => Hash,
+                <<"block-timestamp">> => Timestamp,
                 % Note: Local time on the SU, not Arweave
-                <<"Timestamp">> => erlang:system_time(millisecond),
-                <<"Hash-Chain">> => hb_util:id(HashChain)
+                <<"timestamp">> => erlang:system_time(millisecond),
+                <<"hash-chain">> => hb_util:id(HashChain)
             }, maps:get(wallet, State)),
             maybe_inform_recipient(aggressive, ReplyPID, Message, Assignment),
             ?event(starting_message_write),
@@ -175,7 +175,7 @@ next_hashchain(HashChain, Message) ->
 new_proc_test() ->
     Wallet = ar_wallet:new(),
     SignedItem = hb_message:sign(
-        #{ <<"data">> => <<"test">>, <<"Random-Key">> => rand:uniform(10000) },
+        #{ <<"data">> => <<"test">>, <<"random-key">> => rand:uniform(10000) },
         Wallet
     ),
     SignedItem2 = hb_message:sign(
@@ -185,7 +185,7 @@ new_proc_test() ->
     SignedItem3 = hb_message:sign(
         #{
             <<"data">> => <<"test2">>,
-            <<"Deep-Key">> =>
+            <<"deep-key">> =>
                 #{ <<"data">> => <<"test3">> }
         },
         Wallet
@@ -203,7 +203,7 @@ benchmark_test() ->
     BenchTime = 1,
     Wallet = ar_wallet:new(),
     SignedItem = hb_message:sign(
-        #{ <<"data">> => <<"test">>, <<"Random-Key">> => rand:uniform(10000) },
+        #{ <<"data">> => <<"test">>, <<"random-key">> => rand:uniform(10000) },
         Wallet
     ),
     dev_scheduler_registry:find(ID = hb_converge:get(id, SignedItem), true),
@@ -212,11 +212,11 @@ benchmark_test() ->
         fun(X) ->
             MsgX = #{
                 path => <<"Schedule">>,
-                <<"Method">> => <<"POST">>,
-                <<"Message">> =>
+                <<"method">> => <<"POST">>,
+                <<"message">> =>
                     #{
-                        <<"Type">> => <<"Message">>,
-                        <<"Test-Val">> => X
+                        <<"type">> => <<"Message">>,
+                        <<"test-val">> => X
                     }
             },
             schedule(ID, MsgX)

--- a/src/dev_stack.erl
+++ b/src/dev_stack.erl
@@ -127,7 +127,7 @@ output_prefix(Msg1, _Msg2, Opts) ->
 %% @doc The device stack key router. Sends the request to `resolve_stack',
 %% except for `set/2' which is handled by the default implementation in
 %% `dev_message'.
-router(keys, Message1, Message2, _Opts) ->
+router(<<"keys">>, Message1, Message2, _Opts) ->
 	?event({keys_called, {msg1, Message1}, {msg2, Message2}}),
 	dev_message:keys(Message1);
 router(Key, Message1, Message2, Opts) ->
@@ -267,7 +267,7 @@ resolve_fold(Message1, Message2, Opts) ->
             dev_message:set(
                 Result,
                 #{
-                    device => InitDevMsg,
+                    <<"device">> => InitDevMsg,
                     <<"input-prefix">> =>
                         hb_converge:get(
                             <<"previous-input-prefix">>,

--- a/src/dev_stack.erl
+++ b/src/dev_stack.erl
@@ -354,7 +354,7 @@ resolve_map(Message1, Message2, Opts) ->
                     _ -> false
                 end
             end,
-            maps:without(?CONVERGE_KEYS, hb_converge:ensure_message(DevKeys))
+            maps:without(?CONVERGE_KEYS, hb_converge:normalize_keys(DevKeys))
         )
     },
     Res.

--- a/src/dev_stack.erl
+++ b/src/dev_stack.erl
@@ -106,7 +106,7 @@ info(Msg) ->
             handler => fun router/4,
             excludes => [set, keys]
         },
-        case maps:get(<<"Stack-Keys">>, Msg, not_found) of
+        case maps:get(<<"stack-keys">>, Msg, not_found) of
             not_found -> #{};
             StackKeys -> #{ exports => StackKeys }
         end
@@ -114,15 +114,15 @@ info(Msg) ->
 
 %% @doc Return the default prefix for the stack.
 prefix(Msg1, _Msg2, Opts) ->
-    hb_converge:get(<<"Output-Prefix">>, {as, dev_message, Msg1}, <<"">>, Opts).
+    hb_converge:get(<<"output-prefix">>, {as, dev_message, Msg1}, <<"">>, Opts).
 
 %% @doc Return the input prefix for the stack.
 input_prefix(Msg1, _Msg2, Opts) ->
-    hb_converge:get(<<"Input-Prefix">>, {as, dev_message, Msg1}, <<"">>, Opts).
+    hb_converge:get(<<"input-prefix">>, {as, dev_message, Msg1}, <<"">>, Opts).
 
 %% @doc Return the output prefix for the stack.
 output_prefix(Msg1, _Msg2, Opts) ->
-    hb_converge:get(<<"Output-Prefix">>, {as, dev_message, Msg1}, <<"">>, Opts).
+    hb_converge:get(<<"output-prefix">>, {as, dev_message, Msg1}, <<"">>, Opts).
 
 %% @doc The device stack key router. Sends the request to `resolve_stack',
 %% except for `set/2' which is handled by the default implementation in
@@ -131,17 +131,17 @@ router(keys, Message1, Message2, _Opts) ->
 	?event({keys_called, {msg1, Message1}, {msg2, Message2}}),
 	dev_message:keys(Message1);
 router(Key, Message1, Message2, Opts) ->
-    case hb_path:matches(Key, <<"Transform">>) of
+    case hb_path:matches(Key, <<"transform">>) of
         true -> transformer_message(Message1, Opts);
         false -> router(Message1, Message2, Opts)
     end.
 router(Message1, Message2, Opts) ->
 	?event({router_called, {msg1, Message1}, {msg2, Message2}}),
     Mode =
-        case hb_converge:get(<<"Mode">>, Message2, not_found, Opts) of
+        case hb_converge:get(<<"mode">>, Message2, not_found, Opts) of
             not_found ->
                 hb_converge:get(
-                    <<"Mode">>,
+                    <<"mode">>,
                     {as, dev_message, Message1},
                     <<"Fold">>,
                     Opts
@@ -178,7 +178,7 @@ transformer_message(Msg1, Opts) ->
                             }
                         )
 					end,
-				type => <<"Stack-Transformer">>
+				type => <<"stack-transformer">>
 			}
 		}
 	}.
@@ -190,7 +190,7 @@ transformer_message(Msg1, Opts) ->
 transform(Msg1, Key, Opts) ->
 	% Get the device stack message from Msg1.
     ?event({transforming_stack, {key, Key}, {msg1, Msg1}, {opts, Opts}}),
-	case hb_converge:get(<<"Device-Stack">>, {as, dev_message, Msg1}, Opts) of
+	case hb_converge:get(<<"device-stack">>, {as, dev_message, Msg1}, Opts) of
         not_found -> throw({error, no_valid_device_stack});
         StackMsg ->
 			% Find the requested key in the device stack.
@@ -208,38 +208,38 @@ transform(Msg1, Key, Opts) ->
 					dev_message:set(
                         Msg1,
 						#{
-							<<"Device">> => DevMsg,
-                            <<"Device-Key">> => Key,
-                            <<"Input-Prefix">> =>
+							<<"device">> => DevMsg,
+                            <<"device-key">> => Key,
+                            <<"input-prefix">> =>
                                 hb_converge:get(
-                                    [<<"Input-Prefixes">>, Key],
+                                    [<<"input-prefixes">>, Key],
                                     {as, dev_message, Msg1},
                                     undefined,
                                     Opts
                                 ),
-                            <<"Output-Prefix">> =>
+                            <<"output-prefix">> =>
                                 hb_converge:get(
-                                    [<<"Output-Prefixes">>, Key],
+                                    [<<"output-prefixes">>, Key],
                                     {as, dev_message, Msg1},
                                     undefined,
                                     Opts
                                 ),
-                            <<"Previous-Device">> =>
+                            <<"previous-device">> =>
                                 hb_converge:get(
-                                    <<"Device">>,
+                                    <<"device">>,
                                     {as, dev_message, Msg1},
                                     Opts
                                 ),
-                            <<"Previous-Input-Prefix">> =>
+                            <<"previous-input-prefix">> =>
                                 hb_converge:get(
-                                    <<"Input-Prefix">>,
+                                    <<"input-prefix">>,
                                     {as, dev_message, Msg1},
                                     undefined,
                                     Opts
                                 ),
-                            <<"Previous-Output-Prefix">> =>
+                            <<"previous-output-prefix">> =>
                                 hb_converge:get(
-                                    <<"Output-Prefix">>,
+                                    <<"output-prefix">>,
                                     {as, dev_message, Msg1},
                                     undefined,
                                     Opts
@@ -256,10 +256,10 @@ transform(Msg1, Key, Opts) ->
 %% @doc The main device stack execution engine. See the moduledoc for more
 %% information.
 resolve_fold(Message1, Message2, Opts) ->
-	{ok, InitDevMsg} = dev_message:get(<<"Device">>, Message1),
+	{ok, InitDevMsg} = dev_message:get(<<"device">>, Message1),
     StartingPassValue =
-        hb_converge:get(<<"Pass">>, {as, dev_message, Message1}, unset, Opts),
-    PreparedMessage = hb_converge:set(Message1, <<"Pass">>, 1, Opts),
+        hb_converge:get(<<"pass">>, {as, dev_message, Message1}, unset, Opts),
+    PreparedMessage = hb_converge:set(Message1, <<"pass">>, 1, Opts),
     case resolve_fold(PreparedMessage, Message2, 1, Opts) of
         {ok, Raw} when not is_map(Raw) ->
             {ok, Raw};
@@ -268,23 +268,23 @@ resolve_fold(Message1, Message2, Opts) ->
                 Result,
                 #{
                     device => InitDevMsg,
-                    <<"Input-Prefix">> =>
+                    <<"input-prefix">> =>
                         hb_converge:get(
-                            <<"Previous-Input-Prefix">>,
+                            <<"previous-input-prefix">>,
                             {as, dev_message, Result},
                             undefined,
                             Opts
                         ),
-                    <<"Output-Prefix">> =>
+                    <<"output-prefix">> =>
                         hb_converge:get(
-                            <<"Previous-Output-Prefix">>,
+                            <<"previous-output-prefix">>,
                             {as, dev_message, Result},
                             undefined,
                             Opts
                         ),
-                    <<"Device-Key">> => unset,
-                    <<"Device-Stack-Previous">> => unset,
-                    <<"Pass">> => StartingPassValue
+                    <<"device-key">> => unset,
+                    <<"device-stack-previous">> => unset,
+                    <<"pass">> => StartingPassValue
                 },
                 Opts
             );
@@ -341,7 +341,7 @@ resolve_map(Message1, Message2, Opts) ->
     ?event({resolving_map, {msg1, Message1}, {msg2, Message2}}),
     DevKeys =
         hb_converge:get(
-            <<"Device-Stack">>,
+            <<"device-stack">>,
             {as, dev_message, Message1},
             Opts
         ),
@@ -363,7 +363,7 @@ resolve_map(Message1, Message2, Opts) ->
 increment_pass(Message, Opts) ->
     hb_converge:set(
         Message,
-        #{ pass => hb_converge:get(<<"Pass">>, {as, dev_message, Message}, 1, Opts) + 1 },
+        #{ <<"pass">> => hb_converge:get(<<"pass">>, {as, dev_message, Message}, 1, Opts) + 1 },
         Opts
     ).
 
@@ -391,12 +391,12 @@ generate_append_device(Separator) ->
 generate_append_device(Separator, Status) ->
 	#{
 		append =>
-			fun(M1 = #{ pass := 3 }, _) ->
+			fun(M1 = #{ <<"pass">> := 3 }, _) ->
                 % Stop after 3 passes.
                 {ok, M1};
-			   (M1 = #{ result := Existing }, #{ bin := New }) ->
+			   (M1 = #{ <<"result">> := Existing }, #{ <<"bin">> := New }) ->
 				?event({appending, {existing, Existing}, {new, New}}),
-				{Status, M1#{ result =>
+				{Status, M1#{ <<"result">> =>
 					<< Existing/binary, Separator/binary, New/binary>>
 				}}
 			end
@@ -408,8 +408,8 @@ transform_internal_call_device_test() ->
 	AppendDev = generate_append_device(<<"_">>),
 	Msg1 =
 		#{
-			device => <<"Stack/1.0">>,
-			<<"Device-Stack">> =>
+			<<"device">> => <<"Stack/1.0">>,
+			<<"device-stack">> =>
 				#{
 					<<"1">> => AppendDev,
 					<<"2">> => <<"Message/1.0">>
@@ -418,7 +418,7 @@ transform_internal_call_device_test() ->
 	?assertMatch(
 		<<"Message/1.0">>,
 		hb_converge:get(
-			<<"Device">>,
+			<<"device">>,
 			element(2, transform(Msg1, <<"2">>, #{}))
 		)
 	).
@@ -427,10 +427,10 @@ transform_internal_call_device_test() ->
 %% return a version of msg1 with only that device attached.
 transform_external_call_device_test() ->
 	Msg1 = #{
-		device => <<"Stack/1.0">>,
-		<<"Device-Stack">> =>
+		<<"device">> => <<"Stack/1.0">>,
+		<<"device-stack">> =>
 			#{
-				<<"Make-Cool">> =>
+				<<"make-cool">> =>
 					#{
 						info =>
 							fun() ->
@@ -454,12 +454,12 @@ transform_external_call_device_test() ->
 						suffix => <<"-Cool">>
 					}
 			},
-		<<"Value">> => <<"Super">>
+		<<"value">> => <<"Super">>
 	},
 	?assertMatch(
-		{ok, #{ <<"Value">> := <<"Super-Cool">> }},
+		{ok, #{ <<"value">> := <<"Super-Cool">> }},
 		hb_converge:resolve(Msg1, #{
-			path => <<"/Transform/Make-Cool/Value">>
+			path => <<"/transform/make-cool/value">>
 		}, #{})
 	).
 
@@ -470,32 +470,32 @@ example_device_for_stack_test() ->
 	?assertMatch(
 		{ok, #{ result := <<"1_2">> }},
 		hb_converge:resolve(
-			#{ device => generate_append_device(<<"_">>), result => <<"1">> },
-			#{ path => append, bin => <<"2">> },
+			#{ <<"device">> => generate_append_device(<<"_">>), <<"result">> => <<"1">> },
+			#{ <<"path">> => <<"append">>, <<"bin">> => <<"2">> },
 			#{}
 		)
 	).
 
 simple_stack_execute_test() ->
 	Msg = #{
-		device => <<"Stack/1.0">>,
-		<<"Device-Stack">> =>
+		<<"device">> => <<"Stack/1.0">>,
+		<<"device-stack">> =>
 			#{
 				<<"1">> => generate_append_device(<<"!D1!">>),
 				<<"2">> => generate_append_device(<<"_D2_">>)
 			},
-		result => <<"INIT">>
+		<<"result">> => <<"INIT">>
 	},
 	?event({stack_executing, test, {explicit, Msg}}),
 	?assertMatch(
-		{ok, #{ result := <<"INIT!D1!2_D2_2">> }},
-		hb_converge:resolve(Msg, #{ path => append, bin => <<"2">> }, #{})
+		{ok, #{ <<"result">> := <<"INIT!D1!2_D2_2">> }},
+		hb_converge:resolve(Msg, #{ <<"path">> => <<"append">>, <<"bin">> => <<"2">> }, #{})
 	).
 
 many_devices_test() ->
 	Msg = #{
-		device => <<"Stack/1.0">>,
-		<<"Device-Stack">> =>
+		<<"device">> => <<"Stack/1.0">>,
+		<<"device-stack">> =>
 			#{
 				<<"1">> => generate_append_device(<<"+D1">>),
 				<<"2">> => generate_append_device(<<"+D2">>),
@@ -506,23 +506,23 @@ many_devices_test() ->
 				<<"7">> => generate_append_device(<<"+D7">>),
 				<<"8">> => generate_append_device(<<"+D8">>)
 			},
-		result => <<"INIT">>
+		<<"result">> => <<"INIT">>
 	},
 	?assertMatch(
 		{ok,
 			#{
-				result :=
+				<<"result">> :=
 					<<"INIT+D12+D22+D32+D42+D52+D62+D72+D82">>
 			}
 		},
-		hb_converge:resolve(Msg, #{ path => append, bin => <<"2">> }, #{})
+		hb_converge:resolve(Msg, #{ <<"path">> => <<"append">>, <<"bin">> => <<"2">> }, #{})
 	).
 
 benchmark_test() ->
     BenchTime = 0.3,
 	Msg = #{
-		device => <<"Stack/1.0">>,
-		<<"Device-Stack">> =>
+		<<"device">> => <<"Stack/1.0">>,
+		<<"device-stack">> =>
 			#{
 				<<"1">> => generate_append_device(<<"+D1">>),
 				<<"2">> => generate_append_device(<<"+D2">>),
@@ -530,7 +530,7 @@ benchmark_test() ->
 				<<"4">> => generate_append_device(<<"+D4">>),
 				<<"5">> => generate_append_device(<<"+D5">>)
 			},
-		result => <<"INIT">>
+		<<"result">> => <<"INIT">>
 	},
     Iterations =
         hb:benchmark(
@@ -553,7 +553,7 @@ test_prefix_msg() ->
             fun(M1, M2, Opts) ->
                 In = input_prefix(M1, M2, Opts),
                 Out = output_prefix(M1, M2, Opts),
-                Key = hb_converge:get(<<"Key">>, M2, Opts),
+                Key = hb_converge:get(<<"key">>, M2, Opts),
                 Value = hb_converge:get(<<In/binary, "/", Key/binary>>, M2, Opts),
                 ?event({setting, {inp, In}, {outp, Out}, {key, Key}, {value, Value}}),
                 {ok, hb_converge:set(
@@ -565,73 +565,73 @@ test_prefix_msg() ->
             end
     },
     #{
-        device => <<"Stack/1.0">>,
-        <<"Device-Stack">> => #{ 1 => Dev, 2 => Dev }
+        <<"device">> => <<"Stack/1.0">>,
+        <<"device-stack">> => #{ 1 => Dev, 2 => Dev }
     }.
 
 no_prefix_test() ->
     Msg2 =
         #{
-            path => prefix_set,
-            key => <<"Example">>,
-            <<"Example">> => 1
+            <<"path">> => <<"prefix-set">>,
+            <<"key">> => <<"example">>,
+            <<"example">> => 1
         },
     {ok, Ex1Msg3} = hb_converge:resolve(test_prefix_msg(), Msg2, #{}),
     ?event({ex1, Ex1Msg3}),
-    ?assertMatch(1, hb_converge:get(<<"Example">>, Ex1Msg3, #{})).
+    ?assertMatch(1, hb_converge:get(<<"example">>, Ex1Msg3, #{})).
 
 output_prefix_test() ->
     Msg1 =
         (test_prefix_msg())#{
-            <<"Output-Prefixes">> => #{ 1 => <<"Out1/">>, 2 => <<"Out2/">> }
+            <<"output-prefixes">> => #{ 1 => <<"out1/">>, 2 => <<"out2/">> }
         },
     Msg2 =
         #{
-            path => prefix_set,
-            key => <<"Example">>,
-            <<"Example">> => 1
+            <<"path">> => <<"prefix-set">>,
+            <<"key">> => <<"example">>,
+            <<"example">> => 1
         },
     {ok, Ex2Msg3} = hb_converge:resolve(Msg1, Msg2, #{}),
     ?assertMatch(1,
-        hb_converge:get(<<"Out1/Example">>, {as, dev_message, Ex2Msg3}, #{})),
+        hb_converge:get(<<"out1/example">>, {as, dev_message, Ex2Msg3}, #{})),
     ?assertMatch(1,
-        hb_converge:get(<<"Out2/Example">>, {as, dev_message, Ex2Msg3}, #{})).
+        hb_converge:get(<<"out2/example">>, {as, dev_message, Ex2Msg3}, #{})).
 
 input_and_output_prefixes_test() ->
     Msg1 =
         (test_prefix_msg())#{
-            <<"Input-Prefixes">> => #{ 1 => <<"In1/">>, 2 => <<"In2/">> },
-            <<"Output-Prefixes">> => #{ 1 => <<"Out1/">>, 2 => <<"Out2/">> }
+            <<"input-prefixes">> => #{ 1 => <<"in1/">>, 2 => <<"in2/">> },
+            <<"output-prefixes">> => #{ 1 => <<"out1/">>, 2 => <<"out2/">> }
         },
     Msg2 =
         #{
-            path => prefix_set,
-            key => <<"Example">>,
-            <<"In1">> => #{ <<"Example">> => 1 },
-            <<"In2">> => #{ <<"Example">> => 2 }
+            <<"path">> => <<"prefix-set">>,
+            <<"key">> => <<"example">>,
+            <<"in1">> => #{ <<"example">> => 1 },
+            <<"in2">> => #{ <<"example">> => 2 }
         },
     {ok, Msg3} = hb_converge:resolve(Msg1, Msg2, #{}),
     ?assertMatch(1,
-        hb_converge:get(<<"Out1/Example">>, {as, dev_message, Msg3}, #{})),
+        hb_converge:get(<<"out1/example">>, {as, dev_message, Msg3}, #{})),
     ?assertMatch(2,
-        hb_converge:get(<<"Out2/Example">>, {as, dev_message, Msg3}, #{})).
+        hb_converge:get(<<"out2/example">>, {as, dev_message, Msg3}, #{})).
 
 input_output_prefixes_passthrough_test() ->
     Msg1 =
         (test_prefix_msg())#{
-            <<"Output-Prefix">> => <<"Combined-Out/">>,
-            <<"Input-Prefix">> => <<"Combined-In/">>
+            <<"output-prefix">> => <<"combined-out/">>,
+            <<"input-prefix">> => <<"combined-in/">>
         },
     Msg2 =
         #{
-            path => prefix_set,
-            key => <<"Example">>,
-            <<"Combined-In">> => #{ <<"Example">> => 1 }
+            <<"path">> => <<"prefix-set">>,
+            <<"key">> => <<"example">>,
+            <<"combined-in">> => #{ <<"example">> => 1 }
         },
     {ok, Ex2Msg3} = hb_converge:resolve(Msg1, Msg2, #{}),
     ?assertMatch(1,
         hb_converge:get(
-            <<"Combined-Out/Example">>,
+            <<"combined-out/example">>,
             {as, dev_message, Ex2Msg3},
             #{}
         )
@@ -639,41 +639,41 @@ input_output_prefixes_passthrough_test() ->
 
 reinvocation_test() ->
 	Msg = #{
-		device => <<"Stack/1.0">>,
-		<<"Device-Stack">> =>
+		<<"device">> => <<"Stack/1.0">>,
+		<<"device-stack">> =>
 			#{
 				<<"1">> => generate_append_device(<<"+D1">>),
 				<<"2">> => generate_append_device(<<"+D2">>)
 			},
-		result => <<"INIT">>
+		<<"result">> => <<"INIT">>
 	},
-	Res1 = hb_converge:resolve(Msg, #{ path => append, bin => <<"2">> }, #{}),
+	Res1 = hb_converge:resolve(Msg, #{ <<"path">> => <<"append">>, <<"bin">> => <<"2">> }, #{}),
 	?assertMatch(
-		{ok, #{ result := <<"INIT+D12+D22">> }},
+		{ok, #{ <<"result">> := <<"INIT+D12+D22">> }},
 		Res1
 	),
 	{ok, Msg2} = Res1,
-	Res2 = hb_converge:resolve(Msg2, #{ path => append, bin => <<"3">> }, #{}),
+	Res2 = hb_converge:resolve(Msg2, #{ <<"path">> => <<"append">>, <<"bin">> => <<"3">> }, #{}),
 	?assertMatch(
-		{ok, #{ result := <<"INIT+D12+D22+D13+D23">> }},
+		{ok, #{ <<"result">> := <<"INIT+D12+D22+D13+D23">> }},
 		Res2
 	).
 
 skip_test() ->
 	Msg1 = #{
-		device => <<"Stack/1.0">>,
-		<<"Device-Stack">> =>
+		<<"device">> => <<"Stack/1.0">>,
+		<<"device-stack">> =>
 			#{
 				<<"1">> => generate_append_device(<<"+D1">>, skip),
 				<<"2">> => generate_append_device(<<"+D2">>)
 			},
-		result => <<"INIT">>
+		<<"result">> => <<"INIT">>
 	},
 	?assertMatch(
-		{ok, #{ result := <<"INIT+D12">> }},
+		{ok, #{ <<"result">> := <<"INIT+D12">> }},
 		hb_converge:resolve(
 			Msg1,
-			#{ path => append, bin => <<"2">> },
+			#{ <<"path">> => <<"append">>, <<"bin">> => <<"2">> },
             #{}
 		)
 	).
@@ -683,57 +683,57 @@ pass_test() ->
     % recursively calls the device by forcing its response to be `pass`
     % until that happens.
 	Msg = #{
-		device => <<"Stack/1.0">>,
-		<<"Device-Stack">> =>
+		<<"device">> => <<"Stack/1.0">>,
+		<<"device-stack">> =>
 			#{
 				<<"1">> => generate_append_device(<<"+D1">>, pass)
 			},
-		result => <<"INIT">>
+		<<"result">> => <<"INIT">>
 	},
 	?assertMatch(
-		{ok, #{ result := <<"INIT+D1_+D1_">> }},
-		hb_converge:resolve(Msg, #{ path => append, bin => <<"_">> }, #{})
+		{ok, #{ <<"result">> := <<"INIT+D1_+D1_">> }},
+		hb_converge:resolve(Msg, #{ <<"path">> => <<"append">>, <<"bin">> => <<"_">> }, #{})
 	).
 
 not_found_test() ->
     % Ensure that devices not exposing a key are safely skipped.
 	Msg = #{
-		device => <<"Stack/1.0">>,
-		<<"Device-Stack">> =>
+		<<"device">> => <<"Stack/1.0">>,
+		<<"device-stack">> =>
 			#{
 				<<"1">> => generate_append_device(<<"+D1">>),
 				<<"2">> =>
                     (generate_append_device(<<"+D2">>))#{
                         special =>
                             fun(M1) ->
-                                {ok, M1#{ <<"Output">> => 1337 }}
+                                {ok, M1#{ <<"output">> => 1337 }}
                             end
                     }
 			},
-		result => <<"INIT">>
+		<<"result">> => <<"INIT">>
 	},
-    {ok, Msg3} = hb_converge:resolve(Msg, #{ path => append, bin => <<"_">> }, #{}),
+    {ok, Msg3} = hb_converge:resolve(Msg, #{ <<"path">> => <<"append">>, <<"bin">> => <<"_">> }, #{}),
     ?assertMatch(
-		#{ result := <<"INIT+D1_+D2_">> },
+		#{ <<"result">> := <<"INIT+D1_+D2_">> },
 		Msg3
 	),
-    ?assertEqual(1337, hb_converge:get(<<"Special/Output">>, Msg3, #{})).
+    ?assertEqual(1337, hb_converge:get(<<"special/output">>, Msg3, #{})).
 
 simple_map_test() ->
     Msg = #{
-        device => <<"Stack/1.0">>,
-        <<"Device-Stack">> =>
+        <<"device">> => <<"Stack/1.0">>,
+        <<"device-stack">> =>
             #{
                 <<"1">> => generate_append_device(<<"+D1">>),
                 <<"2">> => generate_append_device(<<"+D2">>)
             },
-        result => <<"INIT">>
+        <<"result">> => <<"INIT">>
     },
     {ok, Msg3} =
         hb_converge:resolve(
             Msg,
-            #{ path => append, <<"Mode">> => <<"Map">>, bin => <<"/">> },
+            #{ <<"path">> => <<"append">>, <<"mode">> => <<"Map">>, <<"bin">> => <<"/">> },
             #{}
         ),
-    ?assertMatch(<<"INIT+D1/">>, hb_converge:get(<<"1/Result">>, Msg3, #{})),
-    ?assertMatch(<<"INIT+D2/">>, hb_converge:get(<<"2/Result">>, Msg3, #{})).
+    ?assertMatch(<<"INIT+D1/">>, hb_converge:get(<<"1/result">>, Msg3, #{})),
+    ?assertMatch(<<"INIT+D2/">>, hb_converge:get(<<"2/result">>, Msg3, #{})).

--- a/src/dev_stack.erl
+++ b/src/dev_stack.erl
@@ -563,7 +563,7 @@ test_prefix_msg() ->
                 Out = output_prefix(M1, M2, Opts),
                 Key = hb_converge:get(<<"key">>, M2, Opts),
                 Value = hb_converge:get(<<In/binary, "/", Key/binary>>, M2, Opts),
-                ?event(debug, {setting, {inp, In}, {outp, Out}, {key, Key}, {value, Value}}),
+                ?event({setting, {inp, In}, {outp, Out}, {key, Key}, {value, Value}}),
                 {ok, hb_converge:set(
                     M1,
                     <<Out/binary, "/", Key/binary>>,

--- a/src/dev_test.erl
+++ b/src/dev_test.erl
@@ -23,15 +23,15 @@ test_func(_) ->
 %% the slots that have been computed in the state message and places the new
 %% slot number in the results key.
 compute(Msg1, Msg2, Opts) ->
-    AssignmentSlot = hb_converge:get(<<"Assignment/Slot">>, Msg2, Opts),
-    Seen = hb_converge:get(<<"Already-Seen">>, Msg1, Opts),
+    AssignmentSlot = hb_converge:get(<<"assignment/slot">>, Msg2, Opts),
+    Seen = hb_converge:get(<<"already-seen">>, Msg1, Opts),
     {ok,
         hb_converge:set(
             Msg1,
             #{
-                <<"Results">> =>
-                    #{ <<"Assignment-Slot">> => AssignmentSlot },
-                <<"Already-Seen">> => [AssignmentSlot | Seen]
+                <<"results">> =>
+                    #{ <<"assignment-slot">> => AssignmentSlot },
+                <<"already-seen">> => [AssignmentSlot | Seen]
             },
             Opts
         )
@@ -40,13 +40,13 @@ compute(Msg1, Msg2, Opts) ->
 %% @doc Example `init/3' handler. Sets the `Already-Seen' key to an empty list.
 init(Msg, _Msg2, Opts) ->
     ?event({init_called_on_dev_test, Msg}),
-    {ok, hb_converge:set(Msg, #{ <<"Already-Seen">> => [] }, Opts)}.
+    {ok, hb_converge:set(Msg, #{ <<"already-seen">> => [] }, Opts)}.
 
 %% @doc Example `restore/3' handler. Sets the hidden key `Test/Started` to the
 %% value of `Current-Slot` and checks whether the `Already-Seen` key is valid.
 restore(Msg, _Msg2, Opts) ->
     ?event({restore_called_on_dev_test, Msg}),
-    case hb_converge:get(<<"Already-Seen">>, Msg, Opts) of
+    case hb_converge:get(<<"already-seen">>, Msg, Opts) of
         not_found ->
             ?event({restore_not_found, Msg}),
             {error, <<"No viable state to restore.">>};
@@ -55,7 +55,7 @@ restore(Msg, _Msg2, Opts) ->
             {ok,
                 hb_private:set(
                     Msg,
-                    #{ <<"Test-Key/Started-State">> => AlreadySeen },
+                    #{ <<"test-key/started-state">> => AlreadySeen },
                     Opts
                 )
             }
@@ -65,10 +65,10 @@ restore(Msg, _Msg2, Opts) ->
 %% executor.
 mul(Msg1, Msg2) ->
     ?event(mul_called),
-    State = hb_converge:get(<<"State">>, Msg1, #{ hashpath => ignore }),
-    [Arg1, Arg2] = hb_converge:get(args, Msg2, #{ hashpath => ignore }),
+    State = hb_converge:get(<<"state">>, Msg1, #{ hashpath => ignore }),
+    [Arg1, Arg2] = hb_converge:get(<<"args">>, Msg2, #{ hashpath => ignore }),
     ?event({mul_called, {state, State}, {args, [Arg1, Arg2]}}),
-    {ok, #{ state => State, results => [Arg1 * Arg2] }}.
+    {ok, #{ <<"state">> => State, <<"results">> => [Arg1 * Arg2] }}.
 
 %% @doc Do nothing when asked to snapshot.
 snapshot(_Msg1, _Msg2, _Opts) ->
@@ -80,7 +80,7 @@ snapshot(_Msg1, _Msg2, _Opts) ->
 device_with_function_key_module_test() ->
 	Msg =
 		#{
-			device => <<"Test-Device/1.0">>
+			<<"device">> => <<"Test-Device/1.0">>
 		},
 	?assertEqual(
 		{ok, <<"GOOD_FUNCTION">>},
@@ -88,33 +88,33 @@ device_with_function_key_module_test() ->
 	).
 
 compute_test() ->
-    Msg0 = #{ device => <<"Test-Device/1.0">> },
+    Msg0 = #{ <<"device">> => <<"Test-Device/1.0">> },
     {ok, Msg1} = hb_converge:resolve(Msg0, init, #{}),
     Msg2 =
         hb_converge:set(
-            #{ path => <<"Compute">> },
+            #{ <<"path">> => <<"compute">> },
             #{
-                <<"Assignment/Slot">> => 1,
-                <<"Message/Number">> => 1337
+                <<"assignment/slot">> => 1,
+                <<"message/number">> => 1337
             },
             #{}
         ),
     {ok, Msg3} = hb_converge:resolve(Msg1, Msg2, #{}),
-    ?assertEqual(1, hb_converge:get(<<"Results/Assignment-Slot">>, Msg3, #{})),
+    ?assertEqual(1, hb_converge:get(<<"results/assignment-slot">>, Msg3, #{})),
     Msg4 =
         hb_converge:set(
-            #{ path => <<"Compute">> },
+            #{ <<"path">> => <<"compute">> },
             #{
-                <<"Assignment/Slot">> => 2,
-                <<"Message/Number">> => 9001
+                <<"assignment/slot">> => 2,
+                <<"message/number">> => 9001
             },
             #{}
         ),
     {ok, Msg5} = hb_converge:resolve(Msg3, Msg4, #{}),
-    ?assertEqual(2, hb_converge:get(<<"Results/Assignment-Slot">>, Msg5, #{})),
-    ?assertEqual([2, 1], hb_converge:get(<<"Already-Seen">>, Msg5, #{})).
+    ?assertEqual(2, hb_converge:get(<<"results/assignment-slot">>, Msg5, #{})),
+    ?assertEqual([2, 1], hb_converge:get(<<"already-seen">>, Msg5, #{})).
 
 restore_test() ->
-    Msg1 = #{ device => <<"Test-Device/1.0">>, <<"Already-Seen">> => [1] },
-    {ok, Msg3} = hb_converge:resolve(Msg1, restore, #{}),
-    ?assertEqual([1], hb_private:get(<<"Test-Key/Started-State">>, Msg3, #{})).
+    Msg1 = #{ <<"device">> => <<"Test-Device/1.0">>, <<"already-seen">> => [1] },
+    {ok, Msg3} = hb_converge:resolve(Msg1, <<"restore">>, #{}),
+    ?assertEqual([1], hb_private:get(<<"test-key/started-state">>, Msg3, #{})).

--- a/src/dev_test.erl
+++ b/src/dev_test.erl
@@ -64,8 +64,10 @@ restore(Msg, _Msg2, Opts) ->
 %% @doc Example implementation of an `imported` function for a WASM
 %% executor.
 mul(Msg1, Msg2) ->
+    ?event(mul_called),
     State = hb_converge:get(<<"State">>, Msg1, #{ hashpath => ignore }),
     [Arg1, Arg2] = hb_converge:get(args, Msg2, #{ hashpath => ignore }),
+    ?event({mul_called, {state, State}, {args, [Arg1, Arg2]}}),
     {ok, #{ state => State, results => [Arg1 * Arg2] }}.
 
 %% @doc Do nothing when asked to snapshot.

--- a/src/dev_wasi.erl
+++ b/src/dev_wasi.erl
@@ -256,7 +256,7 @@ generate_wasi_stack(File, Func, Params) ->
     Msg1 = Msg0#{
         <<"device">> => <<"Stack/1.0">>,
         <<"device-stack">> => [<<"WASI/1.0">>, <<"WASM-64/1.0">>],
-        <<"output-prefixes">> => [<<"WASM">>, <<"WASM">>],
+        <<"output-prefixes">> => [<<"wasm">>, <<"wasm">>],
         <<"stack-keys">> => [<<"init">>, <<"compute">>],
         <<"wasm-function">> => Func,
         <<"wasm-params">> => Params

--- a/src/dev_wasi.erl
+++ b/src/dev_wasi.erl
@@ -158,7 +158,7 @@ fd_write(S, Instance, [FDnum, Ptr, Vecs, RetPtr], BytesWritten, Opts) ->
     {ok, Data} = hb_beamr_io:read(Instance, VecPtr, Len),
     Before =
         binary:part(
-            OrigData = hb_converge:get(<<"Data">>, FD, Opts),
+            OrigData = hb_converge:get(<<"data">>, FD, Opts),
             0,
             StartOffset
         ),

--- a/src/dev_wasi.erl
+++ b/src/dev_wasi.erl
@@ -23,16 +23,16 @@
 -define(INIT_FDS,
     #{
         0 => #{
-            <<"Filename">> => <<"/dev/stdin">>,
-            <<"Offset">> => 0
+            <<"filename">> => <<"/dev/stdin">>,
+            <<"offset">> => 0
         },
         1 => #{
-            <<"Filename">> => <<"/dev/stdout">>,
-            <<"Offset">> => 0
+            <<"filename">> => <<"/dev/stdout">>,
+            <<"offset">> => 0
         },
         2 => #{
-            <<"Filename">> => <<"/dev/stderr">>,
-            <<"Offset">> => 0
+            <<"filename">> => <<"/dev/stderr">>,
+            <<"offset">> => 0
         }
     }
 ).
@@ -47,7 +47,7 @@ init(M1, _M2, Opts) ->
         hb_converge:set(
             M1,
             #{
-                <<"WASM/stdlib/wasi_snapshot_preview1">> =>
+                <<"wasm/stdlib/wasi_snapshot_preview1">> =>
                     #{ device => <<"WASI/1.0">>}
             },
             Opts
@@ -55,14 +55,14 @@ init(M1, _M2, Opts) ->
     MsgWithFDs =
         hb_converge:set(
             MsgWithLib,
-            <<"File-Descriptors">>,
+            <<"file-descriptors">>,
             ?INIT_FDS,
             Opts
         ),
     CompleteMsg =
         hb_converge:set(
             MsgWithFDs,
-            <<"VFS">>,
+            <<"vfs">>,
             ?INIT_VFS,
             Opts
         ),
@@ -100,43 +100,43 @@ stdout(M) ->
 %% @doc Adds a file descriptor to the state message.
 %path_open(M, Instance, [FDPtr, LookupFlag, PathPtr|_]) ->
 path_open(Msg1, Msg2, Opts) ->
-    FDs = hb_converge:get(<<"File-Descriptors">>, Msg1, Opts),
-    Instance = hb_private:get(<<"Instance">>, Msg1, Opts),
-    [FDPtr, LookupFlag, PathPtr|_] = hb_converge:get(<<"Args">>, Msg2, Opts),
+    FDs = hb_converge:get(<<"file-descriptors">>, Msg1, Opts),
+    Instance = hb_private:get(<<"instance">>, Msg1, Opts),
+    [FDPtr, LookupFlag, PathPtr|_] = hb_converge:get(<<"args">>, Msg2, Opts),
     ?event({path_open, FDPtr, LookupFlag, PathPtr}),
     Path = hb_beamr_io:read_string(Instance, PathPtr),
     ?event({path_open, Path}),
     FD = #{
-        index := Index
+        <<"index">> := Index
     } =
-        case hb_converge:get(<<"vfs/", Path/binary>>, Msg1) of
+        case hb_converge:get(<<"vfs/", Path/binary>>, Msg1, Opts) of
             not_found ->
                 #{
-                    index => length(hb_converge:keys(FDs)) + 1,
-                    filename => Path,
-                    offset => 0
+                    <<"index">> => length(hb_converge:keys(FDs)) + 1,
+                    <<"filename">> => Path,
+                    <<"offset">> => 0
                 };
             F -> F
         end,
     {
         ok,
         #{
-            state =>
+            <<"state">> =>
                 hb_converge:set(
                     Msg1,
                     <<"vfs/", Path/binary>>,
                     FD
                 ),
-            results => [0, Index]
+            <<"results">> => [0, Index]
         }
     }.
 
 %% @doc WASM stdlib implementation of `fd_write', using the WASI-p1 standard
 %% interface.
 fd_write(Msg1, Msg2, Opts) ->
-    State = hb_converge:get(<<"State">>, Msg1, Opts),
-    Instance = hb_private:get(<<"WASM/Instance">>, State, Opts),
-    [FD, Ptr, Vecs, RetPtr|_] = hb_converge:get(<<"Args">>, Msg2, Opts),
+    State = hb_converge:get(<<"state">>, Msg1, Opts),
+    Instance = hb_private:get(<<"wasm/instance">>, State, Opts),
+    [FD, Ptr, Vecs, RetPtr|_] = hb_converge:get(<<"args">>, Msg2, Opts),
     ?event({fd_write, {fd, FD}, {ptr, Ptr}, {vecs, Vecs}, {retptr, RetPtr}}),
     Signature = hb_converge:get(<<"func_sig">>, Msg2, Opts),
     ?event({signature, Signature}),
@@ -148,12 +148,12 @@ fd_write(S, Instance, [_, _Ptr, 0, RetPtr], BytesWritten, _Opts) ->
         RetPtr,
         <<BytesWritten:64/little-unsigned-integer>>
     ),
-    {ok, #{ state => S, results => [0] }};
+    {ok, #{ <<"state">> => S, <<"results">> => [0] }};
 fd_write(S, Instance, [FDnum, Ptr, Vecs, RetPtr], BytesWritten, Opts) ->
     FDNumStr = integer_to_binary(FDnum),
-    FD = hb_converge:get(<<"File-Descriptors/", FDNumStr/binary>>, S, Opts),
-    Filename = hb_converge:get(<<"Filename">>, FD, Opts),
-    StartOffset = hb_converge:get(<<"Offset">>, FD, Opts),
+    FD = hb_converge:get(<<"file-descriptors/", FDNumStr/binary>>, S, Opts),
+    Filename = hb_converge:get(<<"filename">>, FD, Opts),
+    StartOffset = hb_converge:get(<<"offset">>, FD, Opts),
     {VecPtr, Len} = parse_iovec(Instance, Ptr),
     {ok, Data} = hb_beamr_io:read(Instance, VecPtr, Len),
     Before =
@@ -167,7 +167,7 @@ fd_write(S, Instance, [FDnum, Ptr, Vecs, RetPtr], BytesWritten, Opts) ->
     S1 =
         hb_converge:set(
             S,
-            <<"File-Descriptors/", FDNumStr/binary, "/Offset">>,
+            <<"file-descriptors/", FDNumStr/binary, "/offset">>,
             StartOffset + byte_size(Data),
             Opts
         ),
@@ -188,9 +188,9 @@ fd_write(S, Instance, [FDnum, Ptr, Vecs, RetPtr], BytesWritten, Opts) ->
 
 %% @doc Read from a file using the WASI-p1 standard interface.
 fd_read(Msg1, Msg2, Opts) ->
-    State = hb_converge:get(<<"State">>, Msg1, Opts),
-    Instance = hb_private:get(<<"WASM/Instance">>, State, Opts),
-    [FD, VecsPtr, NumVecs, RetPtr|_] = hb_converge:get(<<"Args">>, Msg2, Opts),
+    State = hb_converge:get(<<"state">>, Msg1, Opts),
+    Instance = hb_private:get(<<"wasm/instance">>, State, Opts),
+    [FD, VecsPtr, NumVecs, RetPtr|_] = hb_converge:get(<<"args">>, Msg2, Opts),
     Signature = hb_converge:get(<<"func_sig">>, Msg2, Opts),
     ?event({signature, Signature}),
     fd_read(State, Instance, [FD, VecsPtr, NumVecs, RetPtr], 0, Opts).
@@ -199,20 +199,20 @@ fd_read(S, Instance, [FD, _VecsPtr, 0, RetPtr], BytesRead, _Opts) ->
     ?event({{completed_read, FD, BytesRead}}),
     hb_beamr_io:write(Instance, RetPtr,
         <<BytesRead:64/little-unsigned-integer>>),
-    {ok, #{ state => S, results => [0] }};
+    {ok, #{ <<"state">> => S, <<"results">> => [0] }};
 fd_read(S, Instance, [FDNum, VecsPtr, NumVecs, RetPtr], BytesRead, Opts) ->
     ?event({fd_read, FDNum, VecsPtr, NumVecs, RetPtr}),
     % Parse the request
     FDNumStr = integer_to_binary(FDNum),
     Filename =
         hb_converge:get(
-            <<"File-Descriptors/", FDNumStr/binary, "/Filename">>, S, Opts),
+            <<"file-descriptors/", FDNumStr/binary, "/filename">>, S, Opts),
     {VecPtr, Len} = parse_iovec(Instance, VecsPtr),
     % Read the bytes from the file
     Data = hb_converge:get(<<"vfs/", Filename/binary>>, S, Opts),
     Offset =
         hb_converge:get(
-            <<"File-Descriptors/", FDNumStr/binary, "/Offset">>, S, Opts),
+            <<"file-descriptors/", FDNumStr/binary, "/offset">>, S, Opts),
     ReadSize = min(Len, byte_size(Data) - Offset),
     Bin = binary:part(Data, Offset, ReadSize),
     % Write the bytes to the WASM Instance
@@ -220,7 +220,7 @@ fd_read(S, Instance, [FDNum, VecsPtr, NumVecs, RetPtr], BytesRead, Opts) ->
     fd_read(
         hb_converge:set(
             S,
-            <<"File-Descriptors/", FDNumStr/binary, "/Offset">>,
+            <<"file-descriptors/", FDNumStr/binary, "/offset">>,
             Offset + ReadSize,
             Opts
         ),
@@ -242,8 +242,8 @@ parse_iovec(Instance, Ptr) ->
 %%% Misc WASI-preview-1 handlers.
 clock_time_get(Msg1, _Msg2, Opts) ->
     ?event({clock_time_get, {returning, 1}}),
-    State = hb_converge:get(<<"State">>, Msg1, Opts),
-    {ok, #{ state => State, results => [1] }}.
+    State = hb_converge:get(<<"state">>, Msg1, Opts),
+    {ok, #{ <<"state">> => State, <<"results">> => [1] }}.
 
 %%% Tests
 
@@ -254,19 +254,19 @@ generate_wasi_stack(File, Func, Params) ->
     init(),
     Msg0 = dev_wasm:cache_wasm_image(File),
     Msg1 = Msg0#{
-        device => <<"Stack/1.0">>,
-        <<"Device-Stack">> => [<<"WASI/1.0">>, <<"WASM-64/1.0">>],
-        <<"Output-Prefixes">> => [<<"WASM">>, <<"WASM">>],
-        <<"Stack-Keys">> => [<<"Init">>, <<"Compute">>],
-        <<"WASM-Function">> => Func,
-        <<"WASM-Params">> => Params
+        <<"device">> => <<"Stack/1.0">>,
+        <<"device-stack">> => [<<"WASI/1.0">>, <<"WASM-64/1.0">>],
+        <<"output-prefixes">> => [<<"WASM">>, <<"WASM">>],
+        <<"stack-keys">> => [<<"init">>, <<"compute">>],
+        <<"wasm-function">> => Func,
+        <<"wasm-params">> => Params
     },
-    {ok, Msg2} = hb_converge:resolve(Msg1, <<"Init">>, #{}),
+    {ok, Msg2} = hb_converge:resolve(Msg1, <<"init">>, #{}),
     Msg2.
 
 vfs_is_serializable_test() ->
     StackMsg = generate_wasi_stack("test/test-print.wasm", <<"hello">>, []),
-    VFSMsg = hb_converge:get(<<"VFS">>, StackMsg),
+    VFSMsg = hb_converge:get(<<"vfs">>, StackMsg),
     VFSMsg2 =
         hb_message:minimize(
             hb_message:convert(
@@ -291,7 +291,7 @@ basic_aos_exec_test() ->
     Init = generate_wasi_stack("test/aos-2-pure-xs.wasm", <<"handle">>, []),
     Msg = gen_test_aos_msg("return 1+1"),
     Env = gen_test_env(),
-    Instance = hb_private:get(<<"WASM/Instance">>, Init, #{}),
+    Instance = hb_private:get(<<"wasm/instance">>, Init, #{}),
     {ok, Ptr1} = hb_beamr_io:malloc(Instance, byte_size(Msg)),
     ?assertNotEqual(0, Ptr1),
     hb_beamr_io:write(Instance, Ptr1, Msg),
@@ -303,12 +303,12 @@ basic_aos_exec_test() ->
     {ok, EnvBin} = hb_beamr_io:read(Instance, Ptr2, byte_size(Env)),
     ?assertEqual(Env, EnvBin),
     ?assertEqual(Msg, MsgBin),
-    Ready = Init#{ <<"WASM-Params">> => [Ptr1, Ptr2] },
-    {ok, StateRes} = hb_converge:resolve(Ready, <<"Compute">>, #{}),
-    [Ptr] = hb_converge:get(<<"Results/WASM/Output">>, StateRes),
+    Ready = Init#{ <<"wasm-params">> => [Ptr1, Ptr2] },
+    {ok, StateRes} = hb_converge:resolve(Ready, <<"compute">>, #{}),
+    [Ptr] = hb_converge:get(<<"results/wasm/output">>, StateRes),
     {ok, Output} = hb_beamr_io:read_string(Instance, Ptr),
     ?event({got_output, Output}),
-    #{ <<"response">> := #{ <<"Output">> := #{ <<"data">> := Data }} }
+    #{ <<"response">> := #{ <<"output">> := #{ <<"data">> := Data }} }
         = jiffy:decode(Output, [return_maps]),
     ?assertEqual(<<"2">>, Data).
 

--- a/src/dev_wasi.erl
+++ b/src/dev_wasi.erl
@@ -138,7 +138,7 @@ fd_write(Msg1, Msg2, Opts) ->
     Instance = hb_private:get(<<"wasm/instance">>, State, Opts),
     [FD, Ptr, Vecs, RetPtr|_] = hb_converge:get(<<"args">>, Msg2, Opts),
     ?event({fd_write, {fd, FD}, {ptr, Ptr}, {vecs, Vecs}, {retptr, RetPtr}}),
-    Signature = hb_converge:get(<<"func_sig">>, Msg2, Opts),
+    Signature = hb_converge:get(<<"func-sig">>, Msg2, Opts),
     ?event({signature, Signature}),
     fd_write(State, Instance, [FD, Ptr, Vecs, RetPtr], 0, Opts).
 
@@ -191,7 +191,7 @@ fd_read(Msg1, Msg2, Opts) ->
     State = hb_converge:get(<<"state">>, Msg1, Opts),
     Instance = hb_private:get(<<"wasm/instance">>, State, Opts),
     [FD, VecsPtr, NumVecs, RetPtr|_] = hb_converge:get(<<"args">>, Msg2, Opts),
-    Signature = hb_converge:get(<<"func_sig">>, Msg2, Opts),
+    Signature = hb_converge:get(<<"func-sig">>, Msg2, Opts),
     ?event({signature, Signature}),
     fd_read(State, Instance, [FD, VecsPtr, NumVecs, RetPtr], 0, Opts).
 

--- a/src/dev_wasi.erl
+++ b/src/dev_wasi.erl
@@ -308,7 +308,7 @@ basic_aos_exec_test() ->
     [Ptr] = hb_converge:get(<<"results/wasm/output">>, StateRes),
     {ok, Output} = hb_beamr_io:read_string(Instance, Ptr),
     ?event({got_output, Output}),
-    #{ <<"response">> := #{ <<"output">> := #{ <<"data">> := Data }} }
+    #{ <<"response">> := #{ <<"Output">> := #{ <<"data">> := Data }} }
         = jiffy:decode(Output, [return_maps]),
     ?assertEqual(<<"2">>, Data).
 

--- a/src/dev_wasm.erl
+++ b/src/dev_wasm.erl
@@ -111,6 +111,7 @@ default_import_resolver(Msg1, Msg2, Opts) ->
         func_sig := Signature
     } = Msg2,
     Prefix = dev_stack:prefix(Msg1, Msg2, Opts),
+    ?event({import_func_called, {prefix, Prefix}, {module, Module}, {func, Func}, {args, Args}, {func_sig, Signature}}),
     {ok, Msg3} =
         hb_converge:resolve(
             hb_private:set(
@@ -127,7 +128,10 @@ default_import_resolver(Msg1, Msg2, Opts) ->
             },
             Opts
         ),
+    ?event(import_done),
     NextState = hb_converge:get(state, Msg3, Opts),
+    ?event({done_calculating_response_for, {msg1, Msg1}, {msg2, Msg2}, {next_state, NextState}}),
+    ?event({next_state, NextState}),
     Response = hb_converge:get(results, Msg3, Opts),
     {ok, Response, NextState}.
 
@@ -291,7 +295,7 @@ import(Msg1, Msg2, Opts) ->
             #{ StatePath => Msg1 },
             Opts#{ hashpath => ignore }
         ),
-    %?event({state_added_msg1, AdjustedMsg1}),
+    ?event({state_added_msg1, AdjustedMsg1, AdjustedMsg2}),
     % 3. Resolve the adjusted path against the added state.
     case hb_converge:resolve(AdjustedMsg1, AdjustedMsg2, Opts) of
         {ok, Res} ->

--- a/src/dev_wasm.erl
+++ b/src/dev_wasm.erl
@@ -9,27 +9,27 @@
 %%%             M1/Process
 %%%             M1/[Prefix]/Image
 %%%         Generates:
-%%%             /priv/WASM/Instance
-%%%             /priv/WASM/Import-Resolver
+%%%             /priv/wasm/instance
+%%%             /priv/wasm/import-resolver
 %%%         Side-effects:
 %%%             Creates a WASM executor loaded in memory of the HyperBEAM node.
 %%% 
 %%%     M1/Compute ->
 %%%         Assumes:
-%%%             M1/priv/WASM/Instance
-%%%             M1/priv/WASM/Import-Resolver
-%%%             M1/Process
-%%%             M2/Message
-%%%             M2/Message/WASM-Function OR M1/WASM-Function
-%%%             M2/Message/WASM-Params OR M1/WASM-Params
+%%%             M1/priv/wasm/instance
+%%%             M1/priv/wasm/import-resolver
+%%%             M1/process
+%%%             M2/message
+%%%             M2/message/wasm-function OR M1/wasm-function
+%%%             M2/message/wasm-params OR M1/wasm-params
 %%%         Generates:
-%%%             /Results/WASM/Type
-%%%             /Results/WASM/Body
+%%%             /results/wasm/type
+%%%             /results/wasm/body
 %%%         Side-effects:
 %%%             Calls the WASM executor with the message and process.
-%%%     M1/WASM/State ->
+%%%     M1/wasm/state ->
 %%%         Assumes:
-%%%             M1/priv/WASM/Instance
+%%%             M1/priv/wasm/instance
 %%%         Generates:
 %%%             Raw binary WASM state
 %%% '''

--- a/src/dev_wasm.erl
+++ b/src/dev_wasm.erl
@@ -119,11 +119,11 @@ default_import_resolver(Msg1, Msg2, Opts) ->
                 Opts
             ),
             #{
-                path => import,
-                module => list_to_binary(Module),
-                func => list_to_binary(Func),
-                args => Args,
-                func_sig => list_to_binary(Signature)
+                <<"path">> => <<"import">>,
+                <<"module">> => list_to_binary(Module),
+                <<"func">> => list_to_binary(Func),
+                <<"args">> => Args,
+                <<"func-sig">> => list_to_binary(Signature)
             },
             Opts
         ),
@@ -283,7 +283,7 @@ import(Msg1, Msg2, Opts) ->
             ModName/binary,
             "/state"
         >>,
-    AdjustedMsg2 = Msg2#{ path => AdjustedPath },
+    AdjustedMsg2 = Msg2#{ <<"path">> => AdjustedPath },
     % 2. Add the current state to the message at the stdlib path.
     AdjustedMsg1 =
         hb_converge:set(

--- a/src/dev_wasm.erl
+++ b/src/dev_wasm.erl
@@ -281,7 +281,7 @@ import(Msg1, Msg2, Opts) ->
             Prefix/binary,
             "/stdlib/",
             ModName/binary,
-            "state"
+            "/state"
         >>,
     AdjustedMsg2 = Msg2#{ path => AdjustedPath },
     % 2. Add the current state to the message at the stdlib path.

--- a/src/dev_wasm.erl
+++ b/src/dev_wasm.erl
@@ -199,7 +199,7 @@ normalize(RawM1, M2, Opts) ->
                         not_found -> [];
                         Key -> [Key]
                     end,
-                ?event(debug,
+                ?event(
                     {no_instance_attempting_to_get_snapshot,
                         {msg1, RawM1}, {device_key, DeviceKey}
                     }

--- a/src/hb_beamr.erl
+++ b/src/hb_beamr.erl
@@ -189,7 +189,7 @@ monitor_call(WASM, ImportFun, StateMsg, Opts) ->
                         },
                         Opts
                     ),
-                ?event({import_ret, Module, Func, {args, Args}, {params, Res}}),
+                ?event({import_ret, Module, Func, {args, Args}, {res, Res}}),
                 dispatch_response(WASM, Res),
                 monitor_call(WASM, ImportFun, StateMsg2, Opts)
             catch

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -180,7 +180,7 @@ write_link_tree(RootPath, PathMap, Store, Opts) ->
 write_binary(Hashpath, Bin, Opts) ->
     write_binary(Hashpath, Bin, hb_opts:get(store, no_viable_store, Opts), Opts).
 write_binary(Hashpath, Bin, Store, Opts) ->
-    ?event(debug, {writing_binary, {hashpath, Hashpath}, {bin, Bin}, {store, Store}}),
+    ?event({writing_binary, {hashpath, Hashpath}, {bin, Bin}, {store, Store}}),
     {ok, Path} = write_message(Bin, Store, Opts),
     hb_store:make_link(Store, Path, Hashpath),
     {ok, Path}.
@@ -213,7 +213,7 @@ store_read(Path, Store, Opts) ->
             case hb_path:term_to_path_parts(Path) of
                 [BasePath, Key] when not ?IS_ID(Key) and is_binary(Key) ->
                     ?no_prod("This extra `/` looks dubious."),
-                    case hb_store:read(Store, <<BasePath/binary, "/", "/Converge-Type:", Key/binary>>) of
+                    case hb_store:read(Store, <<BasePath/binary, "/", "/Converge-Type-", Key/binary>>) of
                         no_viable_store ->
                             {ok, Binary};
                         {ok, Type} ->
@@ -227,7 +227,7 @@ store_read(Path, Store, Opts) ->
                 {ok, RawSubpaths} ->
                     Subpaths =
                         lists:map(fun hb_converge:normalize_key/1, RawSubpaths),
-                    ?event(debug,
+                    ?event(
                         {listed,
                             {original_path, Path},
                             {subpaths, {explicit, Subpaths}}
@@ -237,7 +237,7 @@ store_read(Path, Store, Opts) ->
                         maps:from_list(
                             lists:map(
                                 fun(Subpath) ->
-                                    ?event(debug, {subpath, Subpath}),
+                                    ?event({subpath, Subpath}),
                                     ResolvedSubpath =
                                         hb_store:resolve(Store,
                                             hb_path:to_binary([
@@ -256,7 +256,7 @@ store_read(Path, Store, Opts) ->
                             Subpaths
                         )
                     ),
-                    ?event(debug, {flat_map, FlatMap}),
+                    ?event({flat_map, FlatMap}),
                     {ok, FlatMap};
                 _ -> not_found
             end

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -283,7 +283,7 @@ link(Existing, New, Opts) ->
 test_unsigned(Data) ->
     #{
         <<"Base-Test-Key">> => <<"Base-Test-Value">>,
-        <<"Data">> => Data
+        <<"data">> => Data
     }.
 
 %% Helper function to create signed #tx items.

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -72,7 +72,7 @@ write_message(Bin, Store, Opts) when is_binary(Bin) ->
     % we store the data items at just their sha256 hash, we get a hash
     % collision between the signed ID of a message, and its signature data.
     Hashpath = hb_path:hashpath(Bin, Opts),
-    ok = hb_store:write(Store, Path = <<"Messages/", Hashpath/binary>>, Bin),
+    ok = hb_store:write(Store, Path = <<"messages/", Hashpath/binary>>, Bin),
     {ok, Path};
 write_message(Msg, Store, Opts) when is_map(Msg) ->
     % Precalculate the hashpath of the message.
@@ -282,7 +282,7 @@ link(Existing, New, Opts) ->
 
 test_unsigned(Data) ->
     #{
-        <<"Base-Test-Key">> => <<"Base-Test-Value">>,
+        <<"base-test-key">> => <<"base-test-value">>,
         <<"data">> => Data
     }.
 
@@ -308,7 +308,7 @@ test_store_simple_unsigned_item(Opts) ->
 
 %% @doc Test storing and retrieving a simple unsigned item
 test_store_simple_signed_item(Opts) ->
-    Item = test_signed(#{ <<"L2-Test-Key">> => <<"L2-Test-Value">> }),
+    Item = test_signed(#{ <<"l2-test-key">> => <<"l2-test-value">> }),
     %% Write the simple unsigned item
     {ok, _Path} = write(Item, Opts),
     %% Read the item back
@@ -325,22 +325,22 @@ test_deeply_nested_complex_item(Opts) ->
     DeepValueMsg = test_signed([1,2,3]),
     Outer =
         #{
-            <<"Level1">> =>
+            <<"level1">> =>
                 hb_message:sign(
                     #{
-                        <<"Level2">> =>
+                        <<"level2">> =>
                             #{
-                                <<"Level3">> => DeepValueMsg,
-                                <<"E">> => <<"F">>,
-                                <<"Z">> => [1,2,3]
+                                <<"level3">> => DeepValueMsg,
+                                <<"e">> => <<"f">>,
+                                <<"z">> => [1,2,3]
                             },
-                        <<"C">> => <<"D">>,
-                        <<"G">> => [<<"H">>, <<"I">>],
-                        <<"J">> => 1337
+                        <<"c">> => <<"d">>,
+                        <<"g">> => [<<"h">>, <<"i">>],
+                        <<"j">> => 1337
                     },
                     ar_wallet:new()
                 ),
-            <<"A">> => <<"B">>
+            <<"a">> => <<"b">>
         },
     %% Write the nested item
     {ok, _} = write(Outer, Opts),
@@ -349,9 +349,9 @@ test_deeply_nested_complex_item(Opts) ->
         read(
             [
                 OuterID = hb_util:human_id(hb_converge:get(unsigned_id, Outer)),
-                <<"Level1">>,
-                <<"Level2">>,
-                <<"Level3">>
+                <<"level1">>,
+                <<"level2">>,
+                <<"level3">>
             ],
             Opts
         ),

--- a/src/hb_cache_control.erl
+++ b/src/hb_cache_control.erl
@@ -18,7 +18,7 @@
 %% itself, without affecting its outputs.
 maybe_store(Msg1, Msg2, Msg3, Opts) ->
     case derive_cache_settings([Msg3, Msg2], Opts) of
-        #{ store := true } ->
+        #{ <<"store">> := true } ->
             ?event(caching, {caching_result, {msg1, Msg1}, {msg2, Msg2}, {msg3, Msg3}}),
             dispatch_cache_write(Msg1, Msg2, Msg3, Opts);
         _ -> 
@@ -42,8 +42,8 @@ maybe_lookup(Msg1, Msg2, Opts) ->
 
 lookup(Msg1, Msg2, Opts) ->
     case derive_cache_settings([Msg1, Msg2], Opts) of
-        #{ lookup := false } -> {continue, Msg1, Msg2};
-        Settings = #{ lookup := true } ->
+        #{ <<"lookup">> := false } -> {continue, Msg1, Msg2};
+        Settings = #{ <<"lookup">> := true } ->
             case hb_cache:read_output(Msg1, Msg2, Opts) of
                 {ok, Msg3} ->
                     ?event(caching,
@@ -61,10 +61,10 @@ lookup(Msg1, Msg2, Opts) ->
                 not_found ->
                     ?event(caching, {cache_miss, Msg1, Msg2}),
                     case Settings of
-                            #{ only_if_cached := true } ->
-                                only_if_cached_not_found_error(Msg1, Msg2, Opts);
-                            _ ->
-                                case ?IS_ID(Msg1) of
+                        #{ <<"only-if-cached">> := true } ->
+                            only_if_cached_not_found_error(Msg1, Msg2, Opts);
+                        _ ->
+                            case ?IS_ID(Msg1) of
                                     false -> {continue, Msg1, Msg2};
                                     true ->
                                         case hb_cache:read(Msg1, Opts) of
@@ -121,8 +121,7 @@ only_if_cached_not_found_error(Msg1, Msg2, Opts) ->
     ),
     {error,
         #{
-            <<"status">> => <<"Gateway Timeout">>,
-            <<"status-code">> => 504,
+            <<"status">> => 504,
             <<"cache-status">> => <<"miss">>,
             <<"body">> =>
                 <<"Computed result not available in cache.">>
@@ -139,8 +138,7 @@ necessary_messages_not_found_error(Msg1, Msg2, Opts) ->
     ),
     {error,
         #{
-            <<"status">> => <<"Not Found">>,
-            <<"status-code">> => 404,
+            <<"status">> => 404,
             <<"body">> =>
                 <<"Necessary messages not found in cache.">>
         }
@@ -152,7 +150,7 @@ exec_likely_faster_heuristic(Msg1, #{ <<"path">> := Key }, Opts) ->
     % For now, just check whether the key is explicitly in the map. That is 
     % a good signal that we will likely be asked by the device to grab it.
     % If we have `only-if-cached` in the opts, we always force lookup, too.
-    case specifiers_to_cache_settings(maps:get(cache_control, Opts, [])) of
+    case specifiers_to_cache_settings(hb_opts:get(cache_control, [], Opts)) of
         #{ <<"only-if-cached">> := true } -> false;
         _ -> is_map(Msg1) andalso maps:is_key(Key, Msg1)
     end.
@@ -169,7 +167,7 @@ derive_cache_settings(SourceList, Opts) ->
         fun(Source, Acc) ->
             maybe_set(Acc, cache_source_to_cache_settings(Source))
         end,
-        #{ store => true, lookup => true },
+        #{ <<"store">> => true, <<"lookup">> => true },
         [{opts, Opts}|lists:filter(fun erlang:is_map/1, SourceList)]
     ).
 
@@ -196,7 +194,7 @@ maybe_set(Map1, Map2) ->
 cache_source_to_cache_settings({opts, Opts}) ->
     CCMap = specifiers_to_cache_settings(hb_opts:get(cache_control, [], Opts)),
     case hb_opts:get(hashpath, update, Opts) of
-        ignore -> CCMap#{ store => false };
+        ignore -> CCMap#{ <<"store">> => false };
         _ -> CCMap
     end;
 cache_source_to_cache_settings(Msg) ->
@@ -257,30 +255,30 @@ opts_override_message_settings_test() ->
     Msg3 = msg_with_cc([<<"no-cache">>]),
     Opts = opts_with_cc([<<"always">>]),
     Result = derive_cache_settings([Msg3, Msg2], Opts),
-    ?assertEqual(#{store => true, lookup => true}, Result).
+    ?assertEqual(#{<<"store">> => true, <<"lookup">> => true}, Result).
 
 msg_precidence_overrides_test() ->
     Msg2 = msg_with_cc([<<"always">>]),
     Msg3 = msg_with_cc([<<"no-store">>]),  % No restrictions
     Result = derive_cache_settings([Msg3, Msg2], opts_with_cc([])),
-    ?assertEqual(#{store => false, lookup => true}, Result).
+    ?assertEqual(#{<<"store">> => false, <<"lookup">> => true}, Result).
 
 %% Test specific directives
 no_store_directive_test() ->
     Msg = msg_with_cc([<<"no-store">>]),
     Result = derive_cache_settings([Msg], opts_with_cc([])),
-    ?assertEqual(#{store => false, lookup => true}, Result).
+    ?assertEqual(#{<<"store">> => false, <<"lookup">> => true}, Result).
 
 no_cache_directive_test() ->
     Msg = msg_with_cc([<<"no-cache">>]),
     Result = derive_cache_settings([Msg], opts_with_cc([])),
-    ?assertEqual(#{store => true, lookup => false}, Result).
+    ?assertEqual(#{<<"store">> => true, <<"lookup">> => false}, Result).
 
 only_if_cached_directive_test() ->
     Msg = msg_with_cc([<<"only-if-cached">>]),
     Result = derive_cache_settings([Msg], opts_with_cc([])),
     ?assertEqual(
-        #{store => true, lookup => true, only_if_cached => true},
+        #{<<"store">> => true, <<"lookup">> => true, <<"only-if-cached">> => true},
         Result
     ).
 
@@ -288,25 +286,25 @@ only_if_cached_directive_test() ->
 hashpath_ignore_prevents_storage_test() ->
     Opts = (opts_with_cc([]))#{hashpath => ignore},
     Result = derive_cache_settings([], Opts),
-    ?assertEqual(#{store => false, lookup => true}, Result).
+    ?assertEqual(#{<<"store">> => false, <<"lookup">> => true}, Result).
 
 %% Test multiple directives
 multiple_directives_test() ->
     Msg = msg_with_cc([<<"no-store">>, <<"no-cache">>, <<"only-if-cached">>]),
     Result = derive_cache_settings([Msg], opts_with_cc([])),
     ?assertEqual(
-        #{store => false, lookup => false, only_if_cached => true},
+        #{<<"store">> => false, <<"lookup">> => false, <<"only-if-cached">> => true},
         Result
     ).
 
 %% Test empty/missing cases
 empty_message_list_test() ->
     Result = derive_cache_settings([], opts_with_cc([])),
-    ?assertEqual(#{store => true, lookup => true}, Result).
+    ?assertEqual(#{<<"store">> => true, <<"lookup">> => true}, Result).
 
 message_without_cache_control_test() ->
     Result = derive_cache_settings([#{}], opts_with_cc([])),
-    ?assertEqual(#{store => true, lookup => true}, Result).
+    ?assertEqual(#{<<"store">> => true, <<"lookup">> => true}, Result).
 
 %% Test the cache_source_to_cache_setting function directly
 opts_source_cache_control_test() ->
@@ -315,18 +313,18 @@ opts_source_cache_control_test() ->
             {opts, opts_with_cc([<<"no-store">>])}
         ),
     ?assertEqual(#{
-        store => false,
-        lookup => undefined,
-        only_if_cached => undefined
+        <<"store">> => false,
+        <<"lookup">> => undefined,
+        <<"only-if-cached">> => undefined
     }, Result).
 
 message_source_cache_control_test() ->
     Msg = msg_with_cc([<<"no-cache">>]),
     Result = cache_source_to_cache_settings(Msg),
     ?assertEqual(#{
-        store => undefined,
-        lookup => false,
-        only_if_cached => undefined
+        <<"store">> => undefined,
+        <<"lookup">> => false,
+        <<"only-if-cached">> => undefined
     }, Result).
 
 %%% Basic cached Converge resolution tests

--- a/src/hb_client.erl
+++ b/src/hb_client.erl
@@ -18,8 +18,8 @@ resolve(Node, Msg1, Msg2, Opts) ->
     TABM2 =
         hb_converge:set(
             #{
-                <<"Path">> => hb_converge:get(<<"Path">>, Msg2, <<"/">>, Opts),
-                <<"2.Path">> => unset
+                <<"path">> => hb_converge:get(<<"path">>, Msg2, <<"/">>, Opts),
+                <<"2.path">> => unset
             },
         prefix_keys(<<"2.">>, Msg2, Opts),
         Opts#{ hashpath => ignore }
@@ -42,11 +42,11 @@ prefix_keys(Prefix, Message, Opts) ->
 routes(Node, Opts) ->
     resolve(Node,
         #{
-            device => <<"Router/1.0">>
+            <<"device">> => <<"Router/1.0">>
         },
         #{
-            path => <<"Routes">>,
-            method => <<"GET">>
+            <<"path">> => <<"routes">>,
+            <<"method">> => <<"GET">>
         },
         Opts
     ).
@@ -54,11 +54,11 @@ routes(Node, Opts) ->
 add_route(Node, Route, Opts) ->
     resolve(Node,
         Route#{
-            device => <<"Router/1.0">>
+            <<"device">> => <<"Router/1.0">>
         },
         #{
-            path => <<"Routes">>,
-            method => <<"POST">>
+            <<"path">> => <<"routes">>,
+            <<"method">> => <<"POST">>
         },
         Opts
     ).
@@ -158,14 +158,14 @@ json_struct_to_result(Struct, Res) ->
             Res#result{
                 messages = lists:map(
                     fun ar_bundles:json_struct_to_item/1,
-                    hb_util:find_value(<<"Messages">>, Struct, [])
+                    hb_util:find_value(<<"messages">>, Struct, [])
                 ),
-                assignments = hb_util:find_value(<<"Assignments">>, Struct, []),
+                assignments = hb_util:find_value(<<"assignments">>, Struct, []),
                 spawns = lists:map(
                     fun ar_bundles:json_struct_to_item/1,
-                    hb_util:find_value(<<"Spawns">>, Struct, [])
+                    hb_util:find_value(<<"spawns">>, Struct, [])
                 ),
-                output = hb_util:find_value(<<"Output">>, Struct, [])
+                output = hb_util:find_value(<<"output">>, Struct, [])
             };
         {_, {NodeStruct}} ->
             json_struct_to_result(

--- a/src/hb_codec_converge.erl
+++ b/src/hb_codec_converge.erl
@@ -15,8 +15,8 @@ from(Msg) when is_map(Msg) ->
             fun(Key) ->
                 case maps:find(Key, Msg) of
                     {ok, <<>>} ->
-                        BinKey = hb_converge:key_to_binary(Key),
-                        {<<"Converge-Type:", BinKey/binary>>, <<"Empty-Binary">>};
+                        BinKey = hb_converge:normalize_key(Key),
+                        {<<"converge-type: ", BinKey/binary>>, <<"empty-binary">>};
                     {ok, Value} when is_binary(Value) ->
                         {Key, Value};
                     {ok, Map} when is_map(Map) ->
@@ -24,17 +24,17 @@ from(Msg) when is_map(Msg) ->
                     {ok, Msgs = [Msg1|_]} when is_map(Msg1) ->
                         % We have a list of maps. Convert to a numbered map and
                         % recurse.
-                        {Key, from(hb_converge:ensure_message(Msgs))};
+                        {Key, from(hb_converge:normalize_keys(Msgs))};
                     {ok, []} ->
-                        BinKey = hb_converge:key_to_binary(Key),
-                        {<<"Converge-Type:", BinKey/binary>>, <<"Empty-List">>};
+                        BinKey = hb_converge:normalize_key(Key),
+                        {<<"converge-type: ", BinKey/binary>>, <<"empty-list">>};
                     {ok, Value} when
                             is_atom(Value) or is_integer(Value)
                             or is_list(Value) ->
-                        ItemKey = hb_converge:key_to_binary(Key),
+                        ItemKey = hb_converge:normalize_key(Key),
                         {Type, BinaryValue} = encode_value(Value),
                         [
-                            {<<"Converge-Type:", ItemKey/binary>>, Type},
+                            {<<"converge-type: ", ItemKey/binary>>, Type},
                             {ItemKey, BinaryValue}
                         ];
                     {ok, _} -> []
@@ -63,9 +63,9 @@ to(TABM0) ->
     TABM1 =
         maps:from_list(
             lists:map(
-                fun({<<"Converge-Type:", Key/binary>>, <<"Empty-Binary">>}) ->
+                fun({<<"converge-type: ", Key/binary>>, <<"empty-binary">>}) ->
                     {Key, <<>>};
-                ({<<"Converge-Type:", Key/binary>>, <<"Empty-List">>}) ->
+                ({<<"converge-type: ", Key/binary>>, <<"empty-list">>}) ->
                     {Key, []};
                 ({Key, Value}) ->
                     {Key, Value}
@@ -78,12 +78,12 @@ to(TABM0) ->
     % 3. Recursively decode any maps that we encounter;
     % 4. Return the remaining keys and values as a map.
     hb_message:filter_default_keys(maps:filtermap(
-        fun(<<"Converge-Type:", _/binary>>, _) ->
+        fun(<<"converge-type: ", _/binary>>, _) ->
             % Remove any keys from output that have a "Converge-Type:" prefix.
             false;
         (RawKey, BinaryValue) when is_binary(BinaryValue) ->
-            Key = hb_converge:key_to_binary(RawKey),
-            case maps:find(<<"Converge-Type:", Key/binary>>, TABM1) of
+            Key = hb_converge:normalize_key(RawKey),
+            case maps:find(<<"converge-type: ", Key/binary>>, TABM1) of
                 error -> {true, BinaryValue};
                 {ok, Type} ->
                     {true, decode_value(Type, BinaryValue)}
@@ -102,29 +102,29 @@ to(TABM0) ->
 %% serialization as a separate tag.
 encode_value(Value) when is_integer(Value) ->
     [Encoded, _] = hb_http_structured_fields:item({item, Value, []}),
-    {<<"Integer">>, Encoded};
+    {<<"integer">>, Encoded};
 encode_value(Value) when is_float(Value) ->
     ?no_prod("Must use structured field representation for floats!"),
-    {<<"Float">>, float_to_binary(Value)};
+    {<<"float">>, float_to_binary(Value)};
 encode_value(Value) when is_atom(Value) ->
     [EncodedIOList, _] =
         hb_http_structured_fields:item(
             {item, {string, atom_to_binary(Value, latin1)}, []}),
     Encoded = list_to_binary(EncodedIOList),
-    {<<"Atom">>, Encoded};
+    {<<"atom">>, Encoded};
 encode_value(Values) when is_list(Values) ->
     EncodedValues =
         lists:map(
             fun(Bin) when is_binary(Bin) -> {item, {string, Bin}, []};
                (Item) ->
                 {RawType, Encoded} = encode_value(Item),
-                Type = hb_converge:key_to_binary(RawType),
+                Type = hb_converge:normalize_key(RawType),
                 {
                     item,
                     {
                         string,
                         <<
-                            "(Converge-Type: ", Type/binary, ") ",
+                            "(converge-type: ", Type/binary, ") ",
                             Encoded/binary
                         >>
                     },
@@ -134,9 +134,9 @@ encode_value(Values) when is_list(Values) ->
             Values
         ),
     EncodedList = hb_http_structured_fields:list(EncodedValues),
-    {<<"List">>, iolist_to_binary(EncodedList)};
+    {<<"list">>, iolist_to_binary(EncodedList)};
 encode_value(Value) when is_binary(Value) ->
-    {<<"Binary">>, Value};
+    {<<"binary">>, Value};
 encode_value(Value) ->
     Value.
 
@@ -159,10 +159,10 @@ decode_value(float, Value) ->
 decode_value(atom, Value) ->
     {item, {string, AtomString}, _} =
         hb_http_structured_fields:parse_item(Value),
-    binary_to_existing_atom(AtomString, latin1);
+    binary_to_existing_atom(AtomString);
 decode_value(list, Value) ->
     lists:map(
-        fun({item, {string, <<"(Converge-Type: ", Rest/binary>>}, _}) ->
+        fun({item, {string, <<"(converge-type: ", Rest/binary>>}, _}) ->
             [Type, Item] = binary:split(Rest, <<") ">>),
             decode_value(Type, Item);
            ({item, {string, Binary}, _}) -> Binary
@@ -186,12 +186,12 @@ decode_value(OtherType, Value) ->
 
 list_encoding_test() ->
     % Test that we can encode and decode a list of integers.
-    {<<"List">>, Encoded} = encode_value(List1 = [1, 2, 3]),
+    {<<"list">>, Encoded} = encode_value(List1 = [1, 2, 3]),
     Decoded = decode_value(list, Encoded),
     ?assertEqual(List1, Decoded),
     % Test that we can encode and decode a list of binaries.
-    {<<"List">>, Encoded2} = encode_value(List2 = [<<"1">>, <<"2">>, <<"3">>]),
+    {<<"list">>, Encoded2} = encode_value(List2 = [<<"1">>, <<"2">>, <<"3">>]),
     ?assertEqual(List2, decode_value(list, Encoded2)),
     % Test that we can encode and decode a mixed list.
-    {<<"List">>, Encoded3} = encode_value(List3 = [1, <<"2">>, 3]),
+    {<<"list">>, Encoded3} = encode_value(List3 = [1, <<"2">>, 3]),
     ?assertEqual(List3, decode_value(list, Encoded3)).

--- a/src/hb_codec_http.erl
+++ b/src/hb_codec_http.erl
@@ -52,7 +52,7 @@
 %% HTTP Structured Field is encoded into it's equivalent TABM encoding.
 from(Bin) when is_binary(Bin) -> Bin;
 from(#{ <<"headers">> := Headers, <<"body">> := Body }) when is_map(Headers) ->
-    from(#{ headers => maps:to_list(Headers), body => Body });
+    from(#{ <<"headers">> => maps:to_list(Headers), <<"body">> => Body });
 from(#{ <<"headers">> := Headers, <<"body">> := Body }) ->
     % First, parse all headers and add as key-value pairs to the TABM
     Map = from_headers(#{}, Headers),
@@ -319,7 +319,7 @@ field_to_http(Http, {Name, Value}, Opts) when is_binary(Value) ->
         headers ->
             Headers = maps:get(<<"headers">>, Http),
             NewHeaders = lists:append(Headers, [{NormalizedName, Value}]),
-            maps:put(headers, NewHeaders, Http);
+            maps:put(<<"headers">>, NewHeaders, Http);
         % Append the value as a part of the multipart body
         %
         % We'll need to prepend a Content-Disposition header to the part, using

--- a/src/hb_codec_http.erl
+++ b/src/hb_codec_http.erl
@@ -5,9 +5,9 @@
 %%% The HTTP Message is an Erlang Map with the following shape:
 %%% #{ 
 %%%     headers => [
-%%%         {<<"Example-Header">>, <<"Value">>}
+%%%         {<<"example-header">>, <<"value">>}
 %%%     ],
-%%%     body: <<"Some body">>
+%%%     body: <<"some body">>
 %%% }
 %%% 
 %%% Every HTTP message is an HTTP multipart message.

--- a/src/hb_codec_tx.erl
+++ b/src/hb_codec_tx.erl
@@ -9,22 +9,30 @@
 -define(MAX_TAG_VAL, 128).
 %% The list of TX fields that users can set directly.
 -define(TX_KEYS,
-    [id, unsigned_id, last_tx, owner, target, signature]).
+    [
+        <<"id">>,
+        <<"unsigned_id">>,
+        <<"last_tx">>,
+        <<"owner">>,
+        <<"target">>,
+        <<"signature">>
+    ]
+).
 -define(FILTERED_TAGS,
     [
-        <<"Bundle-Format">>,
-        <<"Bundle-Map">>,
-        <<"Bundle-Version">>
+        <<"bundle-format">>,
+        <<"bundle-map">>,
+        <<"bundle-version">>
     ]
 ).
 
 %% @doc Convert a #tx record into a message map recursively.
 from(Binary) when is_binary(Binary) -> Binary;
 from(TX) when is_record(TX, tx) ->
-    case lists:keyfind(<<"Converge-Type">>, 1, TX#tx.tags) of
+    case lists:keyfind(<<"converge-type">>, 1, TX#tx.tags) of
         false ->
             do_from(TX);
-        {<<"Converge-Type">>, <<"Binary">>} ->
+        {<<"converge-type">>, <<"binary">>} ->
             TX#tx.data
     end.
 do_from(RawTX) ->
@@ -34,13 +42,16 @@ do_from(RawTX) ->
     % the list of key-value pairs into a map, removing irrelevant fields.
     TXKeysMap =
         maps:with(?TX_KEYS,
-            maps:from_list(
-                lists:zip(
-                    record_info(fields, tx),
-                    tl(tuple_to_list(TX))
+            hb_converge:normalize_keys(
+                maps:from_list(
+                    lists:zip(
+                        record_info(fields, tx),
+                        tl(tuple_to_list(TX))
+                    )
                 )
             )
         ),
+    ?event(debug, {tx_keys_map, {explicit, TXKeysMap}}),
     % Generate a TABM from the tags.
     MapWithoutData = maps:merge(TXKeysMap, maps:from_list(TX#tx.tags)),
     DataMap =
@@ -58,7 +69,7 @@ do_from(RawTX) ->
             Data when Data == ?DEFAULT_DATA ->
                 MapWithoutData;
             Data when is_binary(Data) ->
-                MapWithoutData#{ data => Data };
+                MapWithoutData#{ <<"data">> => Data };
             Data ->
                 ?event({unexpected_data_type, {explicit, Data}}),
                 ?event({was_processing, {explicit, TX}}),
@@ -66,7 +77,9 @@ do_from(RawTX) ->
         end,
     % Merge the data map with the rest of the TX map and remove any keys that
     % are not part of the message.
-    maps:without(?FILTERED_TAGS, maps:merge(DataMap, MapWithoutData)).
+    NormalizedDataMap =
+        hb_converge:normalize_keys(maps:merge(DataMap, MapWithoutData)),
+    maps:without(?FILTERED_TAGS, NormalizedDataMap).
 
 %% @doc Internal helper to translate a message to its #tx record representation,
 %% which can then be used by ar_bundles to serialize the message. We call the 
@@ -78,21 +91,22 @@ to(Binary) when is_binary(Binary) ->
     % we turn it into a TX record with a special tag, tx_to_message will
     % identify this tag and extract just the binary.
     #tx{
-        tags= [{<<"Converge-Type">>, <<"Binary">>}],
+        tags= [{<<"converge-type">>, <<"binary">>}],
         data = Binary
     };
 to(TX) when is_record(TX, tx) -> TX;
-to(TABM) when is_map(TABM) ->
+to(RawTABM) when is_map(RawTABM) ->
     % The path is a special case so we normalized it first. It may have been
     % modified by `hb_converge` in order to set it to the current key that is
     % being executed. We should check whether the path is in the
     % `priv/Converge/Original-Path` field, and if so, use that instead of the
     % stated path. This normalizes the path, such that the signed message will
     % continue to validate correctly.
+    TABM = hb_converge:normalize_keys(RawTABM),
     M =
-        case {maps:find(path, TABM), hb_private:from_message(TABM)} of
-            {{ok, _}, #{ <<"Converge">> := #{ <<"Original-Path">> := Path } }} ->
-                maps:put(path, Path, TABM);
+        case {maps:find(<<"path">>, TABM), hb_private:from_message(TABM)} of
+            {{ok, _}, #{ <<"converge">> := #{ <<"original-path">> := Path } }} ->
+                maps:put(<<"path">>, Path, TABM);
             _ -> TABM
         end,
     % Translate the keys into a binary map. If a key has a value that is a map,
@@ -107,13 +121,14 @@ to(TABM) when is_map(TABM) ->
             end,
             M
         ),
-    NormalizedMsgKeyMap = hb_message:normalize_keys(MsgKeyMap),
+    NormalizedMsgKeyMap = hb_converge:normalize_keys(MsgKeyMap),
+    ?event(debug, {normalized_msg_key_map, {explicit, NormalizedMsgKeyMap}}),
     % Iterate through the default fields, replacing them with the values from
     % the message map if they are present.
     {RemainingMap, BaseTXList} =
         lists:foldl(
             fun({Field, Default}, {RemMap, Acc}) ->
-                NormKey = hb_converge:key_to_binary(Field),
+                NormKey = hb_converge:normalize_key(Field),
                 case maps:find(NormKey, NormalizedMsgKeyMap) of
                     error -> {RemMap, [Default | Acc]};
                     {ok, Value} when is_binary(Default) andalso ?IS_ID(Value) ->
@@ -155,7 +170,7 @@ to(TABM) when is_map(TABM) ->
     % Recursively turn the remaining data items into tx records.
     DataItems = maps:from_list(lists:map(
         fun({Key, Value}) ->
-            {Key, to(Value)}
+            {hb_converge:normalize_key(Key), to(Value)}
         end,
         RawDataItems
     )),
@@ -169,9 +184,9 @@ to(TABM) when is_map(TABM) ->
             {Data, _} when is_map(Data) ->
                 TX#tx { data = maps:merge(Data, DataItems) };
             {Data, _} when is_record(Data, tx) ->
-                TX#tx { data = DataItems#{ data => Data } };
+                TX#tx { data = DataItems#{ <<"data">> => Data } };
             {Data, _} when is_binary(Data) ->
-                TX#tx { data = DataItems#{ data => to(Data) } }
+                TX#tx { data = DataItems#{ <<"data">> => to(Data) } }
         end,
     % ar_bundles:reset_ids(ar_bundles:normalize(TXWithData));
     Res = try ar_bundles:reset_ids(ar_bundles:normalize(TXWithData))

--- a/src/hb_codec_tx.erl
+++ b/src/hb_codec_tx.erl
@@ -121,7 +121,6 @@ to(RawTABM) when is_map(RawTABM) ->
             M
         ),
     NormalizedMsgKeyMap = hb_converge:normalize_keys(MsgKeyMap),
-    ?event(debug, {normalized_msg_key_map, {explicit, NormalizedMsgKeyMap}}),
     % Iterate through the default fields, replacing them with the values from
     % the message map if they are present.
     {RemainingMap, BaseTXList} =

--- a/src/hb_codec_tx.erl
+++ b/src/hb_codec_tx.erl
@@ -51,7 +51,6 @@ do_from(RawTX) ->
                 )
             )
         ),
-    ?event(debug, {tx_keys_map, {explicit, TXKeysMap}}),
     % Generate a TABM from the tags.
     MapWithoutData = maps:merge(TXKeysMap, maps:from_list(TX#tx.tags)),
     DataMap =

--- a/src/hb_converge.erl
+++ b/src/hb_converge.erl
@@ -487,7 +487,7 @@ error_invalid_message(Msg1, Msg2, Opts) ->
     {
         error,
         #{
-            <<"Status-Code">> => 400,
+            <<"status-code">> => 400,
             <<"body">> => <<"Request contains non-verifiable message.">>
         }
     }.
@@ -506,8 +506,8 @@ error_infinite(Msg1, Msg2, Opts) ->
     {
         error,
         #{
-            <<"Status">> => <<"Loop Detected">>,
-            <<"Status-Code">> => 508,
+            <<"status">> => <<"Loop Detected">>,
+            <<"status-code">> => 508,
             <<"body">> => <<"Request creates infinite recursion.">>
         }
     }.
@@ -526,11 +526,11 @@ error_invalid_intermediate_status(_Msg1, Msg2, Msg3, RemainingPath, Opts) ->
     {
         error,
         #{
-            <<"Status">> => <<"Unprocessable Content">>,
-            <<"Status-Code">> => 422,
+            <<"status">> => <<"Unprocessable Content">>,
+            <<"status-code">> => 422,
             <<"body">> => Msg3,
-            <<"Key">> => maps:get(path, Msg2, <<"Key unknown.">>),
-            <<"Remaining-Path">> => RemainingPath
+            <<"key">> => maps:get(<<"path">>, Msg2, <<"Key unknown.">>),
+            <<"remaining-path">> => RemainingPath
         }
     }.
 
@@ -601,7 +601,7 @@ keys(Msg, Opts, remove) ->
 set(Msg1, Msg2) ->
     set(Msg1, Msg2, #{}).
 set(Msg1, RawMsg2, Opts) when is_map(RawMsg2) ->
-    Msg2 = maps:without([hashpath, priv], RawMsg2),
+    Msg2 = maps:without([<<"hashpath">>, <<"priv">>], RawMsg2),
     ?event(converge_internal, {set_called, {msg1, Msg1}, {msg2, Msg2}}, Opts),
     % Get the next key to set. 
     case keys(Msg2, internal_opts(Opts)) of

--- a/src/hb_converge.erl
+++ b/src/hb_converge.erl
@@ -228,7 +228,7 @@ resolve_stage(4, Msg1, Msg2, Opts) ->
                 Res ->
                     % Now that we have the result, we can skip right to potential
                     % recursion (step 11).
-                    {ok, Res}
+                    Res
             end;
         {infinite_recursion, GroupName} ->
             % We are the leader for this resolution, but we executing the 
@@ -585,8 +585,9 @@ keys(Msg, Opts, remove) ->
 %% `HashPath' for each step.
 set(Msg1, Msg2) ->
     set(Msg1, Msg2, #{}).
-set(Msg1, RawMsg2, Opts) when is_map(RawMsg2) ->
-    Msg2 = maps:without([<<"hashpath">>, <<"priv">>], RawMsg2),
+set(RawMsg1, RawMsg2, Opts) when is_map(RawMsg2) ->
+    Msg1 = normalize_keys(RawMsg1),
+    Msg2 = maps:without([<<"hashpath">>, <<"priv">>], normalize_keys(RawMsg2)),
     ?event(converge_internal, {set_called, {msg1, Msg1}, {msg2, Msg2}}, Opts),
     % Get the next key to set. 
     case keys(Msg2, internal_opts(Opts)) of

--- a/src/hb_converge.erl
+++ b/src/hb_converge.erl
@@ -140,7 +140,7 @@ resolve_stage(1, Msg1, Path, Opts) when not is_map(Path) ->
     ?event(converge_core, {stage, 1, normalize_raw_path_to_message}, Opts),
     % If we have been given a Path rather than a full Msg2, construct the
     % message around it and recurse.
-    resolve_stage(1, Msg1, #{ <<"path">> => normalize_key(Path) }, Opts);
+    resolve_stage(1, Msg1, #{ <<"path">> => hb_path:term_to_path_parts(normalize_key(Path)) }, Opts);
 resolve_stage(1, RawMsg1, RawMsg2, Opts) ->
     % Normalize the path to a private key containing the list of remaining
     % keys to resolve.

--- a/src/hb_converge.erl
+++ b/src/hb_converge.erl
@@ -143,7 +143,6 @@ resolve_stage(1, Msg1, Path, Opts) when not is_map(Path) ->
     resolve_stage(1, Msg1, #{ path => Path }, Opts);
 resolve_stage(1, Msg1, Msg2, Opts) ->
     ?event(converge_core, {stage, 1, normalize_path}, Opts),
-    ?event(debug, {path_normalizing, {msg1, Msg1}, {msg2, Msg2}}),
     case hb_path:priv_remaining(Msg2, Opts) of
         undefined ->
             % We are executing our first run with no message list to recurse

--- a/src/hb_converge_test_vectors.erl
+++ b/src/hb_converge_test_vectors.erl
@@ -251,7 +251,7 @@ gen_handler_device() ->
             fun() ->
                 #{
                     handler =>
-                        fun(set, M1, M2, Opts) ->
+                        fun(<<"set">>, M1, M2, Opts) ->
                             dev_message:set(M1, M2, Opts);
                         (_, _, _, _) ->
                             {ok, <<"HANDLER VALUE">>}
@@ -471,7 +471,7 @@ deep_set_with_device_test(Opts) ->
                 % A device where the set function modifies the key
                 % and adds a modified flag.
                 {Key, Val} =
-                    hd(maps:to_list(maps:without([path, priv], Msg2))),
+                    hd(maps:to_list(maps:without([<<"path">>, <<"priv">>], Msg2))),
                 {ok, Msg1#{ Key => Val, <<"modified">> => true }}
             end
     },

--- a/src/hb_converge_test_vectors.erl
+++ b/src/hb_converge_test_vectors.erl
@@ -161,7 +161,7 @@ resolve_key_twice_test(Opts) ->
 
 resolve_from_multiple_keys_test(Opts) ->
     ?assertEqual(
-        {ok, [a]},
+        {ok, [<<"a">>]},
         hb_converge:resolve(#{ a => <<"1">>, "priv_a" => <<"2">> }, keys, Opts)
     ).
 
@@ -171,14 +171,14 @@ resolve_path_element_test(Opts) ->
         hb_converge:resolve(#{ path => [test_path] }, path, Opts)
     ),
     ?assertEqual(
-        {ok, [a]},
-        hb_converge:resolve(#{ <<"Path">> => [a] }, <<"Path">>, Opts)
+        {ok, [<<"a">>]},
+        hb_converge:resolve(#{ <<"Path">> => [<<"a">>] }, <<"Path">>, Opts)
     ).
 
 key_to_binary_test(Opts) ->
-    ?assertEqual(<<"a">>, hb_converge:key_to_binary(a, Opts)),
-    ?assertEqual(<<"a">>, hb_converge:key_to_binary(<<"a">>, Opts)),
-    ?assertEqual(<<"a">>, hb_converge:key_to_binary("a", Opts)).
+    ?assertEqual(<<"a">>, hb_converge:normalize_key(a, Opts)),
+    ?assertEqual(<<"a">>, hb_converge:normalize_key(<<"a">>, Opts)),
+    ?assertEqual(<<"a">>, hb_converge:normalize_key("a", Opts)).
 
 resolve_binary_key_test(Opts) ->
     ?assertEqual(
@@ -202,15 +202,15 @@ generate_device_with_keys_using_args() ->
         key_using_only_state =>
             fun(State) ->
                 {ok,
-                    <<(maps:get(state_key, State))/binary>>
+                    <<(maps:get(<<"state_key">>, State))/binary>>
                 }
             end,
         key_using_state_and_msg =>
             fun(State, Msg) ->
                 {ok,
                     <<
-                        (maps:get(state_key, State))/binary,
-                        (maps:get(msg_key, Msg))/binary
+                        (maps:get(<<"state_key">>, State))/binary,
+                        (maps:get(<<"msg_key">>, Msg))/binary
                     >>
                 }
             end,
@@ -218,9 +218,9 @@ generate_device_with_keys_using_args() ->
             fun(State, Msg, Opts) ->
                 {ok,
                     <<
-                        (maps:get(state_key, State))/binary,
-                        (maps:get(msg_key, Msg))/binary,
-                        (maps:get(opts_key, Opts))/binary
+                        (maps:get(<<"state_key">>, State))/binary,
+                        (maps:get(<<"msg_key">>, Msg))/binary,
+                        (maps:get(<<"opts_key">>, Opts))/binary
                     >>
                 }
             end
@@ -238,7 +238,7 @@ gen_default_device() ->
                         end
                 }
             end,
-        state_key =>
+        <<"state_key">> =>
             fun(_) ->
                 {ok, <<"STATE">>}
             end
@@ -274,8 +274,8 @@ key_from_id_device_with_args_test(Opts) ->
         hb_converge:resolve(
             Msg,
             #{
-                path => key_using_only_state,
-                msg_key => <<"2">> % Param message, which is ignored
+                <<"path">> => <<"key_using_only_state">>,
+                <<"msg_key">> => <<"2">> % Param message, which is ignored
             },
             Opts
         )
@@ -285,8 +285,8 @@ key_from_id_device_with_args_test(Opts) ->
         hb_converge:resolve(
             Msg,
             #{
-                path => key_using_state_and_msg,
-                msg_key => <<"3">> % Param message, with value to add
+                <<"path">> => <<"key_using_state_and_msg">>,
+                <<"msg_key">> => <<"3">> % Param message, with value to add
             },
             Opts
         )
@@ -296,12 +296,12 @@ key_from_id_device_with_args_test(Opts) ->
         hb_converge:resolve(
             Msg,
             #{
-                path => key_using_all,
-                msg_key => <<"3">> % Param message
+                <<"path">> => <<"key_using_all">>,
+                <<"msg_key">> => <<"3">> % Param message
             },
             Opts#{
-                opts_key => <<"37">>,
-                cache_control => [<<"no-cache">>, <<"no-store">>]
+                <<"opts_key">> => <<"37">>,
+                <<"cache_control">> => [<<"no-cache">>, <<"no-store">>]
             }
         )
     ).
@@ -314,7 +314,7 @@ device_with_handler_function_test(Opts) ->
         },
     ?assertEqual(
         {ok, <<"HANDLER VALUE">>},
-        hb_converge:resolve(Msg, test_key, Opts)
+        hb_converge:resolve(Msg, <<"test_key">>, Opts)
     ).
 
 device_with_default_handler_function_test(Opts) ->
@@ -324,17 +324,17 @@ device_with_default_handler_function_test(Opts) ->
         },
     ?assertEqual(
         {ok, <<"STATE">>},
-        hb_converge:resolve(Msg, state_key, Opts)
+        hb_converge:resolve(Msg, <<"state_key">>, Opts)
     ),
     ?assertEqual(
         {ok, <<"DEFAULT">>},
-        hb_converge:resolve(Msg, any_random_key, Opts)
+        hb_converge:resolve(Msg, <<"any_random_key">>, Opts)
     ).
 
 basic_get_test(Opts) ->
     Msg = #{ key1 => <<"value1">>, key2 => <<"value2">> },
-    ?assertEqual(<<"value1">>, hb_converge:get(key1, Msg, Opts)),
-    ?assertEqual(<<"value2">>, hb_converge:get(key2, Msg, Opts)),
+    ?assertEqual(<<"value1">>, hb_converge:get(<<"key1">>, Msg, Opts)),
+    ?assertEqual(<<"value2">>, hb_converge:get(<<"key2">>, Msg, Opts)),
     ?assertEqual(<<"value2">>, hb_converge:get(<<"key2">>, Msg, Opts)),
     ?assertEqual(<<"value2">>, hb_converge:get([<<"key2">>], Msg, Opts)).
 
@@ -344,20 +344,20 @@ recursive_get_test(Opts) ->
         {ok, <<"value1">>},
         hb_converge:resolve(Msg, #{ path => key1 }, Opts)
     ),
-    ?assertEqual(<<"value1">>, hb_converge:get(key1, Msg, Opts)),
+    ?assertEqual(<<"value1">>, hb_converge:get(<<"key1">>, Msg, Opts)),
     ?assertEqual(
         {ok, <<"value3">>},
-        hb_converge:resolve(Msg, #{ path => [key2, key3] }, Opts)
+        hb_converge:resolve(Msg, #{ path => [<<"key2">>, <<"key3">>] }, Opts)
     ),
-    ?assertEqual(<<"value3">>, hb_converge:get([key2, key3], Msg, Opts)),
+    ?assertEqual(<<"value3">>, hb_converge:get([<<"key2">>, <<"key3">>], Msg, Opts)),
     ?assertEqual(<<"value3">>, hb_converge:get(<<"key2/key3">>, Msg, Opts)).
 
 basic_set_test(Opts) ->
     Msg = #{ key1 => <<"value1">>, key2 => <<"value2">> },
     UpdatedMsg = hb_converge:set(Msg, #{ key1 => <<"new_value1">> }, Opts),
     ?event({set_key_complete, {key, key1}, {value, <<"new_value1">>}}),
-    ?assertEqual(<<"new_value1">>, hb_converge:get(key1, UpdatedMsg, Opts)),
-    ?assertEqual(<<"value2">>, hb_converge:get(key2, UpdatedMsg, Opts)).
+    ?assertEqual(<<"new_value1">>, hb_converge:get(<<"key1">>, UpdatedMsg, Opts)),
+    ?assertEqual(<<"value2">>, hb_converge:get(<<"key2">>, UpdatedMsg, Opts)).
 
 get_with_device_test(Opts) ->
     Msg =
@@ -365,8 +365,8 @@ get_with_device_test(Opts) ->
             device => generate_device_with_keys_using_args(),
             state_key => <<"STATE">>
         },
-    ?assertEqual(<<"STATE">>, hb_converge:get(state_key, Msg, Opts)),
-    ?assertEqual(<<"STATE">>, hb_converge:get(key_using_only_state, Msg, Opts)).
+    ?assertEqual(<<"STATE">>, hb_converge:get(<<"state_key">>, Msg, Opts)),
+    ?assertEqual(<<"STATE">>, hb_converge:get(<<"key_using_only_state">>, Msg, Opts)).
 
 get_as_with_device_test(Opts) ->
     Msg =
@@ -386,56 +386,56 @@ get_as_with_device_test(Opts) ->
 set_with_device_test(Opts) ->
     Msg =
         #{
-            device =>
+            <<"device">> =>
                 #{
-                    set =>
+                    <<"set">> =>
                         fun(State, _Msg) ->
-                            Acc = maps:get(set_count, State, <<"">>),
+                            Acc = maps:get(<<"set_count">>, State, <<"">>),
                             {ok,
                                 State#{
-                                    set_count => << Acc/binary, "." >>
+                                    <<"set_count">> => << Acc/binary, "." >>
                                 }
                             }
                         end
                 },
-            state_key => <<"STATE">>
+            <<"state_key">> => <<"STATE">>
         },
-    ?assertEqual(<<"STATE">>, hb_converge:get(state_key, Msg, Opts)),
-    SetOnce = hb_converge:set(Msg, #{ state_key => <<"SET_ONCE">> }, Opts),
-    ?assertEqual(<<".">>, hb_converge:get(set_count, SetOnce, Opts)),
-    SetTwice = hb_converge:set(SetOnce, #{ state_key => <<"SET_TWICE">> }, Opts),
-    ?assertEqual(<<"..">>, hb_converge:get(set_count, SetTwice, Opts)),
-    ?assertEqual(<<"STATE">>, hb_converge:get(state_key, SetTwice, Opts)).
+    ?assertEqual(<<"STATE">>, hb_converge:get(<<"state_key">>, Msg, Opts)),
+    SetOnce = hb_converge:set(Msg, #{ <<"state_key">> => <<"SET_ONCE">> }, Opts),
+    ?assertEqual(<<".">>, hb_converge:get(<<"set_count">>, SetOnce, Opts)),
+    SetTwice = hb_converge:set(SetOnce, #{ <<"state_key">> => <<"SET_TWICE">> }, Opts),
+    ?assertEqual(<<"..">>, hb_converge:get(<<"set_count">>, SetTwice, Opts)),
+    ?assertEqual(<<"STATE">>, hb_converge:get(<<"state_key">>, SetTwice, Opts)).
 
 deep_set_test(Opts) ->
     % First validate second layer changes are handled correctly.
-    Msg0 = #{ a => #{ b => <<"RESULT">> } },
-    ?assertMatch(#{ a := #{ b := <<"RESULT2">> } },
-        hb_converge:set(Msg0, [a, b], <<"RESULT2">>, Opts)),
+    Msg0 = #{ <<"a">> => #{ <<"b">> => <<"RESULT">> } },
+    ?assertMatch(#{ <<"a">> := #{ <<"b">> := <<"RESULT2">> } },
+        hb_converge:set(Msg0, [<<"a">>, <<"b">>], <<"RESULT2">>, Opts)),
     % Now validate deeper layer changes are handled correctly.
-    Msg = #{ a => #{ b => #{ c => 1 } } },
-    ?assertMatch(#{ a := #{ b := #{ c := 2 } } },
-        hb_converge:set(Msg, [a, b, c], 2, Opts)).
+    Msg = #{ <<"a">> => #{ <<"b">> => #{ <<"c">> => 1 } } },
+    ?assertMatch(#{ <<"a">> := #{ <<"b">> := #{ <<"c">> := 2 } } },
+        hb_converge:set(Msg, [<<"a">>, <<"b">>, <<"c">>], 2, Opts)).
 
 deep_set_new_messages_test() ->
     Opts = maps:get(opts, hd(test_opts())),
     % Test that new messages are created when the path does not exist.
-    Msg0 = #{ a => #{ b => #{ c => <<"1">> } } },
+    Msg0 = #{ <<"a">> => #{ <<"b">> => #{ <<"c">> => <<"1">> } } },
     Msg1 = hb_converge:set(Msg0, <<"d/e">>, <<"3">>, Opts),
     Msg2 = hb_converge:set(Msg1, <<"d/f">>, <<"4">>, Opts),
     ?assert(
         hb_message:match(
             Msg2,
             #{ 
-                a =>
+                <<"a">> =>
                     #{
-                        b =>
-                            #{ c => <<"1">> }
+                        <<"b">> =>
+                            #{ <<"c">> => <<"1">> }
                     },
-                d =>
+                <<"d">> =>
                     #{
-                        e => <<"3">>,
-                        f => <<"4">> }
+                        <<"e">> => <<"3">>,
+                        <<"f">> => <<"4">> }
             }
         )
     ),
@@ -452,9 +452,14 @@ deep_set_new_messages_test() ->
         hb_message:match(
             Msg3,
             #{
-                a => #{ b => #{ c => <<"1">> } },
-                d => #{ e => <<"3">>, f => <<"4">> },
-                z => #{ a => <<"0">>, b => <<"1">>, y => #{ x => <<"2">> } }
+                <<"a">> => #{ <<"b">> => #{ <<"c">> => <<"1">> } },
+                <<"d">> => #{ <<"e">> => <<"3">>, <<"f">> => <<"4">> },
+                <<"z">> =>
+                    #{
+                        <<"a">> => <<"0">>,
+                        <<"b">> => <<"1">>,
+                        <<"y">> => #{ <<"x">> => <<"2">> }
+                    }
             }
         )
     ).
@@ -467,36 +472,36 @@ deep_set_with_device_test(Opts) ->
                 % and adds a modified flag.
                 {Key, Val} =
                     hd(maps:to_list(maps:without([path, priv], Msg2))),
-                {ok, Msg1#{ Key => Val, modified => true }}
+                {ok, Msg1#{ Key => Val, <<"modified">> => true }}
             end
     },
     % A message with an interspersed custom device: A and C have it,
     % B does not. A and C will have the modified flag set to true.
     Msg = #{
-        device => Device,
-        a =>
+        <<"device">> => Device,
+        <<"a">> =>
             #{
-                b =>
+                <<"b">> =>
                     #{
-                        device => Device,
-                        c => <<"1">>,
-                        modified => false
+                        <<"device">> => Device,
+                        <<"c">> => <<"1">>,
+                        <<"modified">> => false
                     },
-                modified => false
+                <<"modified">> => false
             },
-        modified => false
+        <<"modified">> => false
     },
-    Outer = hb_converge:deep_set(Msg, [a, b, c], <<"2">>, Opts),
-    A = hb_converge:get(a, Outer, Opts),
-    B = hb_converge:get(b, A, Opts),
-    C = hb_converge:get(c, B, Opts),
+    Outer = hb_converge:deep_set(Msg, [<<"a">>, <<"b">>, <<"c">>], <<"2">>, Opts),
+    A = hb_converge:get(<<"a">>, Outer, Opts),
+    B = hb_converge:get(<<"b">>, A, Opts),
+    C = hb_converge:get(<<"c">>, B, Opts),
     ?assertEqual(<<"2">>, C),
-    ?assertEqual(true, hb_converge:get(modified, Outer)),
-    ?assertEqual(false, hb_converge:get(modified, A)),
-    ?assertEqual(true, hb_converge:get(modified, B)).
+    ?assertEqual(true, hb_converge:get(<<"modified">>, Outer)),
+    ?assertEqual(false, hb_converge:get(<<"modified">>, A)),
+    ?assertEqual(true, hb_converge:get(<<"modified">>, B)).
 
 device_exports_test(Opts) ->
-	Msg = #{ device => dev_message },
+	Msg = #{ <<"device">> => dev_message },
 	?assert(hb_converge:is_exported(Msg, dev_message, info, Opts)),
 	?assert(hb_converge:is_exported(Msg, dev_message, set, Opts)),
 	?assert(
@@ -511,7 +516,7 @@ device_exports_test(Opts) ->
 		info => fun() -> #{ exports => [set] } end,
 		set => fun(_, _) -> {ok, <<"SET">>} end
 	},
-	Msg2 = #{ device => Dev },
+	Msg2 = #{ <<"device">> => Dev },
 	?assert(hb_converge:is_exported(Msg2, Dev, info, Opts)),
 	?assert(hb_converge:is_exported(Msg2, Dev, set, Opts)),
 	?assert(not hb_converge:is_exported(Msg2, Dev, not_exported, Opts)),
@@ -527,24 +532,24 @@ device_exports_test(Opts) ->
                 }
             end
     },
-    Msg3 = #{ device => Dev2, <<"Test1">> => <<"BAD1">>, test3 => <<"GOOD3">> },
-    ?assertEqual(<<"Handler-Value">>, hb_converge:get(test1, Msg3, Opts)),
-    ?assertEqual(<<"Handler-Value">>, hb_converge:get(test2, Msg3, Opts)),
-    ?assertEqual(<<"GOOD3">>, hb_converge:get(test3, Msg3, Opts)),
+    Msg3 = #{ <<"device">> => Dev2, <<"Test1">> => <<"BAD1">>, <<"test3">> => <<"GOOD3">> },
+    ?assertEqual(<<"Handler-Value">>, hb_converge:get(<<"test1">>, Msg3, Opts)),
+    ?assertEqual(<<"Handler-Value">>, hb_converge:get(<<"test2">>, Msg3, Opts)),
+    ?assertEqual(<<"GOOD3">>, hb_converge:get(<<"test3">>, Msg3, Opts)),
     ?assertEqual(<<"GOOD4">>,
         hb_converge:get(
             <<"Test4">>,
             hb_converge:set(Msg3, <<"Test4">>, <<"GOOD4">>, Opts)
         )
     ),
-    ?assertEqual(not_found, hb_converge:get(test5, Msg3, Opts)).
+    ?assertEqual(not_found, hb_converge:get(<<"test5">>, Msg3, Opts)).
 
 device_excludes_test(Opts) ->
     % Create a device that returns an identifiable message for any key, but also
     % sets excludes to [set], such that the message can be modified using the 
     % default handler.
     Dev = #{
-        info =>
+        <<"info">> =>
             fun() ->
                 #{
                     excludes => [set],
@@ -552,17 +557,17 @@ device_excludes_test(Opts) ->
                 }
             end
     },
-    Msg = #{ device => Dev, <<"Test-Key">> => <<"Test-Value">> },
-    ?assert(hb_converge:is_exported(Msg, Dev, <<"Test-Key2">>, Opts)),
+    Msg = #{ <<"device">> => Dev, <<"Test-Key">> => <<"Test-Value">> },
+    ?assert(hb_converge:is_exported(Msg, Dev, <<"test-key2">>, Opts)),
     ?assert(not hb_converge:is_exported(Msg, Dev, set, Opts)),
-    ?assertEqual(<<"Handler-Value">>, hb_converge:get(<<"Test-Key2">>, Msg, Opts)),
-    ?assertMatch(#{ <<"Test-Key2">> := <<"2">> },
-        hb_converge:set(Msg, <<"Test-Key2">>, <<"2">>, Opts)).
+    ?assertEqual(<<"Handler-Value">>, hb_converge:get(<<"test-key2">>, Msg, Opts)),
+    ?assertMatch(#{ <<"test-key2">> := <<"2">> },
+        hb_converge:set(Msg, <<"test-key2">>, <<"2">>, Opts)).
 
 denormalized_device_key_test(Opts) ->
 	Msg = #{ <<"Device">> => dev_test },
 	?assertEqual(dev_test, hb_converge:get(device, Msg, Opts)),
-	?assertEqual(dev_test, hb_converge:get(<<"Device">>, Msg, Opts)),
+	?assertEqual(dev_test, hb_converge:get(<<"device">>, Msg, Opts)),
 	?assertEqual({module, dev_test},
 		erlang:fun_info(
             element(3, hb_converge:message_to_fun(Msg, test_func, Opts)),

--- a/src/hb_converge_test_vectors.erl
+++ b/src/hb_converge_test_vectors.erl
@@ -9,8 +9,8 @@
 %% @doc Easy hook to make a test executable via the command line:
 %% `rebar3 eunit --test hb_converge_test_vectors:run_test`
 %% Comment/uncomment out as necessary.
-% run_test() ->
-%     run_single(normal, no_cache).
+run_test() ->
+    run_single(normal, deep_recursive_get).
 
 %% @doc Run a single test with a given set of opts.
 run_single(OptsName, TestName) ->
@@ -64,6 +64,8 @@ test_suite() ->
             fun basic_get_test/1},
         {recursive_get, "recursive get",
             fun recursive_get_test/1},
+        {deep_recursive_get, "deep recursive get",
+            fun deep_recursive_get_test/1},
         {basic_set, "basic set",
             fun basic_set_test/1},
         {get_with_device, "get with device",
@@ -339,7 +341,18 @@ basic_get_test(Opts) ->
     ?assertEqual(<<"value2">>, hb_converge:get([<<"key2">>], Msg, Opts)).
 
 recursive_get_test(Opts) ->
-    Msg = #{ key1 => <<"value1">>, key2 => #{ key3 => <<"value3">> } },
+    Msg = #{
+        key1 => <<"value1">>,
+        key2 => #{
+            key3 => <<"value3">>,
+            key4 => #{
+                key5 => <<"value5">>,
+                key6 => #{
+                    key7 => <<"value7">>
+                }
+            }
+        }
+    },
     ?assertEqual(
         {ok, <<"value1">>},
         hb_converge:resolve(Msg, #{ path => key1 }, Opts)
@@ -351,6 +364,21 @@ recursive_get_test(Opts) ->
     ),
     ?assertEqual(<<"value3">>, hb_converge:get([<<"key2">>, <<"key3">>], Msg, Opts)),
     ?assertEqual(<<"value3">>, hb_converge:get(<<"key2/key3">>, Msg, Opts)).
+
+deep_recursive_get_test(Opts) ->
+    Msg = #{
+        key1 => <<"value1">>,
+        key2 => #{
+            key3 => <<"value3">>,
+            key4 => #{
+                key5 => <<"value5">>,
+                key6 => #{
+                    key7 => <<"value7">>
+                }
+            }
+        }
+    },
+    ?assertEqual(<<"value7">>, hb_converge:get(<<"key2/key4/key6/key7">>, Msg, Opts)).
 
 basic_set_test(Opts) ->
     Msg = #{ key1 => <<"value1">>, key2 => <<"value2">> },

--- a/src/hb_converge_test_vectors.erl
+++ b/src/hb_converge_test_vectors.erl
@@ -143,7 +143,7 @@ test_opts() ->
 %%% Test vector suite
 
 resolve_simple_test(Opts) ->
-    Res = hb_converge:resolve(#{ a => <<"RESULT">> }, a, Opts),
+    Res = hb_converge:resolve(#{ <<"a">> => <<"RESULT">> }, <<"a">>, Opts),
     ?assertEqual({ok, <<"RESULT">>}, Res).
 
 resolve_id_test(Opts) ->

--- a/src/hb_converge_test_vectors.erl
+++ b/src/hb_converge_test_vectors.erl
@@ -525,7 +525,6 @@ deep_set_with_device_test(Opts) ->
     A = hb_converge:get(<<"a">>, Outer, Opts),
     B = hb_converge:get(<<"b">>, A, Opts),
     C = hb_converge:get(<<"c">>, B, Opts),
-    ?event(debug, {debug, Outer}),
     ?assertEqual(<<"2">>, C),
     ?assertEqual(true, hb_converge:get(<<"modified">>, Outer)),
     ?assertEqual(false, hb_converge:get(<<"modified">>, A)),

--- a/src/hb_converge_test_vectors.erl
+++ b/src/hb_converge_test_vectors.erl
@@ -9,8 +9,8 @@
 %% @doc Easy hook to make a test executable via the command line:
 %% `rebar3 eunit --test hb_converge_test_vectors:run_test`
 %% Comment/uncomment out as necessary.
-run_test() ->
-    run_single(normal, recursive_get).
+% run_test() ->
+%     run_single(normal, no_cache).
 
 %% @doc Run a single test with a given set of opts.
 run_single(OptsName, TestName) ->
@@ -411,6 +411,8 @@ deep_set_test(Opts) ->
     % First validate second layer changes are handled correctly.
     Msg0 = #{ <<"a">> => #{ <<"b">> => <<"RESULT">> } },
     ?assertMatch(#{ <<"a">> := #{ <<"b">> := <<"RESULT2">> } },
+        hb_converge:set(Msg0, <<"a/b">>, <<"RESULT2">>, Opts)),
+    ?assertMatch(#{ <<"a">> := #{ <<"b">> := <<"RESULT2">> } },
         hb_converge:set(Msg0, [<<"a">>, <<"b">>], <<"RESULT2">>, Opts)),
     % Now validate deeper layer changes are handled correctly.
     Msg = #{ <<"a">> => #{ <<"b">> => #{ <<"c">> => 1 } } },
@@ -491,10 +493,11 @@ deep_set_with_device_test(Opts) ->
             },
         <<"modified">> => false
     },
-    Outer = hb_converge:deep_set(Msg, [<<"a">>, <<"b">>, <<"c">>], <<"2">>, Opts),
+    Outer = hb_converge:set(Msg, <<"a/b/c">>, <<"2">>, Opts),
     A = hb_converge:get(<<"a">>, Outer, Opts),
     B = hb_converge:get(<<"b">>, A, Opts),
     C = hb_converge:get(<<"c">>, B, Opts),
+    ?event(debug, {debug, Outer}),
     ?assertEqual(<<"2">>, C),
     ?assertEqual(true, hb_converge:get(<<"modified">>, Outer)),
     ?assertEqual(false, hb_converge:get(<<"modified">>, A)),
@@ -582,3 +585,6 @@ list_transform_test(Opts) ->
     ?assertEqual(<<"C">>, hb_converge:get(3, Msg, Opts)),
     ?assertEqual(<<"D">>, hb_converge:get(4, Msg, Opts)),
     ?assertEqual(<<"E">>, hb_converge:get(5, Msg, Opts)).
+
+    
+    

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -125,7 +125,7 @@ request(Method, Peer, Path, RawMessage, Opts) ->
 %% @doc Turn a set of request arguments into a request message, formatted in the
 %% preferred format.
 prepare_request(Format, Method, Peer, Path, RawMessage, Opts) ->
-    Message = hb_converge:ensure_message(RawMessage),
+    Message = hb_converge:normalize_keys(RawMessage),
     BinPeer = if is_binary(Peer) -> Peer; true -> list_to_binary(Peer) end,
     BinPath = hb_path:normalize(hb_path:to_binary(Path)),
     ReqBase = #{ peer => BinPeer, path => BinPath, method => Method },
@@ -238,7 +238,7 @@ empty_inbox(Ref) ->
 reply(Req, Message) ->
     reply(Req, message_to_status(Message), Message).
 reply(Req, Status, RawMessage) ->
-    Message = hb_converge:ensure_message(RawMessage),
+    Message = hb_converge:normalize_keys(RawMessage),
     Encoded =
         hb_message:convert(
             Message,

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -48,6 +48,7 @@ post(Node, Message, Opts) ->
 post(Node, Path, Message, Opts) ->
     case request(<<"POST">>, Node, Path, Message, Opts) of
         {ok, Res} ->
+            ?event(debug, {post_response, Res}),
             {ok,
                 hb_message:convert(
                     ar_bundles:deserialize(Res),
@@ -248,7 +249,7 @@ reply(Req, Status, RawMessage, Opts) ->
             {encoded, Encoded}
         }
     ),
-    Req2 = cowboy_req:stream_reply(Status, Headers, Req),
+    Req2 = cowboy_req:stream_reply(Status, maps:from_list(Headers), Req),
     Req3 = cowboy_req:stream_body(Encoded, nofin, Req2),
     {ok, Req3, no_state}.
 

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -6,7 +6,7 @@
 -module(hb_http).
 -export([start/0]).
 -export([get/2, get/3, post/3, post/4, request/4, request/5]).
--export([reply/2, reply/3]).
+-export([reply/3, reply/4]).
 -export([message_to_status/1, status_code/1, req_to_tabm_singleton/2]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -235,41 +235,47 @@ empty_inbox(Ref) ->
     end.
 
 %% @doc Reply to the client's HTTP request with a message.
-reply(Req, Message) ->
-    reply(Req, message_to_status(Message), Message).
-reply(Req, Status, RawMessage) ->
+reply(Req, Message, Opts) ->
+    reply(Req, message_to_status(Message), Message, Opts).
+reply(Req, Status, RawMessage, Opts) ->
     Message = hb_converge:normalize_keys(RawMessage),
-    Encoded =
-        hb_message:convert(
-            Message,
-            hb_opts:get(format, http, #{}),
-            converge,
-            #{ topic => converge_internal }
-        ),
+    {ok, #{ <<"headers">> := Headers, <<"body">> := Encoded}} =
+        prepare_reply(Message, Opts),
     ?event(http,
         {replying,
             {status, Status},
-            {path, maps:get(path, Req, undefined_path)},
+            {path, maps:get(<<"path">>, Req, undefined_path)},
             {encoded, Encoded}
         }
     ),
-    Req2 = cowboy_req:stream_reply(
-        Status,
-        case Encoded of
-            #{ headers := Headers } -> maps:from_list(Headers);
-            _ -> #{<<"content-type">> => <<"application/octet-stream">>}
-        end,
-        Req
-    ),
-    Req3 = cowboy_req:stream_body(
-        case Encoded of
-            #{ body := Body } -> Body;
-            _ -> ar_bundles:serialize(Encoded)
-        end,
-        nofin,
-        Req2
-    ),
+    Req2 = cowboy_req:stream_reply(Status, Headers, Req),
+    Req3 = cowboy_req:stream_body(Encoded, nofin, Req2),
     {ok, Req3, no_state}.
+
+%% @doc Generate the headers and body for a HTTP response message.
+prepare_reply(Message, Opts) ->
+    case hb_opts:get(format, http, Opts) of
+        http ->
+            {ok,
+                hb_message:convert(
+                    Message,
+                    http,
+                    converge,
+                    #{ topic => converge_internal }
+                )
+            };
+        ans104 ->
+            {ok,
+                #{
+                    <<"headers">> =>
+                        [
+                            {<<"content-type">>, <<"application/octet-stream">>}
+                        ],
+                    <<"body">> =>
+                        ar_bundles:serialize(hb_message:convert(Message, tx, Opts))
+                }
+            }
+    end.
 
 %% @doc Get the HTTP status code from a transaction (if it exists).
 message_to_status(Item) ->

--- a/src/hb_http_benchmark_tests.erl
+++ b/src/hb_http_benchmark_tests.erl
@@ -8,186 +8,186 @@
 %% 1: 50% performance of Macbook Pro M2 Max
 -define(PERFORMANCE_DIVIDER, 1).
 
-unsigned_resolve_benchmark_test() ->
-    BenchTime = 1,
-    URL = hb_http_server:start_test_node(#{force_signed => false}),
-    Iterations = hb:benchmark(
-        fun() ->
-            hb_http:post(URL,
-                #{
-                    <<"path">> => <<"key1">>,
-                    <<"key1">> => #{<<"key2">> => <<"value1">>}
-                },
-                #{}
-            )
-        end,
-        BenchTime
-    ),
-    hb_util:eunit_print(
-        "Resolved ~p messages through Converge via HTTP in ~p seconds (~.2f msg/s)",
-        [Iterations, BenchTime, Iterations / BenchTime]
-    ),
-    ?assert(Iterations > 400 / ?PERFORMANCE_DIVIDER).
+% unsigned_resolve_benchmark_test() ->
+%     BenchTime = 1,
+%     URL = hb_http_server:start_test_node(#{force_signed => false}),
+%     Iterations = hb:benchmark(
+%         fun() ->
+%             hb_http:post(URL,
+%                 #{
+%                     <<"path">> => <<"key1">>,
+%                     <<"key1">> => #{<<"key2">> => <<"value1">>}
+%                 },
+%                 #{}
+%             )
+%         end,
+%         BenchTime
+%     ),
+%     hb_util:eunit_print(
+%         "Resolved ~p messages through Converge via HTTP in ~p seconds (~.2f msg/s)",
+%         [Iterations, BenchTime, Iterations / BenchTime]
+%     ),
+%     ?assert(Iterations > 400 / ?PERFORMANCE_DIVIDER).
 
-parallel_unsigned_resolve_benchmark_test() ->
-    BenchTime = 1,
-    BenchWorkers = 16,
-    URL = hb_http_server:start_test_node(#{force_signed => false}),
-    Iterations = hb:benchmark(
-        fun(_Count) ->
-            hb_http:post(
-                URL,
-                #{
-                    <<"path">> => <<"key1">>,
-                    <<"key1">> => #{<<"key2">> => <<"value1">>}
-                },
-                #{}
-            )
-        end,
-        BenchTime,
-        BenchWorkers
-    ),
-    hb_util:eunit_print(
-        "Resolved ~p messages via HTTP (~p workers) in ~p seconds (~.2f msg/s)",
-        [Iterations, BenchWorkers, BenchTime, Iterations / BenchTime]
-    ),
-    ?assert(Iterations > 1000 / ?PERFORMANCE_DIVIDER).
-
-wasm_compute_request(ImageFile, Func, Params) ->
-    {ok, Bin} = file:read_file(ImageFile),
-    #{
-        <<"path">> => <<"init/compute/results">>,
-        <<"device">> => <<"wasm-64/1.0">>,
-        <<"wasm-function">> => Func,
-        <<"wasm-params">> => Params,
-        <<"image">> => Bin
-    }.
-
-run_wasm_unsigned_benchmark_test() ->
-    BenchTime = 1,
-    URL = hb_http_server:start_test_node(#{force_signed => false}),
-    Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [10]),
-    Iterations = hb:benchmark(
-        fun(_) ->
-            case hb_http:post(URL, Msg, #{}) of
-                {ok, _} -> 1;
-                _ -> 0
-            end
-        end,
-        BenchTime
-    ),
-    hb_util:eunit_print(
-        "Resolved ~p WASM invocations via HTTP in ~p seconds (~.2f msg/s)",
-        [Iterations, BenchTime, Iterations / BenchTime]
-    ),
-    ?assert(Iterations > 100 / ?PERFORMANCE_DIVIDER).
-
-
-run_wasm_signed_benchmark_test_disabled() ->
-    BenchTime = 1,
-    URL = hb_http_server:start_test_node(#{force_signed => true}),
-    Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [10]),
-    Iterations = hb:benchmark(
-        fun(_) ->
-            case hb_http:post(URL, Msg, #{}) of
-                {ok, _} -> 1;
-                _ -> 0
-            end
-        end,
-        BenchTime
-    ),
-    hb_util:eunit_print(
-        "Resolved ~p WASM invocations via HTTP in ~p seconds (~.2f msg/s)",
-        [Iterations, BenchTime, Iterations / BenchTime]
-    ),
-    ?assert(Iterations > 50 / ?PERFORMANCE_DIVIDER).
-
-parallel_wasm_unsigned_benchmark_test_disabled() ->
-    BenchTime = 1,
-    BenchWorkers = 16,
-    URL = hb_http_server:start_test_node(#{force_signed => false}),
-    Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [10]),
-    Iterations = hb:benchmark(
-        fun(X) ->
-            ?event(debug, {post_start, X}),
-            case hb_http:post(URL, Msg, #{}) of
-                {ok, _} ->
-                    1;
-                _ -> 0
-            end
-        end,
-        BenchTime,
-        BenchWorkers
-    ),
-    hb_util:eunit_print(
-        "Resolved ~p WASM invocations via HTTP (~p workers) in ~p seconds (~.2f msg/s)",
-        [Iterations, BenchWorkers, BenchTime, Iterations / BenchTime]
-    ),
-    ?assert(Iterations > 200 / ?PERFORMANCE_DIVIDER).
-
-parallel_wasm_signed_benchmark_test_disabled() ->
-    BenchTime = 1,
-    BenchWorkers = 16,
-    URL = hb_http_server:start_test_node(#{force_signed => true}),
-    Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [10]),
-    Iterations = hb:benchmark(
-        fun(_) ->
-            case hb_http:post(URL, Msg, #{}) of
-                {ok, _ResMsg} ->
-                    1;
-                _ -> 0
-            end
-        end,
-        BenchTime,
-        BenchWorkers
-    ),
-    hb_util:eunit_print(
-        "Resolved ~p WASM invocations via HTTP (~p workers) in ~p seconds (~.2f msg/s)",
-        [Iterations, BenchWorkers, BenchTime, Iterations / BenchTime]
-    ),
-    ?assert(Iterations > 100 / ?PERFORMANCE_DIVIDER).
-
-% parallel_http_scheduling_benchmark_test() ->
-%     application:ensure_all_started(hb),
-%     URL = hb_http_server:start_test_node(#{force_signed => true}),
-%     BenchTime = 3,
+% parallel_unsigned_resolve_benchmark_test() ->
+%     BenchTime = 1,
 %     BenchWorkers = 16,
-%     Msg1 = dev_scheduler:test_process(),
-%     Proc = hb_converge:get(process, Msg1, #{ hashpath => ignore }),
-%     ProcID = hb_util:id(Proc),
-%     ?event({benchmark_start, ?MODULE}),
+%     URL = hb_http_server:start_test_node(#{force_signed => false}),
+%     Iterations = hb:benchmark(
+%         fun(_Count) ->
+%             hb_http:post(
+%                 URL,
+%                 #{
+%                     <<"path">> => <<"key1">>,
+%                     <<"key1">> => #{<<"key2">> => <<"value1">>}
+%                 },
+%                 #{}
+%             )
+%         end,
+%         BenchTime,
+%         BenchWorkers
+%     ),
+%     hb_util:eunit_print(
+%         "Resolved ~p messages via HTTP (~p workers) in ~p seconds (~.2f msg/s)",
+%         [Iterations, BenchWorkers, BenchTime, Iterations / BenchTime]
+%     ),
+%     ?assert(Iterations > 1000 / ?PERFORMANCE_DIVIDER).
+
+% wasm_compute_request(ImageFile, Func, Params) ->
+%     {ok, Bin} = file:read_file(ImageFile),
+%     #{
+%         <<"path">> => <<"init/compute/results">>,
+%         <<"device">> => <<"wasm-64/1.0">>,
+%         <<"wasm-function">> => Func,
+%         <<"wasm-params">> => Params,
+%         <<"image">> => Bin
+%     }.
+
+% run_wasm_unsigned_benchmark_test() ->
+%     BenchTime = 1,
+%     URL = hb_http_server:start_test_node(#{force_signed => false}),
+%     Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [10]),
+%     Iterations = hb:benchmark(
+%         fun(_) ->
+%             case hb_http:post(URL, Msg, #{}) of
+%                 {ok, _} -> 1;
+%                 _ -> 0
+%             end
+%         end,
+%         BenchTime
+%     ),
+%     hb_util:eunit_print(
+%         "Resolved ~p WASM invocations via HTTP in ~p seconds (~.2f msg/s)",
+%         [Iterations, BenchTime, Iterations / BenchTime]
+%     ),
+%     ?assert(Iterations > 100 / ?PERFORMANCE_DIVIDER).
+
+
+% run_wasm_signed_benchmark_test_disabled() ->
+%     BenchTime = 1,
+%     URL = hb_http_server:start_test_node(#{force_signed => true}),
+%     Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [10]),
+%     Iterations = hb:benchmark(
+%         fun(_) ->
+%             case hb_http:post(URL, Msg, #{}) of
+%                 {ok, _} -> 1;
+%                 _ -> 0
+%             end
+%         end,
+%         BenchTime
+%     ),
+%     hb_util:eunit_print(
+%         "Resolved ~p WASM invocations via HTTP in ~p seconds (~.2f msg/s)",
+%         [Iterations, BenchTime, Iterations / BenchTime]
+%     ),
+%     ?assert(Iterations > 50 / ?PERFORMANCE_DIVIDER).
+
+% parallel_wasm_unsigned_benchmark_test_disabled() ->
+%     BenchTime = 1,
+%     BenchWorkers = 16,
+%     URL = hb_http_server:start_test_node(#{force_signed => false}),
+%     Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [10]),
 %     Iterations = hb:benchmark(
 %         fun(X) ->
-%             MsgX = #{
-%                 <<"device">> => <<"Scheduler/1.0">>,
-%                 <<"path">> => <<"schedule">>,
-%                 <<"method">> => <<"POST">>,
-%                 <<"message">> =>
-%                     #{
-%                         <<"type">> => <<"message">>,
-%                         <<"test-val">> => X
-%                     }
-%             },
-%             Res = hb_http:post(URL, MsgX),
-%             ?event(debug, {post_result, Res}),
-%             case Res of
-%                 {ok, _} -> 1;
+%             ?event(debug, {post_start, X}),
+%             case hb_http:post(URL, Msg, #{}) of
+%                 {ok, _} ->
+%                     1;
 %                 _ -> 0
 %             end
 %         end,
 %         BenchTime,
 %         BenchWorkers
 %     ),
-%     ?event(benchmark, {scheduled, Iterations}),
-%     Msg3 = #{
-%         <<"path">> => <<"slot">>,
-%         <<"method">> => <<"GET">>,
-%         <<"process">> => ProcID
-%     },
-%     Res = hb_http:post(URL, Msg3),
-%     ?event(debug, {slot_result, Res}),
 %     hb_util:eunit_print(
-%         "Scheduled ~p messages through Converge in ~p seconds (~.2f msg/s)",
-%         [Iterations, BenchTime, Iterations / BenchTime]
+%         "Resolved ~p WASM invocations via HTTP (~p workers) in ~p seconds (~.2f msg/s)",
+%         [Iterations, BenchWorkers, BenchTime, Iterations / BenchTime]
 %     ),
-%     ?assert(Iterations > 100).
+%     ?assert(Iterations > 200 / ?PERFORMANCE_DIVIDER).
+
+% parallel_wasm_signed_benchmark_test_disabled() ->
+%     BenchTime = 1,
+%     BenchWorkers = 16,
+%     URL = hb_http_server:start_test_node(#{force_signed => true}),
+%     Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [10]),
+%     Iterations = hb:benchmark(
+%         fun(_) ->
+%             case hb_http:post(URL, Msg, #{}) of
+%                 {ok, _ResMsg} ->
+%                     1;
+%                 _ -> 0
+%             end
+%         end,
+%         BenchTime,
+%         BenchWorkers
+%     ),
+%     hb_util:eunit_print(
+%         "Resolved ~p WASM invocations via HTTP (~p workers) in ~p seconds (~.2f msg/s)",
+%         [Iterations, BenchWorkers, BenchTime, Iterations / BenchTime]
+%     ),
+%     ?assert(Iterations > 100 / ?PERFORMANCE_DIVIDER).
+
+% % parallel_http_scheduling_benchmark_test() ->
+% %     application:ensure_all_started(hb),
+% %     URL = hb_http_server:start_test_node(#{force_signed => true}),
+% %     BenchTime = 3,
+% %     BenchWorkers = 16,
+% %     Msg1 = dev_scheduler:test_process(),
+% %     Proc = hb_converge:get(process, Msg1, #{ hashpath => ignore }),
+% %     ProcID = hb_util:id(Proc),
+% %     ?event({benchmark_start, ?MODULE}),
+% %     Iterations = hb:benchmark(
+% %         fun(X) ->
+% %             MsgX = #{
+% %                 <<"device">> => <<"Scheduler/1.0">>,
+% %                 <<"path">> => <<"schedule">>,
+% %                 <<"method">> => <<"POST">>,
+% %                 <<"message">> =>
+% %                     #{
+% %                         <<"type">> => <<"message">>,
+% %                         <<"test-val">> => X
+% %                     }
+% %             },
+% %             Res = hb_http:post(URL, MsgX),
+% %             ?event(debug, {post_result, Res}),
+% %             case Res of
+% %                 {ok, _} -> 1;
+% %                 _ -> 0
+% %             end
+% %         end,
+% %         BenchTime,
+% %         BenchWorkers
+% %     ),
+% %     ?event(benchmark, {scheduled, Iterations}),
+% %     Msg3 = #{
+% %         <<"path">> => <<"slot">>,
+% %         <<"method">> => <<"GET">>,
+% %         <<"process">> => ProcID
+% %     },
+% %     Res = hb_http:post(URL, Msg3),
+% %     ?event(debug, {slot_result, Res}),
+% %     hb_util:eunit_print(
+% %         "Scheduled ~p messages through Converge in ~p seconds (~.2f msg/s)",
+% %         [Iterations, BenchTime, Iterations / BenchTime]
+% %     ),
+% %     ?assert(Iterations > 100).

--- a/src/hb_http_benchmark_tests.erl
+++ b/src/hb_http_benchmark_tests.erl
@@ -15,8 +15,8 @@ unsigned_resolve_benchmark_test() ->
         fun() ->
             hb_http:post(URL,
                 #{
-                    path => <<"Key1">>,
-                    <<"Key1">> => #{<<"Key2">> => <<"Value1">>}
+                    <<"path">> => <<"key1">>,
+                    <<"key1">> => #{<<"key2">> => <<"value1">>}
                 },
                 #{}
             )
@@ -38,8 +38,8 @@ parallel_unsigned_resolve_benchmark_test() ->
             hb_http:post(
                 URL,
                 #{
-                    path => <<"Key1">>,
-                    <<"Key1">> => #{<<"Key2">> => <<"Value1">>}
+                    <<"path">> => <<"key1">>,
+                    <<"key1">> => #{<<"key2">> => <<"value1">>}
                 },
                 #{}
             )
@@ -56,11 +56,11 @@ parallel_unsigned_resolve_benchmark_test() ->
 wasm_compute_request(ImageFile, Func, Params) ->
     {ok, Bin} = file:read_file(ImageFile),
     #{
-        path => <<"Init/Compute/Results">>,
-        device => <<"WASM-64/1.0">>,
-        <<"WASM-Function">> => Func,
-        <<"WASM-Params">> => Params,
-        <<"Image">> => Bin
+        <<"path">> => <<"init/compute/results">>,
+        <<"device">> => <<"wasm-64/1.0">>,
+        <<"wasm-function">> => Func,
+        <<"wasm-params">> => Params,
+        <<"image">> => Bin
     }.
 
 run_wasm_unsigned_benchmark_test() ->
@@ -159,13 +159,13 @@ parallel_wasm_signed_benchmark_test_disabled() ->
 %     Iterations = hb:benchmark(
 %         fun(X) ->
 %             MsgX = #{
-%                 device => <<"Scheduler/1.0">>,
-%                 path => <<"Schedule">>,
-%                 <<"Method">> => <<"POST">>,
-%                 <<"Message">> =>
+%                 <<"device">> => <<"Scheduler/1.0">>,
+%                 <<"path">> => <<"schedule">>,
+%                 <<"method">> => <<"POST">>,
+%                 <<"message">> =>
 %                     #{
-%                         <<"Type">> => <<"Message">>,
-%                         <<"Test-Val">> => X
+%                         <<"type">> => <<"message">>,
+%                         <<"test-val">> => X
 %                     }
 %             },
 %             Res = hb_http:post(URL, MsgX),
@@ -180,9 +180,9 @@ parallel_wasm_signed_benchmark_test_disabled() ->
 %     ),
 %     ?event(benchmark, {scheduled, Iterations}),
 %     Msg3 = #{
-%         path => <<"Slot">>,
-%         <<"Method">> => <<"GET">>,
-%         <<"Process">> => ProcID
+%         <<"path">> => <<"slot">>,
+%         <<"method">> => <<"GET">>,
+%         <<"process">> => ProcID
 %     },
 %     Res = hb_http:post(URL, Msg3),
 %     ?event(debug, {slot_result, Res}),

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -200,8 +200,8 @@ raw_http_access_test() ->
         ar_bundles:serialize(
             hb_message:convert(
                 #{
-                    path => <<"Key1">>,
-                    <<"Key1">> => #{ <<"Key2">> => <<"Value1">> }
+                    <<"path">> => <<"key1">>,
+                    <<"key1">> => #{ <<"key2">> => <<"value1">> }
                 },
                 tx,
                 converge,
@@ -216,4 +216,4 @@ raw_http_access_test() ->
             [{body_format, binary}]
         ),
     Msg = hb_message:convert(ar_bundles:deserialize(Body), converge, tx, #{}),
-    ?assertEqual(<<"Value1">>, hb_converge:get(<<"Key2">>, Msg, #{})).
+    ?assertEqual(<<"value1">>, hb_converge:get(<<"key2">>, Msg, #{})).

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -3,7 +3,7 @@
 %%% only has to marshal the HTTP request into a message, and then
 %%% pass it to the Converge resolver. 
 %%% 
-%%% `hb_http:reply/3' is used to respond to the client, handling the 
+%%% `hb_http:reply/4' is used to respond to the client, handling the 
 %%% process of converting a message back into an HTTP response.
 %%% 
 %%% The router uses an `Opts` message as its Cowboy initial state, 
@@ -131,7 +131,7 @@ init(Req, ServerID) ->
     ReqSingleton = hb_http:req_to_tabm_singleton(Req, NodeMsg),
     ?event(http, {http_inbound, ReqSingleton}),
     {ok, Res} = dev_meta:handle(NodeMsg, ReqSingleton),
-    hb_http:reply(Req, Res).
+    hb_http:reply(Req, Res, NodeMsg).
 
 %% @doc Return the complete Ranch ETS table for the node for debugging.
 ranch_ets() ->

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -70,7 +70,7 @@ new_server(RawNodeMsg) ->
                 start_http2(ServerID, ProtoOpts, NodeMsg);
             _ -> {error, {unknown_protocol, Protocol}}
         end,
-    ?event(debug,
+    ?event(http,
         {http_server_started,
             {listener, Listener},
             {server_id, ServerID},
@@ -81,7 +81,7 @@ new_server(RawNodeMsg) ->
     {ok, Listener, Port}.
 
 start_http3(ServerID, ProtoOpts, _NodeMsg) ->
-    ?event(debug, {start_http3, ServerID}),
+    ?event(http, {start_http3, ServerID}),
     Parent = self(),
     ServerPID =
         spawn(fun() ->
@@ -115,7 +115,7 @@ start_http3(ServerID, ProtoOpts, _NodeMsg) ->
     end.
 
 start_http2(ServerID, ProtoOpts, NodeMsg) ->
-    ?event(debug, {start_http2, ServerID}),
+    ?event(http, {start_http2, ServerID}),
     {ok, Listener} = cowboy:start_clear(
         ServerID,
         [

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -53,7 +53,7 @@
 %%% retrieving messages.
 -module(hb_message).
 -export([convert/3, convert/4, unsigned/1, attestations/1]).
--export([sign/2, verify/1, type/1, minimize/1, normalize_keys/1]). 
+-export([sign/2, verify/1, type/1, minimize/1]). 
 -export([signers/1, serialize/1, serialize/2, deserialize/1, deserialize/2]).
 -export([match/2, match/3]).
 %%% Helpers:
@@ -83,7 +83,8 @@ convert(Msg, TargetFormat, SourceFormat, Opts) ->
         _ -> convert_to_target(TABM, TargetFormat, Opts)
     end.
 
-convert_to_tabm(Msg, SourceFormat, Opts) ->
+convert_to_tabm(RawMsg, SourceFormat, Opts) ->
+    Msg = hb_converge:normalize_keys(RawMsg),
     SourceCodecMod = get_codec(SourceFormat, Opts),
     case SourceCodecMod:from(Msg) of
         TypicalMsg when is_map(TypicalMsg) ->
@@ -98,11 +99,11 @@ convert_to_target(Msg, TargetFormat, Opts) ->
 %% @doc Return the unsigned version of a message in Converge format.
 unsigned(Bin) when is_binary(Bin) -> Bin;
 unsigned(Msg) ->
-    maps:remove([signed_id, signature, owner], Msg).
+    maps:remove([<<"signed_id">>, <<"signature">>, <<"owner">>], Msg).
 
 %% @doc Return a sub-map of the attestation-related keys in a message.
 attestations(Msg) ->
-    maps:with([signed_id, signature, owner], Msg).
+    maps:with([<<"signed_id">>, <<"signature">>, <<"owner">>], Msg).
 
 %% @doc Get a codec from the options.
 get_codec(TargetFormat, Opts) ->
@@ -125,7 +126,7 @@ format(Bin, Indent) when is_binary(Bin) ->
         Indent
     );
 format(List, Indent) when is_list(List) ->
-    format(hb_converge:ensure_message(List), Indent);
+    format(lists:map(fun hb_converge:normalize_key/1, List), Indent);
 format(Map, Indent) when is_map(Map) ->
     % Define helper functions for formatting elements of the map.
     ValOrUndef =
@@ -215,13 +216,13 @@ format(Map, Indent) when is_map(Map) ->
     % Format the remaining 'normal' keys and values.
     Res = lists:map(
         fun({Key, Val}) ->
-            NormKey = hb_converge:to_key(Key, #{ error_strategy => ignore }),
+            NormKey = hb_converge:normalize_key(Key, #{ error_strategy => ignore }),
             KeyStr = 
                 case NormKey of
                     undefined ->
                         io_lib:format("~p [!!! INVALID KEY !!!]", [Key]);
                     _ ->
-                        hb_converge:key_to_binary(Key)
+                        hb_converge:normalize_key(Key)
                 end,
             hb_util:format_indented(
                 "~s => ~s~n",
@@ -260,7 +261,7 @@ format(Item, Indent) ->
 %% @doc Return the signers of a message. For now, this is just the signer
 %% of the message itself. In the future, we will support multiple signers.
 signers(Msg) when is_map(Msg) ->
-    case {maps:find(owner, Msg), maps:find(signature, Msg)} of
+    case {maps:find(<<"owner">>, Msg), maps:find(<<"signature">>, Msg)} of
         {_, error} -> [];
         {error, _} -> [];
         {{ok, Owner}, {ok, _}} -> [ar_wallet:to_address(Owner)]
@@ -307,11 +308,11 @@ match(Map1, Map2) ->
 match(Map1, Map2, Mode) ->
     Keys1 =
         maps:keys(
-            NormMap1 = minimize(normalize(hb_converge:ensure_message(Map1)))
+            NormMap1 = minimize(normalize(hb_converge:normalize_keys(Map1)))
         ),
     Keys2 =
         maps:keys(
-            NormMap2 = minimize(normalize(hb_converge:ensure_message(Map2)))
+            NormMap2 = minimize(normalize(hb_converge:normalize_keys(Map2)))
         ),
     PrimaryKeysPresent =
         (Mode == primary) andalso
@@ -335,9 +336,11 @@ match(Map1, Map2, Mode) ->
                                     case Val1 == Val2 of
                                         true -> true;
                                         false ->
-                                            ?event(
+                                            ?event(debug,
                                                 {value_mismatch,
-                                                    {key, Val1, Val2}
+                                                    {key, Key},
+                                                    {val1, Val1},
+                                                    {val2, Val2}
                                                 }
                                             ),
                                             false
@@ -348,36 +351,24 @@ match(Map1, Map2, Mode) ->
                 Keys1
             );
         false ->
-            ?event({keys_mismatch, {keys1, Keys1}, {keys2, Keys2}}),
+            ?event(debug, {keys_mismatch, {keys1, Keys1}, {keys2, Keys2}}),
             false
     end.
 	
 matchable_keys(Map) ->
-    lists:sort(lists:map(fun hb_converge:key_to_binary/1, maps:keys(Map))).
-
-%% @doc Normalize the keys in a map. Also takes a list of keys and returns a
-%% sorted list of normalized keys if the input is a list.
-normalize_keys(Keys) when is_list(Keys) ->
-    lists:sort(lists:map(fun hb_converge:key_to_binary/1, Keys));
-normalize_keys(Map) ->
-    maps:from_list(
-        lists:map(
-            fun({Key, Value}) ->
-                {hb_converge:key_to_binary(Key), Value}
-            end,
-            maps:to_list(Map)
-        )
-    ).
+    lists:sort(lists:map(fun hb_converge:normalize_key/1, maps:keys(Map))).
 
 %% @doc Remove keys from the map that can be regenerated. Optionally takes an
 %% additional list of keys to include in the minimization.
 minimize(Msg) -> minimize(Msg, []).
 minimize(RawVal, _) when not is_map(RawVal) -> RawVal;
 minimize(Map, ExtraKeys) ->
-    NormKeys = normalize_keys(?REGEN_KEYS) ++ normalize_keys(ExtraKeys),
+    NormKeys =
+        lists:map(fun hb_converge:normalize_key/1, ?REGEN_KEYS)
+            ++ lists:map(fun hb_converge:normalize_key/1, ExtraKeys),
     maps:filter(
         fun(Key, _) ->
-            (not lists:member(hb_converge:key_to_binary(Key), NormKeys))
+            (not lists:member(hb_converge:normalize_key(Key), NormKeys))
                 andalso (not hb_private:is_private(Key))
         end,
         maps:map(fun(_K, V) -> minimize(V) end, Map)
@@ -386,7 +377,7 @@ minimize(Map, ExtraKeys) ->
 %% @doc Return a map with only the keys that necessary, without those that can
 %% be regenerated.
 normalize(Map) ->
-    NormalizedMap = normalize_keys(Map),
+    NormalizedMap = hb_converge:normalize_keys(Map),
     FilteredMap = filter_default_keys(NormalizedMap),
     maps:with(matchable_keys(FilteredMap), FilteredMap).
 
@@ -396,7 +387,7 @@ filter_default_keys(Map) ->
     DefaultsMap = default_tx_message(),
     maps:filter(
         fun(Key, Value) ->
-            case maps:find(hb_converge:key_to_binary(Key), DefaultsMap) of
+            case maps:find(hb_converge:normalize_key(Key), DefaultsMap) of
                 {ok, Value} -> false;
                 _ -> true
             end
@@ -406,11 +397,13 @@ filter_default_keys(Map) ->
 
 %% @doc Get the normalized fields and default values of the tx record.
 default_tx_message() ->
-    normalize_keys(maps:from_list(default_tx_list())).
+    maps:from_list(default_tx_list()).
 
-%% @doc Get the ordered list of fields and default values of the tx record.
+%% @doc Get the ordered list of fields as Converge keys and default values of
+%% the tx record.
 default_tx_list() ->
-    lists:zip(record_info(fields, tx), tl(tuple_to_list(#tx{}))).
+    Keys = lists:map(fun hb_converge:normalize_key/1, record_info(fields, tx)),
+    lists:zip(Keys, tl(tuple_to_list(#tx{}))).
 
 %% @doc Serialize a message to a binary representation, either as JSON or the
 %% binary format native to the message/bundles spec in use.
@@ -436,21 +429,21 @@ deserialize(B, binary) ->
 default_keys_removed_test() ->
     TX = #tx { unsigned_id = << 1:256 >>, last_tx = << 2:256 >> },
     TXMap = #{
-        unsigned_id => TX#tx.unsigned_id,
-        last_tx => TX#tx.last_tx,
+        <<"unsigned_id">> => TX#tx.unsigned_id,
+        <<"last_tx">> => TX#tx.last_tx,
         <<"owner">> => TX#tx.owner,
         <<"target">> => TX#tx.target,
-        data => TX#tx.data
+        <<"data">> => TX#tx.data
     },
     FilteredMap = filter_default_keys(TXMap),
-    ?assertEqual(<< 1:256 >>, maps:get(unsigned_id, FilteredMap)),
-    ?assertEqual(<< 2:256 >>, maps:get(last_tx, FilteredMap, not_found)),
+    ?assertEqual(<< 1:256 >>, maps:get(<<"unsigned_id">>, FilteredMap)),
+    ?assertEqual(<< 2:256 >>, maps:get(<<"last_tx">>, FilteredMap, not_found)),
     ?assertEqual(not_found, maps:get(<<"owner">>, FilteredMap, not_found)),
     ?assertEqual(not_found, maps:get(<<"target">>, FilteredMap, not_found)).
 
 minimization_test() ->
     Msg = #{
-        unsigned_id => << 1:256 >>,
+        <<"unsigned_id">> => << 1:256 >>,
         <<"id">> => << 2:256 >>
     },
     MinimizedMsg = minimize(Msg),
@@ -459,7 +452,7 @@ minimization_test() ->
 
 
 basic_map_codec_test(Codec) ->
-    Msg = #{ normal_key => <<"NORMAL_VALUE">> },
+    Msg = #{ <<"normal_key">> => <<"NORMAL_VALUE">> },
     Encoded = convert(Msg, Codec, converge, #{}),
     Decoded = convert(Encoded, converge, Codec, #{}),
     ?assert(hb_message:match(Msg, Decoded)).
@@ -467,11 +460,11 @@ basic_map_codec_test(Codec) ->
 %% @doc Test that we can convert a message into a tx record and back.
 single_layer_message_to_encoding_test(Codec) ->
     Msg = #{
-        last_tx => << 2:256 >>,
-        owner => << 3:4096 >>,
-        target => << 4:256 >>,
-        data => <<"DATA">>,
-        <<"Special-Key">> => <<"SPECIAL_VALUE">>
+        <<"last_tx">> => << 2:256 >>,
+        <<"owner">> => << 3:4096 >>,
+        <<"target">> => << 4:256 >>,
+        <<"data">> => <<"DATA">>,
+        <<"special-key">> => <<"SPECIAL_VALUE">>
     },
     Encoded = convert(Msg, Codec, converge, #{}),
     Decoded = convert(Encoded, converge, Codec, #{}),
@@ -558,9 +551,9 @@ nested_message_with_large_keys_and_data_test(Codec) ->
 
 simple_nested_message_test(Codec) ->
     Msg = #{
-        a => <<"1">>,
-        nested => #{ <<"b">> => <<"1">> },
-        c => <<"3">>
+        <<"a">> => <<"1">>,
+        <<"nested">> => #{ <<"b">> => <<"1">> },
+        <<"c">> => <<"3">>
     },
     Encoded = convert(Msg, Codec, converge, #{}),
     Decoded = convert(Encoded, converge, Codec, #{}),
@@ -578,7 +571,7 @@ simple_nested_message_test(Codec) ->
 nested_message_with_large_data_test(Codec) ->
     Msg = #{
         <<"tx_depth">> => <<"outer">>,
-        data => #{
+        <<"data">> => #{
             <<"tx_map_item">> =>
                 #{
                     <<"tx_depth">> => <<"inner">>,
@@ -595,13 +588,13 @@ nested_message_with_large_data_test(Codec) ->
 deeply_nested_message_with_data_test(Codec) ->
     Msg = #{
         <<"tx_depth">> => <<"outer">>,
-        data => #{
+        <<"data">> => #{
             <<"tx_map_item">> =>
                 #{
                     <<"tx_depth">> => <<"inner">>,
-                    data => #{
+                    <<"data">> => #{
                         <<"tx_depth">> => <<"innermost">>,
-                        data => <<"DATA">>
+                        <<"data">> => <<"DATA">>
                     }
                 }
         }
@@ -611,17 +604,17 @@ deeply_nested_message_with_data_test(Codec) ->
     ?assert(match(Msg, Decoded)).
 
 nested_structured_fields_test(Codec) ->
-    NestedMsg = #{ a => #{ b => 1 } },
+    NestedMsg = #{ <<"a">> => #{ <<"b">> => 1 } },
     Encoded = convert(NestedMsg, Codec, converge, #{}),
     Decoded = convert(Encoded, converge, Codec, #{}),
     ?assert(match(NestedMsg, Decoded)).
 
 nested_message_with_large_keys_test(Codec) ->
     Msg = #{
-        a => <<"1">>,
-        long_data => << 0:((1 + 1024) * 8) >>,
-        nested => #{ <<"b">> => <<"1">> },
-        c => <<"3">>
+        <<"a">> => <<"1">>,
+        <<"long_data">> => << 0:((1 + 1024) * 8) >>,
+        <<"nested">> => #{ <<"b">> => <<"1">> },
+        <<"c">> => <<"3">>
     },
     Encoded = convert(Msg, Codec, converge, #{}),
     Decoded = convert(Encoded, converge, Codec, #{}),
@@ -631,18 +624,22 @@ nested_message_with_large_keys_test(Codec) ->
 signed_tx_encode_decode_verify_test(Codec) ->
     TX = #tx {
         data = <<"TEST_DATA">>,
-        tags = [{<<"TEST_KEY">>, <<"TEST_VALUE">>}]
+        tags = [{<<"test_key">>, <<"TEST_VALUE">>}]
     },
+    ?event(debug, {tx, TX}),
     SignedTX = ar_bundles:sign_item(TX, hb:wallet()),
+    ?event(debug, {signed_tx, SignedTX}),
     Encoded = convert(SignedTX, Codec, tx, #{}),
+    ?event(debug, {encoded_tx, Encoded}),
     ?assert(ar_bundles:verify_item(SignedTX)),
     Decoded = convert(Encoded, converge, Codec, #{}),
+    ?event(debug, {decoded_tx, Decoded}),
     ?assert(verify(Decoded)).
 
 signed_message_encode_decode_verify_test(Codec) ->
     Msg = #{
-        data => <<"TEST_DATA">>,
-        tags => [{<<"TEST_KEY">>, <<"TEST_VALUE">>}]
+        <<"data">> => <<"TEST_DATA">>,
+        <<"tags">> => [{<<"test_key">>, <<"TEST_VALUE">>}]
     },
     SignedMsg = hb_message:sign(Msg, hb:wallet()),
     Encoded = convert(SignedMsg, Codec, converge, #{}),
@@ -651,11 +648,11 @@ signed_message_encode_decode_verify_test(Codec) ->
 
 tabm_converge_ids_equal_test() ->
     Msg = #{
-        data => <<"TEST_DATA">>,
-        deep_data => #{
-            data => <<"DEEP_DATA">>,
-            complex_key => 1337,
-            list => [1,2,3]
+        <<"data">> => <<"TEST_DATA">>,
+        <<"deep_data">> => #{
+            <<"data">> => <<"DEEP_DATA">>,
+            <<"complex_key">> => 1337,
+            <<"list">> => [1,2,3]
         }
     },
     ?assertEqual(
@@ -665,7 +662,7 @@ tabm_converge_ids_equal_test() ->
 
 signed_deep_tx_serialize_and_deserialize_test(Codec) ->
     TX = #tx {
-        tags = [{<<"TEST_KEY">>, <<"TEST_VALUE">>}],
+        tags = [{<<"test_key">>, <<"TEST_VALUE">>}],
         data = #{
             <<"NESTED_TX">> =>
                 #tx {
@@ -688,7 +685,7 @@ signed_deep_tx_serialize_and_deserialize_test(Codec) ->
     ).
 
 unsigned_id_test(Codec) ->
-    Msg = #{ data => <<"TEST_DATA">> },
+    Msg = #{ <<"data">> => <<"TEST_DATA">> },
     Encoded = convert(Msg, Codec, converge, #{}),
     Decoded = convert(Encoded, converge, Codec, #{}),
     ?assertEqual(
@@ -710,7 +707,7 @@ unsigned_id_test(Codec) ->
 %     ).
 
 message_with_simple_list_test(Codec) ->
-    Msg = #{ a => [<<"1">>, <<"2">>, <<"3">>] },
+    Msg = #{ <<"a">> => [<<"1">>, <<"2">>, <<"3">>] },
     Encoded = convert(Msg, Codec, converge, #{}),
     Decoded = convert(Encoded, converge, Codec, #{}),
     ?assert(match(Msg, Decoded)).
@@ -733,7 +730,7 @@ empty_string_in_tag_test(Codec) ->
 %%% Test helpers
 
 test_codecs() ->
-    [converge, tx, flat, http].
+    [converge, tx, flat].
 
 generate_test_suite(Suite) ->
     lists:map(
@@ -778,4 +775,4 @@ message_suite_test_() ->
     ]).
 
 simple_test() ->
-    basic_map_codec_test(http).
+    simple_nested_message_test(tx).

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -621,9 +621,7 @@ deeply_nested_message_with_data_test(Codec) ->
 nested_structured_fields_test(Codec) ->
     NestedMsg = #{ <<"a">> => #{ <<"b">> => 1 } },
     Encoded = convert(NestedMsg, Codec, converge, #{}),
-    ?event(debug, {encoded, Encoded}),
     Decoded = convert(Encoded, converge, Codec, #{}),
-    ?event(debug, {decoded, Decoded}),
     ?assert(match(NestedMsg, Decoded)).
 
 nested_message_with_large_keys_test(Codec) ->

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -198,7 +198,7 @@ format(Map, Indent) when is_map(Map) ->
             Indent
         ),
     % Put the path and device rows into the output at the _top_ of the map.
-    PriorityKeys = [{<<"Path">>, ValOrUndef(path)}, {<<"Device">>, ValOrUndef(device)}],
+    PriorityKeys = [{<<"path">>, ValOrUndef(path)}, {<<"device">>, ValOrUndef(device)}],
     FooterKeys =
         case hb_private:from_message(Map) of
             PrivMap when map_size(PrivMap) == 0 -> [];
@@ -210,7 +210,7 @@ format(Map, Indent) when is_map(Map) ->
         maps:to_list(
             minimize(Map,
                 [owner, signature, id, unsigned_id, hashpath, path, device]
-                ++ [<<"Device">>, <<"Path">>] % Hack: Until key capitalization is fixed.
+                ++ [<<"device">>, <<"path">>] % Hack: Until key capitalization is fixed.
             )
         ) ++ FooterKeys,
     % Format the remaining 'normal' keys and values.
@@ -475,26 +475,26 @@ single_layer_message_to_encoding_test(Codec) ->
 % key_encodings_to_tx_test() ->
 %     Msg = #{
 %         <<"last_tx">> => << 2:256 >>,
-%         <<"Owner">> => << 3:4096 >>,
-%         <<"Target">> => << 4:256 >>
+%         <<"owner">> => << 3:4096 >>,
+%         <<"target">> => << 4:256 >>
 %     },
 %     TX = message_to_tx(Msg),
 %     ?event({key_encodings_to_tx, {msg, Msg}, {tx, TX}}),
 %     ?assertEqual(maps:get(<<"last_tx">>, Msg), TX#tx.last_tx),
-%     ?assertEqual(maps:get(<<"Owner">>, Msg), TX#tx.owner),
-%     ?assertEqual(maps:get(<<"Target">>, Msg), TX#tx.target).
+%     ?assertEqual(maps:get(<<"owner">>, Msg), TX#tx.owner),
+%     ?assertEqual(maps:get(<<"target">>, Msg), TX#tx.target).
 
 %% @doc Test that the message matching function works.
 match_test(Codec) ->
-    Msg = #{ a => 1, b => 2 },
+    Msg = #{ <<"a">> => 1, <<"b">> => 2 },
     Encoded = convert(Msg, Codec, converge, #{}),
     Decoded = convert(Encoded, converge, Codec, #{}),
     ?assert(match(Msg, Decoded)).
 
 match_modes_test() ->
-    Msg1 = #{ a => 1, b => 2 },
-    Msg2 = #{ a => 1 },
-    Msg3 = #{ a => 1, b => 2, c => 3 },
+    Msg1 = #{ <<"a">> => 1, <<"b">> => 2 },
+    Msg2 = #{ <<"a">> => 1 },
+    Msg3 = #{ <<"a">> => 1, <<"b">> => 2, <<"c">> => 3 },
     ?assert(match(Msg1, Msg2, only_present)),
     ?assert(not match(Msg2, Msg1, strict)),
     ?assert(match(Msg1, Msg3, primary)),

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -209,8 +209,15 @@ format(Map, Indent) when is_map(Map) ->
         FilterUndef(PriorityKeys) ++
         maps:to_list(
             minimize(Map,
-                [owner, signature, id, unsigned_id, hashpath, path, device]
-                ++ [<<"device">>, <<"path">>] % Hack: Until key capitalization is fixed.
+                [
+                    <<"owner">>,
+                    <<"signature">>,
+                    <<"id">>,
+                    <<"unsigned_id">>,
+                    <<"hashpath">>,
+                    <<"path">>,
+                    <<"device">>
+                ]
             )
         ) ++ FooterKeys,
     % Format the remaining 'normal' keys and values.

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -465,7 +465,7 @@ basic_map_codec_test(Codec) ->
     ?assert(hb_message:match(Msg, Decoded)).
 
 set_body_codec_test(Codec) ->
-    Msg = #{ <<"body">> => <<"NORMAL_VALUE">> },
+    Msg = #{ <<"body">> => <<"NORMAL_VALUE">>, <<"test-key">> => <<"Test-Value">> },
     Encoded = convert(Msg, Codec, converge, #{}),
     ?event(debug, {encoded, Encoded}),
     Decoded = convert(Encoded, converge, Codec, #{}),

--- a/src/hb_path.erl
+++ b/src/hb_path.erl
@@ -72,21 +72,21 @@ tl(Path, Opts) when is_list(Path) ->
 %% can be safely used inside the main Converge resolve function.
 priv_remaining(Msg, _Opts) ->
     Priv = hb_private:from_message(Msg),
-    Converge = maps:get(<<"Converge">>, Priv, #{}),
-    maps:get(<<"Remaining">>, Converge, undefined).
+    Converge = maps:get(<<"converge">>, Priv, #{}),
+    maps:get(<<"remaining">>, Converge, undefined).
 
 %% @doc Store the `Original-Path' (and optionally `Remaining-Path') of a message
 %% in its hidden `Converge' key
 priv_store_original(Msg, OriginalPath, RemainingPath) ->
     Priv = hb_private:from_message(Msg),
-    Converge = maps:get(<<"Converge">>, Priv, #{}),
+    Converge = maps:get(<<"converge">>, Priv, #{}),
     Msg#{
         priv =>
             Priv#{
-                <<"Converge">> =>
+                <<"converge">> =>
                     Converge#{
-                        <<"Original">> => OriginalPath,
-                        <<"Remaining">> => RemainingPath
+                        <<"original">> => OriginalPath,
+                        <<"remaining">> => RemainingPath
                     }
             }
     }.
@@ -94,13 +94,13 @@ priv_store_original(Msg, OriginalPath, RemainingPath) ->
 %% @doc Store the remaining path of a message in its hidden `Converge' key.
 priv_store_remaining(Msg, RemainingPath) ->
     Priv = hb_private:from_message(Msg),
-    Converge = maps:get(<<"Converge">>, Priv, #{}),
+    Converge = maps:get(<<"converge">>, Priv, #{}),
     Msg#{
         priv =>
             Priv#{
-                <<"Converge">> =>
+                <<"converge">> =>
                     Converge#{
-                        <<"Remaining">> => RemainingPath
+                        <<"remaining">> => RemainingPath
                     }
             }
     }.

--- a/src/hb_persistent.erl
+++ b/src/hb_persistent.erl
@@ -315,7 +315,7 @@ test_device(Base) ->
                 )
             end,
         slow_key =>
-            fun(_, #{ wait := Wait }) ->
+            fun(_, #{ <<"wait">> := Wait }) ->
                 ?event({slow_key_wait_started, Wait}),
                 receive after Wait ->
                     {ok,
@@ -329,7 +329,7 @@ test_device(Base) ->
                 end
             end,
         self =>
-            fun(M1, #{ wait := Wait }) ->
+            fun(M1, #{ <<"wait">> := Wait }) ->
                 ?event({self_waiting, {wait, Wait}}),
                 receive after Wait ->
                     ?event({self_returning, M1, {wait, Wait}}),
@@ -358,7 +358,7 @@ wait_for_test_result(Ref) ->
 deduplicated_execution_test() ->
     TestTime = 200,
     Msg1 = #{ device => test_device() },
-    Msg2 = #{ path => [slow_key], wait => TestTime },
+    Msg2 = #{ <<"path">> => [slow_key], <<"wait">> => TestTime },
     T0 = hb:now(),
     Ref1 = spawn_test_client(Msg1, Msg2),
     receive after 100 -> ok end,
@@ -377,9 +377,9 @@ persistent_worker_test() ->
     Msg1 = #{ device => test_device() },
     link(start_worker(Msg1, #{ static_worker => true })),
     receive after 10 -> ok end,
-    Msg2 = #{ path => [slow_key], wait => TestTime },
-    Msg3 = #{ path => [slow_key], wait => trunc(TestTime*1.1) },
-    Msg4 = #{ path => [slow_key], wait => trunc(TestTime*1.2) },
+    Msg2 = #{ <<"path">> => [slow_key], <<"wait">> => TestTime },
+    Msg3 = #{ <<"path">> => [slow_key], <<"wait">> => trunc(TestTime*1.1) },
+    Msg4 = #{ <<"path">> => [slow_key], <<"wait">> => trunc(TestTime*1.2) },
     T0 = hb:now(),
     Ref1 = spawn_test_client(Msg1, Msg2),
     Ref2 = spawn_test_client(Msg1, Msg3),
@@ -396,9 +396,9 @@ spawn_after_execution_test() ->
     ?event(<<"">>),
     TestTime = 500,
     Msg1 = #{ device => test_device() },
-    Msg2 = #{ path => [self], wait => TestTime },
-    Msg3 = #{ path => [slow_key], wait => trunc(TestTime*1.1) },
-    Msg4 = #{ path => [slow_key], wait => trunc(TestTime*1.2) },
+    Msg2 = #{ <<"path">> => [self], <<"wait">> => TestTime },
+    Msg3 = #{ <<"path">> => [slow_key], <<"wait">> => trunc(TestTime*1.1) },
+    Msg4 = #{ <<"path">> => [slow_key], <<"wait">> => trunc(TestTime*1.2) },
     T0 = hb:now(),
     Ref1 =
         spawn_test_client(

--- a/src/hb_persistent.erl
+++ b/src/hb_persistent.erl
@@ -116,15 +116,15 @@ await(Worker, Msg1, Msg2, Opts) ->
                 }
         ),
             {error, leader_died};
-        {resolved, _, GroupName, Msg2, Msg3} ->
+        {resolved, _, GroupName, Msg2, Res} ->
             ?event(worker,
                 {resolved_await,
                     {group, GroupName},
                     {msg2, Msg2},
-                    {msg3, Msg3}
+                    {res, Res}
                 }
             ),
-            Msg3
+            Res
     end.
 
 %% @doc Check our inbox for processes that are waiting for the resolution

--- a/src/hb_private.erl
+++ b/src/hb_private.erl
@@ -62,7 +62,7 @@ set_priv(Msg, PrivMap) ->
 
 %% @doc Check if a key is private.
 is_private(Key) ->
-	case hb_converge:key_to_binary(Key) of
+	case hb_converge:normalize_key(Key) of
 		<<"priv", _/binary>> -> true;
 		_ -> false
 	end.

--- a/src/hb_private.erl
+++ b/src/hb_private.erl
@@ -41,7 +41,7 @@ get(InputPath, Msg, Default, Opts) ->
     Resolve =
         hb_converge:resolve(
             from_message(Msg),
-            #{ path => Path },
+            #{ <<"path">> => Path },
             priv_converge_opts(Opts)
         ),
     case Resolve of
@@ -62,7 +62,7 @@ set(Msg, PrivMap, Opts) ->
 
 %% @doc Helper function for setting the complete private element of a message.
 set_priv(Msg, PrivMap) ->
-    Msg#{ priv => PrivMap }.
+    Msg#{ <<"priv">> => PrivMap }.
 
 %% @doc Check if a key is private.
 is_private(Key) ->
@@ -93,15 +93,15 @@ reset(Msg) ->
 %%% Tests
 
 set_private_test() ->
-    ?assertEqual(#{a => 1, priv => #{b => 2}}, set(#{a => 1}, b, 2, #{})),
-    Res = set(#{a => 1}, a, 1, #{}),
-    ?assertEqual(#{a => 1, priv => #{a => 1}}, Res),
-    ?assertEqual(#{a => 1, priv => #{a => 1}}, set(Res, a, 1, #{})).
+    ?assertEqual(#{<<"a">> => 1, <<"priv">> => #{<<"b">> => 2}}, set(#{<<"a">> => 1}, <<"b">>, 2, #{})),
+    Res = set(#{<<"a">> => 1}, <<"a">>, 1, #{}),
+    ?assertEqual(#{<<"a">> => 1, <<"priv">> => #{<<"a">> => 1}}, Res),
+    ?assertEqual(#{<<"a">> => 1, <<"priv">> => #{<<"a">> => 1}}, set(Res, a, 1, #{})).
 
 get_private_key_test() ->
-    M1 = #{a => 1, priv => #{b => 2}},
-    ?assertEqual(not_found, get(a, M1, #{})),
-    {ok, [a]} = hb_converge:resolve(M1, <<"keys">>, #{}),
-    ?assertEqual(2, get(b, M1, #{})),
+    M1 = #{<<"a">> => 1, <<"priv">> => #{<<"b">> => 2}},
+    ?assertEqual(not_found, get(<<"a">>, M1, #{})),
+    {ok, [<<"a">>]} = hb_converge:resolve(M1, <<"keys">>, #{}),
+    ?assertEqual(2, get(<<"b">>, M1, #{})),
     {error, _} = hb_converge:resolve(M1, <<"priv/a">>, #{}),
-    {error, _} = hb_converge:resolve(M1, priv, #{}).
+    {error, _} = hb_converge:resolve(M1, <<"priv">>, #{}).

--- a/src/hb_private.erl
+++ b/src/hb_private.erl
@@ -101,7 +101,7 @@ set_private_test() ->
 get_private_key_test() ->
     M1 = #{a => 1, priv => #{b => 2}},
     ?assertEqual(not_found, get(a, M1, #{})),
-    {ok, [a]} = hb_converge:resolve(M1, <<"Keys">>, #{}),
+    {ok, [a]} = hb_converge:resolve(M1, <<"keys">>, #{}),
     ?assertEqual(2, get(b, M1, #{})),
     {error, _} = hb_converge:resolve(M1, <<"priv/a">>, #{}),
     {error, _} = hb_converge:resolve(M1, priv, #{}).

--- a/src/hb_singleton.erl
+++ b/src/hb_singleton.erl
@@ -58,7 +58,7 @@ from(RawMsg) ->
 
 %% @doc Parse the relative reference into path, query, and fragment.
 parse_full_path(RelativeRef) ->
-    {Path, QMap} =
+    {Path, QKVList} =
         case binary:split(RelativeRef, <<"?">>) of
             [P, QStr] -> {P, cowboy_req:parse_qs(#{ qs => QStr })};
             [P] -> {P, #{}}
@@ -66,7 +66,7 @@ parse_full_path(RelativeRef) ->
     {
         ok,
         lists:map(fun(Part) -> decode_string(Part) end, path_parts($/, Path)),
-        QMap
+        maps:from_list(QKVList)
     }.
 
 %% @doc Step 2: Decode + Split + Sanitize the path. Split by `/` but avoid

--- a/src/hb_singleton.erl
+++ b/src/hb_singleton.erl
@@ -197,11 +197,11 @@ parse_part(Part) ->
         Part ->
             case part([$+, $&, $!, $|], Part) of
                 {no_match, PartKey, <<>>} ->
-                    #{ path => PartKey };
+                    #{ <<"path">> => PartKey };
                 {Sep, PartKey, PartModBin} ->
                     parse_part_mods(
                         << Sep:8/integer, PartModBin/binary >>,
-                        #{ path => PartKey }
+                        #{ <<"path">> => PartKey }
                     )
             end
     end.
@@ -307,7 +307,7 @@ basic_hashpath_test() ->
     [Base, Msg2] = Msgs,
     ?assertEqual(Base, Hashpath),
     ?assertEqual(<<"GET">>, maps:get(<<"method">>, Msg2)),
-    ?assertEqual(<<"some-other">>, maps:get(path, Msg2)).
+    ?assertEqual(<<"some-other">>, maps:get(<<"path">>, Msg2)).
 
 multiple_messages_test() ->
     Req = #{
@@ -361,9 +361,9 @@ subpath_in_key_test() ->
         {resolve,
             [
                 #{},
-                #{ path => <<"x">> },
-                #{ path => <<"y">> },
-                #{ path => <<"z">> }
+                #{ <<"path">> => <<"x">> },
+                #{ <<"path">> => <<"y">> },
+                #{ <<"path">> => <<"z">> }
             ]
         },
         maps:get(<<"test-key">>, Msg2, not_found)
@@ -379,19 +379,19 @@ subpath_in_path_test() ->
     Msgs = from(Req),
     ?assertEqual(4, length(Msgs)),
     [_, Msg1, Msg2, Msg3] = Msgs,
-    ?assertEqual(<<"a">>, maps:get(path, Msg1)),
+    ?assertEqual(<<"a">>, maps:get(<<"path">>, Msg1)),
     ?assertEqual(
         {resolve,
             [
                 #{},
-                #{ path => <<"x">> },
-                #{ path => <<"y">> },
-                #{ path => <<"z">> }
+                #{ <<"path">> => <<"x">> },
+                #{ <<"path">> => <<"y">> },
+                #{ <<"path">> => <<"z">> }
             ]
         },
         Msg2
     ),
-    ?assertEqual(<<"z">>, maps:get(path, Msg3)).
+    ?assertEqual(<<"z">>, maps:get(<<"path">>, Msg3)).
 
 inlined_keys_test() ->
     Req = #{
@@ -429,10 +429,11 @@ subpath_in_inlined_test() ->
     ?event(debug, {got_msgs, Msgs}),
     ?assertEqual(4, length(Msgs)),
     [_, First, Second, Third] = Msgs,
-    ?assertEqual(<<"part1">>, maps:get(path, First)),
-    ?assertEqual(<<"part3">>, maps:get(path, Third)),
+    ?assertEqual(<<"part1">>, maps:get(<<"path">>, First)),
+    ?assertEqual(<<"part3">>, maps:get(<<"path">>, Third)),
+    ?event(debug, {second, Second}),
     ?assertEqual(
-        {resolve, [#{}, #{ path => <<"x">> }, #{ path => <<"y">> }] },
+        {resolve, [#{}, #{ <<"path">> => <<"x">> }, #{ <<"path">> => <<"y">> }] },
         maps:get(<<"b">>, Second)
     ).
 

--- a/src/hb_singleton.erl
+++ b/src/hb_singleton.erl
@@ -426,12 +426,10 @@ subpath_in_inlined_test() ->
         <<"path">> => Path
     },
     Msgs = from(Req),
-    ?event(debug, {got_msgs, Msgs}),
     ?assertEqual(4, length(Msgs)),
     [_, First, Second, Third] = Msgs,
     ?assertEqual(<<"part1">>, maps:get(<<"path">>, First)),
     ?assertEqual(<<"part3">>, maps:get(<<"path">>, Third)),
-    ?event(debug, {second, Second}),
     ?assertEqual(
         {resolve, [#{}, #{ <<"path">> => <<"x">> }, #{ <<"path">> => <<"y">> }] },
         maps:get(<<"b">>, Second)

--- a/src/hb_singleton.erl
+++ b/src/hb_singleton.erl
@@ -61,7 +61,7 @@ parse_full_path(RelativeRef) ->
     {Path, QKVList} =
         case binary:split(RelativeRef, <<"?">>) of
             [P, QStr] -> {P, cowboy_req:parse_qs(#{ qs => QStr })};
-            [P] -> {P, #{}}
+            [P] -> {P, []}
         end,
     {
         ok,

--- a/src/hb_singleton.erl
+++ b/src/hb_singleton.erl
@@ -15,20 +15,20 @@
 %%%         - Part => #{ path => Part }
 %%%         - Part+Key=Value => #{ path => Part, Key => Value }
 %%%         - Part+Key => #{ path => Part, Key => true }
-%%%         - Part+K1=V1&K2=V2 => #{ path => Part, K1 => <<"V1">>, K2 => <<"V2">> }
+%%%         - Part+k1=v1&k2=v2 => #{ path => Part, k1 => <<"v1">>, k2 => <<"v2">> }
 %%%         - Part!Device => {as, Device, #{ path => Part }}
-%%%         - Part!D+K1=V1 => {as, D, #{ path => Part, K1 => <<"V1">> }}
-%%%         - Part+K1|Int=1 => #{ path => Part, K1 => 1 }
-%%%         - Part!D+K1|Int=1 => {as, D, #{ path => Part, K1 => 1 }}
+%%%         - Part!D+K1=V1 => {as, D, #{ path => Part, K1 => <<"v1">> }}
+%%%         - pt+k1|int=1 => #{ path => pt, k1 => 1 }
+%%%         - pt!d+k1|int=1 => {as, d, #{ path => pt, k1 => 1 }}
 %%%         - (/nested/path) => Resolution of the path /nested/path
-%%%         - (/nested/path+K1=V1) => (resolve /nested/path)#{`K1 => V1}
+%%%         - (/nested/path+k1=v1) => (resolve /nested/path)#{k1 => v1}
 %%%         - (/nested/path!D+K1=V1) => (resolve /nested/path)#{K1 => V1}
-%%%         - Pt+K1|Res=(/a/b/c) => #{ path => Pt, K1 => (resolve /a/b/c) }
+%%%         - pt+k1|res=(/a/b/c) => #{ path => pt, k1 => (resolve /a/b/c) }
 %%%     Key:
-%%%         - Key: <<"Value">> => #{ Key => <<"Value">>, ... } for all messages
-%%%         - N.Key: <<"Value">> => #{ Key => <<"Value">>, ... } for Nth message
-%%%         - Key|Int: 1 => #{ Key => 1, ... }
-%%%         - Key|Res: /nested/path => #{ Key => (resolve /nested/path), ... }
+%%%         - key: <<"value">> => #{ key => <<"value">>, ... } for all messages
+%%%         - n.key: <<"value">> => #{ key => <<"value">>, ... } for Nth message
+%%%         - key|Int: 1 => #{ key => 1, ... }
+%%%         - key|Res: /nested/path => #{ key => (resolve /nested/path), ... }
 %%%         - N.Key|Res=(/a/b/c) => #{ Key => (resolve /a/b/c), ... }
 %%% '''
 -module(hb_singleton).
@@ -267,7 +267,7 @@ maybe_typed(Key, Value) ->
         {no_match, OnlyKey, <<>>} -> {untyped, OnlyKey, Value};
         {$|, OnlyKey, Type} ->
             case {Type, Value} of
-                {<<"Resolve">>, Subpath} ->
+                {<<"resolve">>, Subpath} ->
                     % If the value needs to be resolved before it is converted,
                     % use the `Codec/1.0` device to resolve it.
                     % For example:
@@ -297,7 +297,7 @@ single_message_test() ->
 
 basic_hashpath_test() ->
     Hashpath = hb_util:human_id(crypto:strong_rand_bytes(32)),
-    Path = <<"/", Hashpath/binary, "/someOther">>,
+    Path = <<"/", Hashpath/binary, "/some-other">>,
     Req = #{
         <<"path">> => Path,
         <<"method">> => <<"GET">>
@@ -307,7 +307,7 @@ basic_hashpath_test() ->
     [Base, Msg2] = Msgs,
     ?assertEqual(Base, Hashpath),
     ?assertEqual(<<"GET">>, maps:get(<<"method">>, Msg2)),
-    ?assertEqual(<<"someOther">>, maps:get(path, Msg2)).
+    ?assertEqual(<<"some-other">>, maps:get(path, Msg2)).
 
 multiple_messages_test() ->
     Req = #{
@@ -339,7 +339,7 @@ scoped_key_test() ->
 typed_key_test() ->
     Req = #{
         <<"path">> => <<"/a/b/c">>,
-        <<"2.test-key|Integer">> => <<"123">>
+        <<"2.test-key|integer">> => <<"123">>
     },
     Msgs = from(Req),
     ?assertEqual(4, length(Msgs)),
@@ -351,7 +351,7 @@ typed_key_test() ->
 subpath_in_key_test() ->
     Req = #{
         <<"path">> => <<"/a/b/c">>,
-        <<"2.test-key|Resolve">> => <<"/x/y/z">>
+        <<"2.test-key|resolve">> => <<"/x/y/z">>
     },
     Msgs = from(Req),
     ?assertEqual(4, length(Msgs)),
@@ -396,18 +396,18 @@ subpath_in_path_test() ->
 inlined_keys_test() ->
     Req = #{
         <<"method">> => <<"POST">>,
-        <<"path">> => <<"/a/b+K1=V1/c+K2=V2">>
+        <<"path">> => <<"/a/b+k1=v1/c+k2=v2">>
     },
     Msgs = from(Req),
     ?assertEqual(4, length(Msgs)),
     [_, Msg1, Msg2, Msg3] = Msgs,
-    ?assertEqual(<<"V1">>, maps:get(<<"K1">>, Msg2)),
-    ?assertEqual(<<"V2">>, maps:get(<<"K2">>, Msg3)),
-    ?assertEqual(not_found, maps:get(<<"K1">>, Msg1, not_found)),
-    ?assertEqual(not_found, maps:get(<<"K2">>, Msg2, not_found)).
+    ?assertEqual(<<"v1">>, maps:get(<<"k1">>, Msg2)),
+    ?assertEqual(<<"v2">>, maps:get(<<"k2">>, Msg3)),
+    ?assertEqual(not_found, maps:get(<<"k1">>, Msg1, not_found)),
+    ?assertEqual(not_found, maps:get(<<"k2">>, Msg2, not_found)).
 
 multiple_inlined_keys_test() ->
-    Path = <<"/a/b+K1=V1&K2=V2">>,
+    Path = <<"/a/b+k1=v1&k2=v2">>,
     Req = #{
         <<"method">> => <<"POST">>,
         <<"path">> => Path
@@ -415,13 +415,13 @@ multiple_inlined_keys_test() ->
     Msgs = from(Req),
     ?assertEqual(3, length(Msgs)),
     [_, Msg1, Msg2] = Msgs,
-    ?assertEqual(not_found, maps:get(<<"K1">>, Msg1, not_found)),
-    ?assertEqual(not_found, maps:get(<<"K2">>, Msg1, not_found)),
-    ?assertEqual(<<"V1">>, maps:get(<<"K1">>, Msg2, not_found)),
-    ?assertEqual(<<"V2">>, maps:get(<<"K2">>, Msg2, not_found)).
+    ?assertEqual(not_found, maps:get(<<"k1">>, Msg1, not_found)),
+    ?assertEqual(not_found, maps:get(<<"k2">>, Msg1, not_found)),
+    ?assertEqual(<<"v1">>, maps:get(<<"k1">>, Msg2, not_found)),
+    ?assertEqual(<<"v2">>, maps:get(<<"k2">>, Msg2, not_found)).
 
 subpath_in_inlined_test() ->
-    Path = <<"/Part1/Part2+Test=1&B=(/x/y)/Part3">>,
+    Path = <<"/part1/part2+test=1&b=(/x/y)/part3">>,
     Req = #{
         <<"path">> => Path
     },
@@ -429,11 +429,11 @@ subpath_in_inlined_test() ->
     ?event(debug, {got_msgs, Msgs}),
     ?assertEqual(4, length(Msgs)),
     [_, First, Second, Third] = Msgs,
-    ?assertEqual(<<"Part1">>, maps:get(path, First)),
-    ?assertEqual(<<"Part3">>, maps:get(path, Third)),
+    ?assertEqual(<<"part1">>, maps:get(path, First)),
+    ?assertEqual(<<"part3">>, maps:get(path, Third)),
     ?assertEqual(
         {resolve, [#{}, #{ path => <<"x">> }, #{ path => <<"y">> }] },
-        maps:get(<<"B">>, Second)
+        maps:get(<<"b">>, Second)
     ).
 
 path_parts_test() ->

--- a/src/hb_store_remote_node.erl
+++ b/src/hb_store_remote_node.erl
@@ -30,8 +30,8 @@ read(Opts = #{ node := Node }, Key) ->
     ?event({reading, Key, Path, Opts}),
     case hb_http:get_binary(Path) of
         {ok, Bundle} ->
-            case lists:keyfind(<<"Status">>, 1, Bundle#tx.tags) of
-                {<<"Status">>, <<"404">>} ->
+            case lists:keyfind(<<"status">>, 1, Bundle#tx.tags) of
+                {<<"status">>, <<"404">>} ->
                     not_found;
                 _ ->
                     {ok, Bundle}

--- a/src/hb_test.erl
+++ b/src/hb_test.erl
@@ -71,9 +71,9 @@ default_test_img(Wallet) ->
         Img = ar_bundles:sign_item(
             #tx {
                 tags = [
-                    {<<"Protocol">>, <<"ao">>},
-                    {<<"Variant">>, <<"ao.tn.2">>},
-                    {<<"Type">>, <<"Image">>}
+                    {<<"protocol">>, <<"ao">>},
+                    {<<"variant">>, <<"ao.tn.2">>},
+                    {<<"type">>, <<"image">>}
                 ],
                 data = Module
             },
@@ -88,30 +88,30 @@ default_test_devices(Wallet, Opts) ->
     Img = maps:get(image, Opts),
     Quorum = maps:get(quorum, Opts, 2),
     [
-        {<<"Protocol">>, <<"ao">>},
-        {<<"Variant">>, <<"ao.tn.2">>},
-        {<<"Type">>, <<"Process">>},
-        {<<"Device">>, <<"Stack">>},
-        {<<"Device.1">>, <<"Scheduler">>},
-        {<<"Location">>, hb_util:id(ID)},
-        {<<"Device.2">>, <<"PODA">>},
-        {<<"Quorum">>, integer_to_binary(Quorum)}
+        {<<"protocol">>, <<"ao">>},
+        {<<"variant">>, <<"ao.tn.2">>},
+        {<<"type">>, <<"Process">>},
+        {<<"device">>, <<"Stack">>},
+        {<<"device.1">>, <<"Scheduler">>},
+        {<<"location">>, hb_util:id(ID)},
+        {<<"device.2">>, <<"PODA">>},
+        {<<"quorum">>, integer_to_binary(Quorum)}
     ] ++
     [
-        {<<"Authority">>, Addr} ||
+        {<<"authority">>, Addr} ||
             Addr <- maps:keys(maps:get(compute, hb_opts:get(nodes))),
             Addr =/= '_'
     ] ++
     [
-        {<<"Device.3">>, <<"JSON-Interface">>},
-        {<<"Device.5">>, <<"VFS">>},
-        {<<"Device.6">>, <<"WASM64-pure">>},
-        {<<"Module">>, <<"aos-2-pure">>},
-        {<<"Image">>, hb_util:id(Img)},
-        {<<"Device.7">>, <<"Cron">>},
-        {<<"Time">>, <<"100-Milliseconds">>},
-        {<<"Device.8">>, <<"Multipass">>},
-        {<<"Passes">>, <<"3">>}
+        {<<"device.3">>, <<"JSON-Interface">>},
+        {<<"device.5">>, <<"VFS">>},
+        {<<"device.6">>, <<"WASM64-pure">>},
+        {<<"module">>, <<"aos-2-pure">>},
+        {<<"image">>, hb_util:id(Img)},
+        {<<"device.7">>, <<"Cron">>},
+        {<<"time">>, <<"100-Milliseconds">>},
+        {<<"device.8">>, <<"Multipass">>},
+        {<<"passes">>, <<"3">>}
     ].
 
 % ping_ping_script() ->
@@ -142,10 +142,10 @@ generate_test_data(Script, Wallet, _Opts, Devs) ->
         #tx{
             target = ar_bundles:id(SignedProcess, signed),
             tags = [
-                {<<"Protocol">>, <<"ao">>},
-                {<<"Variant">>, <<"ao.tn.2">>},
-                {<<"Type">>, <<"Message">>},
-                {<<"Action">>, <<"Eval">>}
+                {<<"protocol">>, <<"ao">>},
+                {<<"variant">>, <<"ao.tn.2">>},
+                {<<"type">>, <<"Message">>},
+                {<<"action">>, <<"Eval">>}
             ],
             data = Script
         },

--- a/src/hb_test.erl
+++ b/src/hb_test.erl
@@ -29,7 +29,7 @@ run(Proc, Msg, _Opts) ->
 %     init(),
 %     {Proc, Msg} = generate_test_data(<<"return 42">>),
 %     {ok, Result} = run(Proc, Msg, #{ on_idle => terminate }),
-%     #tx { data = <<"42">> } = maps:get(<<"/Data">>, Result),
+%     #tx { data = <<"42">> } = maps:get(<<"/data">>, Result),
 %     ok.
 
 % full_push_test_() ->

--- a/src/hb_util.erl
+++ b/src/hb_util.erl
@@ -158,23 +158,16 @@ message_to_numbered_list(Message, Opts) ->
 %% @doc Get the first element (the lowest integer key >= 1) of a numbered map.
 %% Optionally, it takes a specifier of whether to return the key or the value,
 %% as well as a standard map of HyperBEAM runtime options.
-%% 
-%% If `error_strategy' is `throw', raise an exception if no integer keys are
-%% found. If `error_strategy' is `any', return `undefined' if no integer keys
-%% are found. By default, the function does not pass a `throw' execution
-%% strategy to `hb_converge:to_key/2', such that non-integer keys present in the
-%% message will not lead to an exception.
 hd(Message) -> hd(Message, value).
 hd(Message, ReturnType) ->
     hd(Message, ReturnType, #{ error_strategy => throw }).
 hd(Message, ReturnType, Opts) -> 
-    {ok, Keys} = hb_converge:resolve(Message, keys, #{}),
-    hd(Message, Keys, 1, ReturnType, Opts).
+    hd(Message, hb_converge:keys(Message, Opts), 1, ReturnType, Opts).
 hd(_Map, [], _Index, _ReturnType, #{ error_strategy := throw }) ->
     throw(no_integer_keys);
 hd(_Map, [], _Index, _ReturnType, _Opts) -> undefined;
 hd(Message, [Key|Rest], Index, ReturnType, Opts) ->
-    case hb_converge:to_key(Key, Opts#{ error_strategy => return }) of
+    case hb_converge:normalize_key(Key, Opts#{ error_strategy => return }) of
         undefined ->
             hd(Message, Rest, Index + 1, ReturnType, Opts);
         Key ->

--- a/src/include/hb.hrl
+++ b/src/include/hb.hrl
@@ -6,9 +6,9 @@
 %% human-readable ID encoding.
 -define(IS_ID(X), (is_binary(X) andalso (byte_size(X) == 43 orelse byte_size(X) == 32))).
 %% @doc List of special keys that are used in the Converge Protocol.
--define(CONVERGE_KEYS, [path, hashpath, priv]).
+-define(CONVERGE_KEYS, [<<"path">>, <<"hashpath">>, <<"priv">>]).
 %% @doc Keys that can be regenerated losslessly.
--define(REGEN_KEYS, [id, unsigned_id]).
+-define(REGEN_KEYS, [<<"id">>, <<"unsigned_id">>]).
 
 %% @doc Record used for parsing relevant components of a cursor-browsable
 %% response.


### PR DESCRIPTION
This PR refactors the codebase to use lower-case binaries for Converge keys, as well as connecting the HTTP-sig codec and ANS-104 APIs to the Cowboy server. Additionally, it also implements a basic version of the Converge `Meta/1.0` device, controlling access to the node.