### PR TITLE
impr: kill child genesis-wasm executor on close of HyperBEAM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,8 @@ $(GENESIS_WASM_SERVER_DIR):
 
 # Set up genesis-wasm@1.0 environment
 setup-genesis-wasm: $(GENESIS_WASM_SERVER_DIR)
-	@# Check if Node.js is installed
-	@if ! command -v node > /dev/null; then \
+	@cp native/genesis-wasm/launch-monitored.sh $(GENESIS_WASM_SERVER_DIR) && \
+	if ! command -v node > /dev/null; then \
 		echo "Error: Node.js is not installed. Please install Node.js before continuing."; \
 		echo "For Ubuntu/Debian, you can install it with:"; \
 		echo "  curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - && \\"; \

--- a/native/genesis-wasm/launch-monitored.sh
+++ b/native/genesis-wasm/launch-monitored.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+"$@" &
+CHILD_PID=$!
+
+while kill -0 "$PPID" 2>/dev/null; do
+  sleep 1
+done
+
+kill -TERM "$CHILD_PID" 2>/dev/null

--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -85,12 +85,18 @@ ensure_started(Opts) ->
                         filelib:ensure_path(DBDir),
                         Port =
                             open_port(
-                                {spawn,
-                                    "npm --prefix _build/genesis-wasm-server "
-                                        "run dev"
+                                {spawn_executable,
+                                    "_build/genesis-wasm-server/launch-monitored.sh"
                                 },
                                 [
                                     binary, use_stdio, stderr_to_stdout,
+                                    {args, [
+                                        "npm",
+                                        "--prefix",
+                                        "_build/genesis-wasm-server",
+                                        "run",
+                                        "dev"
+                                    ]},
                                     {env,
                                         [
                                             {"UNIT_MODE", "hbu"},
@@ -138,7 +144,7 @@ ensure_started(Opts) ->
             % Wait for the device to start.
             hb_util:until(
                 fun() ->
-                    receive after 1000 -> ok end,
+                    receive after 2000 -> ok end,
                     Status = is_genesis_wasm_server_running(Opts),
                     ?event({genesis_wasm_boot_wait, {received_status, Status}}),
                     Status


### PR DESCRIPTION
This PR introduces a monitor to the `genesis-wasm@1.0` flow, which detects the termination of the parent HyperBEAM node and reciprocally closes the child execution server. This allows the pair to neatly boot and terminate together.