### PR TITLE
draft: support IDs in header names for httpsig@1.0 via percent encoding

### DIFF
--- a/src/dev_codec_httpsig_conv.erl
+++ b/src/dev_codec_httpsig_conv.erl
@@ -40,7 +40,9 @@
 %% @doc Convert a HTTP Message into a TABM.
 %% HTTP Structured Field is encoded into it's equivalent TABM encoding.
 from(Bin) when is_binary(Bin) -> Bin;
-from(HTTP) ->
+from(RawHTTP) ->
+    % Decode the keys of the HTTP message
+    HTTP = hb_escape:decode_keys(RawHTTP),
     Body = maps:get(<<"body">>, HTTP, <<>>),
     % First, parse all headers excluding the signature-related headers, as they
     % are handled separately.
@@ -286,6 +288,8 @@ attestations_from_signature(Map, HPs, RawSig, RawSigInput) ->
 to(Bin) when is_binary(Bin) -> Bin;
 to(TABM) -> to(TABM, []).
 to(TABM, Opts) when is_map(TABM) ->
+    % Encode the keys of the TABM
+    EncodedTABM = hb_escape:encode_keys(TABM),
     Stripped =
         maps:without(
             [
@@ -294,7 +298,7 @@ to(TABM, Opts) when is_map(TABM) ->
                 <<"signature-input">>,
                 <<"priv">>
             ],
-            TABM
+            EncodedTABM
         ),
     ?event({stripped, Stripped}),
     {InlineFieldHdrs, InlineKey} = inline_key(TABM),

--- a/src/dev_codec_structured.erl
+++ b/src/dev_codec_structured.erl
@@ -89,7 +89,7 @@ from(Msg) when is_map(Msg) ->
                     lists:map(
                         fun({Key, Value}) ->
                             {ok, Item} = hb_structured_fields:to_item(Value),
-                            {Key, Item}
+                            {hb_escape:encode(Key), Item}
                         end,
                         lists:reverse(T)
                     )
@@ -169,7 +169,9 @@ parse_ao_types(Msg) when is_map(Msg) ->
 parse_ao_types(Bin) ->
     maps:from_list(
         lists:map(
-            fun({Key, {item, {_, Value}, _}}) -> {Key, Value} end,
+            fun({Key, {item, {_, Value}, _}}) ->
+                {hb_escape:decode(Key), Value}
+            end,
             hb_structured_fields:parse_dictionary(Bin)    
         )
     ).

--- a/src/hb_escape.erl
+++ b/src/hb_escape.erl
@@ -1,0 +1,115 @@
+%%% @doc Escape and unescape mixed case values for use in HTTP headers.
+%%% This is necessary for encodings of AO-Core messages for transmission in 
+%%% HTTP/2 and HTTP/3, because uppercase header keys are explicitly disallowed.
+%%% While most map keys in HyperBEAM are normalized to lowercase, IDs are not.
+%%% Subsequently, we encode all header keys to lowercase %-encoded URI-style
+%%% strings because transmission.
+-module(hb_escape).
+-export([encode/1, decode/1, encode_keys/1, decode_keys/1]).
+-include_lib("eunit/include/eunit.hrl").
+
+%% @doc Encode a binary as a URI-encoded string.
+encode(Bin) when is_binary(Bin) ->
+    list_to_binary(percent_escape(binary_to_list(Bin))).
+
+%% @doc Decode a URI-encoded string back to a binary.
+decode(Bin) when is_binary(Bin) ->
+    list_to_binary(percent_unescape(binary_to_list(Bin))).
+
+%% @doc Return a message with all of its keys decoded.
+decode_keys(Msg) when is_map(Msg) ->
+    maps:from_list(
+        lists:map(
+            fun({Key, Value}) -> {decode(Key), Value} end,
+            maps:to_list(Msg)
+        )
+    );
+decode_keys(Other) -> Other.
+
+%% @doc URI encode keys in the base layer of a message. Does not recurse.
+encode_keys(Msg) when is_map(Msg) ->
+    maps:from_list(
+        lists:map(
+            fun({Key, Value}) -> {encode(Key), Value} end,
+            maps:to_list(Msg)
+        )
+    );
+encode_keys(Other) -> Other.
+
+%% @doc Escape a list of characters as a URI-encoded string.
+percent_escape([]) -> [];
+percent_escape([C | Cs]) when C >= $a, C =< $z -> [C | percent_escape(Cs)];
+percent_escape([C | Cs]) when C >= $0, C =< $9 -> [C | percent_escape(Cs)];
+percent_escape([C | Cs]) when
+        C == $.; C == $-; C == $_; C == $/;
+        C == $?; C == $&; C == $+ ->
+    [C | percent_escape(Cs)];
+percent_escape([C | Cs]) -> [escape_byte(C) | percent_escape(Cs)].
+
+%% @doc Escape a single byte as a URI-encoded string.
+escape_byte(C) when C >= 0, C =< 255 ->
+    [$%, hex_digit(C bsr 4), hex_digit(C band 15)].
+
+hex_digit(N) when N >= 0, N =< 9 ->
+    N + $0;
+hex_digit(N) when N > 9, N =< 15 ->
+    N + $a - 10.
+
+%% @doc Unescape a URI-encoded string.
+percent_unescape([$%, H1, H2 | Cs]) ->
+    Byte = (hex_value(H1) bsl 4) + hex_value(H2),
+    [Byte | percent_unescape(Cs)];
+percent_unescape([C | Cs]) ->
+    [C | percent_unescape(Cs)];
+percent_unescape([]) ->
+    [].
+
+hex_value(C) when C >= $0, C =< $9 ->
+    C - $0;
+hex_value(C) when C >= $a, C =< $f ->
+    C - $a + 10;
+hex_value(C) when C >= $A, C =< $F ->
+    C - $A + 10.
+
+%%% Tests
+
+escape_unescape_identity_test() ->
+    % Test that unescape(escape(X)) == X for various inputs
+    TestCases = [
+        <<"hello">>,
+        <<"hello, world!">>,
+        <<"special@chars#here">>,
+        <<"UPPERCASE">>,
+        <<"MixedCASEstring">>,
+        <<"12345">>,
+        <<>> % Empty string
+    ],
+    lists:foreach(fun(TestCase) ->
+        ?assertEqual(TestCase, decode(encode(TestCase)))
+    end, TestCases).
+
+unescape_specific_test() ->
+    % Test specific unescape cases
+    ?assertEqual(<<"a">>, decode(<<"%61">>)),
+    ?assertEqual(<<"A">>, decode(<<"%41">>)),
+    ?assertEqual(<<"!">>, decode(<<"%21">>)),
+    ?assertEqual(<<"hello, World!">>, decode(<<"hello%2c%20%57orld%21">>)),
+    ?assertEqual(<<"/">>, decode(<<"%2f">>)),
+    ?assertEqual(<<"?">>, decode(<<"%3f">>)).
+
+uppercase_test() ->
+    % Test uppercase characters are properly escaped
+    ?assertEqual(<<"%41">>, encode(<<"A">>)),
+    ?assertEqual(<<"%42">>, encode(<<"B">>)),
+    ?assertEqual(<<"%5a">>, encode(<<"Z">>)),
+    ?assertEqual(<<"hello%20%57orld">>, encode(<<"hello World">>)),
+    ?assertEqual(<<"test%41%42%43">>, encode(<<"testABC">>)).
+
+escape_unescape_special_chars_test() ->
+    % Test characters that should be escaped
+    SpecialChars = [
+        $@, $#, $", $$, $%, $&, $', $(, $), $*, $+, $,, $/, $:, $;, 
+        $<, $=, $>, $?, $[, $\\, $], $^, $`, ${, $|, $}, $~, $\s
+    ],
+    TestString = list_to_binary(SpecialChars),
+    ?assertEqual(TestString, decode(encode(TestString))).

--- a/src/hb_structured_fields.erl
+++ b/src/hb_structured_fields.erl
@@ -175,7 +175,7 @@ parse_dict_key(<<$=, R0/bits>>, Acc, K) ->
     parse_dict_before_sep(R, lists:keystore(K, 1, Acc, {K, Item}));
 parse_dict_key(<<C, R/bits>>, Acc, K) when
         ?IS_LC_ALPHA(C) or ?IS_DIGIT(C) or
-        (C =:= $_) or (C =:= $-) or (C =:= $.) or (C =:= $*) ->
+        (C =:= $_) or (C =:= $-) or (C =:= $.) or (C =:= $*) or (C =:= $%) ->
     parse_dict_key(R, Acc, <<K/binary, C>>);
 parse_dict_key(<<$;, R0/bits>>, Acc, K) ->
     {Params, R} = parse_before_param(R0, []),


### PR DESCRIPTION
This proposal implements percent encoding and decoding for IDs that are passed over the wire as HTTP headers. This generates rather long and ugly header names, but critically circumvents the issue of HTTP/2 and HTTP/3 requiring strictly lower-case keys during transmission, and Arweave's usage of mixed case keys. Notably, this only applies to header names -- not their associated values.

One improvement to this patch to minimize the  jank could be to ensure that multipart message elements do not have this encoding applied. Their headers, however, would still require it.
