### PR TITLE
fix(beamr): explicit argument type in `wasm_execute_exported_function`

### DIFF
--- a/native/hb_beamr/hb_wasm.c
+++ b/native/hb_beamr/hb_wasm.c
@@ -512,7 +512,7 @@ int wasm_execute_indirect_function(Proc* proc, const char *field_name, const was
     return result;
 }
 
-int wasm_execute_exported_function(Proc* proc, const *function_name, wasm_val_t* params, wasm_val_t * results) {
+int wasm_execute_exported_function(Proc* proc, const char *function_name, wasm_val_t* params, wasm_val_t * results) {
     DRV_DEBUG("=== Calling Runtime Export Function ===");
     DRV_DEBUG("=   Function name: %s", function_name);
 

--- a/native/hb_beamr/include/hb_wasm.h
+++ b/native/hb_beamr/include/hb_wasm.h
@@ -60,7 +60,7 @@ int wasm_execute_indirect_function(Proc* proc, const char *function_name, const 
  *
  *  returns: A 64-bit status code indicating success (0) or failure (-1).
  */
-int wasm_execute_exported_function(Proc* proc, const *function_name, wasm_val_t* params, wasm_val_t * results);
+int wasm_execute_exported_function(Proc* proc, const char *function_name, wasm_val_t* params, wasm_val_t * results);
 
 
 #endif 


### PR DESCRIPTION
Currently causes a build error for Clang 19:
```
===> Compiling /Users/elliot/Code/AO/Core/Fork/HyperBEAM/native/hb_beamr/hb_beamr.c
===> In file included from /Users/elliot/Code/AO/Core/Fork/HyperBEAM/native/hb_beamr/hb_beamr.c:4:
native/hb_beamr/include/hb_wasm.h:63:55: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
   63 | int wasm_execute_exported_function(Proc* proc, const *function_name, wasm_val_t* params, wasm_val_t * results);
      |                                                ~~~~~  ^
      |                                                int
```