### PR TITLE
impr: `dev_relay`

### DIFF
--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -17,9 +17,9 @@
 %% with a `Meta` key are routed to the `handle_meta/2` function, while all
 %% other messages are routed to the `handle_converge/2` function.
 handle(NodeMsg, RawRequest) ->
-    ?event({raw_request, RawRequest, NodeMsg}),
+    ?event({singleton_request, RawRequest}),
     NormRequest = hb_singleton:from(RawRequest),
-    ?event({processing_messages, NormRequest}),
+    ?event({normalized_request, NormRequest}),
     handle_converge(RawRequest, NormRequest, NodeMsg).
 
 %% @doc Get/set the node message. If the request is a `POST`, we check that the

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -297,7 +297,7 @@ route_template_message_matches_test() ->
         )
     ),
     ?assertEqual(
-        no_matches,
+        {error, no_matches},
         route(
             #{ <<"path">> => <<"/">>, <<"special-key">> => <<"special-value2">> },
             #{ routes => Routes }
@@ -331,7 +331,7 @@ route_regex_matches_test() ->
         route(#{ <<"path">> => <<"/a/b/c/schedule">> }, #{ routes => Routes })
     ),
     ?assertEqual(
-        no_matches,
+        {error, no_matches},
         route(#{ <<"path">> => <<"/a/b/c/bad-key">> }, #{ routes => Routes })
     ).
 

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -88,7 +88,7 @@ route(_, Msg, Opts) ->
     R = match_routes(Msg, Routes, Opts),
     ?event({find_route, {msg, Msg}, {routes, Routes}, {res, R}}),
     case (R =/= no_matches) andalso hb_converge:get(<<"node">>, R, Opts) of
-        false -> no_matches;
+        false -> {error, no_matches};
         Node when is_binary(Node) -> {ok, Node};
         not_found ->
             Nodes = hb_converge:get(<<"peers">>, R, Opts),

--- a/src/hb_converge.erl
+++ b/src/hb_converge.erl
@@ -96,7 +96,8 @@
 -export([normalize_key/1, normalize_key/2, normalize_keys/1]).
 %%% Shortcuts and tools:
 -export([info/2, keys/1, keys/2, keys/3, truncate_args/2]).
--export([get/2, get/3, get/4, set/2, set/3, set/4, remove/2, remove/3]).
+-export([get/2, get/3, get/4, get_first/2, get_first/3]).
+-export([set/2, set/3, set/4, remove/2, remove/3]).
 %%% Exports for tests in hb_converge_tests.erl:
 -export([deep_set/4, is_exported/4, message_to_fun/3]).
 -include("include/hb.hrl").
@@ -466,7 +467,7 @@ resolve_stage(9, Msg1, Msg2, Res, ExecName, Opts) ->
     % unregister ourselves from the group.
     hb_persistent:unregister_notify(ExecName, Msg2, Res, Opts),
     resolve_stage(10, Msg1, Msg2, Res, ExecName, Opts);
-resolve_stage(10, Msg1, Msg2, {ok, Msg3} = Res, ExecName, Opts) ->
+resolve_stage(10, _Msg1, _Msg2, {ok, Msg3} = Res, ExecName, Opts) ->
     ?event(converge_core, {stage, 10, ExecName, maybe_spawn_worker}, Opts),
     % Check if we should spawn a worker for the current execution
     case {is_map(Msg3), hb_opts:get(spawn_worker, false, Opts#{ prefer => local })} of
@@ -595,6 +596,16 @@ get(Path, Msg, Default, Opts) ->
 		{ok, Value} -> Value;
 		{error, _} -> Default
 	end.
+
+%% @doc take a sequence of base messages and paths, then return the value of the
+%% first message that can be resolved using a path.
+get_first(Paths, Opts) -> get_first(Paths, not_found, Opts).
+get_first([], Default, _Opts) -> Default;
+get_first([{Base, Path}|Msgs], Default, Opts) ->
+    case get(Path, Base, Opts) of
+        not_found -> get_first(Msgs, Default, Opts);
+        Value -> Value
+    end.
 
 %% @doc Shortcut to get the list of keys from a message.
 keys(Msg) -> keys(Msg, #{}).

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -59,6 +59,7 @@ default_message() ->
                 <<"json-iface@1.0">> => dev_json_iface,
                 <<"dedup@1.0">> => dev_dedup,
                 <<"router@1.0">> => dev_router,
+                <<"relay@1.0">> => dev_relay,
                 <<"cron@1.0">> => dev_cron,
                 <<"poda@1.0">> => dev_poda,
                 <<"monitor@1.0">> => dev_monitor,


### PR DESCRIPTION
This PR reorganizes `dev_relay` such that the core resolution logic is shared to with `hb_http`. It also fixes a subtle issue with parsing singleton paths that contain multiple slashes in a row (URIs, for example).

To use, start a HB node and call:
```
curl /~relay@.1.0/call?method=GET?0.path=https://www.arweave.net/
```