### PR TITLE
p4 improvements

### DIFF
--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -113,7 +113,7 @@ match_routes(ToMatch, Routes, Opts) ->
     match_routes(
         ToMatch,
         Routes,
-        hb_converge:keys(Routes),
+        hb_converge:keys(hb_converge:normalize_keys(Routes)),
         Opts
     ).
 match_routes(#{ <<"path">> := Explicit = <<"http://", _/binary>> }, _, _, _) ->

--- a/src/dev_simple_pay.erl
+++ b/src/dev_simple_pay.erl
@@ -54,9 +54,13 @@ debit(_, RawReq, NodeMsg) ->
     end.
 
 %% @doc Get the balance of a user in the ledger.
-balance(_, Req, NodeMsg) ->
-    Signer = hd(hb_message:signers(Req)),
-    {ok, get_balance(Signer, NodeMsg)}.
+balance(_, RawReq, NodeMsg) ->
+    Target =
+        case hb_converge:get(<<"request">>, RawReq, NodeMsg#{ hashpath => ignore }) of
+            not_found -> hd(hb_message:signers(RawReq));
+            Req -> hd(hb_message:signers(Req))
+        end,
+    {ok, get_balance(Target, NodeMsg)}.
 
 %% @doc Adjust a user's balance, normalizing their wallet ID first.
 set_balance(Signer, Amount, NodeMsg) ->


### PR DESCRIPTION
Adds support for:
- Operator defined non-chargable routes, which bypass the pricing and ledger devices
- A unified `balance` endpoint, which wraps the underlying ledger device's `balance`