### PR TITLE
fix: dynamically getting priv directory to load beamr

### DIFF
--- a/src/hb_beamr.erl
+++ b/src/hb_beamr.erl
@@ -60,7 +60,7 @@
 
 %% @doc Load the driver for the WASM executor.
 load_driver() ->
-    case erl_ddll:load("./priv", ?MODULE) of
+    case erl_ddll:load(code:priv_dir(hb), ?MODULE) of
         ok -> ok;
         {error, already_loaded} -> ok;
         {error, Error} -> {error, Error}


### PR DESCRIPTION
Instead of loading the **beamr** lib from a relative priv directory `erl_ddll:load("./priv` I am now loading using `code:priv_dir(_APP)` this should allow us the run **beamr** in release.