### PR TITLE
fix(hb_http): strip fields, not signed, from the incoming message

### DIFF
--- a/src/dev_codec_httpsig.erl
+++ b/src/dev_codec_httpsig.erl
@@ -115,7 +115,7 @@ attest(MsgToSign, _Req, Opts) ->
             hb_message:convert(MsgWithHPTForm, <<"httpsig@1.0">>, Opts)
         ),
     ?event({encoded_to_httpsig_for_attestation, {explicit, Enc}}),
-    Authority = authority(maps:keys(Enc), Enc, Wallet),
+    Authority = authority(lists:sort(maps:keys(Enc)), #{}, Wallet),
     {ok, {SignatureInput, Signature}} = sign_auth(Authority, #{}, Enc),
     [ParsedSignatureInput] = dev_codec_structured_conv:parse_list(SignatureInput),
     % Set the name as `http-sig-[hex encoding of the first 8 bytes of the public key]`

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -503,20 +503,22 @@ http_post_schedule_sign(Node, Msg, ProcessMsg, Wallet) ->
     hb_http:post(Node, Msg1, #{}).
 
 http_get_slot(N, PMsg) ->
-    {ok, _} = hb_http:get(N, #{
+    Wallet = hb:wallet(),
+    {ok, _} = hb_http:get(N, hb_message:attest(#{
         <<"path">> => <<"/~scheduler@1.0/slot">>,
         <<"method">> => <<"GET">>,
         <<"process">> => PMsg
-    }, #{}).
+    }, Wallet), #{}).
 
 http_get_schedule(N, PMsg, From, To) ->
-    {ok, _} = hb_http:get(N, #{
+    Wallet = hb:wallet(),
+    {ok, _} = hb_http:get(N, hb_message:attest(#{
         <<"path">> => <<"/~scheduler@1.0/schedule">>,
         <<"method">> => <<"GET">>,
         <<"process">> => PMsg,
         <<"from">> => From,
         <<"to">> => To
-    }, #{}).
+    }, Wallet), #{}).
 
 http_post_schedule_test() ->
     {N, W} = http_init(),


### PR DESCRIPTION
Also fixes issue in `dev_codec_httpsig:hmac/1` where it was producing an invalid signature base. `dev_codec_httpsig:signature_base/3` should be used/composed upon wherever possible, as it encapsulates the 9421 rules for extracting components from message context, encoding signature parameters, and properly producing a signature base.

Also fixes some 9421 implementation logic (although HB most likely will not hit those branches)

Finally, ensures consistent ordering of component identifiers is used.