### PR TITLE
fix(hb_beamr): ensure memory is deallocated for result terms

### DIFF
--- a/c_src/hb_beamr.c
+++ b/c_src/hb_beamr.c
@@ -399,6 +399,8 @@ wasm_trap_t* generic_import_handler(void* env, const wasm_val_vec_t* args, wasm_
     DRV_DEBUG("Cleaning up import response");
     erl_drv_cond_destroy(proc->current_import->cond);
     erl_drv_mutex_destroy(proc->current_import->response_ready);
+    // Clean up the result_terms of current_import as it's not cleaned automatically
+    driver_free(proc->current_import->result_terms);
     driver_free(proc->current_import);
 
     proc->current_import = NULL;


### PR DESCRIPTION
Previously, memory was not deallocated for result_terms in imported_functions. This commit resolves the issue by cleaning proc->current_import->result_terms in generic_import_handler, preventing memory leaks.