### PR TITLE
feat: impl spawning and breaking on HB functions via external debuggers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,14 +2,28 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Launch Erlang with Dependencies",
+      "name": "Launch debugger on a function.",
       "type": "erlang",
       "request": "launch",
       "cwd": "${workspaceRoot}",
+      "projectnode": "hb",
+      "cookie": "hb-debug",
       "preLaunchTask": "Rebar3 Compile",
-      "arguments": "-pa _build/default/lib/*/ebin -eval \"ssl:start(), application:ensure_all_started(hb).\"",
-      "stopOnEntry": false,
-      "internalConsoleOptions": "openOnSessionStart"
+      "postDebugTask": "Stop HyperBEAM",
+      "stopOnEntry": true,
+      "internalConsoleOptions": "openOnSessionStart",
+      "module": "hb_debugger",
+      "function": "start_and_break",
+      "args": "[${input:moduleName}, ${input:functionName}, [${input:funcArgs}]]"
+    },
+    {
+      "name": "Attach to a 'rebar3 debugger' node.",
+      "type": "erlang",
+      "request": "attach",
+      "projectnode": "hb",
+      "cookie": "hb-debug",
+      "timeout": 10,
+      "cwd": "${workspaceRoot}"
     },
     {
       "name": "Attach C Debugger to beam.smp",
@@ -34,6 +48,23 @@
         "traceResponse": true
       },
       "internalConsoleOptions": "neverOpen"
+    }
+  ],
+  "inputs": [
+    {
+      "id": "moduleName",
+      "type": "promptString",
+      "description": "Enter module to break in:"
+    },
+    {
+      "id": "functionName", 
+      "type": "promptString",
+      "description": "Enter function to invoke:"
+    },
+    {
+      "id": "funcArgs",
+      "type": "promptString",
+      "description": "(Optional) Pass arguments to the function:"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,5 +11,10 @@
       },
       "problemMatcher": "$erlang"
     },
+    {
+      "label": "Stop HyperBEAM",
+      "type": "shell",
+      "command": "lsof -i tcp:10000 | tail -n 1 | awk '{print $2}' | xargs kill -9"
+    }
   ]
 }

--- a/rebar.config
+++ b/rebar.config
@@ -114,3 +114,11 @@
 	incremental,
 	{warnings, [no_improper_lists, no_unused]}
 ]}.
+
+{alias, [
+    {debugger,
+        [
+            {shell, "--sname hb --setcookie hb-debug --eval hb_debugger:start()."}
+        ]
+    }
+]}.

--- a/src/hb_debugger.erl
+++ b/src/hb_debugger.erl
@@ -1,0 +1,114 @@
+%%% @doc A module that provides bootstrapping interfaces for external debuggers
+%%% to connect to HyperBEAM.
+%%% 
+%%% The simplest way to utilize an external graphical debugger is to use the 
+%%% `erlang-ls' extension for VS Code, Emacs, or other Language Server Protocol
+%%% (LSP) compatible editors. This repository contains a `launch.json'
+%%% configuration file for VS Code that can be used to spawn a new HyperBEAM,
+%%% attach the debugger to it, and execute the specified `Module:Function(Args)'.
+%%% Additionally, the node can be started with `rebar3 debugging' in order to
+%%% allow access to the console while also allowing the debugger to attach.
+%%% 
+%%% Boot time is approximately 10 seconds.
+-module(hb_debugger).
+-export([start/0, start_and_break/2, start_and_break/3, await_breakpoint/0]).
+
+%% Wait for another node (which we assume to be the debugger) to be attached,
+%% then return to the caller.
+start() ->
+    io:format("Starting debugger...~n", []),
+    DebuggerRes = application:ensure_all_started(debugger),
+    io:format("Started debugger server. Result: ~p.~n", [DebuggerRes]),
+    io:format(
+        "Waiting for debugger. Node is: ~p. Cookie is: ~p.~n",
+        [node(), erlang:get_cookie()]
+    ),
+    await_debugger().
+
+%% @doc Attempt to interpret a specified module to load it into the debugger.
+%% `int:i/1' seems to have an issue that will cause it to fail sporadically 
+%% with `error:undef' on some modules. This error appears not to be catchable
+%% through the normal means. Subsequently, we attempt the load in a separate
+%% process and wait for it to complete. If we do not receive a response in a
+%% reasonable amount of time, we assume that the module failed to load and
+%% return `false'.
+interpret(Module) ->
+    Parent = self(),
+    spawn(fun() ->
+        case int:interpretable(Module) of
+            true ->
+                try Parent ! {interpreted, Module, int:i(Module) == ok}
+                catch _:_ ->
+                    io:format("Could not load module: ~p.~n", [Module]),
+                    false
+                end;
+            Error ->
+                io:format(
+                    "Could not interpret module: ~p. Error: ~p.~n",
+                    [Module, Error]
+                ),
+                false
+        end
+    end),
+    receive {interpreted, Module, Res} -> Res
+    after 250 -> false
+    end.
+
+%% @doc A bootstrapping function to wait for an external debugger to be attached,
+%% then add a breakpoint on the specified `Module:Function(Args)', then call it.
+start_and_break(Module, Function) ->
+    start_and_break(Module, Function, []).
+start_and_break(Module, Function, Args) ->
+    start(),
+    interpret(Module),
+    SetRes = int:break_in(Module, Function, length(Args)),
+    io:format(
+        "Breakpoint set. Result from `int:break_in/3`: ~p.~n",
+        [SetRes]
+    ),
+    io:format("Invoking function...~n", []),
+    apply(Module, Function, Args),
+    io:format("Function invoked. Terminating.~n", []),
+    init:stop().
+
+%% @doc Await a debugger to be attached to the node.
+await_debugger() -> await_debugger(0).
+await_debugger(N) ->
+    case is_debugging_node_connected() of
+        false ->
+            timer:sleep(1000),
+            io:format("Still waiting for debugger after ~p seconds...~n", [N]),
+            await_debugger(N + 1);
+        Node ->
+            io:format(
+                "External node connection detected. Peer: ~p.~n",
+                [Node]
+            ),
+            N
+    end.
+
+%% @doc Is another Distributed Erlang node connected to us?
+is_debugging_node_connected() ->
+    case nodes() ++ nodes(hidden) of
+        [] -> false;
+        [Node | _] -> Node
+    end.
+
+%% @doc Await a new breakpoint being set by the debugger.
+await_breakpoint() ->
+    case is_debugging_node_connected() of
+        false -> start();
+        _ -> do_nothing
+    end,
+    await_breakpoint(0).
+await_breakpoint(N) ->
+    io:format("Waiting for breakpoint to be set in function...~n", []),
+    case int:all_breaks() of
+        [] ->
+            timer:sleep(1000),
+            io:format("Still waiting for breakpoint after ~p seconds...~n", [N]),
+            await_breakpoint(N + 1);
+        [Breakpoint | _] ->
+            io:format("Breakpoint set. Info: ~p.~n", [Breakpoint]),
+            Breakpoint
+    end.


### PR DESCRIPTION
As the moduledoc describes:

```
%%% @doc A module that provides bootstrapping interfaces for external debuggers
%%% to connect to HyperBEAM.
%%% 
%%% The simplest way to utilize an external graphical debugger is to use the 
%%% `erlang-ls' extension for VS Code, Emacs, or other Language Server Protocol
%%% (LSP) compatible editors. This repository contains a `launch.json'
%%% configuration file for VS Code that can be used to spawn a new HyperBEAM,
%%% attach the debugger to it, and execute the specified `Module:Function(Args)'.
%%% Additionally, the node can be started with `rebar3 debugging' in order to
%%% allow access to the console while also allowing the debugger to attach.
```