### PR TITLE
WIP: PROPOSAL: chore(dev_router): Introduce dedicated storage for Node Messages and add HTTP/3 support

### DIFF
--- a/src/ar_http.erl
+++ b/src/ar_http.erl
@@ -23,7 +23,7 @@ req(Args, ReestablishedConnection, Opts) ->
 	StartTime = erlang:monotonic_time(),
 	#{ peer := Peer, path := Path, method := Method } = Args,
 	Response =
-        case catch gen_server:call(?MODULE, {get_connection, Args}, infinity) of
+        case catch gen_server:call(?MODULE, {get_connection, Args, Opts}, infinity) of
             {ok, PID} ->
                 ar_rate_limiter:throttle(Peer, Path, Opts),
                 case request(PID, Args, Opts) of
@@ -105,12 +105,12 @@ init(Opts) ->
     ?event(started),
 	{ok, #state{ opts = Opts }}.
 
-handle_call({get_connection, Args}, From,
+handle_call({get_connection, Args, Opts}, From,
 		#state{ pid_by_peer = PIDPeer, status_by_pid = StatusByPID } = State) ->
-	Peer = maps:get(peer, Args),
+    Peer = maps:get(peer, Args),
 	case maps:get(Peer, PIDPeer, not_found) of
 		not_found ->
-			{ok, PID} = open_connection(Args, State#state.opts),
+			{ok, PID} = open_connection(Args, Opts),
 			MonitorRef = monitor(process, PID),
 			PIDPeer2 = maps:put(Peer, PID, PIDPeer),
 			StatusByPID2 =
@@ -297,7 +297,7 @@ open_connection(#{ peer := Peer }, Opts) ->
             http1 -> BaseGunOpts#{protocols => [http], transport => Transport}
         end,
     ?event(http, {gun_open, {host, Host}, {port, Port}, {protocol, Proto}, {transport, Transport}}),
-	gun:open(Host, Port, GunOpts).
+    gun:open(Host, Port, GunOpts).
 
 parse_peer(Peer, Opts) ->
     case binary:split(Peer, <<":">>, [global]) of

--- a/src/hb_node_messages_server.erl
+++ b/src/hb_node_messages_server.erl
@@ -1,0 +1,56 @@
+-module(hb_node_messages_server).
+
+-behaviour(gen_server).
+-include("include/hb.hrl").
+-export([start_link/0]).
+-export([set/2, get/1]).
+
+-export([init/1, terminate/2, handle_cast/2, handle_info/2, handle_call/3]).
+-export([code_change/3]).
+
+-define(TIMEOUT, 5000).
+
+%% @doc Write given Key and Value to
+-spec set(ServerId, NodeMessage) -> Result when
+    ServerId :: binary(),
+    NodeMessage :: map(),
+    Result :: ok.
+set(ServerId, NodeMessage) ->
+    gen_server:call(?MODULE, {set, ServerId, NodeMessage}, ?TIMEOUT).
+
+%% @doc Write given Key and Value to
+-spec get(ServerId) -> Result when
+    ServerId :: binary(),
+    Result :: {ok, NodeMessage} | {error, not_found},
+    NodeMessage :: map().
+get(ServerId) ->
+    gen_server:call(?MODULE, {get, ServerId}, ?TIMEOUT).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+    {ok, #{}}.
+
+handle_call({set, ServerId, NodeMessage}, _From, State) ->
+    {reply, ok, maps:put(ServerId, NodeMessage, State)};
+handle_call({get, ServerId}, _From, State) ->
+    Reply = maps:get(ServerId, State, {error, not_found}),
+    {reply, Reply, State}.
+
+handle_cast(Message, State) ->
+    ?event(warning, {unhandled_cast, {module, ?MODULE}, {message, Message}}),
+    {noreply, State}.
+
+handle_info(Message, State) ->
+    ?event(warning, {unhandled_info, {module, ?MODULE}, {message, Message}}),
+    {noreply, State}.
+
+
+terminate(Reason, _State) ->
+    ?event(info, {no_messages_terminating, {reason, Reason}}),
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+    

--- a/src/hb_sup.erl
+++ b/src/hb_sup.erl
@@ -32,7 +32,16 @@ init(Opts) ->
             type => worker,
             modules => [ar_http]
         },
-    {ok, {SupFlags, [GunChild | StoreChildren]}}.
+    NodeMessagesServerChild =
+        #{
+            id => hb_node_messages_server,
+            start => {hb_node_messages_server, start_link, []},
+            restart => permanent,
+            shutdown => 5000,
+            type => worker,
+            modules => [hb_node_messages_server]
+        },
+    {ok, {SupFlags, [GunChild, NodeMessagesServerChild | StoreChildren]}}.
 
 %% @doc Generate a child spec for stores in the given Opts.
 store_children(Store) when not is_list(Store) ->


### PR DESCRIPTION
Proposal: Previously, Node Messages were stored within the ranch_server
 using cowboy:set_env and cowboy:get_env as HTTP protocol options.
However, this approach posed several limitations. It overloaded the ranch_server process, which is responsible for critical tasks such as listener monitoring, with dynamic Node Message storage problem. This design became particularly problematic with protocols like QUIC,
 which does not relay on runch.

This commit introduces a dedicated storage process for Node Messages independent of ranch. By decoupling Node Message handling from ranch_server,
 we ensure compatibility across all protocols, including QUIC,
 without compromising the core responsibilities of the ranch_server.