### PR TITLE
impl: Arweave gateways as `hb_store` accessible data repositories

### DIFF
--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -205,11 +205,15 @@ maybe_sign(Res, NodeMsg) ->
     ?event({maybe_sign, Res, NodeMsg}),
     case hb_opts:get(force_signed, false, NodeMsg) of
         true ->
-            hb_message:attest(
-                Res,
-                hb_opts:get(priv_wallet, no_viable_wallet, NodeMsg),
-                hb_opts:get(format, <<"httpsig@1.0">>, NodeMsg)
-            );
+            case hb_message:signers(Res) of
+                [] ->
+                    hb_message:attest(
+                        Res,
+                        hb_opts:get(priv_wallet, no_viable_wallet, NodeMsg),
+                        hb_opts:get(format, <<"httpsig@1.0">>, NodeMsg)
+                    );
+                _ -> Res
+            end;
         false -> Res
     end.
 

--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -128,10 +128,10 @@ update_node_message(Request, NodeMsg) ->
 handle_converge(Req, Msgs, NodeMsg) ->
     % Apply the pre-processor to the request.
     case resolve_processor(<<"preprocess">>, preprocessor, Req, Msgs, NodeMsg) of
-        {ok, PreProcMsg} ->
+        {ok, PreProcessedMsg} ->
             ?event(
                 {result_after_preprocessing,
-                    hb_converge:normalize_keys(PreProcMsg)}
+                    hb_converge:normalize_keys(PreProcessedMsg)}
             ),
             AfterPreprocOpts = hb_http_server:get_opts(NodeMsg),
             % Resolve the request message.
@@ -142,7 +142,7 @@ handle_converge(Req, Msgs, NodeMsg) ->
             {ok, Res} =
                 embed_status(
                     hb_converge:resolve_many(
-                        PreProcMsg,
+                        PreProcessedMsg,
                         HTTPOpts#{ force_message => true }
                     )
                 ),

--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -191,7 +191,7 @@ result_to_message(ExpectedID, Item, Opts) ->
                 ),
             data = Data
         },
-    ?event({raw_ans104, {explicit, TX}}),
+    ?event({raw_ans104, TX}),
     ?event({ans104_form_response, TX}),
     TABM = dev_codec_ans104:from(TX),
     ?event({decoded_tabm, TABM}),

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -187,22 +187,24 @@ get_opts(NodeMsg) ->
 %%% Tests
 
 set_base_opts(Opts) ->
+    % Create a temporary opts map that does not include the defaults.
+    TempOpts = Opts#{ only => local },
     % Generate a random port number between 10000 and 30000 to use
     % for the server.
     Port =
-        case hb_opts:get(port, no_port, Opts#{ only => local }) of
+        case hb_opts:get(port, no_port, TempOpts) of
             no_port ->
                 rand:seed(exsplus, erlang:timestamp()),
                 10000 + rand:uniform(20000);
             PassedPort -> PassedPort
         end,
     Wallet =
-        case hb_opts:get(priv_wallet, no_viable_wallet, Opts) of
+        case hb_opts:get(priv_wallet, no_viable_wallet, TempOpts) of
             no_viable_wallet -> ar_wallet:new();
             PassedWallet -> PassedWallet
         end,
     Store =
-        case hb_opts:get(store, no_store, Opts) of
+        case hb_opts:get(store, no_store, TempOpts) of
             no_store ->
                 {hb_store_fs,
                     #{
@@ -212,6 +214,7 @@ set_base_opts(Opts) ->
                 };
             PassedStore -> PassedStore
         end,
+    ?event({set_base_opts, TempOpts, Port, Store, Wallet}),
     Opts#{
         port => Port,
         store => Store,

--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -1,8 +1,9 @@
 %%% @doc A store module that reads data from the nodes Arweave gateway and 
 %%% GraphQL routes, additionally including additional store-specific routes.
--module(hb_store_graphql).
+-module(hb_store_gateway).
 -export([scope/1, type/2, read/2, resolve/2]).
 -include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
 
 %% @doc The scope of a GraphQL store is always remote, due to performance.
 scope(_) -> remote.
@@ -25,6 +26,7 @@ normalize_opts(StoreOpts) ->
 %% result, so that we don't have to read the data from the GraphQL route
 %% multiple times.
 type(StoreOpts, Key) ->
+    ?event({type, StoreOpts, Key}),
     case read(StoreOpts, Key) of
         not_found -> not_found;
         {ok, Data} ->
@@ -41,8 +43,8 @@ type(StoreOpts, Key) ->
 
 %% @doc Read the data at the given key from the GraphQL route.
 read(StoreOpts, Key) ->
-    Opts = normalize_opts(StoreOpts),
-    case hb_graphql:read(Opts, Key) of
+    ?event({read, StoreOpts, Key}),
+    case hb_gateway_client:read(Key, normalize_opts(StoreOpts)) of
         {error, _} -> not_found;
         {ok, Message} -> {ok, Message}
     end.
@@ -51,6 +53,7 @@ read(StoreOpts, Key) ->
 %% be `false` to disable local caching, or a store definition to use as the
 %% cache.
 maybe_cache(StoreOpts, Data) ->
+    ?event({maybe_cache, StoreOpts, Data}),
     case hb_opts:get(cache, false, StoreOpts) of
         false -> do_nothing;
         Store ->
@@ -59,3 +62,49 @@ maybe_cache(StoreOpts, Data) ->
                 Other -> Other
             end
     end.
+
+%%% Tests
+
+%% @doc Store is accessible via the default options.
+graphql_as_store_test() ->
+    hb_http_server:start_node(#{}),
+    ?assertMatch(
+        {ok, #{ <<"type">> := <<"Assignment">> }},
+        hb_store:read(
+            [{hb_store_gateway, #{}}],
+            <<"0Tb9mULcx8MjYVgXleWMVvqo1_jaw_P6AO_CJMTj0XE">>
+        )
+    ).
+
+%% @doc Stored messages are accessible via `hb_cache` accesses.
+graphql_from_cache_test() ->
+    hb_http_server:start_node(#{}),
+    Opts = #{ store => [{hb_store_gateway, #{}}] },
+    ?assertMatch(
+        {ok, #{ <<"type">> := <<"Assignment">> }},
+        hb_cache:read(
+            <<"0Tb9mULcx8MjYVgXleWMVvqo1_jaw_P6AO_CJMTj0XE">>,
+            Opts
+        )
+    ).
+
+%% @doc Routes can be specified in the options, overriding the default routes.
+%% We test this by inversion: If the above cache read test works, then we know 
+%% that the default routes allow access to the item. If the test below were to
+%% produce the same result, despite an empty 'only' route list, then we would
+%% know that the module is not respecting the route list.
+specific_route_test() ->
+    hb_http_server:start_node(#{}),
+    Opts = #{
+        store =>
+            [
+                {hb_store_gateway, #{ routes => {only, []}}}
+            ]
+    },
+    ?assertMatch(
+        not_found,
+        hb_cache:read(
+            <<"0Tb9mULcx8MjYVgXleWMVvqo1_jaw_P6AO_CJMTj0XE">>,
+            Opts
+        )
+    ).

--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -108,3 +108,20 @@ specific_route_test() ->
             Opts
         )
     ).
+
+%% @doc Test that the default node config allows for data to be accessed.
+external_http_access_test() ->
+    Node = hb_http_server:start_node(
+        #{
+            store => [{hb_store_gateway, #{}}, {hb_store_fs, #{ prefix => "test-cache" }}],
+            http_extra_opts => #{ force_message => true, cache_control => [<<"always">>] }
+        }
+    ),
+    ?assertMatch(
+        {ok, #{ <<"body">> := <<"Assignment">> }},
+        hb_http:get(
+            Node,
+            <<"/0Tb9mULcx8MjYVgXleWMVvqo1_jaw_P6AO_CJMTj0XE/type">>,
+            #{}
+        )
+    ).

--- a/src/hb_store_graphql.erl
+++ b/src/hb_store_graphql.erl
@@ -1,0 +1,61 @@
+%%% @doc A store module that reads data from the nodes Arweave gateway and 
+%%% GraphQL routes, additionally including additional store-specific routes.
+-module(hb_store_graphql).
+-export([scope/1, type/2, read/2, resolve/2]).
+-include("include/hb.hrl").
+
+%% @doc The scope of a GraphQL store is always remote, due to performance.
+scope(_) -> remote.
+resolve(_, Key) -> Key.
+
+%% @doc Normalize the store options, adding the routes if specified.
+%% If no routes are specified, the default routes are used.
+normalize_opts(StoreOpts) when is_map(StoreOpts) ->
+    case maps:get(routes, StoreOpts, not_found) of
+        not_found -> StoreOpts#{ routes => hb_opts:get(routes, [], #{}) };
+        {only, Routes} ->
+            StoreOpts#{ routes => Routes };
+        Routes ->
+            StoreOpts#{ routes => Routes ++ hb_opts:get(routes, [], #{}) }
+    end;
+normalize_opts(StoreOpts) ->
+    StoreOpts.
+
+%% @doc Get the type of the data at the given key. We potentially cache the
+%% result, so that we don't have to read the data from the GraphQL route
+%% multiple times.
+type(StoreOpts, Key) ->
+    case read(StoreOpts, Key) of
+        not_found -> not_found;
+        {ok, Data} ->
+            maybe_cache(StoreOpts, Data),
+            IsFlat = lists:all(
+                fun({_, Value}) -> not is_map(Value) end,
+                maps:to_list(hb_private:reset(hb_message:unattested(Data)))
+            ),
+            if
+                IsFlat -> simple;
+                true -> composite
+            end
+    end.
+
+%% @doc Read the data at the given key from the GraphQL route.
+read(StoreOpts, Key) ->
+    Opts = normalize_opts(StoreOpts),
+    case hb_graphql:read(Opts, Key) of
+        {error, _} -> not_found;
+        {ok, Message} -> {ok, Message}
+    end.
+
+%% @doc Cache the data if the cache is enabled. The `cache` option may either
+%% be `false` to disable local caching, or a store definition to use as the
+%% cache.
+maybe_cache(StoreOpts, Data) ->
+    case hb_opts:get(cache, false, StoreOpts) of
+        false -> do_nothing;
+        Store ->
+            case hb_cache:write(#{ store => Store}, Data) of
+                ok -> Data;
+                Other -> Other
+            end
+    end.

--- a/src/hb_store_remote_node.erl
+++ b/src/hb_store_remote_node.erl
@@ -1,12 +1,12 @@
--module(hb_store_remote_node).
--export([scope/1, type/2, read/2, resolve/2]).
--include("include/hb.hrl").
-
-%%% A store module that reads data from another AO node.
+%%% @doc A store module that reads data from another AO node.
 %%% Notably, this store only provides the _read_ side of the store interface.
 %%% The write side could be added, returning an attestation that the data has
 %%% been written to the remote node. In that case, the node would probably want
 %%% to upload it to an Arweave bundler to ensure persistence, too.
+-module(hb_store_remote_node).
+-export([scope/1, type/2, read/2, resolve/2]).
+-include("include/hb.hrl").
+
 
 scope(_) -> remote.
 

--- a/src/hb_store_remote_node.erl
+++ b/src/hb_store_remote_node.erl
@@ -7,7 +7,6 @@
 -export([scope/1, type/2, read/2, resolve/2]).
 -include("include/hb.hrl").
 
-
 scope(_) -> remote.
 
 resolve(#{ <<"node">> := Node }, Key) ->


### PR DESCRIPTION
This PR allows HyperBEAM nodes to enable any Arweave graphql API endpoint + any gateways that serve data to be used in conjunction to enable decentralized access to data from the network.

HyperBEAM now comes pre-configured to get data from both the `arweave.net` and Goldsky graphql indexes. These can be added to/overriden by changing the node message of the server either by using `POST /~meta@1.0/info`on a live node, setting the routes in the node start call, or changing the defaults in `hb_opts`.