### PR TITLE
impr: Use IDs as keys in commitment submessages

### DIFF
--- a/src/ar_bundles.erl
+++ b/src/ar_bundles.erl
@@ -1064,7 +1064,6 @@ test_deep_member() ->
     ?assertEqual(false, member(crypto:strong_rand_bytes(32), Item2)).
 
 test_serialize_deserialize_deep_signed_bundle() ->
-    application:ensure_all_started(hb),
     W = ar_wallet:new(),
     % Test that we can serialize, deserialize, and get the same IDs back.
     Item1 = sign_item(#tx{data = <<"item1_data">>}, W),
@@ -1082,13 +1081,3 @@ test_serialize_deserialize_deep_signed_bundle() ->
     Item3 = sign_item(Item2, W),
     ?assertEqual(id(Item3, unsigned), id(Item2, unsigned)),
     ?assert(verify_item(Item3)).
-    % Test that we can write to disk and read back the same ID.
-    % hb_cache:write(hb_message:convert(Item2, converge, tx, #{}), #{}),
-    % {ok, MsgFromDisk} = hb_cache:read(hb_util:encode(id(Item2, unsigned)), #{}),
-    % FromDisk = hb_message:convert(MsgFromDisk, tx, converge, #{}),
-    % format(FromDisk),
-    % ?assertEqual(id(Item2, signed), id(FromDisk, signed)),
-    % % Test that normalizing the item and signing it again yields the same unsigned ID.
-    % NormItem2 = normalize(Item2),
-    % SignedNormItem2 = sign_item(NormItem2, W),
-    % ?assertEqual(id(SignedNormItem2, unsigned), id(Item2, unsigned)).

--- a/src/dev_codec_ans104.erl
+++ b/src/dev_codec_ans104.erl
@@ -1,7 +1,7 @@
 %%% @doc Codec for managing transformations from `ar_bundles'-style Arweave TX
 %%% records to and from TABMs.
 -module(dev_codec_ans104).
--export([id/1, to/1, from/1, commit/3, verify/3, commited/3, content_type/1]).
+-export([id/1, to/1, from/1, commit/3, verify/3, committed/3, content_type/1]).
 -export([serialize/1, deserialize/1]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -107,8 +107,8 @@ commit(Msg, _Req, Opts) ->
         }
     }.
 
-%% @doc Return a list of commited keys from an ANS-104 message.
-commited(Msg = #{ <<"trusted-keys">> := RawTKeys, <<"commitments">> := Comms }, _Req, Opts) ->
+%% @doc Return a list of committed keys from an ANS-104 message.
+committed(Msg = #{ <<"trusted-keys">> := RawTKeys, <<"commitments">> := Comms }, _Req, Opts) ->
     % If the message has a `trusted-keys' field in the immediate layer, we validate
     % that it also exists in the commitment's sub-map. If it exists there (which
     % cannot be written to directly by users), we can trust that the stated keys
@@ -121,8 +121,8 @@ commited(Msg = #{ <<"trusted-keys">> := RawTKeys, <<"commitments">> := Comms }, 
             % the keys in the commitment so we return an error.
             throw({trusted_keys_not_found_in_commitment, Msg})
     end;
-commited(Msg = #{ <<"original-tags">> := TagMap, <<"commitments">> := Comms }, _Req, Opts) ->
-    % If the message has an `original-tags' field, the commited fields are only
+committed(Msg = #{ <<"original-tags">> := TagMap, <<"commitments">> := Comms }, _Req, Opts) ->
+    % If the message has an `original-tags' field, the committed fields are only
     % those keys, and maps that are nested in the `data' field.
     ?event({committed_from_original_tags, {input, Msg}}),
     case hb_converge:get(hd(hb_converge:keys(Comms)), Comms, #{}) of
@@ -138,10 +138,10 @@ commited(Msg = #{ <<"original-tags">> := TagMap, <<"commitments">> := Comms }, _
             % Message appears to be tampered with.
             throw({original_tags_not_found_in_commitment, Msg})
     end;
-commited(Msg, Req, Opts) ->
+committed(Msg, Req, Opts) ->
     ?event({running_committed, {input, Msg}}),
     % Remove other commitments that were not 'promoted' to the base layer message
-    % by `message@1.0/commited'. This is safe because `to' will only proceed if 
+    % by `message@1.0/committed'. This is safe because `to' will only proceed if 
     % there is a single signature on the message. Subsequently, we can trust that
     % the keys signed by that single commitment speak for 'all' of the 
     % commitments.
@@ -166,7 +166,7 @@ commited(Msg, Req, Opts) ->
                     false -> []
                 end,
             % Return the immediate and nested keys. The `data' field is always
-            % commited, so we include it in the list of keys.
+            % committed, so we include it in the list of keys.
             {ok, TagKeys ++ NestedKeys ++ Implicit ++ ?COMMITTED_TAGS};
         _ ->
             ?event({could_not_verify, {msg, MsgLessGivenComm}}),

--- a/src/dev_codec_ans104.erl
+++ b/src/dev_codec_ans104.erl
@@ -53,7 +53,7 @@ deserialize(TX) when is_record(TX, tx) ->
 %% @doc Return the ID of a message.
 id(Msg) ->
     TABM = dev_codec_structured:from(Msg),
-    {ok, (to(TABM))#tx.id}.
+    {ok, hb_util:human_id((to(TABM))#tx.id)}.
 
 %% @doc Sign a message using the `priv_wallet' key in the options.
 commit(Msg, _Req, Opts) ->

--- a/src/dev_codec_flat.erl
+++ b/src/dev_codec_flat.erl
@@ -2,7 +2,7 @@
 %%% (potentially multi-layer) paths as their keys, and a normal TABM binary as 
 %%% their value.
 -module(dev_codec_flat).
--export([from/1, to/1, commit/3, verify/3, commited/3]).
+-export([from/1, to/1, commit/3, verify/3, committed/3]).
 %%% Testing utilities
 -export([serialize/1, deserialize/1]).
 -include_lib("eunit/include/eunit.hrl").
@@ -11,7 +11,7 @@
 %%% Route signature functions to the `dev_codec_httpsig' module
 commit(Msg, Req, Opts) -> dev_codec_httpsig:commit(Msg, Req, Opts).
 verify(Msg, Req, Opts) -> dev_codec_httpsig:verify(Msg, Req, Opts).
-commited(Msg, Req, Opts) -> dev_codec_httpsig:commited(Msg, Req, Opts).
+committed(Msg, Req, Opts) -> dev_codec_httpsig:committed(Msg, Req, Opts).
 
 %% @doc Convert a flat map to a TABM.
 from(Bin) when is_binary(Bin) -> Bin;

--- a/src/dev_codec_httpsig.erl
+++ b/src/dev_codec_httpsig.erl
@@ -6,7 +6,7 @@
 %%% `dev_codec_httpsig_conv' module.
 -module(dev_codec_httpsig).
 %%% Device API
--export([id/3, commit/3, commited/3, verify/3, reset_hmac/1, public_keys/1]).
+-export([id/3, commit/3, committed/3, verify/3, reset_hmac/1, public_keys/1]).
 %%% Codec API functions
 -export([to/1, from/1]).
 %%% Public API functions
@@ -201,10 +201,10 @@ commit(MsgToSign, _Req, Opts) ->
         OldCommitments#{ ID => Commitment }
     }).
 
-%% @doc Return the list of commited keys from a message. The message will have
+%% @doc Return the list of committed keys from a message. The message will have
 %% had the `commitments' key removed and the signature inputs added to the
-%% root. Subsequently, we can parse that to get the list of commited keys.
-commited(RawMsg, Req, Opts) ->
+%% root. Subsequently, we can parse that to get the list of committed keys.
+committed(RawMsg, Req, Opts) ->
     Msg = to(RawMsg),
     case maps:get(<<"signature-input">>, Msg, none) of
         none -> {ok, []};
@@ -236,20 +236,20 @@ do_committed(SigInputStr, Msg, _Req, _Opts) ->
         true -> {ok, SignedWithImplicit ++ committed_from_body(Msg)}
     end.
 
-%% @doc Return the list of commited keys from a message that are derived from
+%% @doc Return the list of committed keys from a message that are derived from
 %% the body components.
 committed_from_body(Msg) ->
-    % Body and inline-body-key are always commited if the
+    % Body and inline-body-key are always committed if the
     % content-digest is present.
     [<<"body">>, <<"inline-body-key">>] ++
         % If the inline-body-key is present, add it to the list of
-        % commited keys.
+        % committed keys.
         case maps:get(<<"inline-body-key">>, Msg, []) of
             [] -> [];
             InlineBodyKey -> [InlineBodyKey]
         end
         % If the body-keys are present, add them to the list of
-        % commited keys.
+        % committed keys.
         ++ case maps:get(<<"body-keys">>, Msg, []) of
             [] -> [];
             BodyKeys ->
@@ -268,8 +268,8 @@ committed_from_body(Msg) ->
                     ParsedList   
                 ),
                 % Grab the top most field on the body key
-                % because the top most being commited means all subsequent
-                % fields are also commited
+                % because the top most being committed means all subsequent
+                % fields are also committed
                 Tops = lists:map(
                     fun(BodyKey) ->
                         hd(hb_path:term_to_path_parts(BodyKey, #{}))
@@ -429,7 +429,7 @@ hmac(Msg) ->
     ?event({hmac_result, {string, hb_util:human_id(HMacValue)}}),
     {ok, HMacValue}.
 
-%% @doc Verify different forms of httpsig commited messages. `dev_message:verify'
+%% @doc Verify different forms of httpsig committed messages. `dev_message:verify'
 %% already places the keys from the commitment message into the root of the
 %% message.
 verify(MsgToVerify, #{ <<"commitment">> := ExpectedID, <<"alg">> := <<"hmac-sha256">> }, _Opts) ->

--- a/src/dev_codec_httpsig.erl
+++ b/src/dev_codec_httpsig.erl
@@ -115,12 +115,13 @@ id(Msg, _Params, _Opts) ->
 %% the signature and signature input. If the message already has a signature-input,
 %% directly, it is treated differently: We relabel it as `x-signature-input' to
 %% avoid key collisions.
-find_id(#{ <<"commitments">> := Comms }) when map_size(Comms) > 1 ->
-    CommsWithoutHmac = maps:without([<<"hmac-sha256">>], Comms),
-    IDs = lists:map(
-        fun({_, #{ <<"id">> := ID }}) -> ID end,
-        maps:to_list(CommsWithoutHmac)
-    ),
+find_id(Msg = #{ <<"commitments">> := Comms }) when map_size(Comms) > 1 ->
+    #{ <<"commitments">> := CommsWithoutHmac } =
+        hb_message:without_commitments(
+            #{ <<"alg">> => <<"hmac-sha256">> },
+            Msg
+        ),
+    IDs = maps:keys(CommsWithoutHmac),
     case IDs of
         [] -> throw({could_not_find_ids, CommsWithoutHmac});
         [ID] ->
@@ -138,8 +139,8 @@ find_id(#{ <<"commitments">> := Comms }) when map_size(Comms) > 1 ->
             ?event({sorted_ids, SortedIDs, {sf_list, SFList}}),
             {ok, hb_util:human_id(crypto:hash(sha256, SFList))}
     end;
-find_id(#{ <<"commitments">> := #{ <<"hmac-sha256">> := #{ <<"id">> := ID } } }) ->
-    {ok, ID};
+find_id(#{ <<"commitments">> := CommitmentMap }) ->
+    {ok, hd(maps:keys(CommitmentMap))};
 find_id(AttMsg = #{ <<"signature-input">> := UserSigInput }) ->
     {not_found, (maps:without([<<"signature-input">>], AttMsg))#{
         <<"x-signature-input">> => UserSigInput
@@ -176,12 +177,15 @@ commit(MsgToSign, _Req, Opts) ->
     {ok, {SignatureInput, Signature}} = sign_auth(Authority, #{}, Enc),
     [ParsedSignatureInput] = hb_structured_fields:parse_list(SignatureInput),
     % Set the name as `http-sig-[hex encoding of the first 8 bytes of the public key]'
-    Committer = hb_util:human_id(Address = ar_wallet:to_address(Wallet)),
+    ID = hb_util:human_id(crypto:hash(sha256, Signature)),
+    Address = ar_wallet:to_address(Wallet),
     SigName = address_to_sig_name(Address),
     % Calculate the id and place the signature into the `commitments' key of the message.
     Commitment =
         #{
-            <<"id">> => hb_util:human_id(crypto:hash(sha256, Signature)),
+            <<"commitment-device">> => <<"httpsig@1.0">>,
+            <<"alg">> => <<"rsa-pss-sha512">>,
+            <<"committer">> => hb_util:human_id(Address),
             % https://datatracker.ietf.org/doc/html/rfc9421#section-4.2-1
             <<"signature">> =>
                 bin(hb_structured_fields:dictionary(
@@ -190,12 +194,11 @@ commit(MsgToSign, _Req, Opts) ->
             <<"signature-input">> =>
                 bin(hb_structured_fields:dictionary(
                     #{ SigName => ParsedSignatureInput }
-                )),
-            <<"commitment-device">> => <<"httpsig@1.0">>
+                ))
         },
     OldCommitments = maps:get(<<"commitments">>, NormMsg, #{}),
     reset_hmac(MsgWithoutHP#{<<"commitments">> =>
-        OldCommitments#{ Committer => Commitment }
+        OldCommitments#{ ID => Commitment }
     }).
 
 %% @doc Return the list of commited keys from a message. The message will have
@@ -306,11 +309,15 @@ address_to_sig_name(OtherRef) ->
 %%@doc Ensure that the commitments and hmac are properly encoded
 reset_hmac(RawMsg) ->
     Msg = hb_message:convert(RawMsg, tabm, #{}),
-    Commitments =
-        maps:without(
-            [<<"hmac-sha256">>],
-            maps:get(<<"commitments">>, Msg, #{})
+    WithoutHmac =
+        hb_message:without_commitments(
+            #{
+                <<"commitment-device">> => <<"httpsig@1.0">>,
+                <<"alg">> => <<"hmac-sha256">>
+            },
+            Msg
         ),
+    Commitments = maps:get(<<"commitments">>, WithoutHmac, #{}),
     AllSigs =
         maps:from_list(lists:map(
             fun ({Committer, #{ <<"signature">> := Signature }}) ->
@@ -353,16 +360,17 @@ reset_hmac(RawMsg) ->
     ?event({pre_hmac_sig_input,
         {string, maps:get(<<"signature-input">>, HMacSigInfo, none)}}),
     HMacInputMsg = maps:merge(Msg, HMacSigInfo),
-    {ok, ID} = hmac(HMacInputMsg),
+    {ok, RawID} = hmac(HMacInputMsg),
+    ID = hb_util:human_id(RawID),
     Res = {
         ok,
         maps:put(
             <<"commitments">>,
             Commitments#{
-                <<"hmac-sha256">> =>
+                ID =>
                     HMacSigInfo#{
-                        <<"id">> => hb_util:human_id(ID),
-                        <<"commitment-device">> => <<"httpsig@1.0">>
+                        <<"commitment-device">> => <<"httpsig@1.0">>,
+                        <<"alg">> => <<"hmac-sha256">>
                     }
             },
             Msg
@@ -424,28 +432,34 @@ hmac(Msg) ->
 %% @doc Verify different forms of httpsig commited messages. `dev_message:verify'
 %% already places the keys from the commitment message into the root of the
 %% message.
-verify(MsgToVerify, #{ <<"committer">> := <<"hmac-sha256">> }, _Opts) ->
+verify(MsgToVerify, #{ <<"commitment">> := ExpectedID, <<"alg">> := <<"hmac-sha256">> }, _Opts) ->
     % Verify a hmac on the message
-    ExpectedID = maps:get(<<"id">>, MsgToVerify, not_set),
     ?event({verify_hmac, {target, MsgToVerify}, {expected_id, ExpectedID}}),
     {ok, ResetMsg} = reset_hmac(maps:without([<<"id">>], MsgToVerify)),
     case maps:get(<<"commitments">>, ResetMsg, no_commitments) of
         no_commitments -> {error, could_not_calculate_id};
-        #{ <<"hmac-sha256">> := #{ <<"id">> := ExpectedID } } ->
+        #{ ExpectedID := #{ <<"alg">> := <<"hmac-sha256">> } } ->
             ?event({hmac_verified, {id, ExpectedID}}),
             {ok, true};
-        #{ <<"hmac-sha256">> := #{ <<"id">> := RecalculatedID } } ->
+        _ ->
             ?event({hmac_failed_verification,
-                {recalculated_id, RecalculatedID},
-                {expected, ExpectedID}}),
+                {recalculated_commitments,
+                    maps:keys(maps:get(<<"commitments">>, ResetMsg, #{}))
+                },
+                {expected_id, ExpectedID}}),
             {ok, false}
     end;
 verify(MsgToVerify, Req, _Opts) ->
     % Validate a signed commitment.
     ?event({verify, {target, MsgToVerify}, {req, Req}}),
     % Parse the signature parameters into a map.
-    Committer = maps:get(<<"committer">>, Req),
-    SigName = address_to_sig_name(Committer),
+    CommitmentID = maps:get(<<"commitment">>, Req),
+    Commitment =
+        maps:get(
+            CommitmentID,
+            maps:get(<<"commitments">>, MsgToVerify, #{})
+        ),
+    SigName = address_to_sig_name(maps:get(<<"committer">>, Commitment)),
     {list, _SigInputs, ParamsKVList} =
         maps:get(
             SigName,
@@ -455,9 +469,15 @@ verify(MsgToVerify, Req, _Opts) ->
                 )
             )
         ),
-    Alg = maps:get(<<"alg">>, Params = maps:from_list(ParamsKVList)),
+    {string, Alg} = maps:get(<<"alg">>, Params = maps:from_list(ParamsKVList)),
+    AlgFromCommitment = maps:get(<<"alg">>, Commitment),
     case Alg of
-        {string, <<"rsa-pss-sha512">>} ->
+        _ when AlgFromCommitment =/= Alg ->
+            {error, {commitment_alg_mismatch,
+                {from_commitment_message, AlgFromCommitment},
+                {from_signature_params, Alg}
+            }};
+        <<"rsa-pss-sha512">> when AlgFromCommitment =:= Alg ->
             {string, KeyID} = maps:get(<<"keyid">>, Params),
             PubKey = hb_util:decode(KeyID),
             Address = hb_util:human_id(ar_wallet:to_address(PubKey)),
@@ -1246,13 +1266,13 @@ validate_large_message_from_http_test() ->
     ?assert(length(Signers) == 1),
     ?assert(hb_message:verify(Res, Signers)),
     ?event({sig_verifies, Signers}),
-    ?assert(hb_message:verify(Res, [<<"hmac-sha256">>])),
+    ?assert(hb_message:verify(Res)),
     ?event({hmac_verifies, <<"hmac-sha256">>}),
     {ok, OnlyCommitted} = hb_message:with_only_committed(Res),
     ?event({msg_with_only_committed, OnlyCommitted}),
     ?assert(hb_message:verify(OnlyCommitted, Signers)),
     ?event({msg_with_only_committed_verifies, Signers}),
-    ?assert(hb_message:verify(OnlyCommitted, [<<"hmac-sha256">>])),
+    ?assert(hb_message:verify(OnlyCommitted)),
     ?event({msg_with_only_committed_verifies_hmac, <<"hmac-sha256">>}).
 
 committed_id_test() ->
@@ -1275,7 +1295,7 @@ multicommitted_id_test() ->
     SignedID = hb_message:id(Signed2, all),
     ?event({ids, {unsigned_id, UnsignedID}, {signed_id, SignedID}}),
     ?assertNotEqual(UnsignedID, SignedID),
-    ?assert(hb_message:verify(Signed2, [<<"hmac-sha256">>])),
+    ?assert(hb_message:verify(Signed2, [])),
     ?assert(hb_message:verify(Signed2, [Addr1])),
     ?assert(hb_message:verify(Signed2, [Addr2])),
     ?assert(hb_message:verify(Signed2, [Addr1, Addr2])),

--- a/src/dev_codec_httpsig.erl
+++ b/src/dev_codec_httpsig.erl
@@ -104,11 +104,11 @@ from(Msg) -> dev_codec_httpsig_conv:from(Msg).
 id(Msg, _Params, _Opts) ->
     ?event({calculating_id, {msg, Msg}}),
     case find_id(Msg) of
-        {ok, ID} -> {ok, ID};
+        {ok, ID} -> {ok, hb_util:human_id(ID)};
         {not_found, MsgToID} ->
             {ok, MsgAfterReset} = reset_hmac(MsgToID),
             {ok, ID} = find_id(MsgAfterReset),
-            {ok, ID}
+            {ok, hb_util:human_id(ID)}
     end.
 
 %% @doc Find the ID of the message, which is the hmac of the fields referenced in
@@ -126,7 +126,7 @@ find_id(Msg = #{ <<"commitments">> := Comms }) when map_size(Comms) > 1 ->
         [] -> throw({could_not_find_ids, CommsWithoutHmac});
         [ID] ->
             ?event({returning_single_id, ID}),
-            {ok, ID};
+            {ok, hb_util:human_id(ID)};
         _ ->
             ?event({multiple_ids, IDs}),
             SortedIDs =

--- a/src/dev_codec_json.erl
+++ b/src/dev_codec_json.erl
@@ -2,7 +2,7 @@
 %%% message as TABM and returns an encoded JSON string representation.
 %%% This codec utilizes the httpsig@1.0 codec for signing and verifying.
 -module(dev_codec_json).
--export([to/1, from/1, commit/3, verify/3, commited/1, content_type/1]).
+-export([to/1, from/1, commit/3, verify/3, committed/1, content_type/1]).
 -export([deserialize/3, serialize/3]).
 
 %% @doc Return the content type for the codec.
@@ -20,8 +20,8 @@ commit(Msg, Req, Opts) -> dev_codec_httpsig:commit(Msg, Req, Opts).
 
 verify(Msg, Req, Opts) -> dev_codec_httpsig:verify(Msg, Req, Opts).
 
-commited(Msg) when is_binary(Msg) -> commited(from(Msg));
-commited(Msg) -> hb_message:commited(Msg).
+committed(Msg) when is_binary(Msg) -> committed(from(Msg));
+committed(Msg) -> hb_message:committed(Msg).
 
 %% @doc Deserialize the JSON string found at the given path.
 deserialize(Base, Req, Opts) ->

--- a/src/dev_codec_structured.erl
+++ b/src/dev_codec_structured.erl
@@ -9,7 +9,7 @@
 %%% 
 %%% For more details, see the HTTP Structured Fields (RFC-9651) specification.
 -module(dev_codec_structured).
--export([to/1, from/1, commit/3, commited/3, verify/3]).
+-export([to/1, from/1, commit/3, committed/3, verify/3]).
 -export([decode_value/2, encode_value/1, implicit_keys/1]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -17,7 +17,7 @@
 %%% Route signature functions to the `dev_codec_httpsig' module
 commit(Msg, Req, Opts) -> dev_codec_httpsig:commit(Msg, Req, Opts).
 verify(Msg, Req, Opts) -> dev_codec_httpsig:verify(Msg, Req, Opts).
-commited(Msg, Req, Opts) -> dev_codec_httpsig:commited(Msg, Req, Opts).
+committed(Msg, Req, Opts) -> dev_codec_httpsig:committed(Msg, Req, Opts).
 
 %% @doc Convert a rich message into a 'Type-Annotated-Binary-Message' (TABM).
 from(Bin) when is_binary(Bin) -> Bin;

--- a/src/dev_faff.erl
+++ b/src/dev_faff.erl
@@ -37,13 +37,7 @@ estimate(_, Msg, NodeMsg) ->
 is_admissible(Msg, NodeMsg) ->
     AllowList = hb_opts:get(faff_allow_list, [], NodeMsg),
     Req = hb_converge:get(<<"request">>, Msg, NodeMsg),
-    Signers =
-        lists:filtermap(
-            fun(Signer) when not ?IS_ID(Signer) -> false;
-               (Signer) -> {true, hb_util:human_id(Signer)}
-            end,
-            hb_converge:get(<<"committers">>, Req, undefined, NodeMsg)
-        ),
+    Signers = hb_message:signers(Req),
     ?event(payment, {is_admissible, {signers, Signers}, {allow_list, AllowList}}),
     lists:all(
         fun(Signer) -> lists:member(Signer, AllowList) end,

--- a/src/dev_green_zone.erl
+++ b/src/dev_green_zone.erl
@@ -291,7 +291,7 @@ join_peer(PeerLocation, PeerID, _M1, M2, InitOpts) ->
 				base64:encode(term_to_binary(WalletPub)),
 				Opts
 			),
-			% Create an commited join request using the wallet.
+			% Create an committed join request using the wallet.
 			Req = hb_message:commit(MergedReq, Wallet),
 			?event({join_req, Req}),
 			?event({verify_res, hb_message:verify(Req)}),

--- a/src/dev_json_iface.erl
+++ b/src/dev_json_iface.erl
@@ -98,7 +98,7 @@ denormalize_message(Message) ->
                 Message#{
                     <<"owner">> => hb_util:human_id(PrimarySigner),
                     <<"signature">> =>
-                        hb_converge:get(<<"signature">>, Commitment, <<>>)
+                        hb_converge:get(<<"signature">>, Commitment, <<>>, #{})
                 }
         end,
     NormOwnerMsg#{

--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -86,7 +86,9 @@ id(Base, Req, NodeOpts) ->
     % Apply the function's `id' function with the appropriate arguments. If it
     % doesn't exist, error.
     case hb_converge:find_exported_function(ModBase, DevMod, id, 3, NodeOpts) of
-        {ok, Fun} -> apply(Fun, hb_converge:truncate_args(Fun, [ModBase, Req, NodeOpts]));
+        {ok, Fun} ->
+            ?event(id, {called_id_device, IDMod}, NodeOpts),
+            apply(Fun, hb_converge:truncate_args(Fun, [ModBase, Req, NodeOpts]));
         not_found -> throw({id, id_resolver_not_found_for_device, DevMod})
     end.
 

--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -53,7 +53,7 @@ id(Base, Req) -> id(Base, Req, #{}).
 id(Base, _, NodeOpts) when not is_map(Base) ->
     % Return the hashpath of the message in native format, to match the native
     % format of the message ID return.
-    {ok, hb_util:native_id(hb_path:hashpath(Base, NodeOpts))};
+    {ok, hb_util:human_id(hb_path:hashpath(Base, NodeOpts))};
 id(Base, Req, NodeOpts) ->
     % Remove the commitments from the base message if there are none, after
     % filtering for the committers specified in the request.

--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -55,49 +55,14 @@ id(Base, _, NodeOpts) when not is_map(Base) ->
     % format of the message ID return.
     {ok, hb_util:native_id(hb_path:hashpath(Base, NodeOpts))};
 id(Base, Req, NodeOpts) ->
+    % Remove the commitments from the base message if there are none, after
+    % filtering for the committers specified in the request.
     ModBase =
-        case maps:get(<<"committers">>, Req, <<"none">>) of
-            <<"all">> -> Base;
-            <<"none">> -> maps:without([<<"commitments">>], Base);
-            [] -> Base;
-            RawCommitterIDs ->
-                KeepIDs =
-                    case is_map(RawCommitterIDs) of
-                        true -> maps:keys(RawCommitterIDs);
-                        false -> RawCommitterIDs
-                    end,
-                BaseCommitments = maps:get(<<"commitments">>, Base, #{}),
-                % Add commitments with only the keys that are requested.
-                BaseWithCommitments = 
-                    Base#{
-                        <<"commitments">> =>
-                            maps:from_list(
-                                lists:map(
-                                    fun(Comm) ->
-                                        try {Comm, maps:get(Comm, BaseCommitments)}
-                                        catch _:_ ->
-                                            throw(
-                                                {
-                                                    committer_not_found,
-                                                    Comm,
-                                                    {commitments, BaseCommitments}
-                                                }
-                                            )
-                                        end
-                                    end,
-                                    KeepIDs
-                                )
-                            )
-                    },
-                % Add the hashpath to the message if it is present.
-                case Base of
-                    #{ <<"priv">> := #{ <<"hashpath">> := Hashpath }} ->
-                        BaseWithCommitments#{
-                            <<"hashpath">> => Hashpath
-                        };
-                    _ ->
-                        BaseWithCommitments
-                end
+        case with_relevant_commitments(Base, Req, NodeOpts) of
+            Mod = #{ <<"commitments">> := Commitments }
+                    when map_size(Commitments) == 0 ->
+                maps:without([<<"commitments">>], Mod);
+            Mod -> Mod
         end,
     % Find the ID device for the message.
     IDMod =
@@ -116,7 +81,7 @@ id(Base, Req, NodeOpts) ->
                     #{ <<"device">> => ?DEFAULT_ID_DEVICE },
                     NodeOpts
                 );
-            Mod -> Mod
+            Module -> Module
         end,
     % Apply the function's `id' function with the appropriate arguments. If it
     % doesn't exist, error.
@@ -125,12 +90,9 @@ id(Base, Req, NodeOpts) ->
         not_found -> throw({id, id_resolver_not_found_for_device, DevMod})
     end.
 
-%% @doc Locate the ID device of a message. The ID device is determined by the 
-%% `id-device` if found in the `/commitments/id/commitment-device` key, or the
+%% @doc Locate the ID device of a message. The ID device is determined the
 %% `device` set in _all_ of the commitments. If no commitments are present,
 %% the default device (`httpsig@1.0') is used.
-id_device(#{ <<"commitments">> := #{ <<"id">> := #{ <<"commitment-device">> := IDDev } } }) ->
-    {ok, IDDev};
 id_device(#{ <<"commitments">> := Commitments }) ->
     % Get the device from the first commitment.
     UnfilteredDevs =
@@ -161,32 +123,23 @@ id_device(_) ->
 %% @doc Return the committers of a message that are present in the given request.
 committers(Base) -> committers(Base, #{}).
 committers(Base, Req) -> committers(Base, Req, #{}).
-committers(Base, _, _NodeOpts) ->
-    {ok, maps:keys(maps:get(<<"commitments">>, Base, #{}))}.
-
-% %% @doc Return a device that resolves a given path to a specific commitment.
-% commitments(Base, _Req, _NodeOpts) ->
-%     {ok,
-%         Base#{
-%             <<"device">> =>
-%                 #{
-%                     info =>
-%                         fun(Msg, MsgWithPath, _NodeOpts2) ->
-%                             Committer = maps:get(<<"path">>, MsgWithPath),
-%                             Commitment = maps:get(Committer, Msg),
-%                             % 'Promote' the keys of the commitment to the root
-%                             % of the message.
-%                             {
-%                                 ok,
-%                                 maps:merge(
-%                                     maps:without([<<"commitments">>], Msg),
-%                                     Commitment
-%                                 )
-%                             }
-%                         end
-%                 }
-%         }
-%     }.
+committers(#{ <<"commitments">> := Commitments }, _, _NodeOpts) ->
+    ?event({commitments, Commitments}),
+    {ok,
+        maps:values(
+            maps:filtermap(
+                fun(_ID, Commitment) ->
+                    case maps:get(<<"committer">>, Commitment, undefined) of
+                        undefined -> false;
+                        Committer -> {true, Committer}
+                    end
+                end,
+                Commitments
+            )
+        )
+    };
+committers(_, _, _) ->
+    {ok, []}.
 
 %% @doc Commit to a message, using the `commitment-device' key to specify the
 %% device that should be used to commit to the message. If the key is not set,
@@ -209,47 +162,37 @@ commit(Self, Req, Opts) ->
     {ok, Commited} = apply(AttFun, hb_converge:truncate_args(AttFun, [Encoded, Req, Opts])),
     {ok, hb_message:convert(Commited, <<"structured@1.0">>, Opts)}.
 
-%% @doc Verify a message nested in the body. As with `id', the `committers'
-%% key in the request can be used to specify which commitments should be
-%% verified. 
+%% @doc Verify a message. By default, all commitments are verified. The
+%% `committers' key in the request can be used to specify that only the 
+%% commitments from specific committers should be verified. Similarly, specific
+%% commitments can be specified using the `commitments' key.
 verify(Self, Req, Opts) ->
     % Get the target message of the verification request.
     {ok, Base} = hb_message:find_target(Self, Req, Opts),
-    % Get the commitments to verify.
-    Commitments =
-        case hb_converge:normalize_key(maps:get(<<"committers">>, Req, <<"all">>)) of
-            <<"none">> -> [];
-            <<"all">> -> maps:get(<<"commitments">>, Base, #{});
-            CommitterIDs ->
-                maps:with(
-                    if is_list(CommitterIDs) -> CommitterIDs;
-                       true -> [CommitterIDs]
-                    end,
-                    maps:get(<<"commitments">>, Base, #{})
-                )
-        end,
+    Commitments = maps:get(<<"commitments">>, Base, #{}),
+    IDsToVerify = commitment_ids_from_request(Base, Req, Opts),
     % Remove the commitments from the base message.
     ?event({verifying_commitments, Commitments}),
     % Verify the commitments. Stop execution if any fail.
     Res =
         lists:all(
-            fun(Committer) ->
+            fun(CommitmentID) ->
                 ?event(
                     {verify_commitment,
-                        {committer, Committer},
+                        {commitment_id, CommitmentID},
                         {target, Base}}
                 ),
                 {ok, Res} = exec_for_commitment(
                     verify,
                     Base,
-                    maps:get(Committer, Commitments),
-                    Req#{ <<"committer">> => Committer },
+                    maps:get(CommitmentID, Commitments),
+                    Req#{ <<"commitment">> => CommitmentID },
                     Opts
                 ),
-                ?event({verify_commitment_res, {committer, Committer}, {res, Res}}),
+                ?event({verify_commitment_res, {commitment_id, CommitmentID}, {res, Res}}),
                 Res
             end,
-            maps:keys(Commitments)
+            IDsToVerify
         ),
     ?event({verify_res, Res}),
     {ok, Res}.
@@ -284,35 +227,29 @@ exec_for_commitment(Func, Base, Commitment, Req, Opts) ->
     Encoded = hb_message:convert(CommitmentMessage, tabm, Opts),
     apply(AttFun, [Encoded, Req, Opts]).
 
-%% @doc Return the list of commited keys from a message.
-%% @doc Set keys in a message. Takes a map of key-value pairs and sets them in
-%% the message, overwriting any existing values.
+%% @doc Return the list of committed keys from a message.
 commited(Self, Req, Opts) ->
     % Get the target message of the verification request.
     {ok, Base} = hb_message:find_target(Self, Req, Opts),
+    CommitmentIDs = commitment_ids_from_request(Base, Req, Opts),
     Commitments = maps:get(<<"commitments">>, Base, #{}),
-    Committers =
-        case maps:get(<<"committers">>, Req, <<"all">>) of
-            <<"none">> -> [];
-            <<"all">> -> maps:keys(Commitments);
-            CommitterIDs -> CommitterIDs
-        end,
     % Get the list of commited keys from each committer.
     CommitmentKeys =
         lists:map(
-            fun(Committer) ->
-                Commitment = maps:get(Committer, Commitments),
+            fun(CommitmentID) ->
+                Commitment = maps:get(CommitmentID, Commitments),
                 {ok, CommittedKeys} =
                     exec_for_commitment(
                         commited,
                         Base,
                         Commitment,
-                        #{ <<"committer">> => Committer },
+                        #{ <<"commitment">> => CommitmentID },
                         Opts
                     ),
+                ?event({committed_keys, {commitment_id, CommitmentID}, {keys, CommittedKeys}}),
                 CommittedKeys
             end,
-            Committers
+            CommitmentIDs
         ),
     % Remove commitments that are not in *every* committer's list.
     % To start, we need to create the super-set of commited keys.
@@ -342,6 +279,131 @@ commited(Self, Req, Opts) ->
     ?event({only_committed_keys, OnlyCommittedKeys}),
     {ok, OnlyCommittedKeys}.
 
+%% @doc Return a message with only the relevant commitments for a given request.
+%% See `commitment_ids_from_request/3' for more information on the request format.
+with_relevant_commitments(Base, Req, Opts) ->
+    Commitments = maps:get(<<"commitments">>, Base, #{}),
+    CommitmentIDs = commitment_ids_from_request(Base, Req, Opts),
+    Base#{ <<"commitments">> => maps:with(CommitmentIDs, Commitments) }.
+
+%% @doc Implements a standardized form of specifying commitment IDs for a
+%% message request. The caller may specify a list of committers (by address)
+%% or a list of commitment IDs directly. They may specify both, in which case
+%% the returned list will be the union of the two lists. In each case, they
+%% may specify `all' or `none' for each group. If no specifiers are provided,
+%% the default is `all' for commitments -- also implying `all' for committers.
+commitment_ids_from_request(Base, Req, Opts) ->
+    Commitments = maps:get(<<"commitments">>, Base, #{}),
+    ReqCommitters =
+        case maps:get(<<"committers">>, Req, <<"none">>) of
+            X when is_list(X) -> X;
+            Descriptor -> hb_converge:normalize_key(Descriptor)
+        end,
+    RawReqCommitments =
+        maps:get(
+            <<"commitments">>,
+            Req,
+            case ReqCommitters of
+                <<"none">> -> <<"all">>;
+                _ -> <<"none">>
+            end
+        ),
+    ReqCommitments =
+        case RawReqCommitments of
+            X2 when is_list(X2) -> X2;
+            Descriptor2 -> hb_converge:normalize_key(Descriptor2)
+        end,
+    ?event({commitment_ids_from_request, {req_commitments, ReqCommitments}, {req_committers, ReqCommitters}}),
+    % Get the commitments to verify.
+    FromCommitmentIDs =
+        case ReqCommitments of
+            <<"none">> -> [];
+            <<"all">> -> maps:keys(Commitments);
+            CommitmentIDs ->
+                CommitmentIDs =
+                    if is_list(CommitmentIDs) -> CommitmentIDs;
+                    true -> [CommitmentIDs]
+                    end,
+                lists:map(
+                    fun(CommitmentID) -> maps:get(CommitmentID, Commitments) end,
+                    CommitmentIDs
+                )
+        end,
+    FromCommitterAddrs =
+        case ReqCommitters of
+            <<"none">> ->
+                ?event(no_commitment_ids_for_committers),
+                [];
+            <<"all">> ->
+                ?event(getting_commitment_ids_for_all_committers),
+                {ok, Committers} = committers(Base, Req, Opts),
+                ?event({commitment_ids_from_committers, Committers}),
+                commitment_ids_from_committers(Committers, Commitments);
+            RawCommitterAddrs ->
+                ?event({getting_commitment_ids_for_specific_committers, RawCommitterAddrs}),
+                CommitterAddrs =
+                    if is_list(RawCommitterAddrs) -> RawCommitterAddrs;
+                    true -> [RawCommitterAddrs]
+                    end,
+                commitment_ids_from_committers(CommitterAddrs, Commitments)
+        end,
+    Res = FromCommitterAddrs ++ FromCommitmentIDs,
+    ?event({commitment_ids_from_request, {base, Base}, {req, Req}, {res, Res}}),
+    Res.
+
+%% @doc Returns a list of commitment IDs in a commitments map that are relevant
+%% for a list of given committer addresses.
+commitment_ids_from_committers(CommitterAddrs, Commitments) ->
+    % Get the IDs of all commitments for each committer.
+    Comms =
+        lists:map(
+            fun(CommitterAddr) ->
+                % For each committer, filter the commitments to only
+                % include those with the matching committer address.
+                IDs = 
+                    maps:values(maps:filtermap(
+                        fun(ID, Msg) ->
+                            % If the committer address matches, return
+                            % the ID. If not, ignore the commitment.
+                            case maps:get(<<"committer">>, Msg, undefined) of
+                                CommitterAddr -> {true, ID};
+                                _ -> false
+                            end
+                        end,
+                        Commitments
+                    )),
+                {CommitterAddr, IDs}
+            end,
+            CommitterAddrs
+        ),
+    % Check that each committer has at least one commitment.
+    EachCommitterHasCommitment =
+        lists:all(fun({_, IDs}) -> IDs =/= [] end, Comms),
+    % If all committers have at least one commitment, return the
+    % IDs of all commitments. If any committer does not have a
+    % commitment, error.
+    case EachCommitterHasCommitment of
+        true -> lists:flatten([ IDs || {_, IDs} <- Comms ]);
+        false ->
+            % Get the list of committers that do not have a
+            % commitment.
+            MissingCommitters =
+                [
+                    MissingCommitter
+                ||
+                    {MissingCommitter, []} <- Comms
+                ],
+            throw(
+                {verify,
+                    {requested_committers_not_found,
+                        {missing_commitments, MissingCommitters}
+                    }
+                }
+            )
+    end.
+
+%% @doc Deep merge keys in a message. Takes a map of key-value pairs and sets
+%% them in the message, overwriting any existing values.
 set(Message1, NewValuesMsg, Opts) ->
     OriginalPriv = hb_private:from_message(Message1),
 	% Filter keys that are in the default device (this one).

--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -252,7 +252,7 @@ resolve_processor(PathKey, Processor, Req, Query, NodeMsg) ->
 
 %% @doc Wrap the result of a device call in a status.
 embed_status({ErlStatus, Res}) when is_map(Res) ->
-    case lists:member(<<"status">>, hb_message:commited(Res)) of
+    case lists:member(<<"status">>, hb_message:committed(Res)) of
         false ->
             HTTPCode = status_code({ErlStatus, Res}),
             {ok, Res#{ <<"status">> => HTTPCode }};

--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -8,8 +8,6 @@
 %%% the Converge resolver has returned a result.
 -module(dev_meta).
 -export([info/1, info/3, handle/2, adopt_node_message/2]).
-%%% Helper functions for processors
--export([all_committers/1]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -107,7 +105,7 @@ add_dynamic_keys(NodeMsg) ->
 %% @doc Validate that the request is signed by the operator of the node, then
 %% allow them to update the node message.
 update_node_message(Request, NodeMsg) ->
-    {ok, RequestSigners} = dev_message:committers(Request),
+    RequestSigners = hb_message:signers(Request),
     Operator =
         hb_opts:get(
             operator,
@@ -312,20 +310,6 @@ maybe_sign(Res, NodeMsg) ->
             end;
         false -> Res
     end.
-
-%%% External helpers
-
-%% @doc Return the signers of a list of messages.
-all_committers(Msgs) ->
-    lists:foldl(
-        fun(Msg, Acc) ->
-            Committers =
-                hb_converge:get(<<"committers">>, Msg, #{}, #{ hashpath => ignore }),
-            Acc ++ lists:map(fun hb_util:human_id/1, maps:values(Committers))
-        end,
-        [],
-        Msgs
-    ).
 
 %%% Tests
 

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -545,10 +545,10 @@ ensure_process_key(Msg1, Opts) ->
                         ),
                         Msg1
                 end,
-            {ok, Commited} = hb_message:with_only_committed(ProcessMsg, Opts),
+            {ok, Committed} = hb_message:with_only_committed(ProcessMsg, Opts),
             Res = hb_converge:set(
                 Msg1,
-                #{ <<"process">> => Commited },
+                #{ <<"process">> => Committed },
                 Opts#{ hashpath => ignore }
             ),
             ?event({set_process_key_res, {msg1, Msg1}, {process_msg, ProcessMsg}, {res, Res}}),

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -40,7 +40,7 @@ routes(M1, M2, Opts) ->
         <<"POST">> ->
             Owner = hb_opts:get(operator, undefined, Opts),
             RouteOwners = hb_opts:get(route_owners, [Owner], Opts),
-            {ok, Signers} = dev_message:committers(M2),
+            Signers = hb_message:signers(M2),
             IsTrusted =
                 lists:any(
                     fun(Signer) -> lists:member(Signer, Signers) end,

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -326,14 +326,14 @@ post_schedule(Msg1, Msg2, Opts) ->
                 #{
                     <<"status">> => 400,
                     <<"body">> => <<"Message invalid: ",
-                        "Commited components cannot be validated.">>,
+                        "Committed components cannot be validated.">>,
                     <<"reason">> => Err
                 }
             }
     end.
 
 %% @doc Post schedule the message. `Msg2` by this point has been refined to only
-%% commited keys, and to only include the `target' message that is to be
+%% committed keys, and to only include the `target' message that is to be
 %% scheduled.
 do_post_schedule(ProcID, PID, Msg2, Opts) ->
     % Should we verify the message again before scheduling?

--- a/src/hb.app.src
+++ b/src/hb.app.src
@@ -9,8 +9,6 @@
         inets,
         ssl,
         cowboy,
-        prometheus,
-        prometheus_cowboy,
         os_mon,
         gun
     ]},

--- a/src/hb.erl
+++ b/src/hb.erl
@@ -116,8 +116,6 @@ start_mainnet(Opts) ->
         ranch,
         cowboy,
         gun,
-        prometheus,
-        prometheus_cowboy,
         os_mon
     ]),
     Wallet = hb:wallet(hb_opts:get(priv_key_location, no_viable_wallet_path, Opts)),
@@ -159,8 +157,6 @@ do_start_simple_pay(Opts) ->
         ranch,
         cowboy,
         gun,
-        prometheus,
-        prometheus_cowboy,
         os_mon
     ]),
     Port = maps:get(port, Opts),

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -14,7 +14,7 @@
 %%%    all messages to share the same hashpath space, such that all requests
 %%%    from users additively fill-in the hashpath space, minimizing duplicated
 %%%    compute.
-%%% 3. Messages, referrable by their IDs (commited or uncommitted). These are
+%%% 3. Messages, referrable by their IDs (committed or uncommitted). These are
 %%%    stored as a set of links commitment IDs and the uncommitted message.
 %%%
 %%% Before writing a message to the store, we convert it to Type-Annotated
@@ -51,7 +51,7 @@ list(Path, Store) ->
 %% the hashpath of the data (by default the SHA2-256 hash of the data). We link
 %% the unattended ID's hashpath for the keys (including `/commitments') on the
 %% message to the underlying data and recurse. We then link each commitment ID
-%% to the uncommitted message, such that any of the commited or uncommitted IDs
+%% to the uncommitted message, such that any of the committed or uncommitted IDs
 %% can be read, and once in memory all of the commitments are available. For
 %% deep messages, the commitments will also be read, such that the ID of the
 %% outer message (which does not include its commitments) will be built upon
@@ -324,15 +324,15 @@ test_store_ans104_message(Opts) ->
     Store = hb_opts:get(store, no_viable_store, Opts),
     hb_store:reset(Store),
     Item = #{ <<"type">> => <<"ANS104">>, <<"content">> => <<"Hello, world!">> },
-    Commited = hb_message:commit(Item, hb:wallet()),
-    {ok, _Path} = write(Commited, Opts),
-    CommittedID = hb_util:human_id(hb_message:id(Commited, all)),
-    UncommittedID = hb_util:human_id(hb_message:id(Commited, none)),
-    ?event({test_message_ids, {uncommitted, UncommittedID}, {commited, CommittedID}}),
+    Committed = hb_message:commit(Item, hb:wallet()),
+    {ok, _Path} = write(Committed, Opts),
+    CommittedID = hb_util:human_id(hb_message:id(Committed, all)),
+    UncommittedID = hb_util:human_id(hb_message:id(Committed, none)),
+    ?event({test_message_ids, {uncommitted, UncommittedID}, {committed, CommittedID}}),
     {ok, RetrievedItem} = read(CommittedID, Opts),
     {ok, RetrievedItemU} = read(UncommittedID, Opts),
-    ?assert(hb_message:match(Commited, RetrievedItem)),
-    ?assert(hb_message:match(Commited, RetrievedItemU)),
+    ?assert(hb_message:match(Committed, RetrievedItem)),
+    ?assert(hb_message:match(Committed, RetrievedItemU)),
     ok.
 
 %% @doc Test storing and retrieving a simple unsigned item
@@ -389,7 +389,7 @@ test_deeply_nested_complex_message(Opts) ->
     ?event({string, <<"================================================">>}),
     {ok, CommittedID} = dev_message:id(Outer, #{ <<"committers">> => [Address] }, Opts),
     ?event({string, <<"================================================">>}),
-    ?event({test_message_ids, {uncommitted, UID}, {commited, CommittedID}}),
+    ?event({test_message_ids, {uncommitted, UID}, {committed, CommittedID}}),
     %% Write the nested item
     {ok, _} = write(Outer, Opts),
     %% Read the deep value back using subpath

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -99,7 +99,8 @@ do_write_message(Bin, AllIDs, Store, Opts) when is_binary(Bin) ->
     {ok, Path};
 do_write_message(Msg, AllIDs, Store, Opts) when is_map(Msg) ->
     % Get the ID of the unsigned message.
-    {ok, UncommittedID} = dev_message:id(Msg, #{ <<"committers">> => <<"none">> }, Opts),
+    {ok, UncommittedID} =
+        dev_message:id(Msg, #{ <<"committers">> => <<"none">> }, Opts),
     AltIDs = AllIDs -- [UncommittedID],
     ?event({writing_message_with_unsigned_id, UncommittedID, {alt_ids, AltIDs}}),
     MsgHashpathAlg = hb_path:hashpath_alg(Msg),

--- a/src/hb_client.erl
+++ b/src/hb_client.erl
@@ -158,8 +158,8 @@ upload_raw_ans104_with_anchor_test() ->
 
 upload_empty_message_test() ->
     Msg = #{ <<"data">> => <<"TEST">> },
-    Commited = hb_message:commit(Msg, hb:wallet(), <<"ans104@1.0">>),
-    Result = upload(Commited, #{}, <<"ans104@1.0">>),
+    Committed = hb_message:commit(Msg, hb:wallet(), <<"ans104@1.0">>),
+    Result = upload(Committed, #{}, <<"ans104@1.0">>),
     ?event({upload_result, Result}),
     ?assertMatch({ok, _}, Result).
 
@@ -169,7 +169,7 @@ upload_single_layer_message_test() ->
         <<"basic">> => <<"value">>,
         <<"integer">> => 1
     },
-    Commited = hb_message:commit(Msg, hb:wallet(), <<"ans104@1.0">>),
-    Result = upload(Commited, #{}, <<"ans104@1.0">>),
+    Committed = hb_message:commit(Msg, hb:wallet(), <<"ans104@1.0">>),
+    Result = upload(Committed, #{}, <<"ans104@1.0">>),
     ?event({upload_result, Result}),
     ?assertMatch({ok, _}, Result).

--- a/src/hb_event.erl
+++ b/src/hb_event.erl
@@ -111,4 +111,6 @@ parse_name(Name) when is_tuple(Name) ->
 parse_name(Name) when is_atom(Name) ->
     atom_to_binary(Name, utf8);
 parse_name(Name) when is_binary(Name) ->
-    Name.
+    Name;
+parse_name(Name) when is_list(Name) ->
+    iolist_to_binary(Name).

--- a/src/hb_features.erl
+++ b/src/hb_features.erl
@@ -6,7 +6,7 @@
 %%% Public API.
 -export([all/0, enabled/1]).
 %%% Individual feature flags.
--export([http3/0, rocksdb/0]).
+-export([http3/0, rocksdb/0, test/0]).
 
 %% @doc Returns a list of all feature flags that the node supports.
 all() ->
@@ -48,4 +48,10 @@ http3() -> false.
 rocksdb() -> true.
 -else.
 rocksdb() -> false.
+-endif.
+
+-ifdef(TEST).
+test() -> true.
+-else.
+test() -> false.
 -endif.

--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -214,7 +214,7 @@ result_to_message(ExpectedID, Item, Opts) ->
     % verify the data item and optionally add the explicit keys as committed
     % fields _if_ the node desires it.
     Embedded =
-        case ar_bundles:verify_item(TX) of
+        case try ar_bundles:verify_item(TX) catch _:_ -> false end of
             true ->
                 ?event({gql_verify_succeeded, Structured}),
                 Structured;
@@ -254,6 +254,7 @@ result_to_message(ExpectedID, Item, Opts) ->
     {ok, Embedded}.
 
 normalize_null(null) -> <<>>;
+normalize_null(not_found) -> <<>>;
 normalize_null(Bin) when is_binary(Bin) -> Bin.
 
 decode_id_or_null(Bin) when byte_size(Bin) > 0 ->

--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -211,7 +211,7 @@ result_to_message(ExpectedID, Item, Opts) ->
     ?event({decoded_tabm, TABM}),
     Structured = dev_codec_structured:to(TABM),
     % Some graphql nodes do not grant the `anchor' or `last_tx' fields, so we
-    % verify the data item and optionally add the explicit keys as commited
+    % verify the data item and optionally add the explicit keys as committed
     % fields _if_ the node desires it.
     Embedded =
         case ar_bundles:verify_item(TX) of
@@ -227,7 +227,7 @@ result_to_message(ExpectedID, Item, Opts) ->
                         Structured;
                     true ->
                         % The node trusts the GraphQL API, so we add the explicit
-                        % keys as commited fields.
+                        % keys as committed fields.
                         ?event(warning, {gql_verify_failed, adding_trusted_fields, {tags, Tags}}),
                         Comms = maps:get(<<"commitments">>, Structured),
                         AttName = hd(maps:keys(Comms)),

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -628,7 +628,7 @@ req_to_tabm_singleton(Req, Body, Opts) ->
     case cowboy_req:header(<<"codec-device">>, Req, <<"httpsig@1.0">>) of
         <<"httpsig@1.0">> ->
 			?event({req_to_tabm_singleton, {request, {explicit, Req}, {body, {string, Body}}}}),
-            http_sig_to_tabm_singleton(Req, Body, Opts);
+            httpsig_to_tabm_singleton(Req, Body, Opts);
         <<"ans104@1.0">> ->
             Item = ar_bundles:deserialize(Body),
             ?event(ans104,
@@ -658,7 +658,7 @@ req_to_tabm_singleton(Req, Body, Opts) ->
 %% In particular, the signatures are verified if present and required by the 
 %% node configuration. Additionally, non-committed fields are removed from the
 %% message if it is signed, with the exception of the `path` and `method` fields.
-http_sig_to_tabm_singleton(Req = #{ headers := RawHeaders }, Body, Opts) ->
+httpsig_to_tabm_singleton(Req = #{ headers := RawHeaders }, Body, Opts) ->
     Msg = dev_codec_httpsig_conv:from(
         RawHeaders#{ <<"body">> => Body }
     ),

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -656,7 +656,7 @@ req_to_tabm_singleton(Req, Body, Opts) ->
 %% @doc HTTPSig messages are inherently mixed into the transport layer, so they
 %% require special handling in order to be converted to a normalized message.
 %% In particular, the signatures are verified if present and required by the 
-%% node configuration. Additionally, non-commited fields are removed from the
+%% node configuration. Additionally, non-committed fields are removed from the
 %% message if it is signed, with the exception of the `path` and `method` fields.
 http_sig_to_tabm_singleton(Req = #{ headers := RawHeaders }, Body, Opts) ->
     Msg = dev_codec_httpsig_conv:from(

--- a/src/hb_http_client.erl
+++ b/src/hb_http_client.erl
@@ -127,8 +127,7 @@ gun_req(Args, ReestablishedConnection, Opts) ->
 init(Opts) ->
     case hb_opts:get(prometheus, not hb_features:test(), Opts) of
         true ->
-            ?event(debug,
-                {starting_prometheus_application,
+            ?event({starting_prometheus_application,
                     {test_mode, hb_features:test()}
                 }
             ),

--- a/src/hb_http_client.erl
+++ b/src/hb_http_client.erl
@@ -110,11 +110,14 @@ gun_req(Args, ReestablishedConnection, Opts) ->
 		true ->
 			ok;
 		false ->
-			prometheus_histogram:observe(http_request_duration_seconds, [
-					method_to_list(Method),
-					Path,
-					get_status_class(Response)
-				], EndTime - StartTime)
+            case application:get_application(prometheus) of
+                undefined -> ok;
+                _ -> prometheus_histogram:observe(http_request_duration_seconds, [
+                        method_to_list(Method),
+                        Path,
+                        get_status_class(Response)
+                    ], EndTime - StartTime)
+            end
 	end,
 	Response.
 %%% ==================================================================
@@ -122,6 +125,32 @@ gun_req(Args, ReestablishedConnection, Opts) ->
 %%% ==================================================================
 
 init(Opts) ->
+    case hb_opts:get(prometheus, not hb_features:test(), Opts) of
+        true ->
+            ?event(debug,
+                {starting_prometheus_application,
+                    {test_mode, hb_features:test()}
+                }
+            ),
+            try
+                application:ensure_all_started([prometheus, prometheus_cowboy]),
+                init_prometheus(Opts)
+            catch
+                Type:Reason:Stack ->
+                    ?event(warning,
+                        {prometheus_not_started,
+                            {type, Type},
+                            {reason, Reason},
+                            {stack, Stack}
+                        }
+                    ),
+                    {ok, #state{ opts = Opts }}
+            end;
+        false -> {ok, #state{ opts = Opts }}
+    end.
+
+init_prometheus(Opts) ->
+    ?event(debug, creating_prometheus_metrics_for_http_outbound, Opts),
 	prometheus_counter:new([
 		{name, gun_requests_total},
 		{labels, [http_method, route, status_class]},
@@ -221,7 +250,7 @@ handle_info({gun_up, PID, _Protocol}, #state{ status_by_pid = StatusByPID } = St
 		{{connecting, PendingRequests}, MonitorRef, Peer} ->
 			[gen_server:reply(ReplyTo, {ok, PID}) || {ReplyTo, _} <- PendingRequests],
 			StatusByPID2 = maps:put(PID, {connected, MonitorRef, Peer}, StatusByPID),
-			prometheus_gauge:inc(outbound_connections),
+			inc_prometheus_gauge(outbound_connections),
 			{noreply, State#state{ status_by_pid = StatusByPID2 }};
 		{connected, _MonitorRef, Peer} ->
 			?event(warning,
@@ -251,7 +280,7 @@ handle_info({gun_error, PID, Reason},
 				{connecting, PendingRequests} ->
 					reply_error(PendingRequests, Reason2);
 				connected ->
-					prometheus_gauge:dec(outbound_connections),
+					dec_prometheus_gauge(outbound_connections),
 					ok
 			end,
 			gun:shutdown(PID),
@@ -280,7 +309,7 @@ handle_info({gun_down, PID, Protocol, Reason, _KilledStreams, _UnprocessedStream
 				{connecting, PendingRequests} ->
 					reply_error(PendingRequests, Reason2);
 				_ ->
-					prometheus_gauge:dec(outbound_connections),
+					dec_prometheus_gauge(outbound_connections),
 					ok
 			end,
 			{noreply,
@@ -303,7 +332,7 @@ handle_info({'DOWN', _Ref, process, PID, Reason},
 				{connecting, PendingRequests} ->
 					reply_error(PendingRequests, Reason);
 				_ ->
-					prometheus_gauge:dec(outbound_connections),
+					dec_prometheus_gauge(outbound_connections),
 					ok
 			end,
 			{noreply,
@@ -326,6 +355,26 @@ terminate(Reason, #state{ status_by_pid = StatusByPID }) ->
 %%% ==================================================================
 %%% Private functions.
 %%% ==================================================================
+
+%% @doc Safe wrapper for prometheus_gauge:inc/2.
+inc_prometheus_gauge(Name) ->
+    case application:get_application(prometheus) of
+        undefined -> ok;
+        _ -> prometheus_gauge:inc(Name)
+    end.
+
+%% @doc Safe wrapper for prometheus_gauge:dec/2.
+dec_prometheus_gauge(Name) ->
+    case application:get_application(prometheus) of
+        undefined -> ok;
+        _ -> prometheus_gauge:dec(Name)
+    end.
+
+inc_prometheus_counter(Name, Labels, Value) ->
+    case application:get_application(prometheus) of
+        undefined -> ok;
+        _ -> prometheus_counter:inc(Name, Labels, Value)
+    end.
 
 open_connection(#{ peer := Peer }, Opts) ->
     {Host, Port} = parse_peer(Peer, Opts),
@@ -399,12 +448,13 @@ reply_error([PendingRequest | PendingRequests], Reason) ->
 	reply_error(PendingRequests, Reason).
 
 record_response_status(Method, Path, Response) ->
-	prometheus_counter:inc(gun_requests_total,
+	inc_prometheus_counter(gun_requests_total,
         [
             method_to_list(Method),
 			Path,
 			get_status_class(Response)
-        ]
+        ],
+        1
     ).
 
 method_to_list(get) ->
@@ -522,14 +572,14 @@ log(Type, Event, #{method := Method, peer := Peer, path := Path}, Reason, Opts) 
     ok.
 
 download_metric(Data, #{path := Path}) ->
-	prometheus_counter:inc(
+	inc_prometheus_counter(
 		http_client_downloaded_bytes_total,
 		[Path],
 		byte_size(Data)
 	).
 
 upload_metric(#{method := post, path := Path, body := Body}) ->
-	prometheus_counter:inc(
+	inc_prometheus_counter(
 		http_client_uploaded_bytes_total,
 		[Path],
 		byte_size(Body)

--- a/src/hb_http_client.erl
+++ b/src/hb_http_client.erl
@@ -150,7 +150,6 @@ init(Opts) ->
     end.
 
 init_prometheus(Opts) ->
-    ?event(debug, creating_prometheus_metrics_for_http_outbound, Opts),
 	prometheus_counter:new([
 		{name, gun_requests_total},
 		{labels, [http_method, route, status_class]},

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -136,7 +136,7 @@ new_server(RawNodeMsg) ->
     PrometheusOpts =
         case hb_opts:get(prometheus, not hb_features:test(), NodeMsg) of
             true ->
-                ?event(debug, {starting_prometheus, {test_mode, hb_features:test()}}),
+                ?event(prometheus, {starting_prometheus, {test_mode, hb_features:test()}}),
                 % Attempt to start the prometheus application, if possible.
                 try
                     application:ensure_all_started([prometheus, prometheus_cowboy]),
@@ -150,13 +150,13 @@ new_server(RawNodeMsg) ->
                         % If the prometheus application is not started, we can
                         % still start the HTTP server, but we won't have any
                         % metrics.
-                        ?event(warning,
+                        ?event(prometheus,
                             {prometheus_not_started, {type, Type}, {reason, Reason}}
                         ),
                         ProtoOpts
                 end;
             false ->
-                ?event(debug, {prometheus_not_started, {test_mode, hb_features:test()}}),
+                ?event(prometheus, {prometheus_not_started, {test_mode, hb_features:test()}}),
                 ProtoOpts
         end,
     DefaultProto =

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -99,8 +99,6 @@ start(Opts) ->
         ranch,
         cowboy,
         gun,
-        prometheus,
-        prometheus_cowboy,
         os_mon
     ]),
     hb:init(),
@@ -131,12 +129,36 @@ new_server(RawNodeMsg) ->
     Dispatcher = cowboy_router:compile([{'_', [{'_', ?MODULE, ServerID}]}]),
     ProtoOpts = #{
         env => #{dispatch => Dispatcher, node_msg => NodeMsgWithID},
-        metrics_callback =>
-            fun prometheus_cowboy2_instrumenter:observe/1,
-        stream_handlers => [cowboy_metrics_h, cowboy_stream_h],
+        stream_handlers => [cowboy_stream_h],
         max_connections => infinity,
         idle_timeout => hb_opts:get(idle_timeout, 300000, NodeMsg)
     },
+    PrometheusOpts =
+        case hb_opts:get(prometheus, not hb_features:test(), NodeMsg) of
+            true ->
+                ?event(debug, {starting_prometheus, {test_mode, hb_features:test()}}),
+                % Attempt to start the prometheus application, if possible.
+                try
+                    application:ensure_all_started([prometheus, prometheus_cowboy]),
+                    ProtoOpts#{
+                        metrics_callback =>
+                            fun prometheus_cowboy2_instrumenter:observe/1,
+                        stream_handlers => [cowboy_metrics_h, cowboy_stream_h]
+                    }
+                catch
+                    Type:Reason ->
+                        % If the prometheus application is not started, we can
+                        % still start the HTTP server, but we won't have any
+                        % metrics.
+                        ?event(warning,
+                            {prometheus_not_started, {type, Type}, {reason, Reason}}
+                        ),
+                        ProtoOpts
+                end;
+            false ->
+                ?event(debug, {prometheus_not_started, {test_mode, hb_features:test()}}),
+                ProtoOpts
+        end,
     DefaultProto =
         case hb_features:http3() of
             true -> http3;
@@ -145,10 +167,10 @@ new_server(RawNodeMsg) ->
     {ok, Port, Listener} =
         case Protocol = hb_opts:get(protocol, DefaultProto, NodeMsg) of
             http3 ->
-                start_http3(ServerID, ProtoOpts, NodeMsg);
+                start_http3(ServerID, PrometheusOpts, NodeMsg);
             Pro when Pro =:= http2; Pro =:= http1 ->
         		% The HTTP/2 server has fallback mode to 1.1 as necessary.
-                start_http2(ServerID, ProtoOpts, NodeMsg);
+                start_http2(ServerID, PrometheusOpts, NodeMsg);
             _ -> {error, {unknown_protocol, Protocol}}
         end,
     ?event(http,
@@ -301,8 +323,8 @@ set_default_opts(Opts) ->
     Port =
         case hb_opts:get(port, no_port, TempOpts) of
             no_port ->
-                rand:seed(exsplus, erlang:timestamp()),
-                10000 + rand:uniform(20000);
+                rand:seed(exsplus, erlang:system_time(microsecond)),
+                10000 + rand:uniform(50000);
             PassedPort -> PassedPort
         end,
     Wallet =
@@ -344,8 +366,6 @@ start_node(Opts) ->
         ranch,
         cowboy,
         gun,
-        prometheus,
-        prometheus_cowboy,
         os_mon
     ]),
     hb:init(),

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -611,7 +611,10 @@ commitment(_Spec, _Msg, _Opts) ->
 %% the target is expected to be a key in the message, and the operation is
 %% performed on the value of that key.
 find_target(Self, Req, Opts) ->
-	GetOpts = Opts#{ hashpath => ignore },
+	GetOpts = Opts#{
+        hashpath => ignore,
+        cache_control => [<<"no-cache">>, <<"no-store">>]
+    },
     {ok,
         case hb_converge:get(<<"target">>, Req, <<"self">>, GetOpts) of
             <<"self">> -> Self;

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -124,6 +124,7 @@ default_message() ->
         short_trace_len => 5,
         debug_metadata => true,
         debug_ids => false,
+        debug_committers => false,
         debug_show_priv => if_present,
 		trusted => #{},
         routes => [

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -186,6 +186,12 @@ default_message() ->
         store_all_signed => true,
         % Should the node use persistent processes?
         process_workers => false
+        % Should the node track and expose prometheus metrics?
+        % We do not set this explicitly, so that the hb_features:test() value
+        % can be used to determine if we should expose metrics instead,
+        % dynamically changing the configuration based on whether we are running
+        % tests or not. To override this, set the `prometheus' option explicitly.
+        % prometheus => false
     }.
 
 %% @doc Get an option from the global options, optionally overriding with a
@@ -246,7 +252,7 @@ get(Key, Default, Opts) ->
                     (Str) when Str == "true" -> true;
                     (Str) -> string:tokens(Str, ",")
                 end,
-                "http_short,compute_short,push_short"
+                "error,http_short,compute_short,push_short"
             }
     }
 ).

--- a/src/hb_path.erl
+++ b/src/hb_path.erl
@@ -106,7 +106,7 @@ hashpath(RawMsg1, Opts) ->
                     hb_util:ok(
                         dev_message:id(
                             Msg1,
-                            #{ <<"committers">> => <<"all">> },
+                            #{ <<"commitments">> => <<"all">> },
                             Opts
                         )
                     )
@@ -131,7 +131,7 @@ hashpath(Msg1, Msg2, HashpathAlg, Opts) when is_map(Msg2) ->
             {ok, Msg2ID} =
                 dev_message:id(
                     Msg2,
-                    #{ <<"committers">> => <<"all">> },
+                    #{ <<"commitments">> => <<"all">> },
                     Opts
                 ),
             hashpath(Msg1, hb_util:human_id(Msg2ID), HashpathAlg, Opts)

--- a/src/hb_store.erl
+++ b/src/hb_store.erl
@@ -166,7 +166,7 @@ call_function([Store = #{<<"store-module">> := Mod} | Rest], Function, Args) ->
             Result
     catch
         Class:Reason:Stacktrace ->
-            ?event(error, {store_call_failed, {Class, Reason, Stacktrace}}),
+            ?event(warning, {store_call_failed, {Class, Reason, Stacktrace}}),
             call_function(Rest, Function, Args)
     end.
 
@@ -180,7 +180,7 @@ call_all([Store = #{<<"store-module">> := Mod} | Rest], Function, Args) ->
         apply(Mod, Function, [Store | Args])
     catch
         Class:Reason:Stacktrace ->
-            ?event(error, {store_call_failed, {Class, Reason, Stacktrace}}),
+            ?event(warning, {store_call_failed, {Class, Reason, Stacktrace}}),
             ok
     end,
     call_all(Rest, Function, Args).

--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -66,7 +66,6 @@ maybe_cache(StoreOpts, Data) ->
         FoundStore -> 
             FoundStore
     end,
-    
     case Store of
         false -> do_nothing;
         Store ->
@@ -197,11 +196,20 @@ external_http_access_test() ->
 resolve_on_gateway_test_() ->
     {timeout, 10, fun() ->
         TestProc = <<"p45HPD-ENkLS7Ykqrx6p_DYGbmeHDeeF8LJ09N2K53g">>,
+        EmptyStore = #{
+            <<"store-module">> => hb_store_fs,
+            <<"prefix">> => <<"cache-TEST">>
+        },
+        hb_store:reset(EmptyStore),
         hb_http_server:start_node(#{}),
         Opts = #{
             store =>
                 [
-                    #{ <<"store-module">> => hb_store_gateway, <<"store">> => false }
+                    #{
+                        <<"store-module">> => hb_store_gateway,
+                        <<"store">> => false
+                    },
+                    EmptyStore
                 ],
             cache_control => <<"cache">>
         },

--- a/src/hb_store_remote_node.erl
+++ b/src/hb_store_remote_node.erl
@@ -46,7 +46,7 @@ type(Opts = #{ <<"node">> := Node }, Key) ->
 %% @doc Read a key from the remote node.
 %%
 %% Makes an HTTP GET request to the remote node and returns the
-%% commited message.
+%% committed message.
 %%
 %% @param Opts A map of options (including node configuration).
 %% @param Key The key to read.


### PR DESCRIPTION
This PR changes the commitment hierarchy in AO Core from `/commitments/AttestorID/...` to be keyed instead by the ID of each commitment: `/commitments/commitmentID/...`. Utility functions are provided in `hb_message` to access the list of committers, as was previously the norm.

Additionally, this PR includes:
- Numerous performance improvements, lowering execution time for an average WASM slot via the `genesis-wasm@1.0` device by another approximately 30%. HyperBEAM is now a minimal overhead over the legacynet CU's execution time, in this scenario. In total, this brings the performance improvements since PR #177 to an approximate ~98.5% reduction in execution time (3-5 seconds to ~70ms on our sample process).
- Support for messages that attest to multiple of the same tag with `ans104@1.0`. Previously this caused issues due to HTTP's single-header-with-key semantics. `ans104@1.0` now encodes them as Structured Fields (RFC 8941) lists of items, as HTTP does with headers. When these messages are returned to their ANS-104 form their values are restored correctly.
- Adds support for empty tag values in ANS-104. This is actually against the original spec, but somewhere along the way one of the libraries implemented support for it and it has now proliferated through the ecosystem. Support for empty values is objectively better than arbitrarily _not_ supporting it, so HyperBEAM now does, too.
- Numerous other minor improvements, including the ability to disable prometheus and control default global options via build flags.