### PR TITLE
feat: `initialized` parameter for `dev_meta`.

### DIFF
--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -21,6 +21,7 @@
 default_message() ->
     #{
         %%%%%%%% Functional options %%%%%%%%
+        initialized => true,
         %% What protocol should the node use for HTTP requests?
         %% Options: http1, http2, http3
         protocol => http2,


### PR DESCRIPTION
Nodes with `initialized == false` will not execute operations until the node has received a new node message. Nodes with `permanent` as their `initialized` value will return an error if `POST /~meta@1.0/info` is employed.
