### PR TITLE
feat: add CU server integration with rebar3 profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ cache-*
 
 *.dot
 *.svg
+
+cu/

--- a/rebar.config
+++ b/rebar.config
@@ -2,19 +2,14 @@
 {plugins, [pc, rebar3_rustler]}.
 
 {profiles, [
-    {cu, [
-        {erl_opts, [
-            {d, 'ENABLE_CU', true}
-        ]},
+    {genesis_wasm, [
+        {erl_opts, [{d, 'ENABLE_GENESIS_WASM', true}]},
         {pre_hooks, [
-            {compile, "make -C \"${REBAR_ROOT_DIR}\" setup-cu"},
-            {compile, "make -C \"${REBAR_ROOT_DIR}\" start-cu"}
+            {compile, "make -C \"${REBAR_ROOT_DIR}\" setup-genesis-wasm"}
         ]}
     ]},
     {rocksdb, [
-        {deps, [
-            {rocksdb, "1.8.0"}
-        ]},
+        {deps, [{rocksdb, "1.8.0"}]},
         {erl_opts, [
             {d, 'ENABLE_ROCKSDB', true}
         ]}

--- a/rebar.config
+++ b/rebar.config
@@ -2,6 +2,15 @@
 {plugins, [pc, rebar3_rustler]}.
 
 {profiles, [
+    {cu, [
+        {erl_opts, [
+            {d, 'ENABLE_CU', true}
+        ]},
+        {pre_hooks, [
+            {compile, "make -C \"${REBAR_ROOT_DIR}\" setup-cu"},
+            {compile, "make -C \"${REBAR_ROOT_DIR}\" start-cu"}
+        ]}
+    ]},
     {rocksdb, [
         {deps, [
             {rocksdb, "1.8.0"}

--- a/rebar.lock
+++ b/rebar.lock
@@ -19,23 +19,22 @@
  {<<"prometheus">>,{pkg,<<"prometheus">>,<<"4.11.0">>},0},
  {<<"prometheus_cowboy">>,{pkg,<<"prometheus_cowboy">>,<<"0.1.8">>},0},
  {<<"prometheus_httpd">>,{pkg,<<"prometheus_httpd">>,<<"2.1.11">>},1},
+ {<<"quantile_estimator">>,{pkg,<<"quantile_estimator">>,<<"0.2.1">>},1},
  {<<"ranch">>,
   {git,"https://github.com/ninenines/ranch",
        {ref,"a692f44567034dacf5efcaa24a24183788594eb7"}},
-  1},
- {<<"snabbkaffe">>,
-  {git,"https://github.com/kafka4beam/snabbkaffe.git",
-       {ref,"b59298334ed349556f63405d1353184c63c66534"}},
   1}]}.
 [
 {pkg_hash,[
  {<<"accept">>, <<"B33B127ABCA7CC948BBE6CAA4C263369ABF1347CFA9D8E699C6D214660F10CD1">>},
  {<<"prometheus">>, <<"B95F8DE8530F541BD95951E18E355A840003672E5EDA4788C5FA6183406BA29A">>},
  {<<"prometheus_cowboy">>, <<"CFCE0BC7B668C5096639084FCD873826E6220EA714BF60A716F5BD080EF2A99C">>},
- {<<"prometheus_httpd">>, <<"F616ED9B85B536B195D94104063025A91F904A4CFC20255363F49A197D96C896">>}]},
+ {<<"prometheus_httpd">>, <<"F616ED9B85B536B195D94104063025A91F904A4CFC20255363F49A197D96C896">>},
+ {<<"quantile_estimator">>, <<"EF50A361F11B5F26B5F16D0696E46A9E4661756492C981F7B2229EF42FF1CD15">>}]},
 {pkg_hash_ext,[
  {<<"accept">>, <<"11B18C220BCC2EAB63B5470C038EF10EB6783BCB1FCDB11AA4137DEFA5AC1BB8">>},
  {<<"prometheus">>, <<"719862351AABF4DF7079B05DC085D2BBCBE3AC0AC3009E956671B1D5AB88247D">>},
  {<<"prometheus_cowboy">>, <<"BA286BECA9302618418892D37BCD5DC669A6CC001F4EB6D6AF85FF81F3F4F34C">>},
- {<<"prometheus_httpd">>, <<"0BBE831452CFDF9588538EB2F570B26F30C348ADAE5E95A7D87F35A5910BCF92">>}]}
+ {<<"prometheus_httpd">>, <<"0BBE831452CFDF9588538EB2F570B26F30C348ADAE5E95A7D87F35A5910BCF92">>},
+ {<<"quantile_estimator">>, <<"282A8A323CA2A845C9E6F787D166348F776C1D4A41EDE63046D72D422E3DA946">>}]}
 ].

--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -3,6 +3,7 @@
 %%% AO process definitions to be used in HyperBEAM.
 -module(dev_genesis_wasm).
 -export([init/3, compute/3, normalize/3, snapshot/3]).
+-export([ensure_started/0]).
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("include/hb.hrl").
 
@@ -13,12 +14,80 @@ init(Msg, _Msg2, _Opts) -> {ok, Msg}.
 %% the `patch@1.0` device, applying any state patches that the AO process may have
 %% requested.
 compute(Msg, Msg2, Opts) ->
-    case hb_ao:resolve(Msg, {as, <<"delegated-compute@1.0">>, Msg2}, Opts) of
-        {ok, Msg3} ->
-            {ok, Msg4} = hb_ao:resolve(Msg3, {as, <<"patch@1.0">>, Msg2}, Opts),
-            {ok, Msg4};
-        {error, Error} ->
-            {error, Error}
+    % Validate whether the genesis-wasm feature is enabled.
+    case hb_features:genesis_wasm() andalso ensure_started() of
+        true ->
+            % Resolve the `delegated-compute@1.0` device.
+            case hb_ao:resolve(Msg, {as, <<"delegated-compute@1.0">>, Msg2}, Opts) of
+                {ok, Msg3} ->
+                    % Resolve the `patch@1.0` device.
+                    {ok, Msg4} =
+                        hb_ao:resolve(
+                            Msg3,
+                            {as, <<"patch@1.0">>, Msg2},
+                            Opts
+                        ),
+                    % Return the patched message.
+                    {ok, Msg4};
+                {error, Error} ->
+                    % Return the error.
+                    {error, Error}
+            end;
+        false ->
+            % Return an error if the genesis-wasm feature is disabled.
+            {error, #{
+                <<"status">> => 500,
+                <<"message">> =>
+                    <<"HyperBEAM was not compiled with genesis-wasm@1.0 on "
+                        "this node.">>
+            }}
+    end.
+
+%% @doc Ensure the local `genesis-wasm@1.0` is live. If it not, start it.
+ensure_started() ->
+    % Check if the `genesis-wasm@1.0` device is already running. The presence
+    % of the registered name implies its availability.
+    case hb_name:lookup(<<"genesis-wasm@1.0">>) of
+        PID when is_pid(PID) ->
+            % If it is, do nothing.
+            true;
+        undefined ->
+            % The device is not running, so we need to start it.
+            PID =
+                spawn(
+                    fun() ->
+                        ?event({genesis_wasm_starting, {pid, self()}}),
+                        Port =
+                            open_port(
+                                {spawn,
+                                    "npm --prefix _build/genesis-wasm-server run dev"
+                                },
+                                [binary, use_stdio, stderr_to_stdout]
+                            ),
+                        ?event({genesis_wasm_port_opened, {port, Port}}),
+                        true = port_command(Port, iolist_to_binary(<<>>)),
+                        ?event({genesis_wasm_port_command_sent, {port, Port}}),
+                        collect_events(Port)
+                    end
+                ),
+            hb_name:register(<<"genesis-wasm@1.0">>, PID),
+            ?event({genesis_wasm_starting, {pid, PID}}),
+            % Wait for the device to start.
+            receive after 2000 -> ok end,
+            ?event({genesis_wasm_started, {pid, PID}}),
+            true
+    end.
+
+%% @doc Collect events from the port and log them.
+collect_events(Port) ->
+    receive
+        {Port, {data, Data}} ->
+            ?event(genesis_wasm_event, {data, Data}),
+            collect_events(Port);
+        stop ->
+            port_close(Port),
+            ?event(genesis_wasm_stopped, {pid, self()}),
+            ok
     end.
 
 %% @doc Normalize the device.

--- a/src/hb_features.erl
+++ b/src/hb_features.erl
@@ -6,7 +6,7 @@
 %%% Public API.
 -export([all/0, enabled/1]).
 %%% Individual feature flags.
--export([http3/0, rocksdb/0, test/0]).
+-export([http3/0, rocksdb/0, test/0, cu/0]).
 
 %% @doc Returns a list of all feature flags that the node supports.
 all() ->
@@ -48,6 +48,12 @@ http3() -> false.
 rocksdb() -> true.
 -else.
 rocksdb() -> false.
+-endif.
+
+-ifdef(ENABLE_CU).
+cu() -> true.
+-else.
+cu() -> false.
 -endif.
 
 -ifdef(TEST).

--- a/src/hb_features.erl
+++ b/src/hb_features.erl
@@ -6,7 +6,7 @@
 %%% Public API.
 -export([all/0, enabled/1]).
 %%% Individual feature flags.
--export([http3/0, rocksdb/0, test/0, cu/0]).
+-export([http3/0, rocksdb/0, test/0, genesis_wasm/0]).
 
 %% @doc Returns a list of all feature flags that the node supports.
 all() ->
@@ -50,10 +50,10 @@ rocksdb() -> true.
 rocksdb() -> false.
 -endif.
 
--ifdef(ENABLE_CU).
-cu() -> true.
+-ifdef(ENABLE_GENESIS_WASM).
+genesis_wasm() -> true.
 -else.
-cu() -> false.
+genesis_wasm() -> false.
 -endif.
 
 -ifdef(TEST).


### PR DESCRIPTION
Add functionality to run a Compute Unit (CU) server alongside HyperBEAM via a rebar3 profile. This allows developers to start a local CU server with `rebar3 as cu shell`.

- Add cu feature flag in hb_features.erl
- Create Makefile targets for setup-cu, start-cu, and stop-cu
- Configure rebar.config with cu profile hooks
- Add cu/ directory to .gitignore