### PR TITLE
feat: add a device that searches the `patch-from` location and applies patch messages

### DIFF
--- a/src/dev_delegated_compute.erl
+++ b/src/dev_delegated_compute.erl
@@ -1,0 +1,65 @@
+%%% @doc Simple wrapper module that enables compute on remote machines,
+%%% implementing the JSON-Iface. This can be used either as a standalone, to 
+%%% bring trusted results into the local node, or as the `Execution-Device' of
+%%% an AO process.
+-module(dev_delegated_compute).
+-export([init/3, compute/3, normalize/3, snapshot/3]).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%% @doc Initialize or normalize the compute-lite device. For now, we don't
+%% need to do anything special here.
+init(Msg1, _Msg2, _Opts) ->
+    {ok, Msg1}.
+normalize(Msg1, _Msg2, _Opts) -> {ok, Msg1}.
+snapshot(Msg1, _Msg2, _Opts) -> {ok, Msg1}.
+
+compute(Msg1, Msg2, Opts) ->
+    ProcessID = hb_converge:get(<<"process/id">>, Msg1, Opts),
+    Slot = hb_converge:get(<<"slot">>, Msg2, Opts),
+    ?event(push, {compute_lite_called, {process_id, ProcessID}, {slot, Slot}}),
+    OutputPrefix = dev_stack:prefix(Msg1, Msg2, Opts),
+    Accept = hb_converge:get(<<"accept">>, Msg2, <<"application/http">>, Opts),
+    ProcessID =
+        hb_converge:get_first(
+            [
+                {Msg1, <<"process/id">>},
+                {Msg2, <<"process-id">>}
+            ],
+            Opts
+        ),
+    {ok, JSONRes} = do_compute(ProcessID, Slot, Opts),
+    ?event(push, {compute_lite_res, {process_id, ProcessID}, {slot, Slot}, {json_res, JSONRes}}),
+    {ok, Msg} = dev_json_iface:json_to_message(JSONRes, Opts),
+    {ok,
+        hb_converge:set(
+            Msg1,
+            #{
+                <<OutputPrefix/binary, "/results">> => Msg,
+                <<OutputPrefix/binary, "/results/json">> => JSONRes
+            },
+            Opts
+        )
+    }.
+
+%% @doc Execute computation on a remote machine via relay and the JSON-Iface.
+do_compute(ProcID, Slot, Opts) ->
+    ?event(debug_leader, {do_compute_called, {process_id, ProcID}, {slot, Slot}}),
+    Res = 
+        hb_converge:resolve(#{ <<"device">> => <<"relay@1.0">> }, #{
+            <<"path">> => <<"call">>,
+            <<"relay-path">> =>
+                <<
+                    "/result/",
+                    (integer_to_binary(Slot))/binary,
+                    "?process-id=",
+                    ProcID/binary
+                >>
+            },
+            Opts
+        ),
+    ?event(debug_leader, {res, Res}),
+    {ok, Response} = Res,
+    JSONRes = hb_converge:get(<<"body">>, Response, Opts),
+    ?event({json_res, JSONRes}),
+    {ok, JSONRes}.

--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -1,65 +1,24 @@
-%%% @doc Simple wrapper module that enables compute on remote machines,
-%%% implementing the JSON-Iface. This can be used either as a standalone, to 
-%%% bring trusted results into the local node, or as the `Execution-Device' of
-%%% an AO process.
+%%% @doc A device that mimics an environment suitable for `legacynet` AO 
+%%% processes, using HyperBEAM infrastructure. This allows existing `legacynet`
+%%% AO process definitions to be used in HyperBEAM.
 -module(dev_genesis_wasm).
 -export([init/3, compute/3, normalize/3, snapshot/3]).
--include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("include/hb.hrl").
 
-%% @doc Initialize or normalize the compute-lite device. For now, we don't
-%% need to do anything special here.
-init(Msg1, _Msg2, _Opts) ->
-    {ok, Msg1}.
-normalize(Msg1, _Msg2, _Opts) -> {ok, Msg1}.
-snapshot(Msg1, _Msg2, _Opts) -> {ok, Msg1}.
+%% @doc Initialize the device.
+init(Msg, _Msg2, _Opts) -> {ok, Msg}.
 
-compute(Msg1, Msg2, Opts) ->
-    ProcessID = hb_converge:get(<<"process/id">>, Msg1, Opts),
-    Slot = hb_converge:get(<<"slot">>, Msg2, Opts),
-    ?event(push, {compute_lite_called, {process_id, ProcessID}, {slot, Slot}}),
-    OutputPrefix = dev_stack:prefix(Msg1, Msg2, Opts),
-    Accept = hb_converge:get(<<"accept">>, Msg2, <<"application/http">>, Opts),
-    ProcessID =
-        hb_converge:get_first(
-            [
-                {Msg1, <<"process/id">>},
-                {Msg2, <<"process-id">>}
-            ],
-            Opts
-        ),
-    {ok, JSONRes} = do_compute(ProcessID, Slot, Opts),
-    ?event(push, {compute_lite_res, {process_id, ProcessID}, {slot, Slot}, {json_res, JSONRes}}),
-    {ok, Msg} = dev_json_iface:json_to_message(JSONRes, Opts),
-    {ok,
-        hb_converge:set(
-            Msg1,
-            #{
-                <<OutputPrefix/binary, "/results">> => Msg,
-                <<OutputPrefix/binary, "/results/json">> => JSONRes
-            },
-            Opts
-        )
-    }.
+%% @doc All the `delegated-compute@1.0` device to execute the request. We then apply
+%% the `patch@1.0` device, applying any state patches that the AO process may have
+%% requested.
+compute(Msg, Msg2, Opts) ->
+    {ok, Msg3} = hb_converge:resolve(Msg, {as, <<"delegated-compute@1.0">>, Msg2}, Opts),
+    {ok, Msg4} = hb_converge:resolve(Msg3, {as, <<"patch@1.0">>, Msg2}, Opts),
+    {ok, Msg4}.
 
-%% @doc Execute computation on a remote machine via relay and the JSON-Iface.
-do_compute(ProcID, Slot, Opts) ->
-    ?event(debug_leader, {do_compute_called, {process_id, ProcID}, {slot, Slot}}),
-    Res = 
-        hb_converge:resolve(#{ <<"device">> => <<"relay@1.0">> }, #{
-            <<"path">> => <<"call">>,
-            <<"relay-path">> =>
-                <<
-                    "/result/",
-                    (integer_to_binary(Slot))/binary,
-                    "?process-id=",
-                    ProcID/binary
-                >>
-            },
-            Opts
-        ),
-    ?event(debug_leader, {res, Res}),
-    {ok, Response} = Res,
-    JSONRes = hb_converge:get(<<"body">>, Response, Opts),
-    ?event({json_res, JSONRes}),
-    {ok, JSONRes}.
+%% @doc Normalize the device.
+normalize(Msg, _Msg2, _Opts) -> {ok, Msg}.
+
+%% @doc Snapshot the device.
+snapshot(Msg, _Msg2, _Opts) -> {ok, Msg}.

--- a/src/dev_patch.erl
+++ b/src/dev_patch.erl
@@ -1,0 +1,161 @@
+%%% @doc A device that finds `PATCH' requests in the `results/outbox'
+%%% of its message, and applies them to it. This can be useful for processes
+%%% whose computation would like to manipulate data outside of the `results' key
+%%% of its message.
+-module(dev_patch).
+-export([init/3, compute/3, normalize/3, snapshot/3]).
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("include/hb.hrl").
+
+%% @doc Default process device hooks.
+init(Msg1, _Msg2, _Opts) -> {ok, Msg1}.
+normalize(Msg1, _Msg2, _Opts) -> {ok, Msg1}.
+snapshot(Msg1, _Msg2, _Opts) -> {ok, Msg1}.
+
+%% @doc Find `PATCH' requests in the `results/outbox' of the message, and apply
+%% them to the state.
+compute(Msg1, Msg2, Opts) ->
+    % Find the input keys.
+    PatchFrom = hb_converge:get_first(
+        [
+            {Msg2, <<"patch-from">>},
+            {Msg1, <<"patch-from">>}
+        ],
+        <<"/results/outbox">>,
+        Opts
+    ),
+    PatchTo = hb_converge:get_first(
+        [
+            {Msg2, <<"patch-to">>},
+            {Msg1, <<"patch-to">>}
+        ],
+        <<"/">>,
+        Opts
+    ),
+    ?event({patch_from, PatchFrom}),
+    ?event({patch_to, PatchTo}),
+    % Get the outbox from the message.
+    Outbox = hb_converge:get(PatchFrom, Msg1, #{}, Opts),
+    % Find all messages with the PATCH request.
+    Patches =
+        maps:filter(
+            fun(_, Msg) ->
+                hb_converge:get(<<"method">>, Msg, Opts) == <<"PATCH">>
+            end,
+            Outbox
+        ),
+    OutboxWithoutPatches = maps:without(maps:keys(Patches), Outbox),
+    % Find the state to apply the patches to.
+    % Apply the patches to the state.
+    PatchedSubmessage =
+        maps:fold(
+            fun(_, Patch, MsgN) ->
+                ?event({patching, {patch, Patch}, {before, MsgN}}),
+                Res = hb_converge:set(
+                    MsgN,
+                    maps:without([<<"method">>], Patch),
+                    Opts
+                ),
+                ?event({patched, {'after', Res}}),
+                Res
+            end,
+            case PatchTo of
+                not_found -> Msg1;
+                PatchTo -> hb_converge:get(PatchTo, Msg1, Opts)
+            end,
+            Patches
+        ),
+    PatchedState =
+        case PatchTo of
+            <<"/">> -> PatchedSubmessage;
+            _ -> hb_converge:set(Msg1, PatchTo, PatchedSubmessage, Opts)
+        end,
+    % Return the patched message.
+    Res = {
+        ok,
+        hb_converge:set(
+            PatchedState,
+            <<"/results/outbox">>,
+            OutboxWithoutPatches,
+            Opts
+        )
+    },
+    ?event({patch_result, Res}),
+    Res.
+
+%%% Tests
+
+uninitialized_patch_test() ->
+    InitState = #{
+        <<"device">> => <<"patch@1.0">>,
+        <<"results">> => #{
+            <<"outbox">> => #{
+                <<"1">> => #{
+                    <<"method">> => <<"PATCH">>,
+                    <<"prices">> => #{
+                        <<"apple">> => 100,
+                        <<"banana">> => 200
+                    }
+                },
+                <<"2">> => #{
+                    <<"method">> => <<"GET">>,
+                    <<"prices">> => #{
+                        <<"apple">> => 1000
+                    }
+                }
+            }
+        },
+        <<"other-message">> => <<"other-value">>,
+        <<"patch-to">> => <<"/">>,
+        <<"patch-from">> => <<"/results/outbox">>
+    },
+    {ok, ResolvedState} =
+        hb_converge:resolve(
+            InitState,
+            <<"compute">>,
+            #{}
+        ),
+    ?event({resolved_state, ResolvedState}),
+    ?assertEqual(
+        100,
+        hb_converge:get(<<"prices/apple">>, ResolvedState, #{})
+    ),
+    ?assertMatch(
+        not_found,
+        hb_converge:get(<<"results/outbox/1">>, ResolvedState, #{})
+    ).
+
+patch_to_submessage_test() ->
+    InitState = #{
+        <<"device">> => <<"patch@1.0">>,
+        <<"results">> => #{
+            <<"outbox">> => #{
+                <<"1">> => #{
+                    <<"method">> => <<"PATCH">>,
+                    <<"prices">> => #{
+                        <<"apple">> => 100,
+                        <<"banana">> => 200
+                    }
+                }
+            }
+        },
+        <<"state">> => #{
+            <<"prices">> => #{
+                <<"apple">> => 1000
+            }
+        },
+        <<"other-message">> => <<"other-value">>,
+        <<"patch-to">> => <<"/state">>,
+        <<"patch-from">> => <<"/results/outbox">>
+    },
+    {ok, ResolvedState} =
+        hb_converge:resolve(
+            InitState,
+            <<"compute">>,
+            #{}
+        ),
+    ?event({resolved_state, ResolvedState}),
+    ?assertEqual(
+        100,
+        hb_converge:get(<<"state/prices/apple">>, ResolvedState, #{})
+    ).

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -249,7 +249,7 @@ now(RawMsg1, _Msg2, Opts) ->
     ?event({now_called, {process, ProcessID}, {slot, CurrentSlot}}),
     hb_converge:resolve(
         Msg1,
-        #{ <<"path">> => <<"compute/results">>, <<"slot">> => CurrentSlot },
+        #{ <<"path">> => <<"compute">>, <<"slot">> => CurrentSlot },
         Opts
     ).
 
@@ -891,7 +891,7 @@ now_results_test() ->
         Msg1 = test_aos_process(),
         schedule_aos_call(Msg1, <<"return 1+1">>),
         schedule_aos_call(Msg1, <<"return 2+2">>),
-        ?assertEqual({ok, <<"4">>}, hb_converge:resolve(Msg1, <<"now/data">>, #{}))
+        ?assertEqual({ok, <<"4">>}, hb_converge:resolve(Msg1, <<"now/results/data">>, #{}))
     end}.
 
 full_push_test_() ->
@@ -913,7 +913,7 @@ full_push_test_() ->
         {ok, _} = hb_converge:resolve(Msg1, Msg3, #{}),
         ?assertEqual(
             {ok, <<"Done.">>},
-            hb_converge:resolve(Msg1, <<"now/data">>, #{})
+            hb_converge:resolve(Msg1, <<"now/results/data">>, #{})
         )
     end}.
 

--- a/src/hb.erl
+++ b/src/hb.erl
@@ -124,15 +124,19 @@ do_start_mainnet(Opts) ->
         os_mon,
         rocksdb
     ]),
+    Wallet = wallet(<<"mainnet-wallet.json">>),
+    BaseOpts = hb_http_server:set_default_opts(Opts),
     hb_http_server:start_node(
-        Opts#{
-            store => {hb_store_fs, #{ prefix => "main-cache" }}
-        }
+        FinalOpts =
+            BaseOpts#{
+                store => {hb_store_fs, #{ prefix => "main-cache" }},
+                priv_wallet => Wallet
+            }
     ),
     Address =
-        case hb_opts:get(priv_wallet, no_wallet, Opts) of
-            no_wallet -> <<"[ !!! no-wallet !!! ]">>;
-            Wallet -> ar_wallet:to_address(Wallet)
+        case hb_opts:get(address, no_address, FinalOpts) of
+            no_address -> <<"[ !!! no-address !!! ]">>;
+            Addr -> Addr
         end,
     io:format(
         "Started mainnet node at http://localhost:~p~n"

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -169,7 +169,7 @@ cors_reply(Req, _ServerID) ->
         <<"access-control-allow-origin">> => <<"*">>,
         <<"access-control-allow-headers">> => <<"*">>,
         <<"access-control-allow-methods">> =>
-            <<"GET, POST, PUT, DELETE, OPTIONS">>
+            <<"GET, POST, PUT, DELETE, OPTIONS, PATCH">>
     }, Req).
 
 %% @doc Handle all non-CORS preflight requests as Converge requests. Execution 
@@ -187,7 +187,7 @@ handle_request(Req, ServerID) ->
 
 %% @doc Return the list of allowed methods for the HTTP server.
 allowed_methods(Req, State) ->
-    {[<<"GET">>, <<"POST">>, <<"PUT">>, <<"DELETE">>, <<"OPTIONS">>], Req, State}.
+    {[<<"GET">>, <<"POST">>, <<"PUT">>, <<"DELETE">>, <<"OPTIONS">>, <<"PATCH">>], Req, State}.
 
 %% @doc Update the `Opts' map that the HTTP server uses for all future
 %% requests.

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -11,7 +11,7 @@
 %%% the execution parameters of all downstream requests to be controlled.
 -module(hb_http_server).
 -export([start/0, start/1, allowed_methods/2, init/2, set_opts/1, get_opts/1]).
--export([start_node/0, start_node/1]).
+-export([start_node/0, start_node/1, set_default_opts/1]).
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
 
@@ -44,7 +44,7 @@ start(Opts) ->
         rocksdb
     ]),
     hb:init(),
-    BaseOpts = set_base_opts(Opts),
+    BaseOpts = set_default_opts(Opts),
     {ok, Listener, _Port} = new_server(BaseOpts),
     {ok, Listener}.
 
@@ -201,7 +201,7 @@ get_opts(NodeMsg) ->
 
 %%% Tests
 
-set_base_opts(Opts) ->
+set_default_opts(Opts) ->
     % Create a temporary opts map that does not include the defaults.
     TempOpts = Opts#{ only => local },
     % Generate a random port number between 10000 and 30000 to use
@@ -229,7 +229,12 @@ set_base_opts(Opts) ->
                 };
             PassedStore -> PassedStore
         end,
-    ?event({set_base_opts, TempOpts, Port, Store, Wallet}),
+    ?event({set_default_opts,
+        {given, TempOpts},
+        {port, Port},
+        {store, Store},
+        {wallet, Wallet}
+    }),
     Opts#{
         port => Port,
         store => Store,
@@ -257,6 +262,6 @@ start_node(Opts) ->
     ]),
     hb:init(),
     hb_sup:start_link(Opts),
-    ServerOpts = set_base_opts(Opts),
+    ServerOpts = set_default_opts(Opts),
     {ok, _Listener, Port} = new_server(ServerOpts),
     <<"http://localhost:", (integer_to_binary(Port))/binary, "/">>.

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -79,6 +79,8 @@ default_message() ->
                 <<"structured@1.0">> => dev_codec_structured,
                 <<"lookup@1.0">> => dev_lookup,
                 <<"genesis-wasm@1.0">> => dev_genesis_wasm,
+                <<"delegated-compute@1.0">> => dev_delegated_compute,
+                <<"patch@1.0">> => dev_patch,
                 <<"test-device@1.0">> => dev_test
             },
         %% Default execution cache control options


### PR DESCRIPTION
Also changes a couple of other areas:
- `process@1.0/now` endpoint returns the full state, so that patched state can be accessed by `/procID/now/stateName`.
- `hb_cache_render` options improvements