### PR TITLE
impr: use existing genesis-wasm@1.0 server if already running

### DIFF
--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -219,7 +219,7 @@ message_to_request(M, Opts) ->
         {ok, Routes} ->
             ?event(http_outbound, {found_routes, {req, M}, {routes, Routes}}),
             % The result is a route, so we leave it to `request' to handle it.
-            Path = hb_converge:get(<<"path">>, M, <<"/">>, Opts),
+            Path = hb_ao:get(<<"path">>, M, <<"/">>, Opts),
             {ok, Method, Routes, Path, MsgWithoutMeta};
         {error, Reason} ->
             {error, {no_viable_route, Reason, {message, M}}}


### PR DESCRIPTION
This allows developers to start another server on :6363 and execute against it for debugging purposes. If no server is running and the `as genesis_wasm` flag is set, a new node will be started.

Also fixes an errant `hb_converge` call introduced in #203.