### PR TITLE
feat: remote node store

### DIFF
--- a/src/dev_cache.erl
+++ b/src/dev_cache.erl
@@ -1,70 +1,81 @@
 %%% @doc A device that looks up an ID from a local store and returns it, honoring
-%%% the `accept' key to return the correct format. The cache also supports
-%%% writing messages to the store, if the node message has the writer's address
-%%% in its `cache_writers' key.
+%%% the `accept' key to return the correct format. The cache also supports writing
+%%% messages to the store, if the node message has the writer's address in its
+%%% `cache_writers' key.
 -module(dev_cache).
 -export([read/3, write/3]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-%% @doc Read data from the cache using the given key and options.
-%% The options map can specify which store to use, with appropriate configuration.
+%% @doc Read data from the cache.
+%% Retrieves data corresponding to a key from a local store.
+%% The key is extracted from the incoming message under <<"target">>.
+%% The options map may include store configuration.
+%% If the "accept" header is set to <<"application/aos-2">>,
+%% the result is converted to a JSON structure and encoded.
 %%
-%% Example:
-%%   {ok, Data} = dev_cache:read(Key, #{store => StoreConfig})
-%%
-%% Returns:
-%%   {ok, Data} on success
-%%   not_found if the key doesn't exist
-%%   {error, Reason} on failure
+%% @param M1 Ignored parameter.
+%% @param M2 The request message containing the key (<<"target">>) and an optional "accept" header.
+%% @param Opts A map of configuration options.
+%% @returns {ok, Data} on success,
+%%          not_found if the key does not exist,
+%%          {error, Reason} on failure.
 read(_M1, M2, Opts) ->
     ID = hb_converge:get(<<"target">>, M2, Opts),
-    ?event({cache_read, start, {id, ID}, {m2, M2}}),
+    ?event(dev_cache, {read, {key_extracted, ID}}),
     case hb_cache:read(ID, Opts) of
         {ok, Res} ->
-            ?event({cache_read, success, {result, Res}}),
+            ?event(dev_cache, {read, {cache_result, ok, Res}}),
             case hb_converge:get(<<"accept">>, M2, Opts) of
                 <<"application/aos-2">> ->
-                    ?event({cache_read, format, aos2}),
+                    ?event(dev_cache, {read, {accept_header, <<"application/aos-2">>}}),
                     Struct = dev_json_iface:message_to_json_struct(Res),
+                    ?event(dev_cache, {read, {json_struct, Struct}}),
                     {ok,
                         #{
                             <<"body">> => jiffy:encode(Struct),
                             <<"content-type">> => <<"application/aos-2">>
                         }};
                 _ ->
-                    ?event({cache_read, format, default}),
                     {ok, Res}
             end;
         not_found ->
-            ?event({cache_read, not_found, ID}),
+            ?event(dev_cache, {read, {cache_result, not_found}}),
             {error, not_found}
     end.
 
-%% @doc Write data to the cache with the given options.
-%% The options map can specify which store to use, with appropriate configuration.
+%% @doc Write data to the cache.
+%% Processes a write request by first verifying that the request comes from a trusted
+%% writer (as defined by the `cache_writers' configuration in the options). The write
+%% type is determined from the message ("single" or "batch") and the data is stored
+%% accordingly.
 %%
-%% Example:
-%%   {ok, Path} = dev_cache:write(Data, #{store => StoreConfig})
-%%
-%% Returns:
-%%   {ok, Path} on success where Path is the location the data was stored
-%%   {error, Reason} on failure
+%% @param M1 Ignored parameter.
+%% @param M2 The request message containing the data to write, the write type, and any additional parameters.
+%% @param Opts A map of configuration options.
+%% @returns {ok, Path} on success, where Path indicates where the data was stored,
+%%          {error, Reason} on failure.
 write(_M1, M2, Opts) ->
     case is_trusted_writer(M2, Opts) of
         true ->
+            ?event(dev_cache, {write, {trusted_writer, true}}),
             Type = hb_converge:get(<<"type">>, M2, <<"single">>, Opts),
+            ?event(dev_cache, {write, {write_type, Type}}),
             case Type of
-                <<"single">> -> 
+                <<"single">> ->
+                    ?event(dev_cache, {write, {write_single_called}}),
                     write_single(M2, Opts);
                 <<"batch">> ->
+                    ?event(dev_cache, {write, {write_batch_called}}),
                     maps:map(
                         fun(_, Value) ->
+                            ?event(dev_cache, {write, {batch_item, Value}}),
                             write_single(Value, Opts)
                         end,
                         hb_converge:get(<<"body">>, M2, Opts)
                     );
                 _ ->
+                    ?event(dev_cache, {write, {invalid_write_type, Type}}),
                     {error,
                         #{
                             <<"status">> => 400,
@@ -73,7 +84,8 @@ write(_M1, M2, Opts) ->
                     }
             end;
         false ->
-            {error, 
+            ?event(dev_cache, {write, {trusted_writer, false}}),
+            {error,
                 #{
                     <<"status">> => 403,
                     <<"body">> => <<"Not authorized to write to the cache.">>
@@ -81,15 +93,25 @@ write(_M1, M2, Opts) ->
             }
     end.
 
+%% @doc Helper function to write a single data item to the cache.
+%% Extracts the body, location, and operation from the message.
+%% Depending on the type of data (map or binary) or if a link operation is requested,
+%% it writes the data to the store using the appropriate function.
+%%
+%% @param Msg The message containing data to be written.
+%% @param Opts A map of configuration options.
+%% @returns {ok, #{status := 200, path := Path}} on success,
+%%          {error, Reason} on failure.
 write_single(Msg, Opts) ->
     Body = hb_converge:get(<<"body">>, Msg, Opts),
+    ?event(dev_cache, {write_single, {body_extracted, Body}}),
     Location = hb_converge:get(<<"location">>, Msg, Opts),
+    ?event(dev_cache, {write_single, {location_extracted, Location}}),
     Operation = hb_converge:get(<<"operation">>, Msg, <<"write">>, Opts),
-    ?event({write_single, start, {body, Body}, {location, Location}, {operation, Operation}}),
-    
+    ?event(dev_cache, {write_single, {operation, Operation}}),
     case {Operation, Body, Location} of
         {<<"write">>, not_found, _} ->
-            ?event({write_single, error, no_body}),
+            ?event(dev_cache, {write_single, {error, "No body to write"}}),
             {error,
                 #{
                     <<"status">> => 400,
@@ -97,17 +119,25 @@ write_single(Msg, Opts) ->
                 }
             };
         {<<"write">>, Map, _Location} when is_map(Map) ->
+            ?event(dev_cache, {write_single, {processing_map, Map}}),
             {ok, Path} = hb_cache:write(Map, Opts),
+            ?event(dev_cache, {write_single, {map_written, Path}}),
             {ok, #{ <<"status">> => 200, <<"path">> => Path }};
         {<<"write">>, Binary, Location} when is_binary(Binary) ->
+            ?event(dev_cache, {write_single, {processing_binary, Binary, Location}}),
             {ok, Path} = hb_cache:write_binary(Location, Binary, Opts),
+            ?event(dev_cache, {write_single, {binary_written, Path}}),
             {ok, #{ <<"status">> => 200, <<"path">> => Path }};
         {<<"link">>, _, _} ->
+            ?event(dev_cache, {write_single, {processing_link}}),
             Source = hb_converge:get(<<"source">>, Msg, Opts),
             Destination = hb_converge:get(<<"destination">>, Msg, Opts),
+            ?event(dev_cache, {write_single, {link_params, Source, Destination}}),
             ok = hb_cache:link(Source, Destination, Opts),
+            ?event(dev_cache, {write_single, {link_success}}),
             {ok, #{ <<"status">> => 200 }};
         _ ->
+            ?event(dev_cache, {write_single, {error, "Invalid write type"}}),
             {error,
                 #{
                     <<"status">> => 400,
@@ -116,48 +146,123 @@ write_single(Msg, Opts) ->
             }
     end.
 
+%% @doc Verify that the request originates from a trusted writer.
+%% Checks that the single signer of the request is present in the list
+%% of trusted cache writer addresses specified in the options.
+%%
+%% @param Req The request message.
+%% @param Opts A map of configuration options.
+%% @returns true if the request is from an authorized writer, false otherwise.
 is_trusted_writer(Req, Opts) ->
     Signers = hb_message:signers(Req),
+    ?event(dev_cache, {is_trusted_writer, {signers, Signers}}),
     CacheWriters = hb_opts:get(cache_writers, [], Opts),
+    ?event(dev_cache, {is_trusted_writer, {cache_writers, CacheWriters}}),
     case Signers of
         [Signer] ->
-            IsTrusted = lists:member(Signer, CacheWriters),
-            IsTrusted;
-        _ -> 
+            Trusted = lists:member(Signer, CacheWriters),
+            ?event(dev_cache, {is_trusted_writer, {trusted, Trusted}}),
+            Trusted;
+        _ ->
+            ?event(dev_cache, {is_trusted_writer, {trusted, false}}),
             false
     end.
 
-%% Test helpers
+%%%--------------------------------------------------------------------
+%%% Test Helpers
+%%%--------------------------------------------------------------------
 
-%% @doc Create a test environment with a local store and node
+%% @doc Create a test environment with a local store and node.
+%% Ensures that the required application is started, configures a local file-system store,
+%% resets the store for a clean state, creates a wallet for signing requests,
+%% and starts a node with the store and trusted cache writer configuration.
+%%
+%% @param StorePrefix A binary specifying the prefix for the local store.
+%% @returns {LocalStore, Wallet, Address, Node}
 setup_test_env(StorePrefix) ->
-	% Ensure that node is started using ensure_all_started
-	application:ensure_all_started(hb),
-
-    % Set up a local store configuration
+    ?event(dev_cache, {setup_test_env, {start, StorePrefix}}),
+    application:ensure_all_started(hb),
+    ?event(dev_cache, {setup_test_env, {hb_started}}),
     LocalStore = #{ <<"store-module">> => hb_store_fs, <<"prefix">> => StorePrefix },
-    
-    % Reset the store to ensure a clean test environment
+    ?event(dev_cache, {setup_test_env, {local_store_configured, LocalStore}}),
     hb_store:reset(LocalStore),
-    ?event({test_setup, store_reset, {store, LocalStore}}),
-    
-    % Create a wallet for signing requests
+    ?event(dev_cache, {setup_test_env, {store_reset}}),
     Wallet = ar_wallet:new(),
     Address = hb_util:human_id(ar_wallet:to_address(Wallet)),
-    ?event({test_setup, wallet_created, {address, Address}}),
-    
-    % Start a node with our local store
+    ?event(dev_cache, {setup_test_env, {address, Address}}),
     Node = hb_http_server:start_node(#{ 
         store => LocalStore,
         cache_writers => [Address, hb_util:human_id(ar_wallet:to_address(hb:wallet()))],
-		port => 10001
+        port => 10001
     }),
-    ?event({test_setup, node_started, {node, Node}}),
-    
+    ?event(dev_cache, {setup_test_env, {node_started, Node}}),
     {LocalStore, Wallet, Address, Node}.
 
-%% @doc Create test data for cache tests
-create_test_data() ->
+%% @doc Write data to the cache via HTTP.
+%% Constructs a write request message with the provided data, signs it with the given wallet,
+%% sends it to the node, and verifies that the response indicates a successful write.
+%%
+%% @param Node The target node.
+%% @param Data The data to be written.
+%% @param Wallet The wallet used to sign the request.
+%% @returns {ok, WriteResponse} on success.
+write_to_cache(Node, Data, Wallet) ->
+    ?event(dev_cache, {write_to_cache, {start, Node}}),
+    WriteMsg = #{
+        <<"path">> => <<"/~cache@1.0/write">>,
+        <<"method">> => <<"POST">>,
+        <<"body">> => Data
+    },
+    ?event(dev_cache, {write_to_cache, {message_created, WriteMsg}}),
+    SignedMsg = hb_message:attest(WriteMsg, Wallet),
+    ?event(dev_cache, {write_to_cache, {message_signed}}),
+    WriteResult = hb_http:post(Node, SignedMsg, #{}),
+    ?event(dev_cache, {write_to_cache, {http_post, WriteResult}}),
+    {ok, WriteResponse} = WriteResult,
+    ?event(dev_cache, {write_to_cache, {response_received, WriteResponse}}),
+    Status = hb_converge:get(<<"status">>, WriteResponse, 0, #{}),
+    ?assertEqual(200, Status),
+    Path = hb_converge:get(<<"path">>, WriteResponse, not_found, #{}),
+    ?assertNotEqual(not_found, Path),
+    ?event(dev_cache, {write_to_cache, {write_success, Path}}),
+    {WriteResponse, Path}.
+
+%% @doc Read data from the cache via HTTP.
+%% Constructs a GET request using the provided path, sends it to the node,
+%% and returns the response.
+%%
+%% @param Node The target node.
+%% @param Path The key or location where the data is stored.
+%% @returns The response read from the cache (either binary or wrapped in {ok, Response}).
+read_from_cache(Node, Path) ->
+    ?event(dev_cache, {read_from_cache, {start, Node, Path}}),
+    ReadMsg = #{
+        <<"path">> => <<"/~cache@1.0/read">>,
+        <<"method">> => <<"GET">>,
+        <<"target">> => Path
+    },
+    ?event(dev_cache, {read_from_cache, {request_created, ReadMsg}}),
+    ?event({test_read, request, ReadMsg}),
+    ReadResult = hb_http:get(Node, ReadMsg, #{}),
+    ?event(dev_cache, {read_from_cache, {http_get, ReadResult}}),
+    case ReadResult of
+        ReadResponse when is_binary(ReadResponse) ->
+            ?event(dev_cache, {read_from_cache, {response_binary, ReadResponse}}),
+            ReadResponse;
+        {ok, ReadResponse} ->
+            ?event(dev_cache, {read_from_cache, {response_ok, ReadResponse}}),
+            ReadResponse;
+        {error, Reason} ->
+            ?event(dev_cache, {read_from_cache, {response_error, Reason}}),
+            {error, Reason}
+    end.
+
+%% @doc Test writing a map to the cache and then reading it back.
+%% This test writes a nested map to the cache, reads it back,
+%% and verifies that the written data matches the retrieved data.
+cache_write_read_map_test() ->
+    ?event({cache_write_test, start}),
+    {LocalStore, _Wallet, _Address, _Node} = setup_test_env(<<"cache-TEST-WRITE">>),
     TestData = #{
         <<"test_key">> => <<"test_value">>,
         <<"nested">> => #{
@@ -165,128 +270,40 @@ create_test_data() ->
             <<"key2">> => 42
         }
     },
-    ?event({test_data, created, TestData}),
-    TestData.
-
-%% @doc Write data to cache via HTTP
-write_to_cache(Node, Data, Wallet) ->
-    % Create a write request message
-    WriteMsg = #{
-        <<"path">> => <<"/~cache@1.0/write">>,
-        <<"method">> => <<"POST">>,
-        <<"body">> => Data
-    },
-    ?event({test_write, request_created, WriteMsg}),
-    
-    % Sign the message with our wallet to authorize the write
-    SignedMsg = hb_message:attest(WriteMsg, Wallet),
-    ?event({test_write, msg_signed, {signers, hb_message:signers(SignedMsg)}}),
-    
-    % Send the write request
-    ?event({test_write, sending_request}),
-    WriteResult = hb_http:post(Node, SignedMsg, #{}),
-    ?event(pete, {test_write, {result, {explicit, WriteResult}}}),
-    
-    {ok, WriteResponse} = WriteResult,
-    
-    % Verify write was successful
-    Status = hb_converge:get(<<"status">>, WriteResponse, 0, #{}),
-    ?event({test_write, status, Status}),
-    ?assertEqual(200, Status),
-    
-    % Extract the path from the response
-    Path = hb_converge:get(<<"path">>, WriteResponse, not_found, #{}),
-    ?event({test_write, path, Path}),
-    ?assertNotEqual(not_found, Path),
-    
-    {WriteResponse, Path}.
-
-%% @doc Read data from cache via HTTP and verify contents
-read_from_cache(Node, Path) ->
-    % Create read request
-    ReadMsg = #{
-        <<"path">> => <<"/~cache@1.0/read">>,
-        <<"method">> => <<"GET">>,
-        <<"target">> => Path
-    },
-    ?event({test_read, request, ReadMsg}),
-    
-    % Send the read request
-    ReadResult = hb_http:get(Node, ReadMsg, #{}),
-    ?event({test_read, result, ReadResult}),
-    {ok, ReadResponse} = ReadResult,
-    
-    ReadResponse.
-
-%% @doc Verify that response data matches expected data
-verify_data_match(Response, ExpectedData) ->
-    % Verify the test_key value
-    ExpectedValue = hb_converge:get(<<"test_key">>, ExpectedData, not_found, #{}),
-    TestValue = hb_converge:get(<<"test_key">>, Response, not_found, #{}),
+    ?event(dev_cache, {cache_write_read_map_test, {test_data, TestData}}),
+    {_WriteResponse, Path} = write_to_cache("http://localhost:10000/", TestData, hb:wallet()),
+    ?event(dev_cache, {cache_write_read_map_test, {data_written, Path}}),
+    ReadResponse = read_from_cache("http://localhost:10000/", Path),
+    ?event(dev_cache, {cache_write_read_map_test, {data_read, ReadResponse}}),
+    ExpectedValue = hb_converge:get(<<"test_key">>, TestData, not_found, #{}),
+    TestValue = hb_converge:get(<<"test_key">>, ReadResponse, not_found, #{}),
     ?assertEqual(ExpectedValue, TestValue),
-    
-    % Verify the nested object
-    ExpectedNested = hb_converge:get(<<"nested">>, ExpectedData, not_found, #{}),
-    NestedResponse = hb_converge:get(<<"nested">>, Response, not_found, #{}),
+    ExpectedNested = hb_converge:get(<<"nested">>, TestData, not_found, #{}),
+    NestedResponse = hb_converge:get(<<"nested">>, ReadResponse, not_found, #{}),
     ?assertNotEqual(not_found, NestedResponse),
-    
-    % Verify nested key1
     ExpectedKey1 = hb_converge:get(<<"key1">>, ExpectedNested, not_found, #{}),
     Key1 = hb_converge:get(<<"key1">>, NestedResponse, not_found, #{}),
     ?assertEqual(ExpectedKey1, Key1),
-    
-    % Verify nested key2
     ExpectedKey2 = hb_converge:get(<<"key2">>, ExpectedNested, not_found, #{}),
     Key2 = hb_converge:get(<<"key2">>, NestedResponse, not_found, #{}),
-    ?assertEqual(ExpectedKey2, Key2).
+    ?assertEqual(ExpectedKey2, Key2),
+    hb_store:reset(LocalStore),
+    ?event(dev_cache, {cache_write_read_map_test}),
+    ok.
 
-%% @doc Test writing to cache via HTTP POST and then reading it back
-cache_write_test() ->
-    ?event({cache_write_test, start}),
-    
-    % Setup test environment
-    {LocalStore, Wallet, _Address, Node} = setup_test_env(<<"cache-TEST-WRITE">>),
-    
-    % Create test data
-    TestData = create_test_data(),
-    
-    % Write data to cache
+%% @doc Test writing binary data to the cache and then reading it back.
+%% This test writes binary data, reads it from the cache,
+%% and asserts that the retrieved data matches the original.
+cache_write_read_binary_test() ->
+    ?event(dev_cache, {cache_write_read_binary_test, {start}}),
+    {LocalStore, _Wallet, _Address, _Node} = setup_test_env(<<"cache-TEST-WRITE">>),
+    TestData = <<"test_value">>,
+    ?event(dev_cache, {cache_write_read_binary_test, {test_data, TestData}}),
     {_WriteResponse, Path} = write_to_cache("http://localhost:10000/", TestData, hb:wallet()),
-	?event({cache_write_test, path, Path}),
-    
-    % Read data back and verify
-    ReadResponse = read_from_cache(Node, Path),
-    
-	% Verify the data is correct
-	verify_data_match(ReadResponse, TestData),
-
-    % Clean up
-    hb_store:reset(LocalStore),
-    ?event({cache_write_test, complete}),
-    ok.
-
-%% @doc Test reading from cache via HTTP
-cache_read_test() ->
-    ?event({cache_read_test, start}),
-    
-    % Setup test environment
-    {LocalStore, Wallet, _Address, Node} = setup_test_env(<<"cache-TEST">>),
-    
-    % Create test data
-    TestData = create_test_data(),
-    
-    % Write to the remote node cache.
-	{_WriteResponse, Path} = write_to_cache(Node, TestData, Wallet),
-    ?event({cache_read_test, data_written, {path, Path}}),
-
-    % Read via HTTP and verify
+    ?event(dev_cache, {cache_write_read_binary_test, {data_written, Path}}),
     ReadResponse = read_from_cache("http://localhost:10000/", Path),
-
-	% Verify the data is correct
-	verify_data_match(ReadResponse, TestData),
-    
-    % % Clean up
+    ?event(dev_cache, {cache_write_read_binary_test, {data_read, ReadResponse}}),
+    ?assertEqual(TestData, ReadResponse),
     hb_store:reset(LocalStore),
-    ?event({cache_read_test, complete}),
+    ?event(dev_cache, {cache_write_read_binary_test}),
     ok.
-

--- a/src/dev_cache.erl
+++ b/src/dev_cache.erl
@@ -1,0 +1,292 @@
+%%% @doc A device that looks up an ID from a local store and returns it, honoring
+%%% the `accept' key to return the correct format. The cache also supports
+%%% writing messages to the store, if the node message has the writer's address
+%%% in its `cache_writers' key.
+-module(dev_cache).
+-export([read/3, write/3]).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%% @doc Read data from the cache using the given key and options.
+%% The options map can specify which store to use, with appropriate configuration.
+%%
+%% Example:
+%%   {ok, Data} = dev_cache:read(Key, #{store => StoreConfig})
+%%
+%% Returns:
+%%   {ok, Data} on success
+%%   not_found if the key doesn't exist
+%%   {error, Reason} on failure
+read(_M1, M2, Opts) ->
+    ID = hb_converge:get(<<"target">>, M2, Opts),
+    ?event({cache_read, start, {id, ID}, {m2, M2}}),
+    case hb_cache:read(ID, Opts) of
+        {ok, Res} ->
+            ?event({cache_read, success, {result, Res}}),
+            case hb_converge:get(<<"accept">>, M2, Opts) of
+                <<"application/aos-2">> ->
+                    ?event({cache_read, format, aos2}),
+                    Struct = dev_json_iface:message_to_json_struct(Res),
+                    {ok,
+                        #{
+                            <<"body">> => jiffy:encode(Struct),
+                            <<"content-type">> => <<"application/aos-2">>
+                        }};
+                _ ->
+                    ?event({cache_read, format, default}),
+                    {ok, Res}
+            end;
+        not_found ->
+            ?event({cache_read, not_found, ID}),
+            {error, not_found}
+    end.
+
+%% @doc Write data to the cache with the given options.
+%% The options map can specify which store to use, with appropriate configuration.
+%%
+%% Example:
+%%   {ok, Path} = dev_cache:write(Data, #{store => StoreConfig})
+%%
+%% Returns:
+%%   {ok, Path} on success where Path is the location the data was stored
+%%   {error, Reason} on failure
+write(_M1, M2, Opts) ->
+    case is_trusted_writer(M2, Opts) of
+        true ->
+            Type = hb_converge:get(<<"type">>, M2, <<"single">>, Opts),
+            case Type of
+                <<"single">> -> 
+                    write_single(M2, Opts);
+                <<"batch">> ->
+                    maps:map(
+                        fun(_, Value) ->
+                            write_single(Value, Opts)
+                        end,
+                        hb_converge:get(<<"body">>, M2, Opts)
+                    );
+                _ ->
+                    {error,
+                        #{
+                            <<"status">> => 400,
+                            <<"body">> => <<"Invalid write type.">>
+                        }
+                    }
+            end;
+        false ->
+            {error, 
+                #{
+                    <<"status">> => 403,
+                    <<"body">> => <<"Not authorized to write to the cache.">>
+                }
+            }
+    end.
+
+write_single(Msg, Opts) ->
+    Body = hb_converge:get(<<"body">>, Msg, Opts),
+    Location = hb_converge:get(<<"location">>, Msg, Opts),
+    Operation = hb_converge:get(<<"operation">>, Msg, <<"write">>, Opts),
+    ?event({write_single, start, {body, Body}, {location, Location}, {operation, Operation}}),
+    
+    case {Operation, Body, Location} of
+        {<<"write">>, not_found, _} ->
+            ?event({write_single, error, no_body}),
+            {error,
+                #{
+                    <<"status">> => 400,
+                    <<"body">> => <<"No body to write.">>
+                }
+            };
+        {<<"write">>, Map, _Location} when is_map(Map) ->
+            {ok, Path} = hb_cache:write(Map, Opts),
+            {ok, #{ <<"status">> => 200, <<"path">> => Path }};
+        {<<"write">>, Binary, Location} when is_binary(Binary) ->
+            {ok, Path} = hb_cache:write_binary(Location, Binary, Opts),
+            {ok, #{ <<"status">> => 200, <<"path">> => Path }};
+        {<<"link">>, _, _} ->
+            Source = hb_converge:get(<<"source">>, Msg, Opts),
+            Destination = hb_converge:get(<<"destination">>, Msg, Opts),
+            ok = hb_cache:link(Source, Destination, Opts),
+            {ok, #{ <<"status">> => 200 }};
+        _ ->
+            {error,
+                #{
+                    <<"status">> => 400,
+                    <<"body">> => <<"Invalid write type.">>
+                }
+            }
+    end.
+
+is_trusted_writer(Req, Opts) ->
+    Signers = hb_message:signers(Req),
+    CacheWriters = hb_opts:get(cache_writers, [], Opts),
+    case Signers of
+        [Signer] ->
+            IsTrusted = lists:member(Signer, CacheWriters),
+            IsTrusted;
+        _ -> 
+            false
+    end.
+
+%% Test helpers
+
+%% @doc Create a test environment with a local store and node
+setup_test_env(StorePrefix) ->
+	% Ensure that node is started using ensure_all_started
+	application:ensure_all_started(hb),
+
+    % Set up a local store configuration
+    LocalStore = #{ <<"store-module">> => hb_store_fs, <<"prefix">> => StorePrefix },
+    
+    % Reset the store to ensure a clean test environment
+    hb_store:reset(LocalStore),
+    ?event({test_setup, store_reset, {store, LocalStore}}),
+    
+    % Create a wallet for signing requests
+    Wallet = ar_wallet:new(),
+    Address = hb_util:human_id(ar_wallet:to_address(Wallet)),
+    ?event({test_setup, wallet_created, {address, Address}}),
+    
+    % Start a node with our local store
+    Node = hb_http_server:start_node(#{ 
+        store => LocalStore,
+        cache_writers => [Address, hb_util:human_id(ar_wallet:to_address(hb:wallet()))],
+		port => 10001
+    }),
+    ?event({test_setup, node_started, {node, Node}}),
+    
+    {LocalStore, Wallet, Address, Node}.
+
+%% @doc Create test data for cache tests
+create_test_data() ->
+    TestData = #{
+        <<"test_key">> => <<"test_value">>,
+        <<"nested">> => #{
+            <<"key1">> => <<"value1">>,
+            <<"key2">> => 42
+        }
+    },
+    ?event({test_data, created, TestData}),
+    TestData.
+
+%% @doc Write data to cache via HTTP
+write_to_cache(Node, Data, Wallet) ->
+    % Create a write request message
+    WriteMsg = #{
+        <<"path">> => <<"/~cache@1.0/write">>,
+        <<"method">> => <<"POST">>,
+        <<"body">> => Data
+    },
+    ?event({test_write, request_created, WriteMsg}),
+    
+    % Sign the message with our wallet to authorize the write
+    SignedMsg = hb_message:attest(WriteMsg, Wallet),
+    ?event({test_write, msg_signed, {signers, hb_message:signers(SignedMsg)}}),
+    
+    % Send the write request
+    ?event({test_write, sending_request}),
+    WriteResult = hb_http:post(Node, SignedMsg, #{}),
+    ?event(pete, {test_write, {result, {explicit, WriteResult}}}),
+    
+    {ok, WriteResponse} = WriteResult,
+    
+    % Verify write was successful
+    Status = hb_converge:get(<<"status">>, WriteResponse, 0, #{}),
+    ?event({test_write, status, Status}),
+    ?assertEqual(200, Status),
+    
+    % Extract the path from the response
+    Path = hb_converge:get(<<"path">>, WriteResponse, not_found, #{}),
+    ?event({test_write, path, Path}),
+    ?assertNotEqual(not_found, Path),
+    
+    {WriteResponse, Path}.
+
+%% @doc Read data from cache via HTTP and verify contents
+read_from_cache(Node, Path) ->
+    % Create read request
+    ReadMsg = #{
+        <<"path">> => <<"/~cache@1.0/read">>,
+        <<"method">> => <<"GET">>,
+        <<"target">> => Path
+    },
+    ?event({test_read, request, ReadMsg}),
+    
+    % Send the read request
+    ReadResult = hb_http:get(Node, ReadMsg, #{}),
+    ?event({test_read, result, ReadResult}),
+    {ok, ReadResponse} = ReadResult,
+    
+    ReadResponse.
+
+%% @doc Verify that response data matches expected data
+verify_data_match(Response, ExpectedData) ->
+    % Verify the test_key value
+    ExpectedValue = hb_converge:get(<<"test_key">>, ExpectedData, not_found, #{}),
+    TestValue = hb_converge:get(<<"test_key">>, Response, not_found, #{}),
+    ?assertEqual(ExpectedValue, TestValue),
+    
+    % Verify the nested object
+    ExpectedNested = hb_converge:get(<<"nested">>, ExpectedData, not_found, #{}),
+    NestedResponse = hb_converge:get(<<"nested">>, Response, not_found, #{}),
+    ?assertNotEqual(not_found, NestedResponse),
+    
+    % Verify nested key1
+    ExpectedKey1 = hb_converge:get(<<"key1">>, ExpectedNested, not_found, #{}),
+    Key1 = hb_converge:get(<<"key1">>, NestedResponse, not_found, #{}),
+    ?assertEqual(ExpectedKey1, Key1),
+    
+    % Verify nested key2
+    ExpectedKey2 = hb_converge:get(<<"key2">>, ExpectedNested, not_found, #{}),
+    Key2 = hb_converge:get(<<"key2">>, NestedResponse, not_found, #{}),
+    ?assertEqual(ExpectedKey2, Key2).
+
+%% @doc Test writing to cache via HTTP POST and then reading it back
+cache_write_test() ->
+    ?event({cache_write_test, start}),
+    
+    % Setup test environment
+    {LocalStore, Wallet, _Address, Node} = setup_test_env(<<"cache-TEST-WRITE">>),
+    
+    % Create test data
+    TestData = create_test_data(),
+    
+    % Write data to cache
+    {_WriteResponse, Path} = write_to_cache("http://localhost:10000/", TestData, hb:wallet()),
+	?event({cache_write_test, path, Path}),
+    
+    % Read data back and verify
+    ReadResponse = read_from_cache(Node, Path),
+    
+	% Verify the data is correct
+	verify_data_match(ReadResponse, TestData),
+
+    % Clean up
+    hb_store:reset(LocalStore),
+    ?event({cache_write_test, complete}),
+    ok.
+
+%% @doc Test reading from cache via HTTP
+cache_read_test() ->
+    ?event({cache_read_test, start}),
+    
+    % Setup test environment
+    {LocalStore, Wallet, _Address, Node} = setup_test_env(<<"cache-TEST">>),
+    
+    % Create test data
+    TestData = create_test_data(),
+    
+    % Write to the remote node cache.
+	{_WriteResponse, Path} = write_to_cache(Node, TestData, Wallet),
+    ?event({cache_read_test, data_written, {path, Path}}),
+
+    % Read via HTTP and verify
+    ReadResponse = read_from_cache("http://localhost:10000/", Path),
+
+	% Verify the data is correct
+	verify_data_match(ReadResponse, TestData),
+    
+    % % Clean up
+    hb_store:reset(LocalStore),
+    ?event({cache_read_test, complete}),
+    ok.
+

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -21,82 +21,49 @@
 %%% Binary Messages (TABMs), such that each of the keys in the message is
 %%% either a map or a direct binary.
 -module(hb_cache).
--export([read/2, read_resolved/3]).
--export([write/2, write_binary/3, write_hashpath/2]).
--export([link/3]).
+-export([read/2, read_resolved/3, write/2, write_binary/3, write_hashpath/2, link/3]).
 -export([list/2, list_numbered/2]).
 -export([test_unsigned/1, test_signed/1]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 %% @doc List all items in a directory, assuming they are numbered.
-%%
-%% @param Path A binary representing the directory path.
-%% @param Opts A map of options (including store configuration).
-%% @returns A list of integers converted from the names of the directory items.
 list_numbered(Path, Opts) ->
-    Store = hb_opts:get(store, no_viable_store, Opts),
-    ?event(hb_cache, {list_numbered, {store, Store}, {path, Path}}),
-    SlotDir = hb_store:path(Store, Path),
-    ?event(hb_cache, {list_numbered, {slot_dir, SlotDir}}),
-    RawNames = list(SlotDir, Opts),
-    ?event(hb_cache, {list_numbered, {raw_names, RawNames}}),
-    [to_integer(Name) || Name <- RawNames].
-
+    SlotDir = hb_store:path(hb_opts:get(store, no_viable_store, Opts), Path),
+    [ to_integer(Name) || Name <- list(SlotDir, Opts) ].
 
 %% @doc List all items under a given path.
-%%
-%% @param Path A binary representing the path to list.
-%% @param Opts A map of options (including store configuration).
-%% @returns A list of item names, or an empty list if the store is unavailable.
-list(Path, Opts) when is_map(Opts) ->
-    Store = hb_opts:get(store, no_viable_store, Opts),
-    ?event(hb_cache, {list, {path, Path}, {opts, Opts}, {store, Store}}),
-    case Store of
-        no_viable_store ->
-            ?event(hb_cache, {list, {result, []}}),
-            [];
-        _ ->
+list(Path, Opts) when is_map(Opts)->
+    case hb_opts:get(store, no_viable_store, Opts) of
+        no_viable_store -> [];
+        Store ->
             list(Path, Store)
     end;
 list(Path, Store) ->
     ResolvedPath = hb_store:resolve(Store, Path),
-    ?event(hb_cache, {list, {resolved_path, ResolvedPath}}),
     case hb_store:list(Store, ResolvedPath) of
-        {ok, Names} ->
-            ?event(hb_cache, {list, {result, Names}}),
-            Names;
-        {error, Err} ->
-            ?event(hb_cache, {list, {error, Err}}),
-            [];
-        no_viable_store ->
-            ?event(hb_cache, {list, {result, []}}),
-            []
+        {ok, Names} -> Names;
+        {error, _} -> [];
+        no_viable_store -> []
     end.
 
-%% @doc Write a message to the cache.
-%%
-%% For raw binaries, writes the data at its hashpath (by default, the
-%% SHA2-256 hash of the data). The function links the unattended ID's
-%% hashpath for keys (including `/attestations') to the underlying data and
-%% recursively processes submessages. Additionally, it creates links from
-%% each attestation ID to the unattested message, ensuring that both attested
-%% and unattested IDs can be read and that all attestations are available in
-%% memory. For deep messages, the attestations of inner messages are also
-%% read, so that the ID of the outer message (which does not include its
-%% attestations) is built upon the attestations of the inner messages.
-%% Note: IDs from attestations on signed _inner_ messages are not stored.
-%%       (This behavior may be revisited in the future.)
-%%
-%% @param RawMsg The raw message (binary or map) to be written.
-%% @param Opts A map of configuration options.
-%% @returns {ok, Path} on success or {error, Reason} on failure.
+%% @doc Write a message to the cache. For raw binaries, we write the data at
+%% the hashpath of the data (by default the SHA2-256 hash of the data). We link
+%% the unattended ID's hashpath for the keys (including `/attestations') on the
+%% message to the underlying data and recurse. We then link each attestation ID
+%% to the unattested message, such that any of the attested or unattested IDs
+%% can be read, and once in memory all of the attestations are available. For
+%% deep messages, the attestations will also be read, such that the ID of the
+%% outer message (which does not include its attestations) will be built upon
+%% the attestations of the inner messages. We do not, however, store the IDs from
+%% attestations on signed _inner_ messages. We may wish to revisit this.
 write(RawMsg, Opts) ->
-    ?event(hb_cache, {write, {start, RawMsg}}),
+    % Use the _structured_ format for calculating alternative IDs, but the
+    % _tabm_ format for writing to the store.
     case hb_message:with_only_attested(RawMsg, Opts) of
         {ok, Msg} ->
             AltIDs = calculate_alt_ids(RawMsg, Opts),
-            ?event(hb_cache, {write, {alt_ids, AltIDs}, {msg, Msg}}),
+            ?event({writing_full_message, {alt_ids, AltIDs}, {msg, Msg}}),
             Tabm = hb_message:convert(Msg, tabm, <<"structured@1.0">>, Opts),
             ?event({tabm, Tabm}),
             try do_write_message(
@@ -118,495 +85,208 @@ write(RawMsg, Opts) ->
                     {error, no_viable_store}
             end;
         {error, Err} ->
-            ?event(hb_cache, {write, {error, Err}}),
             {error, Err}
     end.
-
-%% @doc Helper function to write a message or binary to the store.
-%%
-%% For binary data, writes it at its hashpath and creates links for
-%% alternative IDs. For map messages, handles both remote and local store
-%% cases by writing subkeys, creating groups, and establishing links for
-%% attestations.
-%%
-%% @param BinOrMsg A binary or map representing the message.
-%% @param AltIDs A list of alternative IDs derived from attestations.
-%% @param Store The store configuration.
-%% @param Opts A map of configuration options.
-%% @returns {ok, Path} on success or {error, Reason} on failure.
 do_write_message(Bin, AltIDs, Store, Opts) when is_binary(Bin) ->
-    ?event(hb_cache, 
-		{do_write_message_binary, 
-			{start, Bin}, 
-			{alt_ids, AltIDs},
-			{store, Store}
-		}
-	),
+    % Write the binary in the store at its given hash. Return the path.
     Hashpath = hb_path:hashpath(Bin, Opts),
-    ?event(hb_cache, {do_write_message_binary, {hashpath, Hashpath}}),
-    case hb_store:write(Store, Path = <<"data/", Hashpath/binary>>, Bin) of
-        ok ->
-            ?event(hb_cache, 
-				{do_write_message_binary, 
-					{write_result, ok}, {path, Path}
-				}
-			),
-            lists:map(
-                fun(AltID) ->
-                    ?event(hb_cache, 
-						{do_write_message_binary, 
-							{making_link, 
-								{alt_id, AltID}, 
-								{path, Path}
-							}
-						}
-					),
-                    hb_store:make_link(Store, Path, AltID)
-                end,
-                AltIDs
-            ),
-            {ok, Path};
-        {ok, RemotePath} ->
-            ?event(hb_cache, 
-				{do_write_message_binary, 
-					{write_result, {ok, RemotePath}}
-				}
-			),
-            {ok, RemotePath};
-        {error, Err} ->
-            ?event(hb_cache, 
-				{do_write_message_binary, 
-					{write_result, {error, Err}}
-				}
-			),
-            {error, Err}
-    end;
-
+    ok = hb_store:write(Store, Path = <<"data/", Hashpath/binary>>, Bin),
+    lists:map(fun(AltID) -> hb_store:make_link(Store, Path, AltID) end, AltIDs),
+    {ok, Path};
 do_write_message(Msg, AltIDs, Store, Opts) when is_map(Msg) ->
-    ?event(hb_cache, 
-		{do_write_message_map, 
-			{start, Msg}, 
-			{alt_ids, AltIDs}, 
-			{store, Store}
-		}
-	),
-    case is_list(Store) andalso 
-		length(Store) > 0 andalso 
-		maps:get(
-			<<"store-module">>, 
-			hd(Store), undefined
-		) == hb_store_remote_node of
-        true ->
-            ?event(hb_cache, {do_write_message_map, {remote_store, true}}),
-            Hashpath = hb_path:hashpath(Msg, Opts),
-            ?event(hb_cache, {do_write_message_map, {hashpath, Hashpath}}),
-            case hb_store:write(Store, <<"data/", Hashpath/binary>>, Msg) of
-                {ok, RemotePath} ->
-                    ?event(hb_cache, 
-						{do_write_message_map, 
-							{remote_write_success, RemotePath}
-						}
-					),
-                    {ok, RemotePath};
-                {error, Err} ->
-                    ?event(hb_cache, 
-						{do_write_message_map, 
-							{remote_write_error, Err}
-						}
-					),
-                    {error, Err}
-            end;
-        false ->
-            ?event(hb_cache, {do_write_message_map, {remote_store, false}}),
-            {ok, UnattestedID} = 
-				dev_message:id(Msg, #{ <<"attestors">> => <<"none">> }, Opts),
-            ?event(hb_cache, 
-				{do_write_message_map, 
-					{unsigned_id, UnattestedID}, 
-					{alt_ids, AltIDs}
-				}
-			),
-            MsgHashpathAlg = hb_path:hashpath_alg(Msg),
-            hb_store:make_group(Store, UnattestedID),
-            hb_store:make_group(Store, UnattestedID),
-            maps:map(
-                fun(<<"device">>, Map) when is_map(Map) ->
-                    ?event(hb_cache, 
-						{do_write_message_map, 
-							{error, "device_map_cannot_be_written"}, 
-							{id, hb_message:id(Map)}
-						}
-					),
-                    throw(
-						{
-							device_map_cannot_be_written, 
-							{id, hb_message:id(Map)}
-						}
-					);
-                (Key, Value) ->
-                    ?event(hb_cache, 
-						{do_write_message_map, 
-							{writing_subkey, 
-								{key, Key}, 
-								{value, Value}
-							}
-						}
-					),
-                    KeyHashPath =
-                        hb_path:hashpath(
-                            UnattestedID,
-                            hb_path:to_binary(Key),
-                            MsgHashpathAlg,
-                            Opts
-                        ),
-                    ?event(hb_cache, 
-						{do_write_message_map, 
-							{key_hashpath, KeyHashPath}
-							}
-						),
-					% Note: We do not pass the AltIDs here, as we cannot 
-					% calculate them based on the TABM that we have in-memory
-                    % at this point. We could turn the TABM back into a
-                    % structured message, but this is expensive.
-                    {ok, Path} = do_write_message(Value, [], Store, Opts),
-                    hb_store:make_link(Store, Path, KeyHashPath),
-                    ?event(hb_cache, 
-						{do_write_message_map, 
-							{link_created, 
-								{key_hashpath, KeyHashPath}, 
-								{data_path, Path}
-							}
-						}
-					),
-                    Path
-                end,
-                hb_private:reset(Msg)
+    % Get the ID of the unsigned message.
+    {ok, UnattestedID} = dev_message:id(Msg, #{ <<"attestors">> => <<"none">> }, Opts),
+    ?event({writing_message_with_unsigned_id, UnattestedID, {alts, AltIDs}}),
+    MsgHashpathAlg = hb_path:hashpath_alg(Msg),
+    hb_store:make_group(Store, UnattestedID),
+    % Write the keys of the message into the store, rolling the keys into
+    % hashpaths (having only two parts) as we do so.
+    % We start by writing the group, such that if the message is empty, we
+    % still have a group in the store.
+    hb_store:make_group(Store, UnattestedID),
+    maps:map(
+        fun(<<"device">>, Map) when is_map(Map) ->
+            ?event(error, {request_to_write_device_map, {id, hb_message:id(Map)}}),
+            throw({device_map_cannot_be_written, {id, hb_message:id(Map)}});
+        (Key, Value) ->
+            ?event({writing_subkey, {key, Key}, {value, Value}}),
+            KeyHashPath =
+                hb_path:hashpath(
+                    UnattestedID,
+                    hb_path:to_binary(Key),
+                    MsgHashpathAlg,
+                    Opts
+                ),
+            ?event({key_hashpath_from_unsigned, KeyHashPath}),
+            % Note: We do not pass the AltIDs here, as we cannot calculate them
+            % based on the TABM that we have in-memory at this point. We could
+            % turn the TABM back into a structured message, but this is
+            % expensive.
+            {ok, Path} = do_write_message(Value, [], Store, Opts),
+            hb_store:make_link(Store, Path, KeyHashPath),
+            ?event(
+                {
+                    {link, KeyHashPath},
+                    {data_path, Path}
+                }
             ),
-			% Write the attestations to the store, linking each 
-			% attestation ID to the unattested message.
-            lists:map(
-                fun(AltID) ->
-                    ?event(hb_cache, 
-						{do_write_message_map, 
-							{linking_attestation, 
-								{unattested_id, UnattestedID}, 
-								{attested_id, AltID}
-							}
-						}
-					),
-                    hb_store:make_link(Store, UnattestedID, AltID)
-                end,
-                AltIDs
-            ),
-            {ok, UnattestedID}
-    end.
+            Path
+        end,
+        hb_private:reset(Msg)
+    ),
+    % Write the attestations to the store, linking each attestation ID to the
+    % unattested message.
+    lists:map(
+        fun(AltID) ->
+            ?event({linking_attestation,
+                {unattested_id, UnattestedID},
+                {attested_id, AltID}
+            }),
+            hb_store:make_link(Store, UnattestedID, AltID)
+        end,
+        AltIDs
+    ),
+    {ok, UnattestedID}.
 
 %% @doc Calculate the alternative IDs for a message.
-%%
-%% For binary input, returns an empty list.
-%% For map input, extracts alternative IDs from the message's attestations.
-%%
-%% @param Msg A binary or map representing the message.
-%% @param Opts A map of configuration options.
-%% @returns A list of alternative IDs.
-calculate_alt_ids(Bin, _Opts) when is_binary(Bin) ->
-    ?event(hb_cache, {calculate_alt_ids, {binary_input, Bin}}),
-    [];
+calculate_alt_ids(Bin, _Opts) when is_binary(Bin) -> [];
 calculate_alt_ids(Msg, _Opts) ->
-    ?event(hb_cache, {calculate_alt_ids, {msg_input, Msg}}),
     Attestations =
-		 maps:without(
-			[<<"priv">>],
-			maps:get(<<"attestations">>, Msg, #{})
-		),
-    ?event(hb_cache, {calculate_alt_ids, {attestations, Attestations}}),
-    Result = lists:filtermap(
+        maps:without(
+            [<<"priv">>],
+            maps:get(<<"attestations">>, Msg, #{})
+        ),
+    lists:filtermap(
         fun(Attestor) ->
             Att = maps:get(Attestor, Attestations, #{}),
             case maps:get(<<"id">>, Att, undefined) of
-                undefined ->
-                    ?event(hb_cache, 
-						{calculate_alt_ids, 
-							{attestor, Attestor}, 
-							{result, undefined}
-						}
-					),
-                    false;
-                ID ->
-                    ?event(hb_cache, 
-						{calculate_alt_ids, 
-							{attestor, Attestor}, 
-							{result, ID}
-						}
-					),
-                    {true, ID}
+                undefined -> false;
+                ID -> {true, ID}
             end
         end,
         maps:keys(Attestations)
-    ),
-    ?event(hb_cache, {calculate_alt_ids, {result, Result}}),
-    Result.
+    ).
 
-%% @doc Write a hashpath and its message to the store and create a link.
-%%
-%% If the message contains a hashpath in its private data, that hashpath is
-%% used. Otherwise, the message is written normally.
-%%
-%% @param Msg A map representing the message to be written.
-%% @param Opts A map of configuration options.
-%% @returns {ok, Path} on success.
+%% @doc Write a hashpath and its message to the store and link it.
 write_hashpath(Msg = #{ <<"priv">> := #{ <<"hashpath">> := HP } }, Opts) ->
-    ?event(hb_cache, {write_hashpath, {detected_hashpath, HP}, {msg, Msg}}),
     write_hashpath(HP, Msg, Opts);
 write_hashpath(MsgWithoutHP, Opts) ->
-    ?event(hb_cache, {write_hashpath, {no_hashpath, MsgWithoutHP}}),
     write(MsgWithoutHP, Opts).
-
 write_hashpath(HP, Msg, Opts) when is_binary(HP) or is_list(HP) ->
     Store = hb_opts:get(store, no_viable_store, Opts),
-    ?event(hb_cache, 
-		{write_hashpath, 
-			{writing_hashpath, HP}, 
-			{msg, Msg}, 
-			{store, Store}
-		}
-	),
+    ?event({writing_hashpath, {hashpath, HP}, {msg, Msg}, {store, Store}}),
     {ok, Path} = write(Msg, Opts),
     hb_store:make_link(Store, Path, HP),
     {ok, Path}.
 
-%% @doc Write a raw binary key into the store and create a link at a given
-%% hashpath.
-%%
-%% @param Hashpath The hashpath at which to write the binary.
-%% @param Bin The binary data to be stored.
-%% @param Opts A map of configuration options.
-%% @returns The result of writing the binary.
+%% @doc Write a raw binary keys into the store and link it at a given hashpath.
 write_binary(Hashpath, Bin, Opts) ->
-    ?event(hb_cache, 
-		{write_binary, 
-			{start, 
-				{hashpath, Hashpath}, 
-				{bin, Bin}, 
-				{opts, Opts}
-			}
-		}
-	),
-    write_binary(
-		Hashpath, 
-		Bin, 
-		hb_opts:get(store, no_viable_store, Opts), 
-		Opts
-	).
-
+    write_binary(Hashpath, Bin, hb_opts:get(store, no_viable_store, Opts), Opts).
 write_binary(Hashpath, Bin, Store, Opts) ->
-    ?event(hb_cache, 
-		{write_binary, 
-			{start_with_store, 
-				{hashpath, Hashpath}, 
-				{bin, Bin}, 
-				{store, Store}
-			}
-		}
-	),
-    do_write_message(Bin, [Hashpath], Store, Opts).
+    ?event({writing_binary, {hashpath, Hashpath}, {bin, Bin}, {store, Store}}),
+    {ok, Path} = do_write_message(Bin, [Hashpath], Store, Opts),
+    {ok, Path}.
 
-
-%% @doc Read the message at a given path.
-%%
-%% Retrieves the message in `structured@1.0' format, which may be a richly
-%% typed map or a direct binary.
-%%
-%% @param Path The path or key to read.
-%% @param Opts A map of configuration options.
-%% @returns {ok, Structured} on success, or not_found if the message is missing.
+%% @doc Read the message at a path. Returns in `structured@1.0' format: Either a
+%% richly typed map or a direct binary.
 read(Path, Opts) ->
-    ?event(hb_cache, {read, {start, {path, Path}, {opts, Opts}}}),
-    Store = hb_opts:get(store, no_viable_store, Opts),
-    ?event(hb_cache, {read, {store, Store}}),
-    case store_read(Path, Store, Opts) of
-        not_found ->
-            ?event(hb_cache, {read, {result, not_found}}),
-            not_found;
+    case store_read(Path, hb_opts:get(store, no_viable_store, Opts), Opts) of
+        not_found -> not_found;
         {ok, Res} ->
-            ?event(hb_cache, {read, {raw_result, Res}}),
+            ?event({applying_types_to_read_message, Res}),
             Structured = dev_codec_structured:to(Res),
-            ?event(hb_cache, {read, {structured_result, Structured}}),
+            ?event({finished_read, Structured}),
             {ok, Structured}
     end.
 
-%% @doc Recursively read a path from the store, tracking visited paths to
-%% avoid circular links.
-%%
-%% @param Path The path to be read.
-%% @param Store The store configuration.
-%% @param Opts A map of configuration options.
-%% @returns {ok, Result} on success, or not_found if the path cannot be read.
+%% @doc List all of the subpaths of a given path, read each in turn, returning a
+%% flat map. We track the paths that we have already read to avoid circular
+%% links.
 store_read(Path, Store, Opts) ->
-    ?event(hb_cache, 
-		{store_read, 
-			{start, 
-				{path, Path}, 
-				{store, Store},
-				{opts, Opts}
-			}
-		}
-	),
     store_read(Path, Store, Opts, []).
-
 store_read(_Path, no_viable_store, _, _AlreadyRead) ->
-    ?event(hb_cache, {store_read, {result, no_viable_store}}),
     not_found;
 store_read(Path, Store, Opts, AlreadyRead) ->
     case lists:member(Path, AlreadyRead) of
         true ->
-            ?event(hb_cache, 
-				{store_read, 
-					{circular_links_detected, 
-					{path, Path},
-					{already_read, AlreadyRead}
-					}
-				}
-			),
+            ?event(read_error,
+                {circular_links_detected,
+                    {path, Path},
+                    {already_read, AlreadyRead}
+                }
+            ),
             throw({circular_links_detected, Path, {already_read, AlreadyRead}});
         false ->
-            ?event(hb_cache, {store_read, {proceeding, {path, Path}}}),
             do_read(Path, Store, Opts, AlreadyRead)
     end.
 
-%% @doc Read a path from the store.
-%%
-%% This function is unsafe as it may recurse indefinitely if circular links
-%% are present.
-%%
-%% @param Path The path to read.
-%% @param Store The store configuration.
-%% @param Opts A map of configuration options.
-%% @param AlreadyRead A list of paths already visited.
-%% @returns The read result, or not_found if unsuccessful.
+%% @doc Read a path from the store. Unsafe: May recurse indefinitely if circular
+%% links are present.
 do_read(Path, Store, Opts, AlreadyRead) ->
-    ResolvedFullPath = 
-		hb_store:resolve(Store, PathToBin = hb_path:to_binary(Path)),
-    ?event(hb_cache, 
-		{do_read, 
-			{path, PathToBin}, 
-			{resolved, ResolvedFullPath}
-		}
-	),
+    ResolvedFullPath = hb_store:resolve(Store, PathToBin = hb_path:to_binary(Path)),
+    ?event({reading, {path, PathToBin}, {resolved, ResolvedFullPath}}),
     case hb_store:type(Store, ResolvedFullPath) of
-        not_found ->
-            ?event(hb_cache, {do_read, {result, not_found}}),
-            not_found;
-        no_viable_store ->
-            ?event(hb_cache, {do_read, {result, no_viable_store}}),
-            not_found;
-        simple ->
-            ?event(hb_cache, {do_read, {type, simple}}),
-            hb_store:read(Store, ResolvedFullPath);
+        not_found -> not_found;
+        no_viable_store -> not_found;
+        simple -> hb_store:read(Store, ResolvedFullPath);
         _ ->
             case hb_store:list(Store, ResolvedFullPath) of
                 {ok, Subpaths} ->
-                    ?event(hb_cache, 
-					{do_read, 
-						{listed, 
-							{original_path, Path}, 
-							{subpaths, {explicit, Subpaths}}
-						}
-					}
-				),
-				Msg =
-					maps:from_list(
-					lists:map(
-						fun(Subpath) ->
-							?event(hb_cache, 
-								{do_read, 
-									{reading_subpath, 
-										{path, Subpath}, 
-										{store, Store}
-									}
-								}
-							),
-							{ok, Res} = store_read(
-								[ResolvedFullPath, Subpath],
-								 Store, 
-								 Opts, 
-								 [ResolvedFullPath | AlreadyRead]
-							),
-							{iolist_to_binary([Subpath]), Res}
-						end,
-						Subpaths
-					)
-				),
-				?event(hb_cache, {do_read, {read_message, Msg}}),
-				{ok, Msg};
-			_ ->
-				?event(hb_cache, {do_read, {list_error, ResolvedFullPath}}),
-				not_found
-		end
+                    ?event(
+                        {listed,
+                            {original_path, Path},
+                            {subpaths, {explicit, Subpaths}}
+                        }
+                    ),
+                    Msg =
+                        maps:from_list(
+                            lists:map(
+                                fun(Subpath) ->
+                                    ?event({reading_subpath, {path, Subpath}, {store, Store}}),
+                                    {ok, Res} = store_read(
+                                        [ResolvedFullPath, Subpath],
+                                        Store,
+                                        Opts,
+                                        [ResolvedFullPath | AlreadyRead]
+                                    ),
+                                    {iolist_to_binary([Subpath]), Res}
+                                end,
+                                Subpaths
+                            )
+                        ),
+                    ?event({read_message, Msg}),
+                    {ok, Msg};
+                _ -> not_found
+            end
     end.
 
-%% @doc Read the output of a prior computation given two message identifiers
-%% or messages.
-%%
-%% Constructs a composite path from the provided message IDs (or messages)
-%% and retrieves the result.
-%%
-%% @param MsgID1 The first message ID or message.
-%% @param MsgID2 The second message ID or message.
-%% @param Opts A map of configuration options.
-%% @returns The resolved message, or not_found if not available.
+%% @doc Read the output of a prior computation, given Msg1, Msg2, and some
+%% options.
 read_resolved(MsgID1, MsgID2, Opts) when ?IS_ID(MsgID1) and ?IS_ID(MsgID2) ->
-    ?event(hb_cache, 
-		{read_resolved, 
-			{msg1, MsgID1}, 
-			{msg2, MsgID2}, 
-			{opts, Opts}
-		}
-	),
+    ?event({cache_lookup, {msg1, MsgID1}, {msg2, MsgID2}, {opts, Opts}}),
     read(<<MsgID1/binary, "/", MsgID2/binary>>, Opts);
 read_resolved(MsgID1, Msg2, Opts) when ?IS_ID(MsgID1) and is_map(Msg2) ->
-    {ok, MsgID2} = 
-		dev_message:id(Msg2, #{ <<"attestors">> => <<"all">> }, Opts),
-    ?event(hb_cache, {read_resolved, {derived_msgid2, MsgID2}}),
+    {ok, MsgID2} = dev_message:id(Msg2, #{ <<"attestors">> => <<"all">> }, Opts),
     read(<<MsgID1/binary, "/", MsgID2/binary>>, Opts);
 read_resolved(Msg1, Msg2, Opts) when is_map(Msg1) and is_map(Msg2) ->
-    ?event(hb_cache, {read_resolved, {msg1, Msg1}, {msg2, Msg2}}),
     read(hb_path:hashpath(Msg1, Msg2, Opts), Opts);
-read_resolved(_, _, _) ->
-    ?event(hb_cache, {read_resolved, {result, not_found}}),
-    not_found.
+read_resolved(_, _, _) -> not_found.
 
-%% @doc Create a link from one path to another in the store.
-%%
-%% @param Existing The existing path.
-%% @param New The new path to link to.
-%% @param Opts A map of configuration options.
-%% @returns The result of the link creation.
+%% @doc Make a link from one path to another in the store.
+%% Note: Argument order is `link(Src, Dst, Opts)'.
 link(Existing, New, Opts) ->
-    Store = hb_opts:get(store, no_viable_store, Opts),
-    ?event(hb_cache, {link, {existing, Existing}, {new, New}, {store, Store}}),
     hb_store:make_link(
-		Store, 
-		Existing, 
-		New
-	).
+        hb_opts:get(store, no_viable_store, Opts),
+        Existing,
+        New
+    ).
 
-%% @doc Convert a value to an integer.
-%%
-%% @param Value A binary or list representing an integer.
-%% @returns The integer value.
 to_integer(Value) when is_list(Value) ->
-    ?event(hb_cache, {to_integer, {list, Value}}),
     list_to_integer(Value);
 to_integer(Value) when is_binary(Value) ->
-    ?event(hb_cache, {to_integer, {binary, Value}}),
     binary_to_integer(Value).
 
-
-
-%%%--------------------------------------------------------------------
 %%% Tests
-%%%--------------------------------------------------------------------
 
 test_unsigned(Data) ->
     #{
@@ -645,16 +325,12 @@ test_store_simple_unsigned_message(Opts) ->
 test_store_ans104_message(Opts) ->
     Store = hb_opts:get(store, no_viable_store, Opts),
     hb_store:reset(Store),
-    Item = 
-		#{ <<"type">> => <<"ANS104">>, <<"content">> => <<"Hello, world!">> },
+    Item = #{ <<"type">> => <<"ANS104">>, <<"content">> => <<"Hello, world!">> },
     Attested = hb_message:attest(Item, hb:wallet()),
     {ok, _Path} = write(Attested, Opts),
     AttestedID = hb_util:human_id(hb_message:id(Attested, all)),
     UnattestedID = hb_util:human_id(hb_message:id(Attested, none)),
-    ?event({test_message_ids, 
-		{unattested, UnattestedID}, 
-		{attested, AttestedID}
-	}),
+    ?event({test_message_ids, {unattested, UnattestedID}, {attested, AttestedID}}),
     {ok, RetrievedItem} = read(AttestedID, Opts),
     {ok, RetrievedItemU} = read(UnattestedID, Opts),
     ?assert(hb_message:match(Attested, RetrievedItem)),
@@ -674,13 +350,9 @@ test_store_simple_signed_message(Opts) ->
     %% Read the item back
     {ok, UID} = dev_message:id(Item, #{ <<"attestors">> => <<"none">> }, Opts),
     {ok, RetrievedItemU} = read(UID, Opts),
-    ?event({retreived_unsigned_message, 
-		{expected, Item}, 
-		{got, RetrievedItemU}
-	}),
+    ?event({retreived_unsigned_message, {expected, Item}, {got, RetrievedItemU}}),
     ?assert(hb_message:match(Item, RetrievedItemU)),
-    {ok, AttestedID} = 
-		dev_message:id(Item, #{ <<"attestors">> => [Address] }, Opts),
+    {ok, AttestedID} = dev_message:id(Item, #{ <<"attestors">> => [Address] }, Opts),
     {ok, RetrievedItemS} = read(AttestedID, Opts),
     ?assert(hb_message:match(Item, RetrievedItemS)),
     ok.
@@ -717,8 +389,7 @@ test_deeply_nested_complex_message(Opts) ->
         ),
     {ok, UID} = dev_message:id(Outer, #{ <<"attestors">> => <<"none">> }, Opts),
     ?event({string, <<"================================================">>}),
-    {ok, AttestedID} = 
-		dev_message:id(Outer, #{ <<"attestors">> => [Address] }, Opts),
+    {ok, AttestedID} = dev_message:id(Outer, #{ <<"attestors">> => [Address] }, Opts),
     ?event({string, <<"================================================">>}),
     ?event({test_message_ids, {unattested, UID}, {attested, AttestedID}}),
     %% Write the nested item
@@ -737,10 +408,7 @@ test_deeply_nested_complex_message(Opts) ->
     ?event({deep_message, DeepMsg}),
     %% Assert that the retrieved item matches the original deep value
     ?assertEqual([1,2,3], hb_converge:get(<<"deep-test-key">>, DeepMsg)),
-    ?event({deep_message_match, 
-		{read, DeepMsg}, 
-		{write, Level3SignedSubmessage}
-	}),
+    ?event({deep_message_match, {read, DeepMsg}, {write, Level3SignedSubmessage}}),
     ?assert(hb_message:match(Level3SignedSubmessage, DeepMsg)),
     {ok, OuterMsg} = read(OuterID, Opts),
     ?assert(hb_message:match(Outer, OuterMsg)),
@@ -759,18 +427,12 @@ test_message_with_message(Opts) ->
 
 cache_suite_test_() ->
     hb_store:generate_test_suite([
-        {"store unsigned empty message", 
-			fun test_store_unsigned_empty_message/1},
-        {"store binary", 
-			fun test_store_binary/1},
-        {"store simple unsigned message", 
-			fun test_store_simple_unsigned_message/1},
-        {"store simple signed message", 
-			fun test_store_simple_signed_message/1},
-        {"deeply nested complex message", 
-			fun test_deeply_nested_complex_message/1},
-        {"message with message", 
-			fun test_message_with_message/1}
+        {"store unsigned empty message", fun test_store_unsigned_empty_message/1},
+        {"store binary", fun test_store_binary/1},
+        {"store simple unsigned message", fun test_store_simple_unsigned_message/1},
+        {"store simple signed message", fun test_store_simple_signed_message/1},
+        {"deeply nested complex message", fun test_deeply_nested_complex_message/1},
+        {"message with message", fun test_message_with_message/1}
     ]).
 
 %% @doc Test that message whose device is `#{}` cannot be written. If it were to
@@ -778,11 +440,7 @@ cache_suite_test_() ->
 test_device_map_cannot_be_written_test() ->
     try
         Opts = #{ store => StoreOpts =
-            [#{ 
-				<<"store-module">> => hb_store_fs, 
-				<<"prefix">> => <<"cache-TEST">> 
-			}] 
-		},
+            [#{ <<"store-module">> => hb_store_fs, <<"prefix">> => <<"cache-TEST">> }] },
         hb_store:reset(StoreOpts),
         Danger = #{ <<"device">> => #{}},
         write(Danger, Opts),
@@ -793,10 +451,6 @@ test_device_map_cannot_be_written_test() ->
 
 run_test() ->
     Opts = #{ store => StoreOpts = 
-        [#{
-			<<"store-module">> => hb_store_fs, 
-			<<"prefix">> => <<"cache-TEST">> 
-		}]
-	},
+        [#{ <<"store-module">> => hb_store_fs, <<"prefix">> => <<"cache-TEST">> }]},
     test_store_ans104_message(Opts),
     hb_store:reset(StoreOpts).

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -57,7 +57,7 @@ list(Path, Store) ->
 %% outer message (which does not include its attestations) will be built upon
 %% the attestations of the inner messages. We do not, however, store the IDs from
 %% attestations on signed _inner_ messages. We may wish to revisit this.
-write(RawMsg, Opts) ->
+write(RawMsg, Opts) when is_map(RawMsg) ->
     % Use the _structured_ format for calculating alternative IDs, but the
     % _tabm_ format for writing to the store.
     case hb_message:with_only_attested(RawMsg, Opts) of
@@ -86,7 +86,11 @@ write(RawMsg, Opts) ->
             end;
         {error, Err} ->
             {error, Err}
-    end.
+    end;
+write(Bin, Opts) when is_binary(Bin) ->
+    % When asked to write only a binary, we do not calculate any alternative IDs.
+    do_write_message(Bin, [], hb_opts:get(store, no_viable_store, Opts), Opts).
+
 do_write_message(Bin, AltIDs, Store, Opts) when is_binary(Bin) ->
     % Write the binary in the store at its given hash. Return the path.
     Hashpath = hb_path:hashpath(Bin, Opts),

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -28,44 +28,75 @@
 -include_lib("eunit/include/eunit.hrl").
 
 %% @doc List all items in a directory, assuming they are numbered.
+%%
+%% @param Path A binary representing the directory path.
+%% @param Opts A map of options (including store configuration).
+%% @returns A list of integers converted from the names of the directory items.
 list_numbered(Path, Opts) ->
-    SlotDir = hb_store:path(hb_opts:get(store, no_viable_store, Opts), Path),
-    [ to_integer(Name) || Name <- list(SlotDir, Opts) ].
+    Store = hb_opts:get(store, no_viable_store, Opts),
+    ?event(hb_cache, {list_numbered, {store, Store}, {path, Path}}),
+    SlotDir = hb_store:path(Store, Path),
+    ?event(hb_cache, {list_numbered, {slot_dir, SlotDir}}),
+    RawNames = list(SlotDir, Opts),
+    ?event(hb_cache, {list_numbered, {raw_names, RawNames}}),
+    [to_integer(Name) || Name <- RawNames].
+
 
 %% @doc List all items under a given path.
-list(Path, Opts) when is_map(Opts)->
-    case hb_opts:get(store, no_viable_store, Opts) of
-        no_viable_store -> [];
-        Store ->
+%%
+%% @param Path A binary representing the path to list.
+%% @param Opts A map of options (including store configuration).
+%% @returns A list of item names, or an empty list if the store is unavailable.
+list(Path, Opts) when is_map(Opts) ->
+    Store = hb_opts:get(store, no_viable_store, Opts),
+    ?event(hb_cache, {list, {path, Path}, {opts, Opts}, {store, Store}}),
+    case Store of
+        no_viable_store ->
+            ?event(hb_cache, {list, {result, []}}),
+            [];
+        _ ->
             list(Path, Store)
     end;
 list(Path, Store) ->
     ResolvedPath = hb_store:resolve(Store, Path),
+    ?event(hb_cache, {list, {resolved_path, ResolvedPath}}),
     case hb_store:list(Store, ResolvedPath) of
-        {ok, Names} -> Names;
-        {error, _} -> [];
-        no_viable_store -> []
+        {ok, Names} ->
+            ?event(hb_cache, {list, {result, Names}}),
+            Names;
+        {error, Err} ->
+            ?event(hb_cache, {list, {error, Err}}),
+            [];
+        no_viable_store ->
+            ?event(hb_cache, {list, {result, []}}),
+            []
     end.
 
-%% @doc Write a message to the cache. For raw binaries, we write the data at
-%% the hashpath of the data (by default the SHA2-256 hash of the data). We link
-%% the unattended ID's hashpath for the keys (including `/attestations') on the
-%% message to the underlying data and recurse. We then link each attestation ID
-%% to the unattested message, such that any of the attested or unattested IDs
-%% can be read, and once in memory all of the attestations are available. For
-%% deep messages, the attestations will also be read, such that the ID of the
-%% outer message (which does not include its attestations) will be built upon
-%% the attestations of the inner messages. We do not, however, store the IDs from
-%% attestations on signed _inner_ messages. We may wish to revisit this.
+%% @doc Write a message to the cache.
+%%
+%% For raw binaries, writes the data at its hashpath (by default, the
+%% SHA2-256 hash of the data). The function links the unattended ID's
+%% hashpath for keys (including `/attestations') to the underlying data and
+%% recursively processes submessages. Additionally, it creates links from
+%% each attestation ID to the unattested message, ensuring that both attested
+%% and unattested IDs can be read and that all attestations are available in
+%% memory. For deep messages, the attestations of inner messages are also
+%% read, so that the ID of the outer message (which does not include its
+%% attestations) is built upon the attestations of the inner messages.
+%% Note: IDs from attestations on signed _inner_ messages are not stored.
+%%       (This behavior may be revisited in the future.)
+%%
+%% @param RawMsg The raw message (binary or map) to be written.
+%% @param Opts A map of configuration options.
+%% @returns {ok, Path} on success or {error, Reason} on failure.
 write(RawMsg, Opts) ->
-    % Use the _structured_ format for calculating alternative IDs, but the
-    % _tabm_ format for writing to the store.
+    ?event(hb_cache, {write, {start, RawMsg}}),
     case hb_message:with_only_attested(RawMsg, Opts) of
         {ok, Msg} ->
             AltIDs = calculate_alt_ids(RawMsg, Opts),
-            ?event({writing_full_message, {alt_ids, AltIDs}, {msg, Msg}}),
+            ?event(hb_cache, {write, {alt_ids, AltIDs}, {msg, Msg}}),
             Tabm = hb_message:convert(Msg, tabm, <<"structured@1.0">>, Opts),
-            ?event({tabm, Tabm}),
+            ?event(hb_cache, {write, {tabm, Tabm}}),
             do_write_message(
                 Tabm,
                 AltIDs,
@@ -73,51 +104,74 @@ write(RawMsg, Opts) ->
                 Opts
             );
         {error, Err} ->
+            ?event(hb_cache, {write, {error, Err}}),
             {error, Err}
     end.
+
+%% @doc Helper function to write a message or binary to the store.
+%%
+%% For binary data, writes it at its hashpath and creates links for
+%% alternative IDs. For map messages, handles both remote and local store
+%% cases by writing subkeys, creating groups, and establishing links for
+%% attestations.
+%%
+%% @param BinOrMsg A binary or map representing the message.
+%% @param AltIDs A list of alternative IDs derived from attestations.
+%% @param Store The store configuration.
+%% @param Opts A map of configuration options.
+%% @returns {ok, Path} on success or {error, Reason} on failure.
 do_write_message(Bin, AltIDs, Store, Opts) when is_binary(Bin) ->
-    % Write the binary in the store at its given hash. Return the path.
+    ?event(hb_cache, {do_write_message_binary, {start, Bin}, {alt_ids, AltIDs}, {store, Store}}),
     Hashpath = hb_path:hashpath(Bin, Opts),
+    ?event(hb_cache, {do_write_message_binary, {hashpath, Hashpath}}),
     case hb_store:write(Store, Path = <<"data/", Hashpath/binary>>, Bin) of
-	  ok ->
-		lists:map(fun(AltID) -> hb_store:make_link(Store, Path, AltID) end, AltIDs),
-		{ok, Path};
-	{ok, RemotePath} ->	
-		{ok, RemotePath};
-	{error, Err} ->
-		{error, Err}
-	end;
+        ok ->
+            ?event(hb_cache, {do_write_message_binary, {write_result, ok}, {path, Path}}),
+            lists:map(
+                fun(AltID) ->
+                    ?event(hb_cache, {do_write_message_binary, {making_link, {alt_id, AltID}, {path, Path}}}),
+                    hb_store:make_link(Store, Path, AltID)
+                end,
+                AltIDs
+            ),
+            {ok, Path};
+        {ok, RemotePath} ->
+            ?event(hb_cache, {do_write_message_binary, {write_result, {ok, RemotePath}}}),
+            {ok, RemotePath};
+        {error, Err} ->
+            ?event(hb_cache, {do_write_message_binary, {write_result, {error, Err}}}),
+            {error, Err}
+    end;
 
 do_write_message(Msg, AltIDs, Store, Opts) when is_map(Msg) ->
-    % Check if store is hb_store_remote_node
+    ?event(hb_cache, {do_write_message_map, {start, Msg}, {alt_ids, AltIDs}, {store, Store}}),
     case is_list(Store) andalso length(Store) > 0 andalso 
          maps:get(<<"store-module">>, hd(Store), undefined) == hb_store_remote_node of
         true ->
-            % For remote node stores, write the message directly
-			Hashpath = hb_path:hashpath(Msg, Opts),
-			case hb_store:write(Store, <<"data/", Hashpath/binary>>, Msg) of
-                {ok, RemotePath} -> 
+            ?event(hb_cache, {do_write_message_map, {remote_store, true}}),
+            Hashpath = hb_path:hashpath(Msg, Opts),
+            ?event(hb_cache, {do_write_message_map, {hashpath, Hashpath}}),
+            case hb_store:write(Store, <<"data/", Hashpath/binary>>, Msg) of
+                {ok, RemotePath} ->
+                    ?event(hb_cache, {do_write_message_map, {remote_write_success, RemotePath}}),
                     {ok, RemotePath};
-                {error, Err} -> 
+                {error, Err} ->
+                    ?event(hb_cache, {do_write_message_map, {remote_write_error, Err}}),
                     {error, Err}
             end;
         false ->
-            % Get the ID of the unsigned message.
+            ?event(hb_cache, {do_write_message_map, {remote_store, false}}),
             {ok, UnattestedID} = dev_message:id(Msg, #{ <<"attestors">> => <<"none">> }, Opts),
-            ?event({writing_message_with_unsigned_id, UnattestedID, {alts, AltIDs}}),
+            ?event(hb_cache, {do_write_message_map, {unsigned_id, UnattestedID}, {alt_ids, AltIDs}}),
             MsgHashpathAlg = hb_path:hashpath_alg(Msg),
             hb_store:make_group(Store, UnattestedID),
-            % Write the keys of the message into the store, rolling the keys into
-            % hashpaths (having only two parts) as we do so.
-            % We start by writing the group, such that if the message is empty, we
-            % still have a group in the store.
             hb_store:make_group(Store, UnattestedID),
             maps:map(
                 fun(<<"device">>, Map) when is_map(Map) ->
-                    ?event(error, {request_to_write_device_map, {id, hb_message:id(Map)}}),
+                    ?event(hb_cache, {do_write_message_map, {error, "device_map_cannot_be_written"}, {id, hb_message:id(Map)}}),
                     throw({device_map_cannot_be_written, {id, hb_message:id(Map)}});
                 (Key, Value) ->
-                    ?event({writing_subkey, {key, Key}, {value, Value}}),
+                    ?event(hb_cache, {do_write_message_map, {writing_subkey, {key, Key}, {value, Value}}}),
                     KeyHashPath =
                         hb_path:hashpath(
                             UnattestedID,
@@ -125,31 +179,23 @@ do_write_message(Msg, AltIDs, Store, Opts) when is_map(Msg) ->
                             MsgHashpathAlg,
                             Opts
                         ),
-                    ?event({key_hashpath_from_unsigned, KeyHashPath}),
-                    % Note: We do not pass the AltIDs here, as we cannot calculate them
+                    ?event(hb_cache, {do_write_message_map, {key_hashpath, KeyHashPath}}),
+					% Note: We do not pass the AltIDs here, as we cannot calculate them
                     % based on the TABM that we have in-memory at this point. We could
                     % turn the TABM back into a structured message, but this is
                     % expensive.
                     {ok, Path} = do_write_message(Value, [], Store, Opts),
                     hb_store:make_link(Store, Path, KeyHashPath),
-                    ?event(
-                        {
-                            {link, KeyHashPath},
-                            {data_path, Path}
-                        }
-                    ),
+                    ?event(hb_cache, {do_write_message_map, {link_created, {key_hashpath, KeyHashPath}, {data_path, Path}}}),
                     Path
                 end,
                 hb_private:reset(Msg)
             ),
-            % Write the attestations to the store, linking each attestation ID to the
+			% Write the attestations to the store, linking each attestation ID to the
             % unattested message.
             lists:map(
                 fun(AltID) ->
-                    ?event({linking_attestation,
-                        {unattested_id, UnattestedID},
-                        {attested_id, AltID}
-                    }),
+                    ?event(hb_cache, {do_write_message_map, {linking_attestation, {unattested_id, UnattestedID}, {attested_id, AltID}}}),
                     hb_store:make_link(Store, UnattestedID, AltID)
                 end,
                 AltIDs
@@ -158,143 +204,241 @@ do_write_message(Msg, AltIDs, Store, Opts) when is_map(Msg) ->
     end.
 
 %% @doc Calculate the alternative IDs for a message.
-calculate_alt_ids(Bin, _Opts) when is_binary(Bin) -> [];
+%%
+%% For binary input, returns an empty list.
+%% For map input, extracts alternative IDs from the message's attestations.
+%%
+%% @param Msg A binary or map representing the message.
+%% @param Opts A map of configuration options.
+%% @returns A list of alternative IDs.
+calculate_alt_ids(Bin, _Opts) when is_binary(Bin) ->
+    ?event(hb_cache, {calculate_alt_ids, {binary_input, Bin}}),
+    [];
 calculate_alt_ids(Msg, _Opts) ->
+    ?event(hb_cache, {calculate_alt_ids, {msg_input, Msg}}),
     Attestations =
-        maps:without(
-            [<<"priv">>],
-            maps:get(<<"attestations">>, Msg, #{})
-        ),
-    lists:filtermap(
+		 maps:without(
+			[<<"priv">>],
+			maps:get(<<"attestations">>, Msg, #{})
+		),
+    ?event(hb_cache, {calculate_alt_ids, {attestations, Attestations}}),
+    Result = lists:filtermap(
         fun(Attestor) ->
             Att = maps:get(Attestor, Attestations, #{}),
             case maps:get(<<"id">>, Att, undefined) of
-                undefined -> false;
-                ID -> {true, ID}
+                undefined ->
+                    ?event(hb_cache, {calculate_alt_ids, {attestor, Attestor}, {result, undefined}}),
+                    false;
+                ID ->
+                    ?event(hb_cache, {calculate_alt_ids, {attestor, Attestor}, {result, ID}}),
+                    {true, ID}
             end
         end,
         maps:keys(Attestations)
-    ).
+    ),
+    ?event(hb_cache, {calculate_alt_ids, {result, Result}}),
+    Result.
 
-%% @doc Write a hashpath and its message to the store and link it.
+%% @doc Write a hashpath and its message to the store and create a link.
+%%
+%% If the message contains a hashpath in its private data, that hashpath is used.
+%% Otherwise, the message is written normally.
+%%
+%% @param Msg A map representing the message to be written.
+%% @param Opts A map of configuration options.
+%% @returns {ok, Path} on success.
 write_hashpath(Msg = #{ <<"priv">> := #{ <<"hashpath">> := HP } }, Opts) ->
+    ?event(hb_cache, {write_hashpath, {detected_hashpath, HP}, {msg, Msg}}),
     write_hashpath(HP, Msg, Opts);
 write_hashpath(MsgWithoutHP, Opts) ->
+    ?event(hb_cache, {write_hashpath, {no_hashpath, MsgWithoutHP}}),
     write(MsgWithoutHP, Opts).
+
 write_hashpath(HP, Msg, Opts) when is_binary(HP) or is_list(HP) ->
     Store = hb_opts:get(store, no_viable_store, Opts),
-    ?event({writing_hashpath, {hashpath, HP}, {msg, Msg}, {store, Store}}),
+    ?event(hb_cache, {write_hashpath, {writing_hashpath, HP}, {msg, Msg}, {store, Store}}),
     {ok, Path} = write(Msg, Opts),
     hb_store:make_link(Store, Path, HP),
     {ok, Path}.
 
-%% @doc Write a raw binary keys into the store and link it at a given hashpath.
+%% @doc Write a raw binary key into the store and create a link at a given hashpath.
+%%
+%% @param Hashpath The hashpath at which to write the binary.
+%% @param Bin The binary data to be stored.
+%% @param Opts A map of configuration options.
+%% @returns The result of writing the binary.
 write_binary(Hashpath, Bin, Opts) ->
+    ?event(hb_cache, {write_binary, {start, {hashpath, Hashpath}, {bin, Bin}, {opts, Opts}}}),
     write_binary(Hashpath, Bin, hb_opts:get(store, no_viable_store, Opts), Opts).
+
 write_binary(Hashpath, Bin, Store, Opts) ->
-    ?event({writing_binary, {hashpath, Hashpath}, {bin, Bin}, {store, Store}}),
+    ?event(hb_cache, {write_binary, {start_with_store, {hashpath, Hashpath}, {bin, Bin}, {store, Store}}}),
     do_write_message(Bin, [Hashpath], Store, Opts).
 
-%% @doc Read the message at a path. Returns in `structured@1.0' format: Either a
-%% richly typed map or a direct binary.
+
+%% @doc Read the message at a given path.
+%%
+%% Retrieves the message in `structured@1.0' format, which may be a richly typed map
+%% or a direct binary.
+%%
+%% @param Path The path or key to read.
+%% @param Opts A map of configuration options.
+%% @returns {ok, Structured} on success, or not_found if the message is missing.
 read(Path, Opts) ->
-    case store_read(Path, hb_opts:get(store, no_viable_store, Opts), Opts) of
-        not_found -> not_found;
+    ?event(hb_cache, {read, {start, {path, Path}, {opts, Opts}}}),
+    Store = hb_opts:get(store, no_viable_store, Opts),
+    ?event(hb_cache, {read, {store, Store}}),
+    case store_read(Path, Store, Opts) of
+        not_found ->
+            ?event(hb_cache, {read, {result, not_found}}),
+            not_found;
         {ok, Res} ->
-            ?event({applying_types_to_read_message, Res}),
+            ?event(hb_cache, {read, {raw_result, Res}}),
             Structured = dev_codec_structured:to(Res),
-            ?event({finished_read, Structured}),
+            ?event(hb_cache, {read, {structured_result, Structured}}),
             {ok, Structured}
     end.
 
-%% @doc List all of the subpaths of a given path, read each in turn, returning a
-%% flat map. We track the paths that we have already read to avoid circular
-%% links.
+%% @doc Recursively read a path from the store, tracking visited paths to avoid circular links.
+%%
+%% @param Path The path to be read.
+%% @param Store The store configuration.
+%% @param Opts A map of configuration options.
+%% @returns {ok, Result} on success, or not_found if the path cannot be read.
 store_read(Path, Store, Opts) ->
+    ?event(hb_cache, {store_read, {start, {path, Path}, {store, Store}, {opts, Opts}}}),
     store_read(Path, Store, Opts, []).
+
 store_read(_Path, no_viable_store, _, _AlreadyRead) ->
+    ?event(hb_cache, {store_read, {result, no_viable_store}}),
     not_found;
 store_read(Path, Store, Opts, AlreadyRead) ->
     case lists:member(Path, AlreadyRead) of
         true ->
-            ?event(read_error,
-                {circular_links_detected,
-                    {path, Path},
-                    {already_read, AlreadyRead}
-                }
-            ),
+            ?event(hb_cache, 
+				{store_read, 
+					{circular_links_detected, 
+					{path, Path},
+					{already_read, AlreadyRead}
+					}
+				}
+			),
             throw({circular_links_detected, Path, {already_read, AlreadyRead}});
         false ->
+            ?event(hb_cache, {store_read, {proceeding, {path, Path}}}),
             do_read(Path, Store, Opts, AlreadyRead)
     end.
 
-%% @doc Read a path from the store. Unsafe: May recurse indefinitely if circular
-%% links are present.
+%% @doc Read a path from the store.
+%%
+%% This function is unsafe as it may recurse indefinitely if circular links are present.
+%%
+%% @param Path The path to read.
+%% @param Store The store configuration.
+%% @param Opts A map of configuration options.
+%% @param AlreadyRead A list of paths already visited.
+%% @returns The read result, or not_found if unsuccessful.
 do_read(Path, Store, Opts, AlreadyRead) ->
     ResolvedFullPath = hb_store:resolve(Store, PathToBin = hb_path:to_binary(Path)),
-    ?event({reading, {path, PathToBin}, {resolved, ResolvedFullPath}}),
+    ?event(hb_cache, {do_read, {path, PathToBin}, {resolved, ResolvedFullPath}}),
     case hb_store:type(Store, ResolvedFullPath) of
-        not_found -> not_found;
-        no_viable_store -> not_found;
-        simple -> hb_store:read(Store, ResolvedFullPath);
+        not_found ->
+            ?event(hb_cache, {do_read, {result, not_found}}),
+            not_found;
+        no_viable_store ->
+            ?event(hb_cache, {do_read, {result, no_viable_store}}),
+            not_found;
+        simple ->
+            ?event(hb_cache, {do_read, {type, simple}}),
+            hb_store:read(Store, ResolvedFullPath);
         _ ->
             case hb_store:list(Store, ResolvedFullPath) of
                 {ok, Subpaths} ->
-                    ?event(
-                        {listed,
-                            {original_path, Path},
-                            {subpaths, {explicit, Subpaths}}
-                        }
-                    ),
-                    Msg =
-                        maps:from_list(
-                            lists:map(
-                                fun(Subpath) ->
-                                    ?event({reading_subpath, {path, Subpath}, {store, Store}}),
-                                    {ok, Res} = store_read(
-                                        [ResolvedFullPath, Subpath],
-                                        Store,
-                                        Opts,
-                                        [ResolvedFullPath | AlreadyRead]
-                                    ),
-                                    {iolist_to_binary([Subpath]), Res}
-                                end,
-                                Subpaths
-                            )
-                        ),
-                    ?event({read_message, Msg}),
-                    {ok, Msg};
-                _ -> not_found
-            end
+                    ?event(hb_cache, 
+					{do_read, 
+						{listed, 
+							{original_path, Path}, 
+							{subpaths, {explicit, Subpaths}}
+						}
+					}
+				),
+				Msg =
+					maps:from_list(
+					lists:map(
+						fun(Subpath) ->
+							?event(hb_cache, {do_read, {reading_subpath, {path, Subpath}, {store, Store}}}),
+							{ok, Res} = store_read(
+								[ResolvedFullPath, Subpath],
+								 Store, 
+								 Opts, 
+								 [ResolvedFullPath | AlreadyRead]
+							),
+							{iolist_to_binary([Subpath]), Res}
+						end,
+						Subpaths
+					)
+				),
+				?event(hb_cache, {do_read, {read_message, Msg}}),
+				{ok, Msg};
+			_ ->
+				?event(hb_cache, {do_read, {list_error, ResolvedFullPath}}),
+				not_found
+		end
     end.
 
-%% @doc Read the output of a prior computation, given Msg1, Msg2, and some
-%% options.
+%% @doc Read the output of a prior computation given two message identifiers or messages.
+%%
+%% Constructs a composite path from the provided message IDs (or messages) and retrieves the result.
+%%
+%% @param MsgID1 The first message ID or message.
+%% @param MsgID2 The second message ID or message.
+%% @param Opts A map of configuration options.
+%% @returns The resolved message, or not_found if not available.
 read_resolved(MsgID1, MsgID2, Opts) when ?IS_ID(MsgID1) and ?IS_ID(MsgID2) ->
-    ?event({cache_lookup, {msg1, MsgID1}, {msg2, MsgID2}, {opts, Opts}}),
+    ?event(hb_cache, {read_resolved, {msg1, MsgID1}, {msg2, MsgID2}, {opts, Opts}}),
     read(<<MsgID1/binary, "/", MsgID2/binary>>, Opts);
 read_resolved(MsgID1, Msg2, Opts) when ?IS_ID(MsgID1) and is_map(Msg2) ->
     {ok, MsgID2} = dev_message:id(Msg2, #{ <<"attestors">> => <<"all">> }, Opts),
+    ?event(hb_cache, {read_resolved, {derived_msgid2, MsgID2}}),
     read(<<MsgID1/binary, "/", MsgID2/binary>>, Opts);
 read_resolved(Msg1, Msg2, Opts) when is_map(Msg1) and is_map(Msg2) ->
+    ?event(hb_cache, {read_resolved, {msg1, Msg1}, {msg2, Msg2}}),
     read(hb_path:hashpath(Msg1, Msg2, Opts), Opts);
-read_resolved(_, _, _) -> not_found.
+read_resolved(_, _, _) ->
+    ?event(hb_cache, {read_resolved, {result, not_found}}),
+    not_found.
 
-%% @doc Make a link from one path to another in the store.
-%% Note: Argument order is `link(Src, Dst, Opts)'.
+%% @doc Create a link from one path to another in the store.
+%%
+%% @param Existing The existing path.
+%% @param New The new path to link to.
+%% @param Opts A map of configuration options.
+%% @returns The result of the link creation.
 link(Existing, New, Opts) ->
+    Store = hb_opts:get(store, no_viable_store, Opts),
+    ?event(hb_cache, {link, {existing, Existing}, {new, New}, {store, Store}}),
     hb_store:make_link(
-        hb_opts:get(store, no_viable_store, Opts),
-        Existing,
-        New
-    ).
+		Store, 
+		Existing, 
+		New
+	).
 
+%% @doc Convert a value to an integer.
+%%
+%% @param Value A binary or list representing an integer.
+%% @returns The integer value.
 to_integer(Value) when is_list(Value) ->
+    ?event(hb_cache, {to_integer, {list, Value}}),
     list_to_integer(Value);
 to_integer(Value) when is_binary(Value) ->
+    ?event(hb_cache, {to_integer, {binary, Value}}),
     binary_to_integer(Value).
 
+
+
+%%%--------------------------------------------------------------------
 %%% Tests
+%%%--------------------------------------------------------------------
 
 test_unsigned(Data) ->
     #{

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -86,7 +86,8 @@ start() ->
         Loaded#{
             priv_wallet => PrivWallet,
             store => Store,
-            port => hb_opts:get(port, 8734, Loaded)
+            port => hb_opts:get(port, 8734, Loaded),
+            cache_writers => [hb_util:human_id(ar_wallet:to_address(PrivWallet))]
         }
     ).
 start(Opts) ->

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -161,17 +161,16 @@ default_message() ->
         ],
         store =>
             [
-				#{ <<"store-module">> => hb_store_remote_node, <<"node">> => <<"http://localhost:10001/">> }
-                % #{ <<"store-module">> => hb_store_fs, <<"prefix">> => <<"cache-mainnet">> },
-                % #{ <<"store-module">> => hb_store_gateway,
-                %     <<"store">> =>
-                %         [
-                %             #{
-                %                 <<"store-module">> => hb_store_fs,
-                %                 <<"prefix">> => <<"cache-mainnet">>
-                %             }
-                %         ]
-                % }
+                #{ <<"store-module">> => hb_store_fs, <<"prefix">> => <<"cache-mainnet">> },
+                #{ <<"store-module">> => hb_store_gateway,
+                    <<"store">> =>
+                        [
+                            #{
+                                <<"store-module">> => hb_store_fs,
+                                <<"prefix">> => <<"cache-mainnet">>
+                            }
+                        ]
+                }
             ],
         % Should we use the latest cached state of a process when computing?
         process_now_from_cache => false,

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -53,6 +53,7 @@ default_message() ->
         preloaded_devices => [
             #{<<"name">> => <<"ans104@1.0">>, <<"module">> => dev_codec_ans104},
             #{<<"name">> => <<"compute@1.0">>, <<"module">> => dev_cu},
+            #{<<"name">> => <<"cache@1.0">>, <<"module">> => dev_cache},
             #{<<"name">> => <<"cron@1.0">>, <<"module">> => dev_cron},
             #{<<"name">> => <<"dedup@1.0">>, <<"module">> => dev_dedup},
             #{<<"name">> => <<"delegated-compute@1.0">>, <<"module">> => dev_delegated_compute},
@@ -159,16 +160,17 @@ default_message() ->
         ],
         store =>
             [
-                #{ <<"store-module">> => hb_store_fs, <<"prefix">> => <<"cache-mainnet">> },
-                #{ <<"store-module">> => hb_store_gateway,
-                    <<"store">> =>
-                        [
-                            #{
-                                <<"store-module">> => hb_store_fs,
-                                <<"prefix">> => <<"cache-mainnet">>
-                            }
-                        ]
-                }
+				#{ <<"store-module">> => hb_store_remote_node, <<"node">> => <<"http://localhost:10001/">> }
+                % #{ <<"store-module">> => hb_store_fs, <<"prefix">> => <<"cache-mainnet">> },
+                % #{ <<"store-module">> => hb_store_gateway,
+                %     <<"store">> =>
+                %         [
+                %             #{
+                %                 <<"store-module">> => hb_store_fs,
+                %                 <<"prefix">> => <<"cache-mainnet">>
+                %             }
+                %         ]
+                % }
             ],
         % Should we use the latest cached state of a process when computing?
         process_now_from_cache => false,

--- a/src/hb_store_remote_node.erl
+++ b/src/hb_store_remote_node.erl
@@ -8,65 +8,102 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-%% @doc Returns the scope of this store, which is always 'remote'.
-scope(_) -> remote.
+%% @doc Return the scope of this store.
+%%
+%% For the remote store, the scope is always `remote'.
+%%
+%% @param Arg An arbitrary parameter (ignored).
+%% @returns remote.
+scope(Arg) ->
+    ?event(hb_store_remote_node, {scope, {arg, Arg}}),
+    remote.
 
-%% @doc Resolves a key path in the remote store context.
+%% @doc Resolve a key path in the remote store.
+%%
 %% For the remote node store, the key is returned as-is.
+%%
+%% @param Data A map containing node configuration.
+%% @param Key The key to resolve.
+%% @returns The resolved key.
 resolve(#{ <<"node">> := Node }, Key) ->
-    ?event({resolving_to_self, Node, Key}),
+    ?event(hb_store_remote_node, {resolve, {node, Node}, {key, Key}}),
     Key.
 
-%% @doc Determines the type of value at the given key.
-%% Remote nodes only support 'simple' type or 'not_found'.
+%% @doc Determine the type of value at a given key.
+%%
+%% Remote nodes support only the `simple' type or `not_found'.
+%%
+%% @param Opts A map of options (including node configuration).
+%% @param Key The key whose value type is determined.
+%% @returns simple if found, or not_found otherwise.
 type(Opts = #{ <<"node">> := Node }, Key) ->
-    ?event({remote_type, Node, Key}),
+    ?event(hb_store_remote_node, {type, {node, Node}, {key, Key}}),
     case read(Opts, Key) of
         not_found -> not_found;
         _ -> simple
     end.
 
-%% @doc Reads a key from the remote node.
-%% Makes an HTTP request to the remote node and returns the attested message.
+%% @doc Read a key from the remote node.
+%%
+%% Makes an HTTP GET request to the remote node and returns the
+%% attested message.
+%%
+%% @param Opts A map of options (including node configuration).
+%% @param Key The key to read.
+%% @returns {ok, Msg} on success or not_found if the key is missing.
 read(Opts = #{ <<"node">> := Node }, Key) ->
+    ?event(hb_store_remote_node, {read, {node, Node}, {key, Key}}),
     case hb_http:get(Node, Key, Opts) of
         {ok, Res} ->
             {ok, Msg} = hb_message:with_only_attested(Res),
+            ?event(hb_store_remote_node, {read, {result, Msg}}),
             {ok, Msg};
         {error, _Err} ->
+            ?event(hb_store_remote_node, {read, {result, not_found}}),
             not_found
     end.
 
-%% @doc Writes a key to the remote node.
+%% @doc Write a key to the remote node.
+%%
+%% Constructs an HTTP POST write request. If a wallet is provided,
+%% the message is signed. Returns {ok, Path} on HTTP 200, or
+%% {error, Reason} on failure.
+%%
+%% @param Opts A map of options (including node configuration).
+%% @param Key The key to write.
+%% @param Value The value to store.
+%% @returns {ok, Path} on success or {error, Reason} on failure.
 write(Opts = #{ <<"node">> := Node }, Key, Value) ->
-    ?event({writing, Key, Value, Opts}),
-    % Create a write request message
+    ?event(hb_store_remote_node, {write, {node, Node},
+                                  {key, Key}, {value, Value}}),
     WriteMsg = #{
         <<"path">> => <<"/~cache@1.0/write">>,
         <<"method">> => <<"POST">>,
         <<"body">> => Value
     },
-    
-    % Sign the message if wallet is provided
     Wallet = hb:wallet(),
     SignedMsg = case Wallet of
         undefined -> WriteMsg;
         _ -> hb_message:attest(WriteMsg, Wallet)
     end,
-    
-    % Send the write request
+    ?event(hb_store_remote_node, {write, {signed, SignedMsg}}),
     case hb_http:post(Node, SignedMsg, Opts) of
-        {ok, Response} -> 
+        {ok, Response} ->
             Status = hb_converge:get(<<"status">>, Response, 0, #{}),
-			Path = hb_converge:get(<<"path">>, Response, <<>>, #{}),
+            Path = hb_converge:get(<<"path">>, Response, <<>>, #{}),
+            ?event(hb_store_remote_node, {write, {response, Response}}),
             case Status of
                 200 -> {ok, Path};
                 _ -> {error, {unexpected_status, Status}}
             end;
-        {error, Err} -> {error, Err}
+        {error, Err} ->
+            ?event(hb_store_remote_node, {write, {error, Err}}),
+            {error, Err}
     end.
 
+%%%--------------------------------------------------------------------
 %%% Tests
+%%%--------------------------------------------------------------------
 
 %% @doc Test that we can create a store, write a random message to it, then start
 %% a remote node with that store, and read the message from it.

--- a/src/hb_store_remote_node.erl
+++ b/src/hb_store_remote_node.erl
@@ -105,11 +105,14 @@ write(Opts = #{ <<"node">> := Node }, Key, Value) ->
 %%% Tests
 %%%--------------------------------------------------------------------
 
-%% @doc Test that we can create a store, write a random message to it, then start
-%% a remote node with that store, and read the message from it.
+%% @doc Test that we can create a store, write a random message to it, then
+%% start a remote node with that store, and read the message from it.
 read_test() ->
     rand:seed(default),
-    LocalStore = #{ <<"store-module">> => hb_store_fs, <<"prefix">> => <<"cache-mainnet">> },
+    LocalStore = #{ 
+		<<"store-module">> => hb_store_fs,
+		<<"prefix">> => <<"cache-mainnet">> 
+	},
     hb_store:reset(LocalStore),
     M = #{ <<"test-key">> => Rand = rand:uniform(1337) },
     ID = hb_message:id(M),
@@ -125,6 +128,8 @@ read_test() ->
                 store => LocalStore
             }
         ),
-    RemoteStore = [#{ <<"store-module">> => hb_store_remote_node, <<"node">> => Node }],
+    RemoteStore = [
+		#{ <<"store-module">> => hb_store_remote_node, <<"node">> => Node }
+	],
     {ok, RetrievedMsg} = hb_cache:read(ID, #{ store => RemoteStore }),
     ?assertMatch(#{ <<"test-key">> := Rand }, RetrievedMsg).


### PR DESCRIPTION
Implements @pete's remote-node-as-store mechanism. The new `cache@1.0` device that it brings allows you to not just read all data from the caches of other nodes, but also to write to the store if the node trusts the request.