### PR TITLE
fix: Correctly initialize `current_import` during port boot

### DIFF
--- a/native/hb_beamr/hb_beamr.c
+++ b/native/hb_beamr/hb_beamr.c
@@ -37,6 +37,7 @@ static ErlDrvData wasm_driver_start(ErlDrvPort port, char *buff) {
     DRV_DEBUG("Port term: %p", proc->port_term);
     proc->is_running = erl_drv_mutex_create("wasm_instance_mutex");
     proc->is_initialized = 0;
+    proc->current_import = NULL;
     proc->start_time = time(NULL);
     return (ErlDrvData)proc;
 }


### PR DESCRIPTION
h/t to @jim-toth for the report! 🫡