### PR TITLE
fix(http3): quicer version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,8 +12,8 @@
     ]},
     {http3, [
         {deps, [
-            {quicer, {git, "https://github.com/qzhuyan/quic.git",
-                {ref, "97d8be9fb8017f4578248f96f5b35f8e357df792"}}
+            {quicer, {git, "https://github.com/emqx/quic.git",
+                {ref, "e2e9ab3e1ec53e20d5f9401359cc6ee8f971d112"}}
             }
         ]},
         {erl_opts, [


### PR DESCRIPTION
Updates `quicer` from https://github.com/qzhuyan/quic/commit/97d8be9fb8017f4578248f96f5b35f8e357df792 [0.1.11-pre1](https://github.com/qzhuyan/quic/releases/tag/0.1.11-pre1) to https://github.com/emqx/quic/commit/e2e9ab3e1ec53e20d5f9401359cc6ee8f971d112 [0.1.11](https://github.com/emqx/quic/releases/tag/0.1.11)

Notably, it fixes https://github.com/microsoft/msquic/pull/4744 affecting some versions of Clang. Does not introduce any regressions when running `rebar3 as http3 eunit`