### PR TITLE
fix: ensure hashpath is added to hsig message during conversion

### DIFF
--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -497,8 +497,8 @@ set(Message1, NewValuesMsg, Opts) ->
             CommittedKeys
         ),
     ?event({setting, {overwritten_committed_keys, OverwrittenCommittedKeys}}),
-    % Combine with deep_merge
-    Merged = hb_private:set_priv(deep_merge(BaseValues, NewValues), OriginalPriv),
+    % Combine with deep merge
+    Merged = hb_private:set_priv(hb_util:deep_merge(BaseValues, NewValues), OriginalPriv),
     case OverwrittenCommittedKeys of
         [] -> {ok, Merged};
         _ ->
@@ -515,24 +515,6 @@ set(Message1, NewValuesMsg, Opts) ->
 %% for AO-Core to know the key to evaluate in requests.
 set_path(Message1, #{ <<"value">> := Value }, _Opts) ->
     {ok, Message1#{ <<"path">> => Value }}.
-
-%% @doc Deep merge two maps, recursively merging nested maps
-deep_merge(Map1, Map2) when is_map(Map1), is_map(Map2) ->
-    maps:fold(
-        fun(Key, Value2, AccMap) ->
-            case maps:find(Key, AccMap) of
-                {ok, Value1} when is_map(Value1), is_map(Value2) ->
-                    % Both values are maps, recursively merge them
-                    AccMap#{Key => deep_merge(Value1, Value2)};
-                _ ->
-                    % Either the key doesn't exist in Map1 or at least one of 
-                    % the values isn't a map. Simply use the value from Map2
-                    AccMap#{ Key => Value2 }
-            end
-        end,
-        Map1,
-        Map2
-    ).
 
 %% @doc Remove a key or keys from a message.
 remove(Message1, #{ <<"item">> := Key }) ->

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -122,7 +122,7 @@ restore_priv(Msg, EmptyPriv) when map_size(EmptyPriv) == 0 -> Msg;
 restore_priv(Msg, OldPriv) ->
     MsgPriv = maps:get(<<"priv">>, Msg, #{}),
     ?event({restoring_priv, {msg_priv, MsgPriv}, {old_priv, OldPriv}}),
-    NewPriv = hb_ao:set(MsgPriv, OldPriv, #{}),
+    NewPriv = hb_util:deep_merge(MsgPriv, OldPriv),
     ?event({new_priv, NewPriv}),
     Msg#{ <<"priv">> => NewPriv }.
 

--- a/src/hb_util.erl
+++ b/src/hb_util.erl
@@ -5,7 +5,7 @@
 -export([key_to_atom/2]).
 -export([encode/1, decode/1, safe_encode/1, safe_decode/1]).
 -export([find_value/2, find_value/3]).
--export([number/1, list_to_numbered_map/1, message_to_ordered_list/1]).
+-export([deep_merge/2, number/1, list_to_numbered_map/1, message_to_ordered_list/1]).
 -export([is_string_list/1, to_sorted_list/1, to_sorted_keys/1]).
 -export([hd/1, hd/2, hd/3]).
 -export([remove_common/2, to_lower/1]).
@@ -223,6 +223,24 @@ to_hex(Bin) when is_binary(Bin) ->
         iolist_to_binary(
             [io_lib:format("~2.16.0B", [X]) || X <- binary_to_list(Bin)]
         )
+    ).
+
+%% @doc Deep merge two maps, recursively merging nested maps.
+deep_merge(Map1, Map2) when is_map(Map1), is_map(Map2) ->
+    maps:fold(
+        fun(Key, Value2, AccMap) ->
+            case maps:find(Key, AccMap) of
+                {ok, Value1} when is_map(Value1), is_map(Value2) ->
+                    % Both values are maps, recursively merge them
+                    AccMap#{Key => deep_merge(Value1, Value2)};
+                _ ->
+                    % Either the key doesn't exist in Map1 or at least one of 
+                    % the values isn't a map. Simply use the value from Map2
+                    AccMap#{ Key => Value2 }
+            end
+        end,
+        Map1,
+        Map2
     ).
 
 %% @doc Label a list of elements with a number.


### PR DESCRIPTION
Fixes a bug in which the hashpath was sometimes lost during conversion between `structured@1.0`, TABM, and the target format. Hashpaths are always now seen in the `tag` element of each `signature-input` element.