### PR TITLE
impr: encode IDs in a grouped header, improve embedded legacynet executor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,14 +102,5 @@ setup-genesis-wasm: $(GENESIS_WASM_SERVER_DIR)
 		echo "  node -v && npm -v"; \
 		exit 1; \
 	fi
-	@if [ ! -f "$(GENESIS_WASM_SERVER_DIR)/.env" ]; then \
-		cd $(GENESIS_WASM_SERVER_DIR) && \
-			npx --yes @permaweb/wallet >> wallet.json && \
-			echo 'NODE_CONFIG_ENV="development"' > .env && \
-			echo "WALLET_FILE=./wallet.json" >> .env && \
-			echo "HB_URL=http://localhost:10000" >> .env && \
-			echo "UNIT_MODE=hbu" >> .env && \
-			echo "PORT=6363" >> .env; \
-	fi
 	@cd $(GENESIS_WASM_SERVER_DIR) && npm install > /dev/null 2>&1 && \
 		echo "Installed genesis-wasm@1.0 server."

--- a/src/dev_codec_httpsig.erl
+++ b/src/dev_codec_httpsig.erl
@@ -787,23 +787,23 @@ extract_field({item, {_Kind, IParsed}, IParams}, Req, Res) ->
                 >>
             };
 		_ ->
-			Lowered = lower_bin(IParsed),
+			NormParsed = hb_ao:normalize_key(IParsed),
 			NormalizedItem =
                 hb_structured_fields:item(
-                    {item, {string, Lowered}, IParams}
+                    {item, {string, NormParsed}, IParams}
                 ),
             IsRequestIdentifier = find_request_param(IParams),
 			% There may be multiple fields that match the identifier on the Msg,
 			% so we filter, instead of find
             %?event({extracting_field, {identifier, Lowered}, {req, Req}, {res, Res}}),
-			case maps:get(Lowered, if IsRequestIdentifier -> Req; true -> Res end, not_found) of
+			case maps:get(NormParsed, if IsRequestIdentifier -> Req; true -> Res end, not_found) of
 				not_found ->
 					% https://datatracker.ietf.org/doc/html/rfc9421#section-2.5-7.2.2.5.2.6
 					{
                         field_not_found_error,
                         <<"Component Identifier for a field MUST be ",
                             "present on the message">>,
-                        {key, Lowered},
+                        {key, NormParsed},
                         {req, Req},
                         {res, Res}
                     };

--- a/src/dev_codec_httpsig_conv.erl
+++ b/src/dev_codec_httpsig_conv.erl
@@ -40,7 +40,9 @@
 %% @doc Convert a HTTP Message into a TABM.
 %% HTTP Structured Field is encoded into it's equivalent TABM encoding.
 from(Bin) when is_binary(Bin) -> Bin;
-from(HTTP) ->
+from(RawHTTP) ->
+    % Decode the keys of the HTTP message
+    HTTP = hb_escape:decode_keys(RawHTTP),
     Body = maps:get(<<"body">>, HTTP, <<>>),
     % First, parse all headers excluding the signature-related headers, as they
     % are handled separately.
@@ -293,6 +295,8 @@ commitments_from_signature(Map, HPs, RawSig, RawSigInput) ->
 to(Bin) when is_binary(Bin) -> Bin;
 to(TABM) -> to(TABM, []).
 to(TABM, Opts) when is_map(TABM) ->
+    % Encode the keys of the TABM
+    EncodedTABM = hb_escape:encode_keys(TABM),
     Stripped =
         maps:without(
             [
@@ -301,7 +305,7 @@ to(TABM, Opts) when is_map(TABM) ->
                 <<"signature-input">>,
                 <<"priv">>
             ],
-            TABM
+            EncodedTABM
         ),
     ?event({stripped, Stripped}),
     {InlineFieldHdrs, InlineKey} = inline_key(TABM),

--- a/src/dev_codec_structured.erl
+++ b/src/dev_codec_structured.erl
@@ -89,7 +89,7 @@ from(Msg) when is_map(Msg) ->
                     lists:map(
                         fun({Key, Value}) ->
                             {ok, Item} = hb_structured_fields:to_item(Value),
-                            {Key, Item}
+                            {hb_escape:encode(Key), Item}
                         end,
                         lists:reverse(T)
                     )
@@ -169,7 +169,9 @@ parse_ao_types(Msg) when is_map(Msg) ->
 parse_ao_types(Bin) ->
     maps:from_list(
         lists:map(
-            fun({Key, {item, {_, Value}, _}}) -> {Key, Value} end,
+            fun({Key, {item, {_, Value}, _}}) ->
+                {hb_escape:decode(Key), Value}
+            end,
             hb_structured_fields:parse_dictionary(Bin)    
         )
     ).

--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -12,6 +12,12 @@
 %% @doc Initialize the device.
 init(Msg, _Msg2, _Opts) -> {ok, Msg}.
 
+%% @doc Normalize the device.
+normalize(Msg, _Msg2, _Opts) -> {ok, Msg}.
+
+%% @doc Snapshot the device.
+snapshot(Msg, _Msg2, _Opts) -> {ok, Msg}.
+
 %% @doc All the `delegated-compute@1.0' device to execute the request. We then apply
 %% the `patch@1.0' device, applying any state patches that the AO process may have
 %% requested.
@@ -50,56 +56,136 @@ ensure_started(Opts) ->
     % Check if the `genesis-wasm@1.0` device is already running. The presence
     % of the registered name implies its availability.
     ?event({ensure_started, genesis_wasm, self()}),
-    case is_genesis_wasm_server_running(Opts) orelse (hb_features:genesis_wasm() andalso is_pid(hb_name:lookup(<<"genesis-wasm@1.0">>))) of
+    IsRunning = is_genesis_wasm_server_running(Opts),
+    IsCompiled = hb_features:genesis_wasm(),
+    GenWASMProc = is_pid(hb_name:lookup(<<"genesis-wasm@1.0">>)),
+    case IsRunning orelse (IsCompiled andalso GenWASMProc) of
         true ->
             % If it is, do nothing.
             true;
         false ->
-            % The device is not running, so we need to start it.
+			% The device is not running, so we need to start it.
             PID =
                 spawn(
                     fun() ->
-                        ?event({genesis_wasm_starting, {pid, self()}}),
+                        ?event({genesis_wasm_booting, {pid, self()}}),
+                        % Create genesis_wasm cache dir, if it does not exist.
+                        NodeURL =
+                            "http://localhost:" ++
+                            integer_to_list(hb_opts:get(port, no_port, Opts)),
+                        DBDir =
+                            hb_util:list(
+                                hb_opts:get(
+                                    genesis_wasm_db_dir,
+                                    "cache-mainnet/genesis-wasm",
+                                    Opts
+                                )
+                            ),
+                        DatabaseUrl = "../../" ++ DBDir ++ "/genesis-wasm-db",
+                        filelib:ensure_path(DBDir),
                         Port =
                             open_port(
                                 {spawn,
-                                    "npm --prefix _build/genesis-wasm-server run dev"
+                                    "npm --prefix _build/genesis-wasm-server "
+                                        "run dev"
                                 },
-                                [binary, use_stdio, stderr_to_stdout]
+                                [
+                                    binary, use_stdio, stderr_to_stdout,
+                                    {env,
+                                        [
+                                            {"UNIT_MODE", "hbu"},
+                                            {"HB_URL", NodeURL},
+                                            {"PORT",
+                                                integer_to_list(
+                                                    hb_opts:get(
+                                                        genesis_wasm_port,
+                                                        6363,
+                                                        Opts
+                                                    )
+                                                )
+                                            },
+                                            {"DB_URL", DatabaseUrl},
+                                            {"NODE_CONFIG_ENV", "development"},
+                                            {"DEFAULT_LOG_LEVEL",
+                                                hb_util:list(
+                                                    hb_opts:get(
+                                                        genesis_wasm_log_level,
+                                                        "error",
+                                                        Opts
+                                                    )
+                                                )
+                                            },
+                                            {"WALLET_FILE",
+                                                "../../" ++
+                                                    hb_util:list(
+                                                        hb_opts:get(
+                                                            priv_key_location,
+                                                            no_key,
+                                                            Opts
+                                                        )
+                                                    )
+                                            }
+                                        ]
+                                    }
+                                ]
                             ),
                         ?event({genesis_wasm_port_opened, {port, Port}}),
-                        true = port_command(Port, iolist_to_binary(<<>>)),
-                        ?event({genesis_wasm_port_command_sent, {port, Port}}),
                         collect_events(Port)
                     end
                 ),
             hb_name:register(<<"genesis-wasm@1.0">>, PID),
             ?event({genesis_wasm_starting, {pid, PID}}),
             % Wait for the device to start.
-            receive after 2000 -> ok end,
+            hb_util:until(
+                fun() ->
+                    receive after 1000 -> ok end,
+                    Status = is_genesis_wasm_server_running(Opts),
+                    ?event({genesis_wasm_boot_wait, {received_status, Status}}),
+                    Status
+                end
+            ),
             ?event({genesis_wasm_started, {pid, PID}}),
-            is_genesis_wasm_server_running(Opts)
+            true
     end.
 
+%% @doc Check if the genesis-wasm server is running, using the cached process ID
+%% if available.
 is_genesis_wasm_server_running(Opts) ->
-    ?event({genesis_wasm_checking_status, self()}),
-    Parent = self(),
-    PID = spawn(
-        fun() ->
-            ?event({genesis_wasm_checking_status, {pid, self()}}),
-            Parent ! {ok, self(), status(Opts)}
-        end
-    ),
-    receive
-        {ok, PID, Status} -> Status
-    after ?STATUS_TIMEOUT ->
-        ?event({genesis_wasm_status_check, {timeout, {pid, PID}}}),
-        erlang:exit(PID, kill),
-        false
+    case get(genesis_wasm_pid) of
+        undefined ->
+            ?event(genesis_wasm_pinging_server),
+            Parent = self(),
+            PID = spawn(
+                fun() ->
+                    ?event({genesis_wasm_get_info_endpoint, {worker, self()}}),
+                    Parent ! {ok, self(), status(Opts)}
+                end
+            ),
+            receive
+                {ok, PID, Status} ->
+                    put(genesis_wasm_pid, Status),
+                    ?event({genesis_wasm_received_status, Status}),
+                    Status
+            after ?STATUS_TIMEOUT ->
+                ?event({genesis_wasm_status_check, timeout}),
+                erlang:exit(PID, kill),
+                false
+            end;
+        _ -> true
     end.
 
+%% @doc Check if the genesis-wasm server is running by requesting its status
+%% endpoint.
 status(Opts) ->
-    try hb_http:get(<<"http://localhost:6363/">>, Opts) of
+    ServerPort =
+        integer_to_binary(
+            hb_opts:get(
+                genesis_wasm_port,
+                6363,
+                Opts
+            )
+        ),
+    try hb_http:get(<<"http://localhost:", ServerPort/binary, "/status">>, Opts) of
         {ok, Res} ->
             ?event({genesis_wasm_status_check, {res, Res}}),
             true;
@@ -108,24 +194,29 @@ status(Opts) ->
             false
     catch
         _:Err ->
-            ?event({genesis_wasm_status_check, {connect_error, Err}}),
+            ?event({genesis_wasm_status_check, {error, Err}}),
             false
     end.
 
 %% @doc Collect events from the port and log them.
 collect_events(Port) ->
+    collect_events(Port, <<>>).
+collect_events(Port, Acc) ->
     receive
         {Port, {data, Data}} ->
-            ?event(genesis_wasm_event, {data, Data}),
-            collect_events(Port);
+            collect_events(Port,
+                log_server_events(<<Acc/binary, Data/binary>>)
+            );
         stop ->
             port_close(Port),
             ?event(genesis_wasm_stopped, {pid, self()}),
             ok
     end.
 
-%% @doc Normalize the device.
-normalize(Msg, _Msg2, _Opts) -> {ok, Msg}.
-
-%% @doc Snapshot the device.
-snapshot(Msg, _Msg2, _Opts) -> {ok, Msg}.
+%% @doc Log lines of output from the genesis-wasm server.
+log_server_events(Bin) when is_binary(Bin) ->
+    log_server_events(binary:split(Bin, <<"\n">>, [global]));
+log_server_events([Remaining]) -> Remaining;
+log_server_events([Line | Rest]) ->
+    ?event(genesis_wasm_server, {server_logged, Line}),
+    log_server_events(Rest).

--- a/src/dev_json_iface.erl
+++ b/src/dev_json_iface.erl
@@ -181,7 +181,7 @@ prepare_tags(Msg) ->
             case maps:find(<<"original-tags">>, Commitment) of
                 {ok, OriginalTags} ->
                     Res = hb_util:message_to_ordered_list(OriginalTags),
-                    ?event(debug, {using_original_tags, Res}),
+                    ?event({using_original_tags, Res}),
                     Res;
                 error -> 
                     prepare_header_case_tags(Msg)

--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -437,9 +437,7 @@ set(Message1, NewValuesMsg, Opts) ->
 	% note them for removal.
 	ConflictingKeys =
 		lists:filter(
-			fun(Key) ->
-				lists:member(Key, KeysToSet)
-			end,
+			fun(Key) -> lists:member(Key, KeysToSet) end,
 			maps:keys(Message1)
 		),
     UnsetKeys =

--- a/src/hb.erl
+++ b/src/hb.erl
@@ -266,7 +266,7 @@ debug_wait(T, Mod, Func, Line) ->
 %% @doc Run a function as many times as possible in a given amount of time.
 benchmark(Fun, TLen) ->
     T0 = erlang:system_time(millisecond),
-    until(
+    hb_util:until(
         fun() -> erlang:system_time(millisecond) - T0 > (TLen * 1000) end,
         Fun,
         0
@@ -296,15 +296,3 @@ benchmark(Fun, TLen, Procs) ->
         end,
     Refs = lists:map(StartWorker, lists:seq(1, Procs)),
     lists:sum(lists:map(CollectRes, Refs)).
-
-until(Condition, Fun, Count) ->
-    case Condition() of
-        false ->
-            case apply(Fun, hb_ao:truncate_args(Fun, [Count])) of
-                {count, AddToCount} ->
-                    until(Condition, Fun, Count + AddToCount);
-                _ ->
-                    until(Condition, Fun, Count + 1)
-            end;
-        true -> Count
-    end.

--- a/src/hb_escape.erl
+++ b/src/hb_escape.erl
@@ -1,0 +1,115 @@
+%%% @doc Escape and unescape mixed case values for use in HTTP headers.
+%%% This is necessary for encodings of AO-Core messages for transmission in 
+%%% HTTP/2 and HTTP/3, because uppercase header keys are explicitly disallowed.
+%%% While most map keys in HyperBEAM are normalized to lowercase, IDs are not.
+%%% Subsequently, we encode all header keys to lowercase %-encoded URI-style
+%%% strings because transmission.
+-module(hb_escape).
+-export([encode/1, decode/1, encode_keys/1, decode_keys/1]).
+-include_lib("eunit/include/eunit.hrl").
+
+%% @doc Encode a binary as a URI-encoded string.
+encode(Bin) when is_binary(Bin) ->
+    list_to_binary(percent_escape(binary_to_list(Bin))).
+
+%% @doc Decode a URI-encoded string back to a binary.
+decode(Bin) when is_binary(Bin) ->
+    list_to_binary(percent_unescape(binary_to_list(Bin))).
+
+%% @doc Return a message with all of its keys decoded.
+decode_keys(Msg) when is_map(Msg) ->
+    maps:from_list(
+        lists:map(
+            fun({Key, Value}) -> {decode(Key), Value} end,
+            maps:to_list(Msg)
+        )
+    );
+decode_keys(Other) -> Other.
+
+%% @doc URI encode keys in the base layer of a message. Does not recurse.
+encode_keys(Msg) when is_map(Msg) ->
+    maps:from_list(
+        lists:map(
+            fun({Key, Value}) -> {encode(Key), Value} end,
+            maps:to_list(Msg)
+        )
+    );
+encode_keys(Other) -> Other.
+
+%% @doc Escape a list of characters as a URI-encoded string.
+percent_escape([]) -> [];
+percent_escape([C | Cs]) when C >= $a, C =< $z -> [C | percent_escape(Cs)];
+percent_escape([C | Cs]) when C >= $0, C =< $9 -> [C | percent_escape(Cs)];
+percent_escape([C | Cs]) when
+        C == $.; C == $-; C == $_; C == $/;
+        C == $?; C == $&; C == $+ ->
+    [C | percent_escape(Cs)];
+percent_escape([C | Cs]) -> [escape_byte(C) | percent_escape(Cs)].
+
+%% @doc Escape a single byte as a URI-encoded string.
+escape_byte(C) when C >= 0, C =< 255 ->
+    [$%, hex_digit(C bsr 4), hex_digit(C band 15)].
+
+hex_digit(N) when N >= 0, N =< 9 ->
+    N + $0;
+hex_digit(N) when N > 9, N =< 15 ->
+    N + $a - 10.
+
+%% @doc Unescape a URI-encoded string.
+percent_unescape([$%, H1, H2 | Cs]) ->
+    Byte = (hex_value(H1) bsl 4) + hex_value(H2),
+    [Byte | percent_unescape(Cs)];
+percent_unescape([C | Cs]) ->
+    [C | percent_unescape(Cs)];
+percent_unescape([]) ->
+    [].
+
+hex_value(C) when C >= $0, C =< $9 ->
+    C - $0;
+hex_value(C) when C >= $a, C =< $f ->
+    C - $a + 10;
+hex_value(C) when C >= $A, C =< $F ->
+    C - $A + 10.
+
+%%% Tests
+
+escape_unescape_identity_test() ->
+    % Test that unescape(escape(X)) == X for various inputs
+    TestCases = [
+        <<"hello">>,
+        <<"hello, world!">>,
+        <<"special@chars#here">>,
+        <<"UPPERCASE">>,
+        <<"MixedCASEstring">>,
+        <<"12345">>,
+        <<>> % Empty string
+    ],
+    lists:foreach(fun(TestCase) ->
+        ?assertEqual(TestCase, decode(encode(TestCase)))
+    end, TestCases).
+
+unescape_specific_test() ->
+    % Test specific unescape cases
+    ?assertEqual(<<"a">>, decode(<<"%61">>)),
+    ?assertEqual(<<"A">>, decode(<<"%41">>)),
+    ?assertEqual(<<"!">>, decode(<<"%21">>)),
+    ?assertEqual(<<"hello, World!">>, decode(<<"hello%2c%20%57orld%21">>)),
+    ?assertEqual(<<"/">>, decode(<<"%2f">>)),
+    ?assertEqual(<<"?">>, decode(<<"%3f">>)).
+
+uppercase_test() ->
+    % Test uppercase characters are properly escaped
+    ?assertEqual(<<"%41">>, encode(<<"A">>)),
+    ?assertEqual(<<"%42">>, encode(<<"B">>)),
+    ?assertEqual(<<"%5a">>, encode(<<"Z">>)),
+    ?assertEqual(<<"hello%20%57orld">>, encode(<<"hello World">>)),
+    ?assertEqual(<<"test%41%42%43">>, encode(<<"testABC">>)).
+
+escape_unescape_special_chars_test() ->
+    % Test characters that should be escaped
+    SpecialChars = [
+        $@, $#, $", $$, $%, $&, $', $(, $), $*, $+, $,, $/, $:, $;, 
+        $<, $=, $>, $?, $[, $\\, $], $^, $`, ${, $|, $}, $~, $\s
+    ],
+    TestString = list_to_binary(SpecialChars),
+    ?assertEqual(TestString, decode(encode(TestString))).

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -1433,6 +1433,20 @@ priv_survives_conversion_test(Codec) ->
         maps:get(<<"priv">>, Decoded, #{})
     ).
 
+encode_balance_table_test(Codec) ->
+    Msg =
+        #{
+            hb_util:encode(crypto:strong_rand_bytes(32)) =>
+                integer_to_binary(rand:uniform(1_000_000_000_000_000))
+        ||
+            _ <- lists:seq(1, 20000)
+        },
+    Encoded = convert(Msg, Codec, #{}),
+    ?event({encoded, Encoded}),
+    Decoded = convert(Encoded, <<"structured@1.0">>, Codec, #{}),
+    ?event({decoded, Decoded}),
+    ?assert(match(Msg, Decoded)).
+
 %%% Test helpers
 
 test_codecs() ->
@@ -1515,4 +1529,4 @@ message_suite_test_() ->
     ]).
 
 run_test() ->
-    signed_message_encode_decode_verify_test(<<"ans104@1.0">>).
+    encode_balance_table_test(<<"httpsig@1.0">>).

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -1433,19 +1433,25 @@ priv_survives_conversion_test(Codec) ->
         maps:get(<<"priv">>, Decoded, #{})
     ).
 
-encode_balance_table_test(Codec) ->
+encode_balance_table(Size, Codec) ->
     Msg =
         #{
             hb_util:encode(crypto:strong_rand_bytes(32)) =>
-                integer_to_binary(rand:uniform(1_000_000_000_000_000))
+                rand:uniform(1_000_000_000_000_000)
         ||
-            _ <- lists:seq(1, 20000)
+            _ <- lists:seq(1, Size)
         },
     Encoded = convert(Msg, Codec, #{}),
-    ?event({encoded, Encoded}),
+    ?event(debug, {encoded, {explicit, Encoded}}),
     Decoded = convert(Encoded, <<"structured@1.0">>, Codec, #{}),
-    ?event({decoded, Decoded}),
+    ?event(debug, {decoded, Decoded}),
     ?assert(match(Msg, Decoded)).
+
+encode_small_balance_table_test(Codec) ->
+    encode_balance_table(5, Codec).
+
+encode_large_balance_table_test(Codec) ->
+    encode_balance_table(1000, Codec).
 
 %%% Test helpers
 
@@ -1525,8 +1531,10 @@ message_suite_test_() ->
         {"priv survives conversion test", fun priv_survives_conversion_test/1},
         {"sign node message test", fun sign_node_message_test/1},
         {"nested list test", fun nested_body_list_test/1},
-        {"recursive nested list test", fun recursive_nested_list_test/1}
+        {"recursive nested list test", fun recursive_nested_list_test/1},
+        {"encode small balance table test", fun encode_small_balance_table_test/1},
+        {"encode large balance table test", fun encode_large_balance_table_test/1}
     ]).
 
 run_test() ->
-    encode_balance_table_test(<<"httpsig@1.0">>).
+    encode_balance_table(1000, <<"httpsig@1.0">>).

--- a/src/hb_structured_fields.erl
+++ b/src/hb_structured_fields.erl
@@ -164,7 +164,7 @@ key_to_binary(Key) -> iolist_to_binary(Key).
 -spec parse_dictionary(binary()) -> sh_dictionary().
 parse_dictionary(<<>>) ->
     [];
-parse_dictionary(<<C, R/bits>>) when ?IS_LC_ALPHA(C)
+parse_dictionary(<<C, R/bits>>) when ?IS_ALPHA(C)
         or ?IS_DIGIT(C) or (C =:= $*) or (C =:= $%) or (C =:= $_) or (C =:= $-) ->
     parse_dict_key(R, [], <<C>>).
 
@@ -175,7 +175,7 @@ parse_dict_key(<<$=, R0/bits>>, Acc, K) ->
     {Item, R} = parse_item1(R0),
     parse_dict_before_sep(R, lists:keystore(K, 1, Acc, {K, Item}));
 parse_dict_key(<<C, R/bits>>, Acc, K) when
-        ?IS_LC_ALPHA(C) or ?IS_DIGIT(C) or
+        ?IS_ALPHA(C) or ?IS_DIGIT(C) or
         (C =:= $_) or (C =:= $-) or (C =:= $.) or (C =:= $*) or (C =:= $%) ->
     parse_dict_key(R, Acc, <<K/binary, C>>);
 parse_dict_key(<<$;, R0/bits>>, Acc, K) ->
@@ -199,7 +199,9 @@ parse_dict_before_member(<<$\s, R/bits>>, Acc) ->
     parse_dict_before_member(R, Acc);
 parse_dict_before_member(<<$\t, R/bits>>, Acc) ->
     parse_dict_before_member(R, Acc);
-parse_dict_before_member(<<C, R/bits>>, Acc) when ?IS_LC_ALPHA(C) or ?IS_DIGIT(C) or (C =:= $*) ->
+parse_dict_before_member(<<C, R/bits>>, Acc)
+        when ?IS_ALPHA(C) or ?IS_DIGIT(C) or (C =:= $*)
+        or (C =:= $%) or (C =:= $_) or (C =:= $-) ->
     parse_dict_key(R, Acc, <<C>>).
 
 %% @doc Parse a binary SF item to an SF `item'.

--- a/src/hb_structured_fields.erl
+++ b/src/hb_structured_fields.erl
@@ -175,7 +175,7 @@ parse_dict_key(<<$=, R0/bits>>, Acc, K) ->
     parse_dict_before_sep(R, lists:keystore(K, 1, Acc, {K, Item}));
 parse_dict_key(<<C, R/bits>>, Acc, K) when
         ?IS_LC_ALPHA(C) or ?IS_DIGIT(C) or
-        (C =:= $_) or (C =:= $-) or (C =:= $.) or (C =:= $*) ->
+        (C =:= $_) or (C =:= $-) or (C =:= $.) or (C =:= $*) or (C =:= $%) ->
     parse_dict_key(R, Acc, <<K/binary, C>>);
 parse_dict_key(<<$;, R0/bits>>, Acc, K) ->
     {Params, R} = parse_before_param(R0, []),

--- a/src/hb_structured_fields.erl
+++ b/src/hb_structured_fields.erl
@@ -164,7 +164,8 @@ key_to_binary(Key) -> iolist_to_binary(Key).
 -spec parse_dictionary(binary()) -> sh_dictionary().
 parse_dictionary(<<>>) ->
     [];
-parse_dictionary(<<C, R/bits>>) when ?IS_LC_ALPHA(C) or ?IS_DIGIT(C) or (C =:= $*) ->
+parse_dictionary(<<C, R/bits>>) when ?IS_LC_ALPHA(C)
+        or ?IS_DIGIT(C) or (C =:= $*) or (C =:= $%) or (C =:= $_) or (C =:= $-) ->
     parse_dict_key(R, [], <<C>>).
 
 parse_dict_key(<<$=, $(, R0/bits>>, Acc, K) ->

--- a/src/hb_structured_fields.erl
+++ b/src/hb_structured_fields.erl
@@ -516,13 +516,17 @@ trim_ws_end(Value, N) ->
 dictionary(Map) when is_map(Map) ->
     dictionary(maps:to_list(Map));
 dictionary(KVList) when is_list(KVList) ->
-    lists:join(<<", ">>, [
-        case Value of
-            true -> Key;
-            _ -> [Key, $=, item_or_inner_list(Value)]
-        end
-    || {Key, Value} <- KVList
-    ]).
+    lists:join(
+        <<", ">>,
+        [
+            case Value of
+                true -> Key;
+                _ -> [Key, $=, item_or_inner_list(Value)]
+            end
+        ||
+            {Key, Value} <- KVList
+        ]
+    ).
 
 -spec item(sh_item()) -> iolist().
 item({item, BareItem, Params}) ->


### PR DESCRIPTION
This PR introduces a new `ao-ids` key to `httpsig@1.0` encoded messages that contain all elements of the message that have an ID as their key, as well as an immediate binary value. This is necessary because HTTP/2+3 require lower case keys. The alternative -- lower-casing all IDs -- would make encoding information-lossy and lead to lost idempotency. Lowering all IDs across the protocol is possible in theory, but would lead to security of 43 character (traditionally 256-bit values) diminishing to around ~225 bits of security.

The encoding used by the `ao-ids` key is a 'relaxed' form of structured field dictionaries. In particular, upper-case keys are admissible in this encoding, as well as the typical `-` and `_` characters. As such, the `ao-ids` key is not listed in `ao-types`, such that its parsing can be handled separately by interested parties. To parse the key without a modified SF-dict library:

1. Split the `ao-ids` field on `, `, avoiding characters found inside `"` delimited zones.
2. For example resulting element, split the string on the first `=` character.
3. The characters before the `=` are the key for the element.
4. Remove the leading and trailing `"` on the second value per element in order to derive its value.

Additionally, this PR also merges some improvements to the handling of the `genesis-wasm@1.0` server. See `feat/genesis-environment` for details.