### PR TITLE
chore: visualize rocksdb errors

### DIFF
--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -153,7 +153,7 @@ store_read(Path, Store, Opts) ->
     ?event({reading, {path, PathToBin}, {resolved, ResolvedFullPath}}),
     case hb_store:type(Store, ResolvedFullPath) of
         simple -> hb_store:read(Store, ResolvedFullPath);
-        _ ->
+        composite ->
             case hb_store:list(Store, ResolvedFullPath) of
                 {ok, Subpaths} ->
                     ?event(
@@ -178,7 +178,8 @@ store_read(Path, Store, Opts) ->
                         ),
                     ?event({read_message, Msg}),
                     {ok, Msg};
-                _ -> not_found
+                _ -> 
+                    not_found
             end
     end.
 


### PR DESCRIPTION
Rocksdb storage is not working correctly with the refactored hb_cache.

Previousely some of the tests was not failing becase the output of the `hb_store:type/2` was not checked.

The commit above adds the check, and makes it possible to see, that all rocksdb test are not working.