### PR TITLE
feat: implement path manifest resolver, following the v1 JSON standard

### DIFF
--- a/src/dev_manifest.erl
+++ b/src/dev_manifest.erl
@@ -1,0 +1,66 @@
+%%% @doc An Arweave path manifest resolution device. Follows the v1 schema:
+%%% https://specs.ar.io/?tx=lXLd0OPwo-dJLB_Amz5jgIeDhiOkjXuM3-r0H_aiNj0
+-module(dev_manifest).
+-export([info/0]).
+-include("include/hb.hrl").
+
+%% @doc Use the `route/4' function as the handler for all requests, aside 
+%% from `keys' and `set', which are handled by the default resolver.
+info() ->
+    #{
+        default => fun route/4,
+        excludes => [keys, set]
+    }.
+
+%% @doc Route a request to the associated data via its manifest.
+route(<<"index">>, M1, M2, Opts) ->
+    ?event({manifest_index, M1, M2}),
+    case manifest(M1, M2, Opts) of
+        {ok, JSONStruct} ->
+            ?event({manifest_json_struct, JSONStruct}),
+            case hb_ao:resolve(JSONStruct, [<<"index">>, <<"path">>], Opts) of
+                {ok, Path} ->
+                    ?event({manifest_path, Path}),
+                    route(Path, M1, M2, Opts);
+                _ -> {error, not_found}
+            end;
+        {error, not_found} ->
+            {error, not_found}
+    end;
+route(Key, M1, M2, Opts) ->
+    ?event({manifest_lookup, Key}),
+    {ok, JSONStruct} = manifest(M1, M2, Opts),
+    ?event({manifest_json_struct, JSONStruct}),
+    case hb_ao:resolve(JSONStruct, [<<"paths">>, Key], Opts) of
+        {ok, Entry} ->
+            ID = maps:get(<<"id">>, Entry),
+            ?event({manifest_serving, ID}),
+            case hb_cache:read(ID, Opts) of
+                {ok, Data} ->
+                    ?event({manifest_data, Data}),
+                    {ok, Data};
+                {error, not_found} ->
+                    Fallback = hb_ao:get(JSONStruct, <<"fallback">>, Opts),
+                    FallbackID = maps:get(<<"id">>, Fallback),
+                    ?event({manifest_serving_fallback, FallbackID}),
+                    hb_cache:read(FallbackID, Opts)
+            end;
+        _ -> {error, not_found}
+    end.
+
+%% @doc Find and deserialize a manifest from the given base.
+manifest(Base, _Req, Opts) ->
+    JSON =
+        hb_ao:get_first(
+            [
+                {{as, <<"message@1.0">>, Base}, [<<"data">>]},
+                {{as, <<"message@1.0">>, Base}, [<<"body">>]}
+            ],
+            Opts
+        ),
+    ?event({manifest_json, JSON}),
+    hb_ao:resolve(
+        #{ <<"device">> => <<"json@1.0">>, <<"body">> => JSON },
+        <<"deserialize">>,
+        Opts
+    ).

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -109,7 +109,13 @@ route(_, Msg, Opts) ->
                     Base = extract_base(Msg, Opts),
                     Nodes = hb_ao:get(<<"nodes">>, ModR, Opts),
                     Chosen = choose(ChooseN, Strategy, Base, Nodes, Opts),
-                    ?event({choose, {strategy, Strategy}, {choose_n, ChooseN}, {base, Base}, {nodes, Nodes}, {chosen, Chosen}}),
+                    ?event({choose,
+                        {strategy, Strategy},
+                        {choose_n, ChooseN},
+                        {base, Base},
+                        {nodes, Nodes},
+                        {chosen, Chosen}
+                    }),
                     case Chosen of
                         [Node] when is_map(Node) ->
                             apply_route(Msg, Node);

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -64,6 +64,7 @@ default_message() ->
             #{<<"name">> => <<"json-iface@1.0">>, <<"module">> => dev_json_iface},
             #{<<"name">> => <<"lookup@1.0">>, <<"module">> => dev_lookup},
             #{<<"name">> => <<"lua@5.3a">>, <<"module">> => dev_lua},
+            #{<<"name">> => <<"manifest@1.0">>, <<"module">> => dev_manifest},
             #{<<"name">> => <<"message@1.0">>, <<"module">> => dev_message},
             #{<<"name">> => <<"meta@1.0">>, <<"module">> => dev_meta},
             #{<<"name">> => <<"monitor@1.0">>, <<"module">> => dev_monitor},


### PR DESCRIPTION
Implements the standard as described here:

https://specs.ar.io/?tx=lXLd0OPwo-dJLB_Amz5jgIeDhiOkjXuM3-r0H_aiNj0

The only notable deviation from this standard is that callers must resolve `.../index` in order to receive the index page, as HyperBEAM does not (yet?) allow us to resolve empty string requests.