### PR TITLE
feat: rocksdb as compile option

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,16 @@
 {erl_opts, [debug_info, {d, 'COWBOY_QUICER', 1}, {d, 'GUN_QUICER', 1}]}.
 {plugins, [pc, rebar3_rustler]}.
 
+{profiles, [
+    {rocksdb, [
+        {deps, [
+            {rocksdb, "1.8.0"}
+        ]},
+        {erl_opts, [
+            {d, 'ENABLE_ROCKSDB', true}
+        ]}
+    ]}
+]}.
 
 {cargo_opts, [
     {src_dir, "native/dev_snp_nif"}
@@ -58,7 +68,6 @@
 	{quicer, {git, "https://github.com/qzhuyan/quic.git", {ref, "97d8be9fb8017f4578248f96f5b35f8e357df792"}}},
 	{prometheus, "4.11.0"},
 	{prometheus_cowboy, "0.1.8"},
-    {rocksdb, "1.8.0"},
     {gun, "0.10.0"}
 ]}.
 
@@ -73,7 +82,7 @@
 {eunit_opts, [verbose]}.
 
 {relx, [
-	{release, {'hb', "0.0.1"}, [hb, b64fast, cowboy, gun, quicer, prometheus, prometheus_cowboy, rocksdb]},
+	{release, {'hb', "0.0.1"}, [hb, b64fast, cowboy, gun, quicer, prometheus, prometheus_cowboy]},
 	{include_erts, true},
 	{extended_start_script, true},
 	{overlay, [
@@ -84,7 +93,7 @@
 ]}.
 
 {dialyzer, [
-	{plt_extra_apps, [public_key, ranch, cowboy, prometheus, prometheus_cowboy, b64fast, eunit, rocksdb, gun, quicer]},
+	{plt_extra_apps, [public_key, ranch, cowboy, prometheus, prometheus_cowboy, b64fast, eunit, gun, quicer]},
 	incremental,
 	{warnings, [no_improper_lists, no_unused]}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -19,7 +19,6 @@
  {<<"prometheus">>,{pkg,<<"prometheus">>,<<"4.11.0">>},0},
  {<<"prometheus_cowboy">>,{pkg,<<"prometheus_cowboy">>,<<"0.1.8">>},0},
  {<<"prometheus_httpd">>,{pkg,<<"prometheus_httpd">>,<<"2.1.11">>},1},
- {<<"quantile_estimator">>,{pkg,<<"quantile_estimator">>,<<"0.2.1">>},1},
  {<<"quicer">>,
   {git,"https://github.com/qzhuyan/quic.git",
        {ref,"97d8be9fb8017f4578248f96f5b35f8e357df792"}},
@@ -28,7 +27,6 @@
   {git,"https://github.com/ninenines/ranch",
        {ref,"a692f44567034dacf5efcaa24a24183788594eb7"}},
   1},
- {<<"rocksdb">>,{pkg,<<"rocksdb">>,<<"1.8.0">>},0},
  {<<"snabbkaffe">>,
   {git,"https://github.com/kafka4beam/snabbkaffe.git",
        {ref,"b59298334ed349556f63405d1353184c63c66534"}},
@@ -38,14 +36,10 @@
  {<<"accept">>, <<"B33B127ABCA7CC948BBE6CAA4C263369ABF1347CFA9D8E699C6D214660F10CD1">>},
  {<<"prometheus">>, <<"B95F8DE8530F541BD95951E18E355A840003672E5EDA4788C5FA6183406BA29A">>},
  {<<"prometheus_cowboy">>, <<"CFCE0BC7B668C5096639084FCD873826E6220EA714BF60A716F5BD080EF2A99C">>},
- {<<"prometheus_httpd">>, <<"F616ED9B85B536B195D94104063025A91F904A4CFC20255363F49A197D96C896">>},
- {<<"quantile_estimator">>, <<"EF50A361F11B5F26B5F16D0696E46A9E4661756492C981F7B2229EF42FF1CD15">>},
- {<<"rocksdb">>, <<"0AE072F9818DAC03E18BA0E4B436450D24040DFB1A526E2198B451FD9FA0284F">>}]},
+ {<<"prometheus_httpd">>, <<"F616ED9B85B536B195D94104063025A91F904A4CFC20255363F49A197D96C896">>}]},
 {pkg_hash_ext,[
  {<<"accept">>, <<"11B18C220BCC2EAB63B5470C038EF10EB6783BCB1FCDB11AA4137DEFA5AC1BB8">>},
  {<<"prometheus">>, <<"719862351AABF4DF7079B05DC085D2BBCBE3AC0AC3009E956671B1D5AB88247D">>},
  {<<"prometheus_cowboy">>, <<"BA286BECA9302618418892D37BCD5DC669A6CC001F4EB6D6AF85FF81F3F4F34C">>},
- {<<"prometheus_httpd">>, <<"0BBE831452CFDF9588538EB2F570B26F30C348ADAE5E95A7D87F35A5910BCF92">>},
- {<<"quantile_estimator">>, <<"282A8A323CA2A845C9E6F787D166348F776C1D4A41EDE63046D72D422E3DA946">>},
- {<<"rocksdb">>, <<"185E645EA480E9325D5EFE362BF3D2A38EDFC31B5145031B0CBEED978E89523C">>}]}
+ {<<"prometheus_httpd">>, <<"0BBE831452CFDF9588538EB2F570B26F30C348ADAE5E95A7D87F35A5910BCF92">>}]}
 ].

--- a/src/hb.app.src
+++ b/src/hb.app.src
@@ -12,7 +12,6 @@
         prometheus,
         prometheus_cowboy,
         os_mon,
-        rocksdb,
         quicer,
         gun
     ]},

--- a/src/hb.erl
+++ b/src/hb.erl
@@ -118,8 +118,7 @@ start_mainnet(Opts) ->
         gun,
         prometheus,
         prometheus_cowboy,
-        os_mon,
-        rocksdb
+        os_mon
     ]),
     Wallet = hb:wallet(hb_opts:get(priv_key_location, no_viable_wallet_path, Opts)),
     BaseOpts = hb_http_server:set_default_opts(Opts),
@@ -162,8 +161,7 @@ do_start_simple_pay(Opts) ->
         gun,
         prometheus,
         prometheus_cowboy,
-        os_mon,
-        rocksdb
+        os_mon
     ]),
     Port = maps:get(port, Opts),
     Processor =

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -101,8 +101,7 @@ start(Opts) ->
         gun,
         prometheus,
         prometheus_cowboy,
-        os_mon,
-        rocksdb
+        os_mon
     ]),
     hb:init(),
     BaseOpts = set_default_opts(Opts),
@@ -341,8 +340,7 @@ start_node(Opts) ->
         gun,
         prometheus,
         prometheus_cowboy,
-        os_mon,
-        rocksdb
+        os_mon
     ]),
     hb:init(),
     hb_sup:start_link(Opts),

--- a/src/hb_store.erl
+++ b/src/hb_store.erl
@@ -187,19 +187,27 @@ call_all([Store = #{<<"store-module">> := Mod} | Rest], Function, Args) ->
 
 %%% Test helpers
 
+-ifdef(ENABLE_ROCKSDB).
 test_stores() ->
     [
         #{
-            <<"store-module">> =>
-            hb_store_rocksdb,
+            <<"store-module">> => hb_store_rocksdb,
             <<"prefix">> => <<"cache-TEST/rocksdb">>
         },
         #{
-            <<"store-module">> =>
-            hb_store_fs,
+            <<"store-module">> => hb_store_fs,
             <<"prefix">> => <<"cache-TEST/fs">>
         }
     ].
+-else.
+test_stores() ->
+    [
+        #{
+            <<"store-module">> => hb_store_fs,
+            <<"prefix">> => <<"cache-TEST/fs">>
+        }
+    ].
+-endif.
 
 generate_test_suite(Suite) ->
     generate_test_suite(Suite, test_stores()).


### PR DESCRIPTION
In order to compile HyperBEAM with rocksdb support, you should now run `rebar3 as rocksdb compile` (where `compile` can be replaced by any other function you wish to run). This eliminates one of the more complex dependencies for building HyperBEAM for newbies. More advanced users will still likely still want to use rocksdb or another store implementation.