### PR TITLE
feat(hb_codec_http): properly encode and decode body, distinguishing between multiple keys or sole body key #13

### DIFF
--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -391,14 +391,14 @@ run_wasm_unsigned_test() ->
     Node = hb_http_server:start_test_node(#{force_signed => false}),
     Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [3.0]),
     {ok, Res} = post(Node, Msg, #{}),
-    ?assertEqual([6.0], hb_converge:get(<<"body">>, Res, #{})).
+    ?assertEqual([6.0], hb_converge:get(<<"body">>, Res, #{})),
     ?assertEqual([6.0], hb_converge:get(<<"output">>, Res, #{})).
 
 run_wasm_signed_test() ->
     URL = hb_http_server:start_test_node(#{force_signed => true}),
     Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [3.0]),
     {ok, Res} = post(URL, Msg, #{}),
-    ?assertEqual([6.0], hb_converge:get(<<"body">>, Res, #{})).
+    ?assertEqual([6.0], hb_converge:get(<<"body">>, Res, #{})),
     ?assertEqual([6.0], hb_converge:get(<<"output">>, Res, #{})).
 
 get_deep_unsigned_wasm_state_test() ->


### PR DESCRIPTION
Also fixes a compilation error introduced in fb7df6c

```
  hb_message: -generate_test_suite/1-fun-1- (http: basic map codec test)...[0.001 s] ok
  hb_message: -generate_test_suite/1-fun-1- (http: set body codec test)...ok
  hb_message: -generate_test_suite/1-fun-1- (http: match test)...ok
  hb_message: -generate_test_suite/1-fun-1- (http: single layer message to encoding test)...ok
  hb_message: -generate_test_suite/1-fun-1- (http: message with large keys test)...ok
  hb_message: -generate_test_suite/1-fun-1- (http: nested message with large keys and content test)...ok
  hb_message: -generate_test_suite/1-fun-1- (http: simple nested message test)...ok
  hb_message: -generate_test_suite/1-fun-1- (http: nested message with large content test)...[0.001 s] ok
  hb_message: -generate_test_suite/1-fun-1- (http: deeply nested message with content test)...[0.002 s] ok
  hb_message: -generate_test_suite/1-fun-1- (http: structured field atom parsing test)...ok
  hb_message: -generate_test_suite/1-fun-1- (http: structured field decimal parsing test)...ok
  hb_message: -generate_test_suite/1-fun-1- (http: binary to binary test)...ok
  hb_message: -generate_test_suite/1-fun-1- (http: nested structured fields test)...ok
  hb_message: -generate_test_suite/1-fun-1- (http: nested message with large keys test)...ok
  hb_message: -generate_test_suite/1-fun-1- (http: message with simple list test)...ok
  hb_message: -generate_test_suite/1-fun-1- (http: empty string in tag test)...ok
  hb_message: -generate_test_suite/1-fun-1- (http: signed item to message and back test)...[0.019 s] ok
  hb_message: -generate_test_suite/1-fun-1- (http: signed deep serialize and deserialize test)...[0.015 s] ok
  hb_message: -generate_test_suite/1-fun-1- (http: unsigned id test)...ok
```