### PR TITLE
feat: cache scheduler data and support POST of data items to `delegated-compute@1.0`.

### DIFF
--- a/src/dev_codec_json.erl
+++ b/src/dev_codec_json.erl
@@ -9,6 +9,7 @@
 content_type(_) -> {ok, <<"application/json">>}.
 
 %% @doc Encode a message to a JSON string.
+to(Msg) when is_binary(Msg) -> iolist_to_binary(json:encode(Msg));
 to(Msg) -> iolist_to_binary(json:encode(hb_private:reset(Msg))).
 
 %% @doc Decode a JSON string to a message.

--- a/src/dev_delegated_compute.erl
+++ b/src/dev_delegated_compute.erl
@@ -16,20 +16,19 @@ snapshot(Msg1, _Msg2, _Opts) -> {ok, Msg1}.
 
 compute(Msg1, Msg2, Opts) ->
     RawProcessID = dev_process:process_id(Msg1, #{}, Opts),
-    Slot = hb_converge:get(<<"slot">>, Msg2, Opts),
     OutputPrefix = dev_stack:prefix(Msg1, Msg2, Opts),
     ProcessID =
         case RawProcessID of
             not_found -> hb_converge:get(<<"process-id">>, Msg2, Opts);
             ProcID -> ProcID
         end,
-    Res = do_compute(ProcessID, Slot, Opts),
+    Res = do_compute(ProcessID, Msg2, Opts),
     case Res of
         {ok, JSONRes} ->
             ?event(
                 {compute_lite_res,
                     {process_id, ProcessID},
-                    {slot, Slot},
+                    {slot, hb_converge:get(<<"slot">>, Msg2, Opts)},
                     {json_res, {string, JSONRes}},
                     {req, Msg2}
                 }
@@ -54,17 +53,33 @@ compute(Msg1, Msg2, Opts) ->
     end.
 
 %% @doc Execute computation on a remote machine via relay and the JSON-Iface.
-do_compute(ProcID, Slot, Opts) ->
+do_compute(ProcID, Msg2, Opts) ->
+    ?event(debug_cu, {do_compute_msg, {msg2, Msg2}}),
+    Slot = hb_converge:get(<<"slot">>, Msg2, Opts),
+    {ok, AOS2 = #{ <<"body">> := Body }} =
+        dev_scheduler_formats:assignments_to_aos2(
+            ProcID,
+            #{
+                Slot => Msg2
+            },
+            false,
+            Opts
+        ),
+    ?event(debug_cu, {do_compute_msg, {aos2, {string, Body}}}),
     Res = 
-        hb_converge:resolve(#{ <<"device">> => <<"relay@1.0">> }, #{
-            <<"path">> => <<"call">>,
-            <<"relay-path">> =>
-                <<
-                    "/result/",
-                    (integer_to_binary(Slot))/binary,
-                    "?process-id=",
-                    ProcID/binary
-                >>
+        hb_converge:resolve(#{ <<"device">> => <<"relay@1.0">>, <<"content-type">> => <<"application/json">> },
+            AOS2#{
+                <<"path">> => <<"call">>,
+                <<"relay-method">> => <<"POST">>,
+                <<"relay-body">> => Body,
+                <<"relay-path">> =>
+                    <<
+                        "/result/",
+                        (integer_to_binary(Slot))/binary,
+                        "?process-id=",
+                        ProcID/binary
+                    >>,
+                <<"content-type">> => <<"application/json">>
             },
             Opts
         ),

--- a/src/dev_json_iface.erl
+++ b/src/dev_json_iface.erl
@@ -124,6 +124,7 @@ message_to_json_struct(RawMsg, Features) ->
             #{}
         ),
     ID = hb_message:id(RawMsg, all),
+    ?event(next_debug, {encoding, {id, ID}, {msg, RawMsg}}),
     Last = hb_converge:get(<<"anchor">>, {as, <<"message@1.0">>, Message}, <<>>, #{}),
 	Owner =
         case hb_message:signers(RawMsg) of

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -301,7 +301,7 @@ remote_schedule_result(Location, SignedReq, Opts) ->
             <<"Message">> -> RedirectPath
         end,
     % Store a copy of the message for ourselves.
-    hb_cache:write(SignedReq, Opts),
+    {ok, _} = hb_cache:write(SignedReq, Opts),
     ?event(push, {remote_schedule_result, {path, Path}}, Opts),
     case hb_http:post(Node, Path, maps:without([<<"path">>], SignedReq), Opts) of
         {ok, Res} ->

--- a/src/dev_relay.erl
+++ b/src/dev_relay.erl
@@ -31,7 +31,8 @@ call(M1, RawM2, Opts) ->
         hb_converge:get_first(
             [
                 {RawM2, <<"relay-path">>},
-                {M1, <<"relay-path">>}
+                {M1, <<"relay-path">>},
+                {M1, <<"path">>}
             ],
             Opts
         ),

--- a/src/dev_relay.erl
+++ b/src/dev_relay.erl
@@ -35,13 +35,31 @@ call(M1, RawM2, Opts) ->
             ],
             Opts
         ),
-    TargetMod1 =
-        case RelayPath of
-            not_found -> BaseTarget;
-            RPath ->
-                ?event({setting_path, {base_target, BaseTarget}, {relay_path, {explicit, RPath}}}),
-                hb_converge:set(BaseTarget, <<"path">>, RPath, Opts)
-        end,
+    RelayMethod =
+        hb_converge:get_first(
+            [
+                {RawM2, <<"relay-method">>},
+                {M1, <<"relay-method">>},
+                {RawM2, <<"method">>},
+                {M1, <<"method">>}
+            ],
+            Opts
+        ),
+    RelayBody =
+        hb_converge:get_first(
+            [
+                {RawM2, <<"relay-body">>},
+                {M1, <<"relay-body">>},
+                {RawM2, <<"body">>},
+                {M1, <<"body">>}
+            ],
+            Opts
+        ),
+    TargetMod1 = BaseTarget#{
+        <<"method">> => RelayMethod,
+        <<"body">> => RelayBody,
+        <<"path">> => RelayPath
+    },
     TargetMod2 =
         case hb_converge:get(<<"requires-sign">>, BaseTarget, false, Opts) of
             true -> hb_message:attest(TargetMod1, Opts);
@@ -52,7 +70,7 @@ call(M1, RawM2, Opts) ->
             not_found -> hb_opts:get(relay_http_client, Opts);
             RequestedClient -> RequestedClient
         end,
-    ?event({relaying_message, TargetMod2}),
+    ?event(debug_cu, {relaying_message, TargetMod2}),
     % Let `hb_http:request/2' handle finding the peer and dispatching the request.
     hb_http:request(TargetMod2, Opts#{ http_client => Client }).
 

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -342,7 +342,7 @@ do_post_schedule(ProcID, PID, Msg2, Opts) ->
                 }
             };
         {true, <<"Process">>} ->
-            hb_cache:write(Msg2, Opts),
+            {ok, _} = hb_cache:write(Msg2, Opts),
             spawn(fun() -> hb_client:upload(Msg2, Opts) end),
             ?event(
                 {registering_new_process,

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -854,6 +854,8 @@ cache_remote_schedule(Schedule, Opts) ->
     Assignments = hb_converge:get(<<"assignments">>, Schedule, Opts),
     lists:foreach(
         fun(Assignment) ->
+            % We do not care about the result of the write because it is only
+            % an additional cache.
             dev_scheduler_cache:write(Assignment, Opts)
         end,
         AssignmentList =

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -73,7 +73,7 @@ next(Msg1, Msg2, Opts) ->
             Opts
         ),
     LastProcessed = hb_util:int(hb_converge:get(<<"at-slot">>, Msg1, Opts)),
-    ?event(next, {local_schedule_cache, {schedule, Schedule}}),
+    ?event(next, {in_message_cache, {schedule, Schedule}}),
     Assignments =
         case Schedule of
             X when is_map(X) and map_size(X) > 0 -> X;
@@ -99,6 +99,7 @@ next(Msg1, Msg2, Opts) ->
                 maps:to_list(maps:without([<<"priv">>, <<"attestations">>], Assignments))
             )
         ),
+    ?event(next, {norm_assignments, {assignments, NormAssignments}}),
     ValidKeys =
         lists:filter(
             fun(Slot) -> Slot > LastProcessed end,
@@ -106,14 +107,19 @@ next(Msg1, Msg2, Opts) ->
         ),
     % Remove assignments that are below the last processed slot.
     FilteredAssignments = maps:with(ValidKeys, NormAssignments),
-    ?event(next, {filtered_assignments, FilteredAssignments}),
+    ?event(next, {filtered_slots, {explicit, ValidKeys}}),
     Slot =
         case ValidKeys of
             [] -> hb_util:int(LastProcessed);
             Slots -> lists:min(Slots)
         end,
     ?event(next,
-        {next_slot_to_process, Slot, {last_processed, LastProcessed}}),
+        {calculating_next_from_assignments,
+            {last_processed, LastProcessed},
+            {next_slot, LastProcessed + 1},
+            {minimum_slot_received, Slot},
+            {assignments_received, maps:size(FilteredAssignments)}
+        }),
     case (LastProcessed + 1) == Slot of
         true ->
             NextMessage =
@@ -540,7 +546,7 @@ remote_slot(<<"ao.TN.1">>, ProcID, Node, Opts) ->
     ?event({getting_slot_from_ao_core_remote, {path, {string, Path}}}),
     case hb_http:get(Node, Path, Opts#{ http_client => httpc }) of
         {ok, Res} ->
-            ?event(debug_sched, {remote_slot_result, {res, Res}}),
+            ?event({remote_slot_result, {res, Res}}),
             case hb_util:int(hb_converge:get(<<"status">>, Res, 200, Opts)) of
                 200 ->
                     Body = hb_converge:get(<<"body">>, Res, Opts),
@@ -578,7 +584,7 @@ remote_slot(<<"ao.TN.1">>, ProcID, Node, Opts) ->
                     {error, Res}
             end;
         {error, Res} ->
-            ?event(debug_sched, {remote_slot_error, {error, Res}}),
+            ?event({remote_slot_error, {error, Res}}),
             {error, Res}
     end.
 
@@ -637,9 +643,39 @@ get_schedule(Msg1, Msg2, Opts) ->
             end
     end.
 
-%% @doc Get a schedule from a remote scheduler.
+%% @doc Get a schedule from a remote scheduler, but first read all of the 
+%% assignments from the local cache that we already know about.
 get_remote_schedule(RawProcID, From, To, Redirect, Opts) ->
     ProcID = without_hint(RawProcID),
+    {FromLocalCache, _} = get_local_assignments(ProcID, From, To, Opts),
+    ?event(debug_sched, {from_local_cache, {from, From}, {to, To}, {read, length(FromLocalCache)}}),
+    do_get_remote_schedule(
+        ProcID,
+        FromLocalCache,
+        length(FromLocalCache),
+        To,
+        Redirect,
+        Opts
+    ).
+
+%% @doc Get a schedule from a remote scheduler, unless we already have already
+%% read all of the assignments from the local cache.
+do_get_remote_schedule(ProcID, LocalAssignments, From, To, _, Opts) when From > To ->
+    % We already have all of the assignments from the local cache. Return them
+    % as a bundle. We set the 'more' to `undefined' to indicate that there may
+    % be more assignments to fetch, but we don't know for sure.
+    Res = 
+        dev_scheduler_formats:assignments_to_bundle(
+            ProcID,
+            LocalAssignments,
+            undefined,
+            Opts
+        ),
+    ?event(debug_sched, {returning_remote_schedule_from_only_cache, Res}),
+    Res;
+do_get_remote_schedule(ProcID, LocalAssignments, From, To, Redirect, Opts) ->
+    % We don't have all of the assignments from the local cache, so we need to
+    % fetch the rest from the remote scheduler.
     Node = node_from_redirect(Redirect, Opts),
     Variant = hb_converge:get(<<"variant">>, Redirect, <<"ao.N.1">>, Opts),
     ?event(
@@ -699,38 +735,91 @@ get_remote_schedule(RawProcID, From, To, Redirect, Opts) ->
             ?event(push, {remote_schedule_result, {res, Res}}, Opts),
             case hb_util:int(hb_converge:get(<<"status">>, Res, 200, Opts)) of
                 200 ->
-                    case Variant of
-                        <<"ao.N.1">> ->
-                            {ok, Res};
-                        <<"ao.TN.1">> ->
-                            JSONRes =
-                                jiffy:decode(
-                                    hb_converge:get(
-                                        <<"body">>,
-                                        Res,
-                                        <<"">>,
-                                        Opts
+                    {ok, NormSched} = 
+                        case Variant of
+                            <<"ao.N.1">> ->
+                                {ok, Res};
+                            <<"ao.TN.1">> ->
+                                JSONRes =
+                                    jiffy:decode(
+                                        hb_converge:get(
+                                            <<"body">>,
+                                            Res,
+                                            <<"">>,
+                                            Opts
+                                        ),
+                                        [return_maps]
                                     ),
-                                    [return_maps]
-                                ),
-                            Filtered = filter_json_assignments(JSONRes, To, From),
-                            dev_scheduler_formats:aos2_to_assignments(
-                                ProcID,
-                                Filtered,
-                                Opts
+                                Filtered = filter_json_assignments(JSONRes, To, From),
+                                dev_scheduler_formats:aos2_to_assignments(
+                                    ProcID,
+                                    Filtered,
+                                    Opts
+                                )
+                        end,
+                    cache_remote_schedule(NormSched, Opts),
+                    % Add existing local assignments we read to the remote schedule.
+                    % In order to do this, we need to first convert the remote
+                    % assignments to a list, maintaining the order of the keys.
+                    RemoteAssignments =
+                        hb_util:message_to_ordered_list(
+                            hb_converge:normalize_keys(
+                                hb_converge:get(
+                                    <<"assignments">>,
+                                    NormSched,
+                                    Opts
+                                )
                             )
-                    end;
+                        ),
+                    % Merge the local assignments with the remote assignments,
+                    % and normalize the keys.
+                    Merged =
+                        dev_scheduler_formats:assignments_to_bundle(
+                            ProcID,
+                            MergedAssignments = LocalAssignments ++ RemoteAssignments,
+                            hb_converge:get(<<"continues">>, NormSched, false, Opts),
+                            Opts
+                        ),
+                    ?event(debug_sched,
+                        {returning_remote_schedule,
+                            {length, length(MergedAssignments)},
+                            {from_local_cache, length(LocalAssignments)},
+                            {from_remote_cache, length(RemoteAssignments)}
+                        }
+                    ),
+                    Merged;
                 307 ->
                     % NOTE: Shouldn't this be using the `Res' location key to
                     % regenerate the redirect and recurse on that, instead of
                     % just using the same redirect?
                     ?event({recursing_on_same_redirect, {redirect, Redirect}}),
-                    get_remote_schedule(ProcID, From, To, Redirect, Opts)
+                    do_get_remote_schedule(
+                        ProcID,
+                        LocalAssignments,
+                        From,
+                        To,
+                        Redirect,
+                        Opts
+                    )
             end;
         {error, Res} ->
             ?event(push, {remote_schedule_result, {res, Res}}, Opts),
             {error, Res}
     end.
+
+%% @doc Cache a schedule received from a remote scheduler.
+cache_remote_schedule(Schedule, Opts) ->
+    Assignments = hb_converge:get(<<"assignments">>, Schedule, Opts),
+    lists:foreach(
+        fun(Assignment) ->
+            dev_scheduler_cache:write(Assignment, Opts)
+        end,
+        AssignmentList =
+            maps:values(
+                maps:without([<<"priv">>], hb_converge:normalize_keys(Assignments))
+            )
+    ),
+    ?event(debug_sched, {caching_remote_schedule, {assignments, length(AssignmentList)}}).
 
 %% @doc Get the node URL from a redirect.
 node_from_redirect(Redirect, Opts) ->
@@ -968,21 +1057,22 @@ get_local_assignments(ProcID, From, RequestedTo, Opts) ->
             false -> RequestedTo
         end,
     {
-        do_get_assignments(ProcID, From, ComputedTo, Opts),
+        read_local_assignments(ProcID, From, ComputedTo, Opts),
         ComputedTo < RequestedTo
     }.
 
 %% @doc Get the assignments for a process.
-do_get_assignments(_ProcID, From, To, _Opts) when From > To ->
+read_local_assignments(_ProcID, From, To, _Opts) when From > To ->
     [];
-do_get_assignments(ProcID, CurrentSlot, To, Opts) ->
+read_local_assignments(ProcID, CurrentSlot, To, Opts) ->
     case dev_scheduler_cache:read(ProcID, CurrentSlot, Opts) of
         not_found ->
-            throw(assignment_not_found);
+            % No assignment found in cache.
+            [];
         {ok, Assignment} ->
             [
                 Assignment
-                | do_get_assignments(
+                | read_local_assignments(
                     ProcID,
                     CurrentSlot + 1,
                     To,

--- a/src/dev_scheduler_cache.erl
+++ b/src/dev_scheduler_cache.erl
@@ -111,20 +111,18 @@ read_location(Address, Opts) ->
         ]),
         Opts
     ),
-    ?event(debug_sched, {read_location_msg, {address, Address}, {res, Res}}),
+    ?event({read_location_msg, {address, Address}, {res, Res}}),
     Res.
 
 %% @doc Write the latest known scheduler location for an address.
 write_location(LocationMsg, Opts) ->
     {ok, RootPath} = hb_cache:write(LocationMsg, Opts),
     Signers = hb_message:signers(LocationMsg),
-    ?event(debug_sched,
-        {writing_location_msg,
-            {signers, Signers},
-            {path, RootPath},
-            {location_msg, LocationMsg}
-        }
-    ),
+    ?event({writing_location_msg,
+        {signers, Signers},
+        {path, RootPath},
+        {location_msg, LocationMsg}
+    }),
     lists:foreach(
         fun(Signer) ->
             hb_store:make_link(

--- a/src/dev_scheduler_formats.erl
+++ b/src/dev_scheduler_formats.erl
@@ -9,6 +9,7 @@
 -module(dev_scheduler_formats).
 -export([assignments_to_bundle/4, assignments_to_aos2/4]).
 -export([aos2_to_assignments/3, aos2_to_assignment/2]).
+-export([aos2_normalize_types/1]).
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
 
@@ -21,7 +22,7 @@ assignments_to_bundle(ProcID, Assignments, More, TimeInfo, Opts) ->
     {ok, #{
         <<"type">> => <<"schedule">>,
         <<"process">> => hb_util:human_id(ProcID),
-        <<"continues">> => atom_to_binary(More, utf8),
+        <<"continues">> => hb_util:atom(More),
         <<"timestamp">> => hb_util:int(Timestamp),
         <<"block-height">> => hb_util:int(Height),
         <<"block-hash">> => hb_util:human_id(Hash),

--- a/src/dev_scheduler_server.erl
+++ b/src/dev_scheduler_server.erl
@@ -132,7 +132,7 @@ do_assign(State, Message, ReplyPID) ->
                 State
             ),
             ?event(starting_message_write),
-            dev_scheduler_cache:write(Assignment, maps:get(opts, State)),
+            ok = dev_scheduler_cache:write(Assignment, maps:get(opts, State)),
             maybe_inform_recipient(
                 local_confirmation,
                 ReplyPID,

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -66,12 +66,24 @@ write(RawMsg, Opts) ->
             ?event({writing_full_message, {alt_ids, AltIDs}, {msg, Msg}}),
             Tabm = hb_message:convert(Msg, tabm, <<"structured@1.0">>, Opts),
             ?event({tabm, Tabm}),
-            do_write_message(
+            try do_write_message(
                 Tabm,
                 AltIDs,
                 hb_opts:get(store, no_viable_store, Opts),
                 Opts
-            );
+            )
+            catch
+                Type:Reason:Stacktrace ->
+                    ?event(error,
+                        {cache_write_error,
+                            {type, Type},
+                            {reason, Reason},
+                            {stacktrace, Stacktrace}
+                        },
+                        Opts
+                    ),
+                    {error, no_viable_store}
+            end;
         {error, Err} ->
             {error, Err}
     end.

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -674,15 +674,16 @@ http_sig_to_tabm_singleton(Req = #{ headers := RawHeaders }, Body, Opts) ->
             case Signers =/= [] andalso hb_opts:get(store_all_signed, false, Opts) of
                 true ->
                     ?event(http_verify, {storing_signed_from_wire, SignedMsg}),
-                    hb_cache:write(Msg,
-                        Opts#{
-                            store =>
-                                #{
-                                    <<"store-module">> => hb_store_fs,
-                                    <<"prefix">> => <<"cache-http">>
-                                }
-                        }
-                    );
+                    {ok, _} =
+                        hb_cache:write(Msg,
+                            Opts#{
+                                store =>
+                                    #{
+                                        <<"store-module">> => hb_store_fs,
+                                        <<"prefix">> => <<"cache-http">>
+                                    }
+                            }
+                        );
                 false ->
                     do_nothing
             end,

--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -74,7 +74,7 @@ maybe_cache(StoreOpts, Data) ->
             case hb_cache:write(Data, #{ store => Store}) of
                 {ok, _} -> Data;
                 {error, Err} ->
-                    ?event(warning, {error_writing_to_local_gteway_cache, Err}),
+                    ?event(warning, {error_writing_to_local_gateway_cache, Err}),
                     Data
             end
     end.


### PR DESCRIPTION
This patch improves performance of `milestone 3` evaluation on an embedded legacy CU by approximately 30x (~97% eval time reduction).