### PR TITLE
Fix scheduler_location_test by making ANS-104 validation operate on original, not normalized tx tags

### DIFF
--- a/src/dev_codec_ans104.erl
+++ b/src/dev_codec_ans104.erl
@@ -120,9 +120,9 @@ do_from(RawTX) ->
     % Necessary for reconstructing deephash material in ar_bundles that would match
     % the signature and make ar_bundle:verify_item pass
     OriginalTags = TX#tx.tags,
-    PrivMap0 = maps:get(<<"priv">>, MapWithoutData, #{}),
-    PrivMap1 = maps:put(<<"original_tags">>, OriginalTags, PrivMap0),
-    MapWithPreservedTags = MapWithoutData#{ <<"priv">> => PrivMap1 },
+    OriginalPriv = maps:get(<<"priv">>, MapWithoutData, #{}),
+    PrivWithOriginalTags = maps:put(<<"original_tags">>, OriginalTags, OriginalPriv),
+    MapWithPreservedTags = MapWithoutData#{ <<"priv">> => PrivWithOriginalTags },
 
     DataMap =
         case TX#tx.data of

--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -257,14 +257,14 @@ exec_for_attestation(Func, Base, Attestation, Req, Opts) ->
             3,
             Opts
         ),
-	% Remove `priv' from the message before running hb_message:convert
-	Encodable = maps:remove(<<"priv">>, AttestionMessage),
-	Encoded = hb_message:convert(Encodable, tabm, Opts),
-	% Re-inject `priv' into the message.
-	PrivMap = maps:get(<<"priv">>, AttestionMessage, #{}),
-	EncodedFixed = Encoded#{ <<"priv">> => PrivMap },
-	Applied = apply(AttFun, [EncodedFixed, Req, Opts]),
-	{ok, Applied}.
+    % Remove `priv' from the message before running hb_message:convert
+    Encodable = maps:remove(<<"priv">>, AttestionMessage),
+    Encoded = hb_message:convert(Encodable, tabm, Opts),
+    % Re-inject `priv' into the message.
+    PrivMap = maps:get(<<"priv">>, AttestionMessage, #{}),
+    EncodedFixed = Encoded#{ <<"priv">> => PrivMap },
+    Applied = apply(AttFun, [EncodedFixed, Req, Opts]),
+    {ok, Applied}.
 
 %% @doc Return the list of attested keys from a message.
 %% @doc Set keys in a message. Takes a map of key-value pairs and sets them in

--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -257,8 +257,14 @@ exec_for_attestation(Func, Base, Attestation, Req, Opts) ->
             3,
             Opts
         ),
-    Encoded = hb_message:convert(AttestionMessage, tabm, Opts),
-    apply(AttFun, [Encoded, Req, Opts]).
+	% Remove `priv' from the message before running hb_message:convert
+	Encodable = maps:remove(<<"priv">>, AttestionMessage),
+	Encoded = hb_message:convert(Encodable, tabm, Opts),
+	% Re-inject `priv' into the message.
+	PrivMap = maps:get(<<"priv">>, AttestionMessage, #{}),
+	EncodedFixed = Encoded#{ <<"priv">> => PrivMap },
+	Applied = apply(AttFun, [EncodedFixed, Req, Opts]),
+	{ok, Applied}.
 
 %% @doc Return the list of attested keys from a message.
 %% @doc Set keys in a message. Takes a map of key-value pairs and sets them in

--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -206,6 +206,7 @@ ans104_no_data_item_test() ->
     {ok, Res} = read(<<"0Tb9mULcx8MjYVgXleWMVvqo1_jaw_P6AO_CJMTj0XE">>, #{}),
     ?event(gateway, {get_ans104_test, Res}),
     ?event(gateway, {signer, hb_message:signers(Res)}),
+    % ?assert(hb_message:verify(Res)).
     ?assert(true).
 
 %% @doc Test that we can get the scheduler location.
@@ -214,6 +215,7 @@ scheduler_location_test() ->
     _Node = hb_http_server:start_node(#{}),
     {ok, Res} = scheduler_location(<<"fcoN_xJeisVsPXA-trzVAuIiqO3ydLQxM-L4XbrQKzY">>, #{}),
     ?event(gateway, {get_scheduler_location_test, Res}),
+    ?assert(hb_message:verify(Res)),
     ?assertEqual(<<"Scheduler-Location">>, hb_converge:get(<<"Type">>, Res, #{})),
     ?event(gateway, {scheduler_location, {explicit, hb_converge:get(<<"url">>, Res, #{})}}),
     % Will need updating when Legacynet terminates.


### PR DESCRIPTION
This PR addresses a tag normalization issue that was breaking [ANS-104](https://github.com/ArweaveTeam/arweave-standards/blob/master/ans/ANS-104.md/) signature validation.

ANS-104 signature validation happens on top of an ephemeral binary blob constructed using these rules from ANS-102: https://github.com/ArweaveTeam/arweave-standards/blob/master/ans/ANS-102.md#2-dataitem-signature-and-id

Part of it is an array of Tags. Inside `dev_codec_ans104.erl`, tags have to be normalized to be compatible with the rest of HyperBEAM, which was causing `ar_bundles:verify_item` to fail, because the blob would be reconstructed with lowercased and potentially permuted tags.

To fix this, we preserve `original_tags` inside `priv` field when converting to TABM, keep it throughout its lifetime, and patch the tx with original_tags just before sending to `ar_bundles:verify_item`.

Test with: `rebar3 eunit --test=hb_gateway_client:scheduler_location_test`,
or: `HB_PRINT=dev_codec_ans104,hb_gateway_client,dev_message,hb_message,ar_bundles rebar3 eunit --test=hb_gateway_client:scheduler_location_test` for more verbosity.