### PR TITLE
fix(hb_codec_http): ensure nested message structure is preserved, even with only sub bodies #13

### DIFF
--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -641,6 +641,24 @@ deeply_nested_message_with_content_test(Codec) ->
     Decoded = convert(Encoded, converge, Codec, #{}),
     ?assert(match(Msg, Decoded)).
 
+deeply_nested_message_with_only_content(Codec) ->
+    MainBodyKey =
+        case Codec of
+            tx -> <<"data">>;
+            _ -> <<"body">>
+        end,
+    Msg = #{
+         <<"depth">> => <<"outer">>,
+        MainBodyKey => #{
+            MainBodyKey => #{
+                MainBodyKey => <<"DATA">>    
+            }
+        }
+    },
+    Encoded = convert(Msg, Codec, converge, #{}),
+    Decoded = convert(Encoded, converge, Codec, #{}),
+    ?assert(match(Msg, Decoded)).
+
 nested_structured_fields_test(Codec) ->
     NestedMsg = #{ <<"a">> => #{ <<"b">> => 1 } },
     Encoded = convert(NestedMsg, Codec, converge, #{}),
@@ -786,6 +804,8 @@ message_suite_test_() ->
             fun nested_message_with_large_content_test/1},
         {"deeply nested message with content test",
             fun deeply_nested_message_with_content_test/1},
+        {"deeply nested message with only content test",
+            fun deeply_nested_message_with_only_content/1},
         {"structured field atom parsing test",
             fun structured_field_atom_parsing_test/1},
         {"structured field decimal parsing test",


### PR DESCRIPTION
This issue was introduced in #84

The root problem was that, during encoding, the "body only" nested messages were being encoded following that rule. This was effectively "collapsing" the nested "body only" messages into the body of the top message, but with an additional CRLF added at each layer.  So then on parsing, those added CRLF would end up being parsed as part of the top level body, thus invalidating it.

Basically, "body-only" nested messages require different behavior, in order to preserve the hierarchy of nesting. That behavior is implemented in this PR.

See comments for further details.