### PR TITLE
fix(hb_beamr): clean up memory allocated for storing import results

### DIFF
--- a/native/hb_beamr/hb_wasm.c
+++ b/native/hb_beamr/hb_wasm.c
@@ -94,6 +94,7 @@ wasm_trap_t* wasm_handle_import(void* env, const wasm_val_vec_t* args, wasm_val_
 
     // Clean up
     DRV_DEBUG("Cleaning up import response");
+    driver_free(proc->current_import->result_terms);
     erl_drv_cond_destroy(proc->current_import->cond);
     proc->current_import->cond = NULL;
     erl_drv_mutex_destroy(proc->current_import->response_ready);

--- a/src/hb_http_benchmark_tests.erl
+++ b/src/hb_http_benchmark_tests.erl
@@ -8,186 +8,139 @@
 %% 1: 50% performance of Macbook Pro M2 Max
 -define(PERFORMANCE_DIVIDER, 1).
 
-% unsigned_resolve_benchmark_test() ->
-%     BenchTime = 1,
-%     URL = hb_http_server:start_test_node(#{force_signed => false}),
-%     Iterations = hb:benchmark(
-%         fun() ->
-%             hb_http:post(URL,
-%                 #{
-%                     <<"path">> => <<"key1">>,
-%                     <<"key1">> => #{<<"key2">> => <<"value1">>}
-%                 },
-%                 #{}
-%             )
-%         end,
-%         BenchTime
-%     ),
-%     hb_util:eunit_print(
-%         "Resolved ~p messages through Converge via HTTP in ~p seconds (~.2f msg/s)",
-%         [Iterations, BenchTime, Iterations / BenchTime]
-%     ),
-%     ?assert(Iterations > 400 / ?PERFORMANCE_DIVIDER).
+unsigned_resolve_benchmark_test() ->
+    BenchTime = 1,
+    URL = hb_http_server:start_test_node(#{force_signed => false}),
+    Iterations = hb:benchmark(
+        fun() ->
+            hb_http:post(URL,
+                #{
+                    <<"path">> => <<"key1">>,
+                    <<"key1">> => #{<<"key2">> => <<"value1">>}
+                },
+                #{}
+            )
+        end,
+        BenchTime
+    ),
+    hb_util:eunit_print(
+        "Resolved ~p messages through Converge via HTTP in ~p seconds (~.2f msg/s)",
+        [Iterations, BenchTime, Iterations / BenchTime]
+    ),
+    ?assert(Iterations > 400 / ?PERFORMANCE_DIVIDER).
 
-% parallel_unsigned_resolve_benchmark_test() ->
-%     BenchTime = 1,
-%     BenchWorkers = 16,
-%     URL = hb_http_server:start_test_node(#{force_signed => false}),
-%     Iterations = hb:benchmark(
-%         fun(_Count) ->
-%             hb_http:post(
-%                 URL,
-%                 #{
-%                     <<"path">> => <<"key1">>,
-%                     <<"key1">> => #{<<"key2">> => <<"value1">>}
-%                 },
-%                 #{}
-%             )
-%         end,
-%         BenchTime,
-%         BenchWorkers
-%     ),
-%     hb_util:eunit_print(
-%         "Resolved ~p messages via HTTP (~p workers) in ~p seconds (~.2f msg/s)",
-%         [Iterations, BenchWorkers, BenchTime, Iterations / BenchTime]
-%     ),
-%     ?assert(Iterations > 1000 / ?PERFORMANCE_DIVIDER).
+parallel_unsigned_resolve_benchmark_test() ->
+    BenchTime = 1,
+    BenchWorkers = 16,
+    URL = hb_http_server:start_test_node(#{force_signed => false}),
+    Iterations = hb:benchmark(
+        fun(_Count) ->
+            hb_http:post(
+                URL,
+                #{
+                    <<"path">> => <<"key1">>,
+                    <<"key1">> => #{<<"key2">> => <<"value1">>}
+                },
+                #{}
+            )
+        end,
+        BenchTime,
+        BenchWorkers
+    ),
+    hb_util:eunit_print(
+        "Resolved ~p messages via HTTP (~p workers) in ~p seconds (~.2f msg/s)",
+        [Iterations, BenchWorkers, BenchTime, Iterations / BenchTime]
+    ),
+    ?assert(Iterations > 1000 / ?PERFORMANCE_DIVIDER).
 
-% wasm_compute_request(ImageFile, Func, Params) ->
-%     {ok, Bin} = file:read_file(ImageFile),
-%     #{
-%         <<"path">> => <<"init/compute/results">>,
-%         <<"device">> => <<"wasm-64@1.0">>,
-%         <<"wasm-function">> => Func,
-%         <<"wasm-params">> => Params,
-%         <<"image">> => Bin
-%     }.
+wasm_compute_request(ImageFile, Func, Params) ->
+    {ok, Bin} = file:read_file(ImageFile),
+    #{
+        <<"path">> => <<"init/compute/results">>,
+        <<"device">> => <<"wasm-64@1.0">>,
+        <<"wasm-function">> => Func,
+        <<"wasm-params">> => Params,
+        <<"image">> => Bin
+    }.
 
-% run_wasm_unsigned_benchmark_test() ->
-%     BenchTime = 1,
-%     URL = hb_http_server:start_test_node(#{force_signed => false}),
-%     Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [10]),
-%     Iterations = hb:benchmark(
-%         fun(_) ->
-%             case hb_http:post(URL, Msg, #{}) of
-%                 {ok, _} -> 1;
-%                 _ -> 0
-%             end
-%         end,
-%         BenchTime
-%     ),
-%     hb_util:eunit_print(
-%         "Resolved ~p WASM invocations via HTTP in ~p seconds (~.2f msg/s)",
-%         [Iterations, BenchTime, Iterations / BenchTime]
-%     ),
-%     ?assert(Iterations > 100 / ?PERFORMANCE_DIVIDER).
+run_wasm_unsigned_benchmark_test() ->
+    BenchTime = 1,
+    URL = hb_http_server:start_test_node(#{force_signed => false}),
+    Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [10]),
+    Iterations = hb:benchmark(
+        fun(_) ->
+            case hb_http:post(URL, Msg, #{}) of
+                {ok, _} -> 1;
+                _ -> 0
+            end
+        end,
+        BenchTime
+    ),
+    hb_util:eunit_print(
+        "Resolved ~p WASM invocations via HTTP in ~p seconds (~.2f msg/s)",
+        [Iterations, BenchTime, Iterations / BenchTime]
+    ),
+    ?assert(Iterations > 100 / ?PERFORMANCE_DIVIDER).
 
 
-% run_wasm_signed_benchmark_test_disabled() ->
-%     BenchTime = 1,
-%     URL = hb_http_server:start_test_node(#{force_signed => true}),
-%     Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [10]),
-%     Iterations = hb:benchmark(
-%         fun(_) ->
-%             case hb_http:post(URL, Msg, #{}) of
-%                 {ok, _} -> 1;
-%                 _ -> 0
-%             end
-%         end,
-%         BenchTime
-%     ),
-%     hb_util:eunit_print(
-%         "Resolved ~p WASM invocations via HTTP in ~p seconds (~.2f msg/s)",
-%         [Iterations, BenchTime, Iterations / BenchTime]
-%     ),
-%     ?assert(Iterations > 50 / ?PERFORMANCE_DIVIDER).
+run_wasm_signed_benchmark_test() ->
+    BenchTime = 1,
+    URL = hb_http_server:start_test_node(#{force_signed => true}),
+    Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [10]),
+    Iterations = hb:benchmark(
+        fun(_) ->
+            case hb_http:post(URL, Msg, #{}) of
+                {ok, _} -> 1;
+                _ -> 0
+            end
+        end,
+        BenchTime
+    ),
+    hb_util:eunit_print(
+        "Resolved ~p WASM invocations via HTTP in ~p seconds (~.2f msg/s)",
+        [Iterations, BenchTime, Iterations / BenchTime]
+    ),
+    ?assert(Iterations > 50 / ?PERFORMANCE_DIVIDER).
 
-% parallel_wasm_unsigned_benchmark_test_disabled() ->
-%     BenchTime = 1,
-%     BenchWorkers = 16,
-%     URL = hb_http_server:start_test_node(#{force_signed => false}),
-%     Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [10]),
-%     Iterations = hb:benchmark(
-%         fun(X) ->
-%             ?event({post_start, X}),
-%             case hb_http:post(URL, Msg, #{}) of
-%                 {ok, _} ->
-%                     1;
-%                 _ -> 0
-%             end
-%         end,
-%         BenchTime,
-%         BenchWorkers
-%     ),
-%     hb_util:eunit_print(
-%         "Resolved ~p WASM invocations via HTTP (~p workers) in ~p seconds (~.2f msg/s)",
-%         [Iterations, BenchWorkers, BenchTime, Iterations / BenchTime]
-%     ),
-%     ?assert(Iterations > 200 / ?PERFORMANCE_DIVIDER).
+parallel_wasm_unsigned_benchmark_test() ->
+    BenchTime = 1,
+    BenchWorkers = 16,
+    URL = hb_http_server:start_test_node(#{force_signed => false}),
+    Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [10]),
+    Iterations = hb:benchmark(
+        fun(X) ->
+            ?event(debug, {post_start, X}),
+            case hb_http:post(URL, Msg, #{}) of
+                {ok, _} ->
+                    1;
+                _ -> 0
+            end
+        end,
+        BenchTime,
+        BenchWorkers
+    ),
+    hb_util:eunit_print(
+        "Resolved ~p WASM invocations via HTTP (~p workers) in ~p seconds (~.2f msg/s)",
+        [Iterations, BenchWorkers, BenchTime, Iterations / BenchTime]
+    ).
 
-% parallel_wasm_signed_benchmark_test_disabled() ->
-%     BenchTime = 1,
-%     BenchWorkers = 16,
-%     URL = hb_http_server:start_test_node(#{force_signed => true}),
-%     Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [10]),
-%     Iterations = hb:benchmark(
-%         fun(_) ->
-%             case hb_http:post(URL, Msg, #{}) of
-%                 {ok, _ResMsg} ->
-%                     1;
-%                 _ -> 0
-%             end
-%         end,
-%         BenchTime,
-%         BenchWorkers
-%     ),
-%     hb_util:eunit_print(
-%         "Resolved ~p WASM invocations via HTTP (~p workers) in ~p seconds (~.2f msg/s)",
-%         [Iterations, BenchWorkers, BenchTime, Iterations / BenchTime]
-%     ),
-%     ?assert(Iterations > 100 / ?PERFORMANCE_DIVIDER).
-
-% % parallel_http_scheduling_benchmark_test() ->
-% %     application:ensure_all_started(hb),
-% %     URL = hb_http_server:start_test_node(#{force_signed => true}),
-% %     BenchTime = 3,
-% %     BenchWorkers = 16,
-% %     Msg1 = dev_scheduler:test_process(),
-% %     Proc = hb_converge:get(process, Msg1, #{ hashpath => ignore }),
-% %     ProcID = hb_util:id(Proc),
-% %     ?event({benchmark_start, ?MODULE}),
-% %     Iterations = hb:benchmark(
-% %         fun(X) ->
-% %             MsgX = #{
-% %                 <<"device">> => <<"Scheduler@1.0">>,
-% %                 <<"path">> => <<"schedule">>,
-% %                 <<"method">> => <<"POST">>,
-% %                 <<"body">> =>
-% %                     #{
-% %                         <<"type">> => <<"body">>,
-% %                         <<"test-val">> => X
-% %                     }
-% %             },
-% %             Res = hb_http:post(URL, MsgX),
-% %             ?event({post_result, Res}),
-% %             case Res of
-% %                 {ok, _} -> 1;
-% %                 _ -> 0
-% %             end
-% %         end,
-% %         BenchTime,
-% %         BenchWorkers
-% %     ),
-% %     ?event(benchmark, {scheduled, Iterations}),
-% %     Msg3 = #{
-% %         <<"path">> => <<"slot">>,
-% %         <<"method">> => <<"GET">>,
-% %         <<"process">> => ProcID
-% %     },
-% %     Res = hb_http:post(URL, Msg3),
-% %     ?event({slot_result, Res}),
-% %     hb_util:eunit_print(
-% %         "Scheduled ~p messages through Converge in ~p seconds (~.2f msg/s)",
-% %         [Iterations, BenchTime, Iterations / BenchTime]
-% %     ),
-% %     ?assert(Iterations > 100).
+parallel_wasm_signed_benchmark_test() ->
+    BenchTime = 1,
+    BenchWorkers = 16,
+    URL = hb_http_server:start_test_node(#{force_signed => true}),
+    Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [10]),
+    Iterations = hb:benchmark(
+        fun(_) ->
+            case hb_http:post(URL, Msg, #{}) of
+                {ok, _ResMsg} ->
+                    1;
+                _ -> 0
+            end
+        end,
+        BenchTime,
+        BenchWorkers
+    ),
+    hb_util:eunit_print(
+        "Resolved ~p WASM invocations via HTTP (~p workers) in ~p seconds (~.2f msg/s)",
+        [Iterations, BenchWorkers, BenchTime, Iterations / BenchTime]
+    ).

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -183,7 +183,7 @@ test_opts(Opts) ->
                 }
             },
         priv_wallet => Wallet,
-        force_signed => true
+        force_signed => maps:get(force_signed, Opts, true)
     }.
 
 %% @doc Test that we can start the server, send a message, and get a response.


### PR DESCRIPTION
Now it also cleans up the import_results structure, that allows to decrease the memory leakage even more:

```
{driver_alloc,0.40625}

{driver_alloc,0.65625}       -> first run
{driver_alloc,0.65625}.      -> second run
{driver_alloc,0.65625}.      -> third run
```