### PR TITLE
impr: `hb_singleton` syntax improvements

### DIFF
--- a/docs/converge-http-api.md
+++ b/docs/converge-http-api.md
@@ -31,7 +31,7 @@ For example, `GET /hashpath1/key1+dict1=val1/key2` adds `dict1=val1` to the
 message for the resolution of the `key1` key.
 - `N.KeyName` in headers or query parameters is interpreted as `KeyName` in the
 message dictionary for the resolution of the `N`th key.
-- `Key!DevName` in a path segment is interpreted as executing the message with
+- `Key~DevName` in a path segment is interpreted as executing the message with
 the `Device` set to `DevName`.
 - A dictionary key of form `Key|Type` is interpreted as a type annotation for
 `Key`, which can be used to parse the value of the key using HTTP Structured
@@ -92,9 +92,9 @@ curl -X POST http://host:port/Init/Compute \
     -H "2.WASM-Function: fac" -H "2.WASM-Params: [10]"
 ```
 
-To fork an existing process to use a new device, we can use the `!` key operator:
+To fork an existing process to use a new device, we can use the `~` key operator:
 ```
-curl -X POST http://host:port/Schedule!Process/2.0/(/ProcID/Now)+Method=POST
+curl -X POST http://host:port/Schedule~Process/2.0/(/ProcID/Now)+Method=POST
 ```
 
 To run multiple computations in the same request, with separate headers for

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -382,7 +382,9 @@ run_as(Key, Msg1, Msg2, Opts) ->
             },
             Opts
         ),
-    %?event({resolving_proc, {msg1, PreparedMsg}, {msg2, Msg2}, {opts, Opts}}),
+    ?event({resolving_proc, {msg1, PreparedMsg}, {msg2, Msg2}, {opts, Opts}}),
+    DeviceAsSet = hb_converge:get(<<"device">>, PreparedMsg, Opts),
+    ?event({device_set, DeviceAsSet}),
     {ok, BaseResult} =
         hb_converge:resolve(
             PreparedMsg,

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -585,6 +585,7 @@ single_converge(Opts) ->
     ?assertMatch({ok, #{ <<"current-slot">> := CurrentSlot }}
             when CurrentSlot == Iterations - 1,
         hb_converge:resolve(Msg1, Msg3, Opts)),
+    ?event(bench, {res, Iterations - 1}),
     hb_util:eunit_print(
         "Scheduled ~p messages through Converge in ~p seconds (~.2f msg/s)",
         [Iterations, BenchTime, Iterations / BenchTime]
@@ -616,6 +617,8 @@ many_clients(Opts) ->
         "Scheduled ~p messages with ~p workers through HTTP in ~ps (~.2f msg/s)",
         [Iterations, Processes, BenchTime, Iterations / BenchTime]
     ),
+    {ok, Res} = http_get_slot(Node, PMsg),
+    ?event(bench, {res, Res}),
     ?assert(Iterations > 10).
 
 benchmark_suite_test_() ->

--- a/src/dev_wasm.erl
+++ b/src/dev_wasm.erl
@@ -162,6 +162,8 @@ compute(RawM1, M2, Opts) ->
                 {
                     calling_wasm_executor,
                     {prefix, Prefix},
+                    {wasm_function, {explicit, WASMFunction}},
+                    {wasm_params, WASMParams},
                     {m1, M1},
                     {m2, M2},
                     {priv, hb_private:from_message(M1)}

--- a/src/hb_codec_http.erl
+++ b/src/hb_codec_http.erl
@@ -39,6 +39,7 @@
 %%% 
 -module(hb_codec_http).
 -export([to/1, from/1]).
+%%% Helper utilities
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -92,7 +93,11 @@ from_signature(Map, RawSig, RawSigInput) ->
 
             SigMap = lists:foldl(
                 fun({PName, PBareItem}, PAcc) ->
-                    maps:put(PName, from_sf_bare_item(PBareItem), PAcc)
+                    maps:put(
+                        PName,
+                        hb_http_structured_fields:from_bare_item(PBareItem),
+                        PAcc
+                    )
                 end,
                 #{ <<"signature">> => Sig, <<"inputs">> => Inputs },
                  % Signature parameters are converted into top-level keys on the signature Map
@@ -107,15 +112,6 @@ from_signature(Map, RawSig, RawSigInput) ->
     % Finally place the Signatures as a top-level Map on the parent Map
     maps:put(<<"signatures">>, Signatures, Map).
 
-from_sf_bare_item (BareItem) ->
-    case BareItem of
-        I when is_integer(I) -> I;
-        B when is_boolean(B) -> B;
-        D = {decimal, _} -> list_to_float(hb_http_structured_fields:bare_item(D));
-        {string, S} -> S;
-        {token, T} -> binary_to_existing_atom(T);
-        {binary, B} -> B
-    end.
 
 find_header(Headers, Name) ->
     find_header(Headers, Name, []).

--- a/src/hb_http_structured_fields.erl
+++ b/src/hb_http_structured_fields.erl
@@ -1,7 +1,7 @@
 -module(hb_http_structured_fields).
 
 -export([parse_dictionary/1, parse_item/1, parse_list/1, parse_bare_item/1]).
--export([dictionary/1, item/1, list/1, bare_item/1]).
+-export([dictionary/1, item/1, list/1, bare_item/1, from_bare_item/1]).
 -export([to_dictionary/1, to_list/1, to_item/1, to_item/2]).
 
 -include_lib("eunit/include/eunit.hrl").
@@ -139,6 +139,23 @@ to_bare_item(BareItem) ->
             Dec;
         A when is_atom(A) -> {token, atom_to_binary(A)};
         S when is_binary(S) or is_list(S) -> {string, iolist_to_binary(S)}
+    end.
+
+from_bare_item(BareItem) ->
+    case BareItem of
+        I when is_integer(I) -> I;
+        B when is_boolean(B) -> B;
+        D = {decimal, _} ->
+            list_to_float(
+                binary_to_list(
+                    iolist_to_binary(
+                        hb_http_structured_fields:bare_item(D)
+                    )
+                )
+            );
+        {string, S} -> S;
+        {token, T} -> binary_to_existing_atom(T);
+        {binary, B} -> B
     end.
 
 key_to_binary(Key) when is_atom(Key) -> atom_to_binary(Key);


### PR DESCRIPTION
Implements the following API syntax changes:

`...!device` => `...~device`.
`...key1=val1&key2=val2` => `...&key1=val1&key2=val2`
`...|type` => `...+type`

Additionally, lists and maps can be represented inline in a single HTTP key using the `+list` and `+map` calls, which automatically convert to the appropriate Erlang type using the RFC 8941 rules.

Still to add: `*` auto type modifier.