### PR TITLE
feat: impl p4

### DIFF
--- a/src/dev_faff.erl
+++ b/src/dev_faff.erl
@@ -1,0 +1,55 @@
+%%% @doc A module that implements a 'friends and family' pricing policy.
+%%% It will allow users to process requests only if their addresses are
+%%% in the allow-list for the node.
+%%% 
+%%% Fundamentally against the spirit of permissionlessness, but it is useful if
+%%% you are running a node for your own purposes and would not like to allow 
+%%% others to make use of it -- even for a fee. It also serves as a useful
+%%% example of how to implement a custom pricing policy, as it implements stubs
+%%% for both the pricing and ledger P4 APIs.
+-module(dev_faff).
+%%% Pricing API
+%%% We only implement `estimate/3' as we do not want to charge for requests, so
+%%% we are fine with the estimate being the same as the price.
+-export([estimate/3]).
+%%% Ledger API
+%%% We need to implement `debit/3' as it is required by the ledger API, but we
+%%% do not want to charge for requests, so we return `ok' and do not actually
+%%% debit the user's account. Similarly, we are not interested in taking payments
+%%% from users, so we do not implement `credit/3'.
+-export([debit/3]).
+-include("include/hb.hrl").
+
+%% @doc Decide whether or not to service a request from a given address.
+estimate(_, Msg, NodeMsg) ->
+    ?event(payment, {estimate, {msg, Msg}}),
+    % Check if the address is in the allow-list.
+    case hb_converge:get(<<"type">>, Msg, <<"request">>, NodeMsg) of
+        <<"request">> ->
+            case is_admissible(Msg, NodeMsg) of
+                true -> {ok, 0};
+                false -> {ok, <<"infinity">>}
+            end;
+        <<"response">> -> {ok, 0}
+    end.
+
+
+%% @doc Check whether all of the signers of the request are in the allow-list.
+is_admissible(Msg, NodeMsg) ->
+    AllowList = hb_opts:get(faff_allow_list, [], NodeMsg),
+    Req = hb_converge:get(<<"request">>, Msg, NodeMsg),
+    Signers =
+        lists:map(
+            fun hb_util:human_id/1,
+            maps:values(hb_converge:get(<<"signers">>, Req, undefined, NodeMsg))
+        ),
+    ?event(payment, {is_admissible, {signers, Signers}, {allow_list, AllowList}}),
+    lists:all(
+        fun(Signer) -> lists:member(Signer, AllowList) end,
+        Signers
+    ).
+
+%% @doc Debit the user's account if the request is allowed.
+debit(_, Req, _NodeMsg) ->
+    ?event(payment, {debit, Req}),
+    {ok, true}.

--- a/src/dev_faff.erl
+++ b/src/dev_faff.erl
@@ -24,13 +24,13 @@
 estimate(_, Msg, NodeMsg) ->
     ?event(payment, {estimate, {msg, Msg}}),
     % Check if the address is in the allow-list.
-    case hb_converge:get(<<"type">>, Msg, <<"request">>, NodeMsg) of
-        <<"request">> ->
+    case hb_converge:get(<<"type">>, Msg, <<"pre">>, NodeMsg) of
+        <<"pre">> ->
             case is_admissible(Msg, NodeMsg) of
                 true -> {ok, 0};
                 false -> {ok, <<"infinity">>}
             end;
-        <<"response">> -> {ok, 0}
+        <<"post">> -> {ok, 0}
     end.
 
 

--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -1,9 +1,15 @@
 %%% @doc The hyperbeam meta device, which is the default entry point
 %%% for all messages processed by the machine. This device executes a
 %%% Converge singleton request, after first applying the node's 
-%%% pre-processor, if set.
+%%% pre-processor, if set. The pre-processor can halt the request by
+%%% returning an error, or return a modified version if it deems necessary --
+%%% the result of the pre-processor is used as the request for the Converge
+%%% resolver. Additionally, a post-processor can be set, which is executed after
+%%% the Converge resolver has returned a result.
 -module(dev_meta).
 -export([handle/2, info/3]).
+%%% Helper functions for processors
+-export([all_signers/1]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -14,7 +20,7 @@ handle(NodeMsg, RawRequest) ->
     ?event({raw_request, RawRequest, NodeMsg}),
     NormRequest = hb_singleton:from(RawRequest),
     ?event({processing_messages, NormRequest}),
-    handle_converge(NormRequest, NodeMsg).
+    handle_converge(RawRequest, NormRequest, NodeMsg).
 
 %% @doc Get/set the node message. If the request is a `POST`, we check that the
 %% request is signed by the owner of the node. If not, we return the node message
@@ -57,10 +63,11 @@ info(_, Request, NodeMsg) ->
 %% using the node's Converge implementation if its response was `ok`.
 %% After execution, we run the node's `postprocessor` message on the result of
 %% the request before returning the result it grants back to the user.
-handle_converge(Request, NodeMsg) ->
+handle_converge(Req, Msgs, NodeMsg) ->
     % Apply the pre-processor to the request.
-    case resolve_processor(preprocessor, Request, NodeMsg) of
+    case resolve_processor(<<"preprocess">>, preprocessor, Req, Msgs, NodeMsg) of
         {ok, PreProcMsg} ->
+            ?event({result_after_preprocessing, PreProcMsg}),
             % Resolve the request message.
             {ok, Res} =
                 embed_status(
@@ -74,7 +81,9 @@ handle_converge(Request, NodeMsg) ->
             maybe_sign(
                 embed_status(
                     resolve_processor(
+                        <<"postprocess">>,
                         postprocessor,
+                        Req,
                         Res,
                         NodeMsg
                     )
@@ -85,15 +94,22 @@ handle_converge(Request, NodeMsg) ->
     end.
 
 %% @doc execute a message from the node message upon the user's request.
-resolve_processor(Processor, Request, NodeMsg) ->
+resolve_processor(PathKey, Processor, Req, Query, NodeMsg) ->
     case hb_opts:get(Processor, undefined, NodeMsg) of
-        undefined -> {ok, Request};
+        undefined -> {ok, Query};
         ProcessorMsg ->
-            hb_converge:resolve(
+            ?event(payment, {resolve_processor, PathKey, ProcessorMsg}),
+            Res = hb_converge:resolve(
                 ProcessorMsg,
-                Request,
-                NodeMsg#{ force_message => true }
-            )
+                #{
+                    <<"path">> => PathKey,
+                    <<"body">> => Query,
+                    <<"request">> => Req
+                },
+                NodeMsg#{ hashpath => ignore }
+            ),
+            ?event(payment, {preprocessor_result, Res}),
+            Res
     end.
 
 %% @doc Wrap the result of a device call in a status.
@@ -116,6 +132,20 @@ maybe_sign(Res, NodeMsg) ->
             );
         false -> Res
     end.
+
+%%% External helpers
+
+%% @doc Return the signers of a list of messages.
+all_signers(Msgs) ->
+    lists:foldl(
+        fun(Msg, Acc) ->
+            Signers =
+                hb_converge:get(<<"signers">>, Msg, #{}, #{ hashpath => ignore }),
+            Acc ++ lists:map(fun hb_util:human_id/1, maps:values(Signers))
+        end,
+        [],
+        Msgs
+    ).
 
 %%% Tests
 
@@ -229,3 +259,76 @@ claim_node_test() ->
     {ok, Res2} = hb_http:get(Node, <<"/!meta@1.0/info">>, #{}),
     ?event({res, Res2}),
     ?assertEqual(<<"test2">>, hb_converge:get(<<"test_config_item">>, Res2, #{})).
+
+%% @doc Test that we can use a preprocessor upon a request.
+preprocessor_test() ->
+    Parent = self(),
+    Node = hb_http_server:start_test_node(
+        #{
+            preprocessor =>
+                #{
+                    <<"device">> => #{
+                        <<"preprocess">> =>
+                            fun(_, #{ <<"body">> := Msgs }, _) ->
+                                Parent ! ok,
+                                {ok, Msgs}
+                            end
+                    }
+                }
+        }),
+    hb_http:get(Node, <<"/!meta@1.0/info">>, #{}),
+    ?assert(receive ok -> true after 1000 -> false end).
+
+%% @doc Test that we can halt a request if the preprocessor returns an error.
+halt_request_test() ->
+    Node = hb_http_server:start_test_node(
+        #{
+            preprocessor =>
+                #{
+                    <<"device">> => #{
+                        <<"preprocess">> =>
+                            fun(_, _, _) ->
+                                {error, <<"Bad">>}
+                            end
+                    }
+                }
+        }),
+    {error, Res} = hb_http:get(Node, <<"/!meta@1.0/info">>, #{}),
+    ?assertEqual(<<"Bad">>, Res).
+
+%% @doc Test that a preprocessor can modify a request.
+modify_request_test() ->
+    Node = hb_http_server:start_test_node(
+        #{
+            preprocessor =>
+                #{
+                    <<"device">> => #{
+                        <<"preprocess">> =>
+                            fun(_, #{ <<"body">> := [M|Ms] }, _) ->
+                                {ok, [M#{ <<"added">> => <<"value">> }|Ms]}
+                            end
+                    }
+                }
+        }),
+    {ok, Res} = hb_http:get(Node, <<"/added">>, #{}),
+    ?event({res, Res}),
+    ?assertEqual(<<"value">>, hb_converge:get(<<"body">>, Res, #{})).
+
+%% @doc Test that we can use a postprocessor upon a request.
+postprocessor_test() ->
+    Parent = self(),
+    Node = hb_http_server:start_test_node(
+        #{
+            postprocessor =>
+                #{
+                    <<"device">> => #{
+                        <<"postprocess">> =>
+                            fun(_, #{ <<"body">> := Msgs }, _) ->
+                                Parent ! ok,
+                                {ok, Msgs}
+                            end
+                    }
+                }
+        }),
+    hb_http:get(Node, <<"/!meta@1.0/info">>, #{}),
+    ?assert(receive ok -> true after 1000 -> false end).

--- a/src/dev_p4.erl
+++ b/src/dev_p4.erl
@@ -1,6 +1,210 @@
+%%% @doc The HyperBEAM core payment ledger. This module allows the operator to
+%%% specify another device that can act as a pricing mechanism for transactions
+%%% on the node, as well as orchestrating a payment ledger to calculate whether
+%%% the node should fulfil services for users.
+%%%
+%%% The device requires the following node message settings in order to function:
+%%%
+%%% - `p4_pricing_device`: The device that will estimate the cost of a request.
+%%% - `p4_ledger_device`: The device that will act as a payment ledger.
+%%%
+%%% The pricing device should implement the following keys:
+%%% ```
+%%%             GET /estimate?type=request|response&body=[...]&request=RequestMessage
+%%%             GET /price?type=request|response&body=[...]&request=RequestMessage
+%%% ```
+%%% 
+%%% The `body` key is used to pass either the request or response messages to the
+%%% device. The `type` key is used to specify whether the inquiry is for a request
+%%% or a response object -- requests carry lists of messages that will be executed,
+%%% while responses carry the results of the execution. The `price` key may return
+%%% `infinity` if the node will not serve a user under any circumstances. Else,
+%%% the value returned by the `price` key will be passed to the ledger device as
+%%% the `amount` key.
+%%%
+%%% The ledger device should implement the following keys:
+%%% ```
+%%%             POST /credit?message=PaymentMessage&request=RequestMessage
+%%%             POST /debit?quantity=PriceMessage&simulate=true|false
+%%%                         &request=RequestMessage
+%%% ```
+%%%
+%%% The `simulate` key is optional and defaults to `false`. If `simulate` is set to
+%%% `true`, the debit will not be applied to the ledger, but it should return
+%%% whether the debit would have succeeded.
 -module(dev_p4).
--export([push/2]).
+-export([preprocess/3, postprocess/3]).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
 
-push(_Item, S) ->
-    % TODO: Check payment.
-    {ok, S}.
+%% @doc Estimate the cost of a transaction and decide whether to proceed with
+%% a request. The default behavior if `pricing_device` or `p4_balances` are
+%% not set is to proceed, so it is important that a user initialize them.
+preprocess(State, Raw, NodeMsg) ->
+    PricingDevice = hb_converge:get(<<"pricing_device">>, State, false, NodeMsg),
+    LedgerDevice = hb_converge:get(<<"ledger_device">>, State, false, NodeMsg),
+    Messages = hb_converge:get(<<"body">>, Raw, NodeMsg#{ hashpath => ignore }),
+    Request = hb_converge:get(<<"request">>, Raw, NodeMsg),
+    ?event(payment, {p4_processing_with_device, PricingDevice, LedgerDevice}),
+    case (PricingDevice =/= false) and (LedgerDevice =/= false) of
+        false -> {ok, Messages};
+        true ->
+            PricingMsg = #{ <<"device">> => PricingDevice },
+            LedgerMsg = #{ <<"device">> => LedgerDevice },
+            PricingReq = #{
+                <<"path">> => <<"estimate">>,
+                <<"type">> => <<"request">>,
+                <<"request">> => Request,
+                <<"body">> => Messages
+            },
+            ?event(payment,
+                {p4_pricing_request, {devmsg, PricingMsg}, {req, PricingReq}}),
+            case hb_converge:resolve(PricingMsg, PricingReq, NodeMsg) of
+                {error, Error} ->
+                    % The device is unable to estimate the cost of the request,
+                    % so we don't proceed.
+                    {error, {error_calculating_price, Error}};
+                {ok, <<"infinity">>} ->
+                    % The device states that under no circumstances should we
+                    % proceed with the request.
+                    ?event(payment, {p4_pricing_response, {error, <<"infinity">>}}),
+                    {error,
+                        <<"Node will not service this request "
+                            "under any circumstances.">>};
+                {ok, Price} ->
+                    % The device has estimated the cost of the request. We 
+                    % forward the request to the ledger device to check if we
+                    % have enough funds to service the request.
+                    LedgerReq =
+                        #{
+                            <<"path">> => <<"debit">>,
+                            <<"amount">> => Price,
+                            <<"simulate">> => true,
+                            <<"request">> => Request
+                        },
+                    ?event(payment, {p4_ledger_request, LedgerReq}),
+                    case hb_converge:resolve(LedgerMsg, LedgerReq, NodeMsg) of
+                        {ok, true} ->
+                            % The ledger device has confirmed that the user has
+                            % enough funds for the request, so we proceed.
+                            {ok, Messages};
+                        {ok, false} ->
+                            ?event(payment, {p4_ledger_response, {error, false}}),
+                            {error, 
+                                #{
+                                    <<"status">> => 429,
+                                    <<"reason">> => <<"Insufficient funds">>,
+                                    <<"price">> => Price
+                                }
+                            };
+                        {error, Error} ->
+                            % The ledger device is unable to process the request,
+                            % so we don't proceed.
+                            ?event(payment, {p4_ledger_response, {error, Error}}),
+                            {error, {error_checking_ledger, Error}}
+                    end
+            end
+    end.
+
+%% @doc Postprocess the request after it has been fulfilled.
+postprocess(State, RawResponse, NodeMsg) ->
+    PricingDevice = hb_converge:get(<<"pricing_device">>, State, false, NodeMsg),
+    LedgerDevice = hb_converge:get(<<"ledger_device">>, State, false, NodeMsg),
+    Response =
+        hb_converge:get(
+            <<"body">>,
+            RawResponse,
+            NodeMsg#{ hashpath => ignore }
+        ),
+    Request = hb_converge:get(<<"request">>, Response, NodeMsg),
+    ?event(payment, {p4_postprocessing_with_device, PricingDevice, LedgerDevice}),
+    case (PricingDevice =/= false) and (LedgerDevice =/= false) of
+        false -> {ok, Response};
+        true ->
+            PricingMsg = #{ <<"device">> => PricingDevice },
+            LedgerMsg = #{ <<"device">> => LedgerDevice },
+            PricingReq = #{
+                <<"path">> => <<"price">>,
+                <<"type">> => <<"response">>,
+                <<"request">> => Request,
+                <<"body">> => Response
+            },
+            ?event(payment, {p4_pricing_request, PricingReq}),
+            PricingRes =
+                case hb_converge:resolve(PricingMsg, PricingReq, NodeMsg) of
+                    {error, _Error} ->
+                        % The pricing device is unable to give us a cost for
+                        % the request, so we try to estimate it instead.
+                        EstimateReq = PricingReq#{ <<"path">> => <<"estimate">> },
+                        hb_converge:resolve(PricingMsg, EstimateReq, NodeMsg);
+                    {ok, P} -> {ok, P}
+                end,
+            ?event(payment, {p4_pricing_response, PricingRes}),
+            case PricingRes of
+                {ok, Price} ->
+                    % We have successfully estimated the cost of the request,
+                    % so we proceed to debit the user's account.
+                    LedgerReq =
+                        #{
+                            <<"path">> => <<"debit">>,
+                            <<"amount">> => Price,
+                            <<"simulate">> => false,
+                            <<"request">> => Request
+                        },
+                    ?event(payment, {p4_ledger_request, LedgerReq}),
+                    {ok, _} = 
+                        hb_converge:resolve(
+                            LedgerMsg,
+                            LedgerReq,
+                            NodeMsg
+                        ),
+                    % Return the original request.
+                    {ok, Response};
+                {error, PricingError} ->
+                    % The pricing device is unable to process the request,
+                    % so we don't proceed.
+                    {error, PricingError}
+            end
+    end.
+
+%%% Tests
+
+test_opts(Opts) ->
+    test_opts(Opts, <<"faff@1.0">>).
+test_opts(Opts, PricingDev) ->
+    test_opts(Opts, PricingDev, <<"faff@1.0">>).
+test_opts(Opts, PricingDev, LedgerDev) ->
+    ProcessorMsg =
+        #{
+            <<"device">> => <<"p4@1.0">>,
+            <<"pricing_device">> => PricingDev,
+            <<"ledger_device">> => LedgerDev
+        },
+    Opts#{
+        preprocessor => ProcessorMsg,
+        postprocessor => ProcessorMsg
+    }.
+
+faff_test() ->
+    GoodWallet = ar_wallet:new(),
+    BadWallet = ar_wallet:new(),
+    Node = hb_http_server:start_test_node(
+       test_opts(
+            #{
+                faff_allow_list =>
+                    [hb_util:human_id(ar_wallet:to_address(GoodWallet))]
+            }
+        )
+    ),
+    Req = #{
+        <<"path">> => <<"/greeting">>,
+        <<"greeting">> => <<"Hello, world!">>
+    },
+    GoodSignedReq = hb_message:sign(Req, GoodWallet),
+    ?event({req, GoodSignedReq}),
+    BadSignedReq = hb_message:sign(Req, BadWallet),
+    ?event({req, BadSignedReq}),
+    {ok, Res} = hb_http:get(Node, GoodSignedReq, #{}),
+    ?event(payment, {res, Res}),
+    ?assertEqual(<<"Hello, world!">>, hb_converge:get(<<"body">>, Res, #{})),
+    ?assertMatch({error, _}, hb_http:get(Node, BadSignedReq, #{})).

--- a/src/dev_simple_pay.erl
+++ b/src/dev_simple_pay.erl
@@ -1,0 +1,145 @@
+%%% @doc A simple device that allows the operator to specify a price for a
+%%% request and then charge the user for it, on a per message basis.
+%%% The device's ledger is stored in the node message at `simple_pay_ledger`,
+%%% and can be topped-up by either the operator, or an external device. The 
+%%% price is specified in the node message at `simple_pay_price`.
+%%% This device acts as both a pricing device and a ledger device, by p4's
+%%% definition.
+-module(dev_simple_pay).
+-export([estimate/3, debit/3, balance/3, top_up/3]).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%% @doc Estimate the cost of a request by counting the number of messages in
+%% the request, then multiplying by the per-message price.
+estimate(_, Req, NodeMsg) ->
+    Messages = hb_converge:get(<<"body">>, Req, NodeMsg#{ hashpath => ignore }),
+    {ok, length(Messages) * hb_opts:get(simple_pay_price, 1, NodeMsg)}.
+
+%% @doc Preprocess a request by checking the ledger and charging the user.
+debit(_, RawReq, NodeMsg) ->
+    Req = hb_converge:get(<<"request">>, RawReq, NodeMsg#{ hashpath => ignore }),
+    Signer = hb_converge:get(<<"signers/1">>, Req, undefined, NodeMsg),
+    UserBalance = get_balance(Signer, NodeMsg),
+    Simulation = hb_converge:get(<<"simulate">>, Req, false, NodeMsg),
+    Price = hb_opts:get(simple_pay_price, 1, NodeMsg),
+    ?event(payment,
+        {debit,
+            {signer, Signer},
+            {balance, UserBalance},
+            {price, Price},
+            {simulation, Simulation}
+        }),
+    case {Simulation, (UserBalance >= Price)} of
+        {true, Admissible} -> {ok, Admissible};
+        {false, false} -> {error, <<"Insufficient funds">>};
+        {false, true} ->
+            set_balance(Signer, UserBalance - Price, NodeMsg),
+            {ok, true}
+    end.
+
+%% @doc Get the balance of a user in the ledger.
+balance(_, Req, NodeMsg) ->
+    Signer = hb_converge:get(<<"signers/1">>, Req, NodeMsg),
+    {ok, get_balance(Signer, NodeMsg)}.
+
+set_balance(Signer, Amount, NodeMsg) ->
+    NormSigner = hb_util:human_id(Signer),
+    Ledger = hb_converge:get(<<"simple_pay_ledger">>, NodeMsg, #{}, NodeMsg),
+    ?event(payment,
+        {modifying_balance,
+            {user, NormSigner},
+            {amount, Amount},
+            {ledger, Ledger}
+        }
+    ),
+    hb_http_server:set_opts(
+        NodeMsg#{
+            simple_pay_ledger =>
+                hb_converge:set(
+                    Ledger,
+                    NormSigner,
+                    Amount,
+                    NodeMsg
+                )
+        }
+    ).
+
+%% @doc Get the balance of a user in the ledger.
+get_balance(Signer, NodeMsg) ->
+    NormSigner = hb_util:human_id(Signer),
+    Ledger = hb_opts:get(simple_pay_ledger, #{}, NodeMsg),
+    hb_converge:get(NormSigner, Ledger, 0, NodeMsg).
+
+%% @doc Top up the user's balance in the ledger.
+top_up(_, Req, NodeMsg) ->
+    SignerRaw = hb_converge:get(<<"signers/1">>, Req, NodeMsg),
+    Signer = hb_util:human_id(SignerRaw),
+    case hb_opts:get(operator, undefined, NodeMsg) of
+        Unauth when Unauth =/= Signer -> {error, <<"Unauthorized">>};
+        Operator ->
+            Amount = hb_converge:get(<<"amount">>, Req, 0, NodeMsg),
+            Recipient = hb_converge:get(<<"recipient">>, Req, Operator, NodeMsg),
+            set_balance(Recipient, Amount, NodeMsg),
+            {ok, get_balance(Recipient, NodeMsg)}
+    end.
+
+%%% Tests
+
+test_opts() ->
+    Wallet = ar_wallet:new(),
+    Address = hb_util:human_id(ar_wallet:to_address(Wallet)),
+    ProcessorMsg =
+        #{
+            <<"device">> => <<"p4@1.0">>,
+            <<"ledger_device">> => <<"simple-pay@1.0">>,
+            <<"pricing_device">> => <<"simple-pay@1.0">>
+        },
+    {
+        Address,
+        Wallet,
+        #{
+            simple_pay_ledger => #{Address => 100},
+            simple_pay_price => 10,
+            operator => Address,
+            preprocessor => ProcessorMsg,
+            postprocessor => ProcessorMsg
+        }
+    }.
+
+get_balance_and_top_up_test() ->
+    {Address, Wallet, Opts} = test_opts(),
+    Node = hb_http_server:start_test_node(Opts),
+    {ok, Res} =
+        hb_http:get(
+            Node,
+            hb_message:sign(
+                #{<<"path">> => <<"/!simple-pay@1.0/balance">>},
+                Wallet
+            ),
+            #{}
+        ),
+    ?assertEqual(100, hb_converge:get(<<"body">>, Res, #{})),
+    {ok, _} =
+        hb_http:post(
+            Node,
+            hb_message:sign(
+                #{
+                    <<"path">> => <<"/!simple-pay@1.0/top-up">>,
+                    <<"amount">> => 100,
+                    <<"recipient">> => Address
+                },
+                Wallet
+            ),
+            #{}
+        ),
+    {ok, Res2} =
+        hb_http:get(
+            Node,
+            hb_message:sign(
+                #{<<"path">> => <<"/!simple-pay@1.0/balance">>},
+                Wallet
+            ),
+            #{}
+        ),
+    ?assertEqual(170, hb_converge:get(<<"body">>, Res2, #{})).

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -18,8 +18,16 @@ start() ->
 %% @doc Gets a URL via HTTP and returns the resulting message in deserialized
 %% form.
 get(Node, Opts) -> get(Node, <<"/">>, Opts).
-get(Node, Path, Opts) ->
-    request(<<"GET">>, Node, Path, #{}, Opts).
+get(Node, PathBin, Opts) when is_binary(PathBin) ->
+    get(Node, #{ <<"path">> => PathBin }, Opts);
+get(Node, Message, Opts) ->
+    request(
+        <<"GET">>,
+        Node,
+        hb_converge:get(<<"path">>, Message, <<"/">>, Opts),
+        Message,
+        Opts
+    ).
 
 %% @doc Posts a message to a URL on a remote peer via HTTP. Returns the
 %% resulting message in deserialized form.

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -10,7 +10,7 @@
 %%% such that changing it on start of the router server allows for
 %%% the execution parameters of all downstream requests to be controlled.
 -module(hb_http_server).
--export([start/0, start/1, allowed_methods/2, init/2, set_opts/1]).
+-export([start/0, start/1, allowed_methods/2, init/2, set_opts/1, get_opts/1]).
 -export([start_test_node/0, start_test_node/1]).
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
@@ -129,7 +129,7 @@ start_http2(ServerID, ProtoOpts, NodeMsg) ->
     {ok, Port, Listener}.
 
 init(Req, ServerID) ->
-    NodeMsg = cowboy:get_env(ServerID, node_msg, no_node_msg),
+    NodeMsg = get_opts(#{ http_server => ServerID }),
     % Parse the HTTP request into HyerBEAM's message format.
     ReqSingleton = hb_http:req_to_tabm_singleton(Req, NodeMsg),
     ?event(http, {http_inbound, ReqSingleton}),
@@ -151,6 +151,10 @@ allowed_methods(Req, State) ->
 set_opts(Opts) ->
     ServerRef = hb_opts:get(http_server, no_server_ref, Opts),
     ok = cowboy:set_env(ServerRef, node_msg, Opts).
+
+get_opts(NodeMsg) ->
+    ServerRef = hb_opts:get(http_server, no_server_ref, NodeMsg),
+    cowboy:get_env(ServerRef, node_msg, no_node_msg).
 
 %%% Tests
 

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -66,6 +66,7 @@ default_message() ->
                 <<"compute@1.0">> => dev_cu,
                 <<"p4@1.0">> => dev_p4,
                 <<"faff@1.0">> => dev_faff,
+                <<"simple-pay@1.0">> => dev_simple_pay,
                 <<"test-device@1.0">> => dev_test
             },
         codecs => 

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -65,6 +65,7 @@ default_message() ->
                 <<"push@1.0">> => dev_mu,
                 <<"compute@1.0">> => dev_cu,
                 <<"p4@1.0">> => dev_p4,
+                <<"faff@1.0">> => dev_faff,
                 <<"test-device@1.0">> => dev_test
             },
         codecs => 


### PR DESCRIPTION
Features two simple payment devices:
- `faff@1.0`, offering 'friends and family' private access to a node's services; and
- `simple-pay@1.0`, offering static pricing in a current managed by the node operators discretion. This pattern allows node operators to offer fiat payments to users through the normal payment mechanisms (CC, etc), then send a request to their node to update that user's balance -- akin to ArDrive's Turbo service for Arweave.