### PR TITLE
dpshade/add option docs to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,36 @@ rebar3 shell
 The default configuration uses settings from `hb_opts.erl`, which preloads 
 all devices and sets up default stores on port 10000.
 
+### Optional Build Profiles
+
+HyperBEAM supports several optional build profiles that enable additional features:
+
+- `genesis_wasm`: Enables Genesis WebAssembly support
+- `rocksdb`: Enables RocksDB storage backend (adds RocksDB v1.8.0 dependency)
+- `http3`: Enables HTTP/3 support via QUIC protocol
+
+
+Using these profiles allows you to optimize HyperBEAM for your specific use case without adding unnecessary dependencies to the base installation.
+
+To start a shell with profiles:
+
+```bash
+# Single profile
+rebar3 as rocksdb shell
+
+# Multiple profiles
+rebar3 as rocksdb,genesis_wasm shell
+```
+
+To create a release with profiles:
+
+```bash
+# Create release with profiles
+rebar3 as rocksdb,genesis_wasm release
+```
+
+Note: Profiles modify compile-time options that get baked into the release. Choose the profiles you need before starting HyperBEAM.
+
 ### Verify Installation
 
 To verify that your HyperBEAM node is running correctly, check:

--- a/src/dev_cache.erl
+++ b/src/dev_cache.erl
@@ -9,13 +9,13 @@
 
 %% @doc Read data from the cache.
 %% Retrieves data corresponding to a key from a local store.
-%% The key is extracted from the incoming message under <<"target">>.
+%% The key is extracted from the incoming message under &lt;&lt;"target"&gt;&gt;.
 %% The options map may include store configuration.
-%% If the "accept" header is set to <<"application/aos-2">>, the result is 
+%% If the "accept" header is set to &lt;&lt;"application/aos-2"&gt;&gt;, the result is 
 %% converted to a JSON structure and encoded.
 %%
 %% @param M1 Ignored parameter.
-%% @param M2 The request message containing the key (<<"target">>) and an
+%% @param M2 The request message containing the key (&lt;&lt;"target"&gt;&gt;) and an
 %%            optional "accept" header.
 %% @param Opts A map of configuration options.
 %% @returns {ok, Data} on success,

--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -43,7 +43,7 @@ compute(Msg, Msg2, Opts) ->
             }}
     end.
 
-%% @doc Ensure the local `genesis-wasm@1.0` is live. If it not, start it.
+%% @doc Ensure the local `genesis-wasm@1.0' is live. If it not, start it.
 ensure_started() ->
     % Check if the `genesis-wasm@1.0` device is already running. The presence
     % of the registered name implies its availability.

--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -1,5 +1,5 @@
-%%% @doc A device that mimics an environment suitable for `legacynet` AO 
-%%% processes, using HyperBEAM infrastructure. This allows existing `legacynet`
+%%% @doc A device that mimics an environment suitable for `legacynet' AO 
+%%% processes, using HyperBEAM infrastructure. This allows existing `legacynet'
 %%% AO process definitions to be used in HyperBEAM.
 -module(dev_genesis_wasm).
 -export([init/3, compute/3, normalize/3, snapshot/3]).
@@ -10,8 +10,8 @@
 %% @doc Initialize the device.
 init(Msg, _Msg2, _Opts) -> {ok, Msg}.
 
-%% @doc All the `delegated-compute@1.0` device to execute the request. We then apply
-%% the `patch@1.0` device, applying any state patches that the AO process may have
+%% @doc All the `delegated-compute@1.0' device to execute the request. We then apply
+%% the `patch@1.0' device, applying any state patches that the AO process may have
 %% requested.
 compute(Msg, Msg2, Opts) ->
     % Validate whether the genesis-wasm feature is enabled.

--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -477,7 +477,7 @@ claim_node_test() ->
     ?assertEqual(<<"test2">>, hb_ao:get(<<"test_config_item">>, Res2, #{})),
     ?assertEqual(2, length(hb_ao:get(<<"node_history">>, Res2, [], #{}))).
 
-%% @doc Test that we can use a preprocessor upon a request.
+%% Test that we can use a preprocessor upon a request.
 % preprocessor_test() ->
 %     Parent = self(),
 %     Node = hb_http_server:start_node(
@@ -530,7 +530,7 @@ modify_request_test() ->
     {ok, Res} = hb_http:get(Node, <<"/added">>, #{}),
     ?assertEqual(<<"value">>, Res).
 
-%% @doc Test that we can use a postprocessor upon a request. Calls the `test@1.0'
+%% Test that we can use a postprocessor upon a request. Calls the `test@1.0'
 %% device's postprocessor, which sets the `postprocessor-called' key to true in
 %% the HTTP server.
 % postprocessor_test() ->

--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -283,7 +283,7 @@ status_code(unavailable) -> 503.
 message_to_status(#{ <<"body">> := Status }) when is_atom(Status) ->
     status_code(Status);
 message_to_status(Item) when is_map(Item) ->
-    % Note: We use `dev_message` directly here, such that we do not cause 
+    % Note: We use `dev_message' directly here, such that we do not cause 
     % additional AO-Core calls for every request. This is particularly important
     % if a remote server is being used for all AO-Core requests by a node.
     case dev_message:get(<<"status">>, Item) of

--- a/src/dev_process_worker.erl
+++ b/src/dev_process_worker.erl
@@ -91,7 +91,7 @@ server(GroupName, Msg1, Opts) ->
         {ok, Msg1}
     end.
 
-%% @doc Await a resolution from a worker executing the `process@1.0` device.
+%% @doc Await a resolution from a worker executing the `process@1.0' device.
 await(Worker, GroupName, Msg1, Msg2, Opts) ->
     case hb_path:matches(<<"compute">>, hb_path:hd(Msg2, Opts)) of
         false -> 

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -116,7 +116,7 @@ route(_, Msg, Opts) ->
             end
     end.
 
-%% @doc Generate a `uri` key for each node in a route.
+%% @doc Generate a `uri' key for each node in a route.
 apply_routes(Msg, R, Opts) ->
     Nodes = hb_ao:get(<<"nodes">>, R, Opts),
     NodesWithRouteApplied =

--- a/src/hb.erl
+++ b/src/hb.erl
@@ -139,7 +139,7 @@ start_mainnet(Opts) ->
     ),
     <<"http://localhost:", (integer_to_binary(maps:get(port, Opts)))/binary>>.
 
-%%% @doc Start a server with a `simple-pay@1.0` pre-processor.
+%%% @doc Start a server with a `simple-pay@1.0' pre-processor.
 start_simple_pay() ->
     start_simple_pay(address()).
 start_simple_pay(Addr) ->

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -455,7 +455,7 @@ cache_suite_test_() ->
         {"message with message", fun test_message_with_message/1}
     ]).
 
-%% @doc Test that message whose device is `#{}` cannot be written. If it were to
+%% @doc Test that message whose device is `#{}' cannot be written. If it were to
 %% be written, it would cause an infinite loop.
 test_device_map_cannot_be_written_test() ->
     try

--- a/src/hb_features.erl
+++ b/src/hb_features.erl
@@ -1,5 +1,5 @@
 %%% @doc A module that exports a list of feature flags that the node supports
-%%% using the `-ifdef` macro.
+%%% using the `-ifdef' macro.
 %%% As a consequence, this module acts as a proxy of information between the
 %%% build system and the runtime execution environment.
 -module(hb_features).
@@ -34,8 +34,8 @@ enabled(Feature) ->
     maps:get(Feature, all(), false).
 
 %%% Individual feature flags.
-%%% These functions use the `-ifdef` macro to conditionally return a boolean
-%%% value based on the presence of the `ENABLE_<FEATURE>` macro during
+%%% These functions use the `-ifdef' macro to conditionally return a boolean
+%%% value based on the presence of the `ENABLE_<FEATURE>' macro during
 %%% compilation.
 
 -ifdef(ENABLE_HTTP3).

--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -154,7 +154,7 @@ query(Query, Opts) ->
     end.
 
 %% @doc Takes a GraphQL item node, matches it with the appropriate data from a
-%% gateway, then returns `{ok, ParsedMsg}`.
+%% gateway, then returns `{ok, ParsedMsg}'.
 result_to_message(Item, Opts) ->
     case hb_ao:get(<<"id">>, Item, Opts) of
         ExpectedID when is_binary(ExpectedID) ->

--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -7,9 +7,9 @@
 %%% GraphQL API. When gateways integrate serving in `httpsig@1.0' form, this
 %%% module will be deprecated.
 -module(hb_gateway_client).
-%% @doc Raw access primitives:
+%% Raw access primitives:
 -export([read/2, data/2, result_to_message/2]).
-%% @doc Application-specific data access functions:
+%% Application-specific data access functions:
 -export([scheduler_location/2]).
 -include_lib("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -75,8 +75,8 @@ item_spec() ->
 %% @doc Get the data associated with a transaction by its ID, using the node's
 %% Arweave `gateway' peers. The item is expected to be available in its 
 %% unmodified (by caches or other proxies) form at the following location:
-%%      https://<gateway>/raw/<id>
-%% where `<id>' is the base64-url-encoded transaction ID.
+%%      https://&lt;gateway&gt;/raw/&lt;id&gt;
+%% where `&lt;id&gt;' is the base64-url-encoded transaction ID.
 data(ID, Opts) ->
     Req = #{
         <<"multirequest-accept-status">> => 200,

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -60,8 +60,8 @@ request(Message, Opts) ->
 request(Method, Peer, Path, Opts) ->
     request(Method, Peer, Path, #{}, Opts).
 request(Method, Config = #{ <<"nodes">> := Nodes }, Path, Message, Opts) when is_list(Nodes) ->
-    % The request has a `route` (see `dev_router` for more details), so we use the
-    % `multirequest` functionality, rather than a single request.
+    % The request has a `route' (see `dev_router' for more details), so we use the
+    % `multirequest' functionality, rather than a single request.
     multirequest(Config, Method, Path, Message, Opts);
 request(Method, #{ <<"opts">> := NodeOpts, <<"uri">> := URI }, _Path, Message, Opts) ->
     % The request has a set of additional options, so we apply them to the
@@ -218,8 +218,8 @@ message_to_request(M, Opts) ->
             {ok, Method, Node, Path, MsgWithoutMeta};
         {ok, Routes} ->
             ?event(http_outbound, {found_routes, {req, M}, {routes, Routes}}),
-            % The result is a route, so we leave it to `request` to handle it.
-            Path = hb_ao:get(<<"path">>, M, <<"/">>, Opts),
+            % The result is a route, so we leave it to `request' to handle it.
+            Path = hb_converge:get(<<"path">>, M, <<"/">>, Opts),
             {ok, Method, Routes, Path, MsgWithoutMeta};
         {error, Reason} ->
             {error, {no_viable_route, Reason, {message, M}}}
@@ -494,7 +494,7 @@ add_cors_headers(Msg, ReqHdr) ->
         }
     end,
     % Keys in the given message will overwrite the defaults listed below if 
-    % included, due to `maps:merge`'s precidence order.
+    % included, due to `maps:merge''s precidence order.
     maps:merge(WithAllowHeaders, Msg).
 
 %% @doc Generate the headers and body for a HTTP response message.
@@ -512,7 +512,7 @@ encode_reply(TABMReq, Message, Opts) ->
             end
         ),
     % Codecs generally do not need to specify headers outside of the content-type,
-    % aside the default `httpsig@1.0` codec, which expresses its form in HTTP
+    % aside the default `httpsig@1.0' codec, which expresses its form in HTTP
     % documents, and subsequently must set its own headers.
     case Codec of
         <<"httpsig@1.0">> ->
@@ -529,7 +529,7 @@ encode_reply(TABMReq, Message, Opts) ->
                 maps:get(<<"body">>, EncMessage, <<>>)
             };
         <<"ans104@1.0">> ->
-            % The `ans104@1.0` codec is a binary format, so we must serialize
+            % The `ans104@1.0' codec is a binary format, so we must serialize
             % the message to a binary before sending it.
             {
                 ok,
@@ -566,10 +566,10 @@ encode_reply(TABMReq, Message, Opts) ->
 %% @doc Calculate the codec name to use for a reply given its initiating Cowboy
 %% request, the parsed TABM request, and the response message. The precidence
 %% order for finding the codec is:
-%% 1. The `accept-codec` field in the message
-%% 2. The `accept` field in the request headers
+%% 1. The `accept-codec' field in the message
+%% 2. The `accept' field in the request headers
 %% 3. The default codec
-%% Options can be specified in mime-type format (`application/*`) or in
+%% Options can be specified in mime-type format (`application/*') or in
 %% AO device format (`device@1.0').
 accept_to_codec(TABMReq, Opts) ->
     AcceptCodec =
@@ -582,7 +582,7 @@ accept_to_codec(TABMReq, Opts) ->
     case AcceptCodec of
         not_specified ->
             % We hold off until confirming that the codec is not directly in the
-            % message before calling `hb_opts:get/3`, as it is comparatively
+            % message before calling `hb_opts:get/3', as it is comparatively
             % expensive.
             default_codec(Opts);
         _ -> AcceptCodec
@@ -607,7 +607,7 @@ mime_to_codec(_, _Opts) -> not_specified.
 default_codec(Opts) ->
     hb_opts:get(default_codec, <<"httpsig@1.0">>, Opts).
 
-%% @doc Call the `content-type` key on a message with the given codec, using
+%% @doc Call the `content-type' key on a message with the given codec, using
 %% a fast-path for options that are not needed for this one-time lookup.
 codec_to_content_type(Codec, Opts) ->
     FastOpts =
@@ -657,7 +657,7 @@ req_to_tabm_singleton(Req, Body, Opts) ->
 %% require special handling in order to be converted to a normalized message.
 %% In particular, the signatures are verified if present and required by the 
 %% node configuration. Additionally, non-committed fields are removed from the
-%% message if it is signed, with the exception of the `path` and `method` fields.
+%% message if it is signed, with the exception of the `path' and `method' fields.
 httpsig_to_tabm_singleton(Req = #{ headers := RawHeaders }, Body, Opts) ->
     Msg = dev_codec_httpsig_conv:from(
         RawHeaders#{ <<"body">> => Body }

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -261,7 +261,7 @@ cors_reply(Req, _ServerID) ->
 
 %% @doc Handle all non-CORS preflight requests as AO-Core requests. Execution 
 %% starts by parsing the HTTP request into HyerBEAM's message format, then
-%% passing the message directly to `meta@1.0` which handles calling AO-Core in
+%% passing the message directly to `meta@1.0' which handles calling AO-Core in
 %% the appropriate way.
 handle_request(RawReq, Body, ServerID) ->
     % Insert the start time into the request so that it can be used by the

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -116,8 +116,8 @@ from_tabm(Msg, TargetFormat, OldPriv, Opts) ->
         OtherTypeRes -> OtherTypeRes
     end.
 
-%% @doc Add the existing `priv` sub-map back to a converted message, honoring
-%% any existing `priv` sub-map that may already be present.
+%% @doc Add the existing `priv' sub-map back to a converted message, honoring
+%% any existing `priv' sub-map that may already be present.
 restore_priv(Msg, EmptyPriv) when map_size(EmptyPriv) == 0 -> Msg;
 restore_priv(Msg, OldPriv) ->
     MsgPriv = maps:get(<<"priv">>, Msg, #{}),
@@ -576,9 +576,9 @@ without_commitments(Spec, Msg = #{ <<"commitments">> := Commitments }, _Opts) ->
 without_commitments(_Spec, Msg, _Opts) ->
     Msg.
 
-%% @doc Extract a commitment from a message given a `committer` ID, or a spec
+%% @doc Extract a commitment from a message given a `committer' ID, or a spec
 %% message to match against. Returns only the first matching commitment, or
-%% `not_found`.
+%% `not_found'.
 commitment(Committer, Msg) ->
     commitment(Committer, Msg, #{}).
 commitment(CommitterID, Msg, Opts) when is_binary(CommitterID) ->

--- a/src/hb_name.erl
+++ b/src/hb_name.erl
@@ -1,6 +1,6 @@
 %%% @doc An abstraction for name registration/deregistration in Hyperbeam.
 %%% Its motivation is to provide a way to register names that are not necessarily
-%%% atoms, but can be any term (for example: hashpaths or `process@1.0` IDs).
+%%% atoms, but can be any term (for example: hashpaths or `process@1.0' IDs).
 %%% An important characteristic of these functions is that they are atomic:
 %%% There can only ever be one registrant for a given name at a time.
 -module(hb_name).

--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -52,8 +52,8 @@ read(StoreOpts, Key) ->
             not_found
     end.
 
-%% @doc Cache the data if the cache is enabled. The `store` option may either
-%% be `false` to disable local caching, or a store definition to use as the
+%% @doc Cache the data if the cache is enabled. The `store' option may either
+%% be `false' to disable local caching, or a store definition to use as the
 %% cache.
 maybe_cache(StoreOpts, Data) ->
     ?event({maybe_cache, StoreOpts, Data}),
@@ -93,7 +93,7 @@ graphql_as_store_test_() ->
 		)
 	end}.
 
-%% @doc Stored messages are accessible via `hb_cache` accesses.
+%% @doc Stored messages are accessible via `hb_cache' accesses.
 graphql_from_cache_test() ->
     hb_http_server:start_node(#{}),
     Opts = #{ store => [#{ <<"store-module">> => hb_store_gateway, <<"opts">> => #{} }] },
@@ -225,7 +225,7 @@ resolve_on_gateway_test_() ->
             {ok, <<"Process">>},
             hb_ao:resolve(TestProc, <<"type">>, Opts)
         ),
-        % Next, we resolve the schedule key on the message, as a `process@1.0`
+        % Next, we resolve the schedule key on the message, as a `process@1.0'
         % message.
         {ok, X} =
             hb_ao:resolve(


### PR DESCRIPTION
# Add Optional Build Profiles Documentation to README

## Changes

This PR adds documentation about the available build profiles to the README, making it easier for users to discover and utilize these optional features.

### Added

- New section "Optional Build Profiles" under the "Running HyperBEAM" section that:
  - Documents the three available profiles (`genesis_wasm`, `rocksdb`, and `http3`)
  - Short description of what each profile enables
  - Provides example commands for using profiles with both shell and release targets
  - Notes that profiles modify compile-time options that get baked into releases
