### PR TITLE
Feat/hb maps opts

### DIFF
--- a/src/ar_rate_limiter.erl
+++ b/src/ar_rate_limiter.erl
@@ -74,10 +74,10 @@ handle_cast({throttle, Peer, Path, From}, State) ->
 	#state{ traces = Traces, opts = Opts } = State,
 	{Type, Limit} = hb_opts:get(throttle_rpm_by_path, Path, Opts),
 	Now = os:system_time(millisecond),
-	case hb_maps:get({Peer, Type}, Traces, not_found) of
+	case hb_maps:get({Peer, Type}, Traces, not_found, Opts) of
 		not_found ->
 			gen_server:reply(From, ok),
-			Traces2 = hb_maps:put({Peer, Type}, {1, queue:from_list([Now])}, Traces),
+			Traces2 = hb_maps:put({Peer, Type}, {1, queue:from_list([Now])}, Traces, Opts),
 			{noreply, State#state{ traces = Traces2 }};
 		{N, Trace} ->
 			{N2, Trace2} = cut_trace(N, queue:in(Now, Trace), Now, Opts),
@@ -103,7 +103,7 @@ handle_cast({throttle, Peer, Path, From}, State) ->
 					{noreply, State};
 				false ->
 					gen_server:reply(From, ok),
-					Traces2 = hb_maps:put({Peer, Type}, {N2 + 1, Trace2}, Traces),
+					Traces2 = hb_maps:put({Peer, Type}, {N2 + 1, Trace2}, Traces, Opts),
 					{noreply, State#state{ traces = Traces2 }}
 			end
 	end;

--- a/src/ar_wallet.erl
+++ b/src/ar_wallet.erl
@@ -1,7 +1,7 @@
 -module(ar_wallet).
 -export([sign/2, sign/3, hmac/1, hmac/2, verify/3, verify/4]).
 -export([to_pubkey/1, to_pubkey/2, to_address/1, to_address/2, new/0, new/1]).
--export([new_keyfile/2, load_keyfile/1, load_key/1]).
+-export([new_keyfile/2, load_keyfile/1, load_keyfile/2, load_key/1, load_key/2]).
 -include("include/ar.hrl").
 -include_lib("public_key/include/public_key.hrl").
 

--- a/src/dev_codec_httpsig.erl
+++ b/src/dev_codec_httpsig.erl
@@ -172,7 +172,8 @@ commit(Msg, Req = #{ <<"type">> := <<"hmac-sha256">> }, Opts) ->
                         <<"committed">> => hb_ao:normalize_keys(CommittedKeys)
                     }
             },
-            Msg
+            Msg,
+			Opts
         )
     },
     ?event({reset_hmac_complete, Res}),
@@ -591,7 +592,9 @@ derive_component(Identifier, Req, Res) when map_size(Res) == 0 ->
 	derive_component(Identifier, Req, Res, req);
 derive_component(Identifier, Req, Res) ->
 	derive_component(Identifier, Req, Res, res).
-derive_component({item, {_Kind, IParsed}, IParams}, Req, Res, Subject) ->
+derive_component(Identifier, Req, Res, Subject) ->
+	derive_component(Identifier, Req, Res, Subject, #{}).
+derive_component({item, {_Kind, IParsed}, IParams}, Req, Res, Subject, Opts) ->
 	case find_request_param(IParams) andalso Subject =:= req of
 		% https://datatracker.ietf.org/doc/html/rfc9421#section-2.5-7.2.2.5.2.3
 		true ->
@@ -610,23 +613,23 @@ derive_component({item, {_Kind, IParsed}, IParams}, Req, Res, Subject) ->
 				case Lowered of
 					% https://datatracker.ietf.org/doc/html/rfc9421#section-2.2-4.2.1
 					<<"@method">> ->
-						{ok, upper_bin(hb_maps:get(<<"method">>, Req, <<>>))};
+						{ok, upper_bin(hb_maps:get(<<"method">>, Req, <<>>, Opts))};
 					% https://datatracker.ietf.org/doc/html/rfc9421#section-2.2-4.4.1
 					<<"@target-uri">> ->
-						{ok, bin(hb_maps:get(<<"path">>, Req, <<>>))};
+						{ok, bin(hb_maps:get(<<"path">>, Req, <<>>, Opts))};
 					% https://datatracker.ietf.org/doc/html/rfc9421#section-2.2-4.6.1
 					<<"@authority">> ->
-						URI = uri_string:parse(hb_maps:get(<<"path">>, Req, <<>>)),
-						Authority = hb_maps:get(host, URI, <<>>),
+						URI = uri_string:parse(hb_maps:get(<<"path">>, Req, <<>>, Opts)),
+						Authority = hb_maps:get(host, URI, <<>>, Opts),
 						{ok, lower_bin(Authority)};
 					% https://datatracker.ietf.org/doc/html/rfc9421#section-2.2-4.8.1
 					<<"@scheme">> ->
-						URI = uri_string:parse(hb_maps:get(<<"path">>, Req)),
-						Scheme = hb_maps:get(scheme, URI, <<>>),
+						URI = uri_string:parse(hb_maps:get(<<"path">>, Req, Opts)),
+						Scheme = hb_maps:get(scheme, URI, <<>>, Opts),
 						{ok, lower_bin(Scheme)};
 					% https://datatracker.ietf.org/doc/html/rfc9421#section-2.2-4.10.1
 					<<"@request-target">> ->
-						URI = uri_string:parse(hb_maps:get(<<"path">>, Req)),
+						URI = uri_string:parse(hb_maps:get(<<"path">>, Req, Opts)),
 						% If message contains the absolute form value, then
 						% the value must be the absolut url
 						%
@@ -635,13 +638,13 @@ derive_component({item, {_Kind, IParsed}, IParams}, Req, Res, Subject) ->
 						%
 						% See https://datatracker.ietf.org/doc/html/rfc9421#section-2.2.5-10
 						RequestTarget =
-							case hb_maps:get(is_absolute_form, Req, false) of
-								true -> hb_maps:get(url, Req);
+							case hb_maps:get(is_absolute_form, Req, false, Opts) of
+								true -> hb_maps:get(url, Req, undefined, Opts);
 								_ ->
                                     lists:join($?,
                                         [
-                                            hb_maps:get(path, URI, <<>>),
-                                            hb_maps:get(query, URI, ?EMPTY_QUERY_PARAMS)
+                                            hb_maps:get(path, URI, <<>>, Opts),
+                                            hb_maps:get(query, URI, ?EMPTY_QUERY_PARAMS, Opts)
                                         ]
                                     )
 							end,
@@ -649,15 +652,15 @@ derive_component({item, {_Kind, IParsed}, IParams}, Req, Res, Subject) ->
 					% https://datatracker.ietf.org/doc/html/rfc9421#section-2.2-4.12.1
 					<<"@path">> ->
 						URI = uri_string:parse(hb_maps:get(<<"path">>, Req)),
-						Path = hb_maps:get(path, URI),
+						Path = hb_maps:get(path, URI, undefined, Opts),
 						{ok, bin(Path)};
 					% https://datatracker.ietf.org/doc/html/rfc9421#section-2.2-4.14.1
 					<<"@query">> ->
-						URI = uri_string:parse(hb_maps:get(<<"path">>, Req)),
+						URI = uri_string:parse(hb_maps:get(<<"path">>, Req, undefined, Opts)),
 						% No query params results in a "?" value
 						% See https://datatracker.ietf.org/doc/html/rfc9421#section-2.2.7-14
 						Query =
-							case hb_maps:get(query, URI, <<>>) of
+							case hb_maps:get(query, URI, <<>>, Opts) of
 								<<>> -> ?EMPTY_QUERY_PARAMS;
 								Q -> Q
 							end,
@@ -674,9 +677,9 @@ derive_component({item, {_Kind, IParsed}, IParams}, Req, Res, Subject) ->
                                     "must specify a name parameter">>
                                 };
 							Name ->
-								URI = uri_string:parse(hb_maps:get(<<"path">>, Req)),
+								URI = uri_string:parse(hb_maps:get(<<"path">>, Req, undefined, Opts)),
 								QueryParams =
-                                    uri_string:dissect_query(hb_maps:get(query, URI, "")),
+                                    uri_string:dissect_query(hb_maps:get(query, URI, "", Opts)),
 								QueryParam =
 									case lists:keyfind(Name, 1, QueryParams) of
 										{_, QP} -> QP;
@@ -698,7 +701,7 @@ derive_component({item, {_Kind, IParsed}, IParams}, Req, Res, Subject) ->
                                     "used if target is a request message">>
                                 };
 							_ ->
-								Status = hb_maps:get(<<"status">>, Res, <<"200">>),
+								Status = hb_maps:get(<<"status">>, Res, <<"200">>, Opts),
 								{ok, Status}
 						end
 				end,
@@ -967,7 +970,7 @@ derive_component_error_req_param_on_request_target_test() ->
 	Result =
         derive_component(
             {item, {string, <<"@query-param">>}, [{<<"req">>, true}]},
-            #{}, #{}, req),
+            #{}, #{}, req, #{}),
 	?assertMatch(
 		{req_identifier_error, _},
 		Result
@@ -979,14 +982,19 @@ derive_component_error_query_param_no_name_test() ->
             {item,
                 {string, <<"@query-param">>},
                 [{<<"noname">>, {string, <<"foo">>}}]
-            }, #{}, #{}, req),
+            },
+			#{},
+			#{},
+			req,
+			#{}
+		),
 	?assertMatch(
 		{req_identifier_error, _},
 		Result
 	).
 
 derive_component_error_status_req_target_test() ->
-	Result = derive_component({item, {string, <<"@status">>}, []}, #{}, #{}, req),
+	Result = derive_component({item, {string, <<"@status">>}, []}, #{}, #{}, req, #{}),
 	{E, _M} = Result,
 	?assertEqual(res_identifier_error, E).
 

--- a/src/dev_dedup.erl
+++ b/src/dev_dedup.erl
@@ -15,8 +15,8 @@ info(_M1) ->
 
 %% @doc Forward the keys function to the message device, handle all others
 %% with deduplication. We only act on the first pass.
-handle(<<"keys">>, M1, _M2, _Opts) ->
-    dev_message:keys(M1);
+handle(<<"keys">>, M1, _M2, Opts) ->
+    dev_message:keys(M1, Opts);
 handle(<<"set">>, M1, M2, Opts) ->
     dev_message:set(M1, M2, Opts);
 handle(Key, M1, M2, Opts) ->

--- a/src/dev_delegated_compute.erl
+++ b/src/dev_delegated_compute.erl
@@ -95,7 +95,7 @@ do_compute(ProcID, Msg2, Opts) ->
             JSONRes = hb_ao:get(<<"body">>, Response, Opts),
             ?event({
                 delegated_compute_res_metadata,
-                {req, hb_maps:without([<<"body">>], Response)}
+                {req, hb_maps:without([<<"body">>], Response, Opts)}
             }),
             {ok, JSONRes};
         {Err, Error} when Err == error; Err == failure ->

--- a/src/dev_green_zone.erl
+++ b/src/dev_green_zone.erl
@@ -459,7 +459,7 @@ calculate_node_message(RequiredOpts, Req, true) ->
                 <<"adopt-config">>, <<"peer-location">>,
                 <<"peer-id">>, <<"path">>, <<"method">>
             ],
-            hb_message:uncommitted(Req)
+            hb_message:uncommitted(Req, RequiredOpts)
         ),
 	% Convert atoms to binaries in RequiredOpts to prevent binary_to_existing_atom errors
     % The required config should override the request, if necessary.
@@ -544,12 +544,16 @@ validate_peer_opts(Req, Opts) ->
 	% Get the required config from the local node's configuration.
 	RequiredConfig =
 		hb_ao:normalize_keys(
-			hb_opts:get(green_zone_required_opts, #{}, Opts)),
+			hb_opts:get(green_zone_required_opts, #{}, Opts),
+			Opts
+		),
 	?event(green_zone, {validate_peer_opts, required_config, RequiredConfig}),
 	
 	PeerOpts =
 		hb_ao:normalize_keys(
-			hb_ao:get(<<"node-message">>, Req, undefined, Opts)),
+			hb_ao:get(<<"node-message">>, Req, undefined, Opts),
+			Opts
+		),
 	?event(green_zone, {validate_peer_opts, peer_opts, PeerOpts}),
 	
 	% Add the required config itself to the required options of the peer. This

--- a/src/dev_hyperbuddy.erl
+++ b/src/dev_hyperbuddy.erl
@@ -47,7 +47,8 @@ metrics(_, Req, Opts) ->
             Headers =
                 hb_maps:map(
                     fun(_, Value) -> hb_util:bin(Value) end,
-                    RawHeaderMap
+                    RawHeaderMap,
+					Opts
                 ),
             {ok, Headers#{ <<"body">> => Body }};
         false ->
@@ -81,11 +82,11 @@ format(Base, Req, Opts) ->
 
 %% @doc Serve a file from the priv directory. Only serves files that are explicitly
 %% listed in the `routes' field of the `info/0' return value.
-serve(<<"keys">>, M1, _M2, _Opts) -> dev_message:keys(M1);
+serve(<<"keys">>, M1, _M2, Opts) -> dev_message:keys(M1, Opts);
 serve(<<"set">>, M1, M2, Opts) -> dev_message:set(M1, M2, Opts);
-serve(Key, _, _, _) ->
+serve(Key, _, _, Opts) ->
     ?event({hyperbuddy_serving, Key}),
-    case hb_maps:get(Key, hb_maps:get(routes, info(), no_routes), undefined) of
+    case hb_maps:get(Key, hb_maps:get(routes, info(), no_routes, Opts), undefined, Opts) of
         undefined -> {error, not_found};
         Filename -> return_file(Filename)
     end.

--- a/src/dev_json_iface.erl
+++ b/src/dev_json_iface.erl
@@ -84,7 +84,7 @@ denormalize_message(Message, Opts) ->
         case hb_message:signers(Message, Opts) of
             [] -> Message;
             [PrimarySigner|_] ->
-                {ok, _, Commitment} = hb_message:commitment(PrimarySigner, Message),
+                {ok, _, Commitment} = hb_message:commitment(PrimarySigner, Message, Opts),
                 Message#{
                     <<"owner">> => hb_util:human_id(PrimarySigner),
                     <<"signature">> =>

--- a/src/dev_json_iface.erl
+++ b/src/dev_json_iface.erl
@@ -104,7 +104,7 @@ message_to_json_struct(RawMsg, Features, Opts) ->
             tabm,
             #{}
         ),
-    MsgWithoutCommitments = hb_maps:without([<<"commitments">>], TABM),
+    MsgWithoutCommitments = hb_maps:without([<<"commitments">>], TABM, Opts),
     ID = hb_message:id(RawMsg, all),
     ?event({encoding, {id, ID}, {msg, RawMsg}}),
     Last = hb_ao:get(<<"anchor">>, {as, <<"message@1.0">>, MsgWithoutCommitments}, <<>>, #{}),
@@ -151,7 +151,7 @@ message_to_json_struct(RawMsg, Features, Opts) ->
         % NOTE: When sent to ao "Owner" is the wallet address
         <<"Owner">> => hb_util:encode(Owner),
         <<"From">> => case ?IS_ID(From) of true -> safe_to_id(From); false -> From end,
-        <<"Tags">> => prepare_tags(TABM),
+        <<"Tags">> => prepare_tags(TABM, Opts),
         <<"Target">> => safe_to_id(Target),
         <<"Data">> => Data,
         <<"Signature">> =>
@@ -164,25 +164,25 @@ message_to_json_struct(RawMsg, Features, Opts) ->
 
 %% @doc Prepare the tags of a message as a key-value list, for use in the 
 %% construction of the JSON-Struct message.
-prepare_tags(Msg) ->
+prepare_tags(Msg, Opts) ->
     % Prepare an ANS-104 message for JSON-Struct construction.
     case hb_message:commitment(#{ <<"commitment-device">> => <<"ans104@1.0">> }, Msg, #{}) of
         {ok, _, Commitment} ->
-            case hb_maps:find(<<"original-tags">>, Commitment) of
+            case hb_maps:find(<<"original-tags">>, Commitment, Opts) of
                 {ok, OriginalTags} ->
                     Res = hb_util:message_to_ordered_list(OriginalTags),
                     ?event({using_original_tags, Res}),
                     Res;
                 error -> 
-                    prepare_header_case_tags(Msg)
+                    prepare_header_case_tags(Msg, Opts)
             end;
         _ ->
-            prepare_header_case_tags(Msg)
+            prepare_header_case_tags(Msg, Opts)
     end.
 
 %% @doc Convert a message without an `original-tags' field into a list of
 %% key-value pairs, with the keys in HTTP header-case.
-prepare_header_case_tags(TABM) ->
+prepare_header_case_tags(TABM, Opts) ->
     % Prepare a non-ANS-104 message for JSON-Struct construction. 
     lists:map(
         fun({Name, Value}) ->
@@ -197,8 +197,10 @@ prepare_header_case_tags(TABM) ->
                     <<"id">>, <<"anchor">>, <<"owner">>, <<"data">>,
                     <<"target">>, <<"signature">>, <<"commitments">>
                 ],
-                TABM
-            )
+                TABM,
+                Opts
+            ),
+			Opts
         )
     ).
 
@@ -207,7 +209,7 @@ prepare_header_case_tags(TABM) ->
 json_to_message(JSON, Opts) when is_binary(JSON) ->
     json_to_message(hb_json:decode(JSON), Opts);
 json_to_message(Resp, Opts) when is_map(Resp) ->
-    {ok, Data, Messages, Patches} = normalize_results(Resp),
+    {ok, Data, Messages, Patches} = normalize_results(Resp, Opts),
     Output = 
         #{
             <<"outbox">> =>
@@ -222,7 +224,7 @@ json_to_message(Resp, Opts) when is_map(Resp) ->
                             )
                     ]
                 ),
-            <<"patches">> => lists:map(fun tags_to_map/1, Patches),
+            <<"patches">> => lists:map(fun(Patch) -> tags_to_map(Patch, Opts) end, Patches),
             <<"data">> => Data
         },
     {ok, Output};
@@ -348,26 +350,27 @@ env_write(ProcessStr, MsgStr, Base, Req, Opts) ->
 
 %% @doc Normalize the results of an evaluation.
 normalize_results(
-    Msg = #{ <<"Output">> := #{<<"data">> := Data} }) ->
+    Msg = #{ <<"Output">> := #{<<"data">> := Data} }, Opts) ->
     {ok,
         Data,
-        hb_maps:get(<<"Messages">>, Msg, []),
-        hb_maps:get(<<"patches">>, Msg, [])
+        hb_maps:get(<<"Messages">>, Msg, [], Opts),
+        hb_maps:get(<<"patches">>, Msg, [], Opts)
     };
-normalize_results(#{ <<"Error">> := Error }) ->
+normalize_results(#{ <<"Error">> := Error }, _Opts) ->
     {ok, Error, [], []};
-normalize_results(Other) ->
+normalize_results(Other, _Opts) ->
     throw({invalid_results, Other}).
 
 %% @doc After the process returns messages from an evaluation, the
 %% signing node needs to add some tags to each message and spawn such that
 %% the target process knows these messages are created by a process.
-preprocess_results(Msg, _Opts) ->
-    Tags = tags_to_map(Msg),
+preprocess_results(Msg, Opts) ->
+    Tags = tags_to_map(Msg, Opts),
     FilteredMsg =
         hb_maps:without(
             [<<"from-process">>, <<"from-image">>, <<"anchor">>, <<"tags">>],
-            Msg
+            Msg,
+            Opts
         ),
     hb_maps:merge(
         hb_maps:from_list(
@@ -375,19 +378,20 @@ preprocess_results(Msg, _Opts) ->
                 fun({Key, Value}) ->
                     {hb_ao:normalize_key(Key), Value}
                 end,
-                hb_maps:to_list(FilteredMsg)
+                hb_maps:to_list(FilteredMsg, Opts)
             )
         ),
-        Tags
+        Tags,
+        Opts
     ).
 
 %% @doc Convert a message with tags into a map of their key-value pairs.
-tags_to_map(Msg) ->
-    NormMsg = hb_ao:normalize_keys(Msg),
-    RawTags = hb_maps:get(<<"tags">>, NormMsg, []),
+tags_to_map(Msg, Opts) ->
+    NormMsg = hb_ao:normalize_keys(Msg, Opts),
+    RawTags = hb_maps:get(<<"tags">>, NormMsg, [], Opts),
     TagList =
         [
-            {hb_maps:get(<<"name">>, Tag), hb_maps:get(<<"value">>, Tag)}
+            {hb_maps:get(<<"name">>, Tag, Opts), hb_maps:get(<<"value">>, Tag, Opts)}
         ||
             Tag <- RawTags
         ],

--- a/src/dev_lua_lib.erl
+++ b/src/dev_lua_lib.erl
@@ -57,13 +57,13 @@ install(Base, State, Opts) ->
                 #{};
             {ok, ExistingTable, _} ->
                 ?event({existing_ao_table, ExistingTable}),
-                dev_lua:decode(ExistingTable)
+                dev_lua:decode(ExistingTable, Opts)
         end,
     ?event({base_ao_table, BaseAOTable}),
     {ok, State2} =
         luerl:set_table_keys_dec(
             [ao],
-            dev_lua:encode(BaseAOTable),
+            dev_lua:encode(BaseAOTable, Opts),
             State
         ),
     {
@@ -80,7 +80,8 @@ install(Base, State, Opts) ->
                                 lists:map(
                                     fun(Arg) ->
                                         dev_lua:decode(
-                                            luerl:decode(Arg, ImportState)
+                                            luerl:decode(Arg, ImportState),
+                                            Opts
                                         )
                                     end,
                                     RawArgs
@@ -89,7 +90,7 @@ install(Base, State, Opts) ->
                             {Res, ResState} =
                                 ?MODULE:FuncName(Args, ImportState, ExecOpts),
                             % Encode the response for return to Lua
-                            return(Res, ResState)
+                            return(Res, ResState, Opts)
                         end,
                         StateIn
                     ),
@@ -107,9 +108,9 @@ install(Base, State, Opts) ->
     }.
 
 %% @doc Helper function for returning a result from a Lua function.
-return(Result, ExecState) ->
+return(Result, ExecState, Opts) ->
     ?event(lua_import, {import_returning, {result, Result}}),
-    TableEncoded = dev_lua:encode(Result),
+    TableEncoded = dev_lua:encode(Result, Opts),
     {ReturnParams, ResultingState} =
         lists:foldr(
             fun(LuaEncoded, {Params, StateIn}) ->

--- a/src/dev_multipass.erl
+++ b/src/dev_multipass.erl
@@ -13,8 +13,8 @@ info(_M1) ->
 
 %% @doc Forward the keys function to the message device, handle all others
 %% with deduplication. We only act on the first pass.
-handle(<<"keys">>, M1, _M2, _Opts) ->
-    dev_message:keys(M1);
+handle(<<"keys">>, M1, _M2, Opts) ->
+    dev_message:keys(M1, Opts);
 handle(<<"set">>, M1, M2, Opts) ->
     dev_message:set(M1, M2, Opts);
 handle(_Key, M1, _M2, Opts) ->

--- a/src/dev_patch.erl
+++ b/src/dev_patch.erl
@@ -43,9 +43,10 @@ compute(Msg1, Msg2, Opts) ->
                 (hb_ao:get(<<"method">>, Msg, Opts) == <<"PATCH">>) orelse
                     (hb_ao:get(<<"device">>, Msg, Opts) == <<"patch@1.0">>)
             end,
-            Outbox
+            Outbox,
+			Opts
         ),
-    OutboxWithoutPatches = hb_maps:without(hb_maps:keys(Patches), Outbox),
+    OutboxWithoutPatches = hb_maps:without(hb_maps:keys(Patches, Opts), Outbox, Opts),
     % Remove the outbox from the message.
     Msg1WithoutOutbox = hb_ao:set(Msg1, PatchFrom, should_never_happen, Opts),
     % Set the new outbox.
@@ -58,7 +59,7 @@ compute(Msg1, Msg2, Opts) ->
                 ?event({patching, {patch, Patch}, {before, MsgN}}),
                 Res = hb_ao:set(
                     MsgN,
-                    hb_maps:without([<<"method">>], Patch),
+                    hb_maps:without([<<"method">>], Patch, Opts),
                     Opts
                 ),
                 ?event({patched, {'after', Res}}),
@@ -68,7 +69,8 @@ compute(Msg1, Msg2, Opts) ->
                 not_found -> Msg1WithNewOutbox;
                 PatchTo -> hb_ao:get(PatchTo, Msg1WithNewOutbox, Opts)
             end,
-            Patches
+            Patches,
+			Opts
         ),
     PatchedState =
         case PatchTo of

--- a/src/dev_process_worker.erl
+++ b/src/dev_process_worker.erl
@@ -64,7 +64,7 @@ server(GroupName, Msg1, Opts) ->
                 hb_ao:resolve(
                     Msg1,
                     #{ <<"path">> => <<"compute">>, <<"slot">> => TargetSlot },
-                    hb_maps:merge(ListenerOpts, ServerOpts)
+                    hb_maps:merge(ListenerOpts, ServerOpts, Opts)
                 ),
             ?event(worker, {work_done, {group, GroupName}, {req, Msg2}, {res, Res}}),
             send_notification(Listener, GroupName, TargetSlot, Res),
@@ -172,7 +172,7 @@ info_test() ->
     test_init(),
     M1 = dev_process:test_wasm_process(<<"test/aos-2-pure-xs.wasm">>),
     Res = hb_ao:info(M1, #{}),
-    ?assertEqual(fun dev_process_worker:group/3, hb_maps:get(grouper, Res)).
+    ?assertEqual(fun dev_process_worker:group/3, hb_maps:get(grouper, Res, undefined, #{})).
 
 grouper_test() ->
     test_init(),

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -209,7 +209,7 @@ apply_route(Msg, Route = #{ <<"opts">> := RouteOpts }, Opts) ->
             hb_util:ok(
                 apply_route(
                     Msg,
-                    hb_maps:without([<<"opts">>], Route),
+                    hb_maps:without([<<"opts">>], Route, Opts),
                     Opts
                 )
             )
@@ -257,7 +257,7 @@ match_routes(ToMatch, Routes, Opts) ->
     match_routes(
         ToMatch,
         Routes,
-        hb_ao:keys(hb_ao:normalize_keys(Routes)),
+        hb_ao:keys(hb_ao:normalize_keys(Routes, Opts)),
         Opts
     ).
 match_routes(#{ <<"path">> := Explicit = <<"http://", _/binary>> }, _, _, _) ->
@@ -1008,7 +1008,7 @@ simulation_occurences(SimRes, Nodes) ->
         fun(NearestNodes, Acc) ->
             lists:foldl(
                 fun(Node, Acc2) ->
-                    Acc2#{ Node => hb_maps:get(Node, Acc2) + 1 }
+                    Acc2#{ Node => hb_maps:get(Node, Acc2, 0, #{}) + 1 }
                 end,
                 Acc,
                 NearestNodes
@@ -1019,7 +1019,7 @@ simulation_occurences(SimRes, Nodes) ->
     ).
 
 simulation_distribution(SimRes, Nodes) ->
-    hb_maps:values(simulation_occurences(SimRes, Nodes)).
+    hb_maps:values(simulation_occurences(SimRes, Nodes), #{}).
 
 within_norms(SimRes, Nodes, TestSize) ->
     Distribution = simulation_distribution(SimRes, Nodes),

--- a/src/dev_scheduler_server.erl
+++ b/src/dev_scheduler_server.erl
@@ -90,8 +90,9 @@ assign(State, Message, ReplyPID) ->
 
 %% @doc Generate and store the actual assignment message.
 do_assign(State, Message, ReplyPID) ->
-    HashChain = next_hashchain(hb_maps:get(hash_chain, State), Message),
-    NextSlot = hb_maps:get(current, State) + 1,
+	Opts = maps:get(opts, State),
+    HashChain = next_hashchain(hb_maps:get(hash_chain, State, undefined, Opts), Message),
+    NextSlot = hb_maps:get(current, State, undefined, Opts) + 1,
     % Run the signing of the assignment and writes to the disk in a separate
     % process.
     AssignFun =
@@ -116,7 +117,7 @@ do_assign(State, Message, ReplyPID) ->
                 <<"hash-chain">> => hb_util:id(HashChain),
                 <<"body">> => Message
             }, maps:get(wallet, State)),
-            AssignmentID = hb_message:id(Assignment, all, maps:get(opts, State)),
+            AssignmentID = hb_message:id(Assignment, all, Opts),
             ?event(scheduling,
                 {assigned,
                     {proc_id, maps:get(id, State)},
@@ -132,7 +133,7 @@ do_assign(State, Message, ReplyPID) ->
                 State
             ),
             ?event(starting_message_write),
-            ok = dev_scheduler_cache:write(Assignment, maps:get(opts, State)),
+            ok = dev_scheduler_cache:write(Assignment, Opts),
             maybe_inform_recipient(
                 local_confirmation,
                 ReplyPID,
@@ -142,7 +143,7 @@ do_assign(State, Message, ReplyPID) ->
             ),
             ?event(writes_complete),
             ?event(uploading_assignment),
-            hb_client:upload(Assignment, maps:get(opts, State)),
+            hb_client:upload(Assignment, Opts),
             ?event(uploads_complete),
             maybe_inform_recipient(
                 remote_confirmation,
@@ -152,7 +153,7 @@ do_assign(State, Message, ReplyPID) ->
                 State
             )
         end,
-    case hb_opts:get(scheduling_mode, sync, maps:get(opts, State)) of
+    case hb_opts:get(scheduling_mode, sync, Opts) of
         aggressive ->
             spawn(AssignFun);
         Other ->
@@ -164,8 +165,8 @@ do_assign(State, Message, ReplyPID) ->
         hash_chain := HashChain
     }.
 
-maybe_inform_recipient(Mode, ReplyPID, Message, Assignment, State) ->
-    case hb_opts:get(scheduling_mode, remote_confirmation, maps:get(opts, State)) of
+maybe_inform_recipient(Mode, ReplyPID, Message, Assignment, Opts) ->
+    case hb_opts:get(scheduling_mode, remote_confirmation, Opts) of
         Mode -> ReplyPID ! {scheduled, Message, Assignment};
         _ -> ok
     end.

--- a/src/dev_wasm.erl
+++ b/src/dev_wasm.erl
@@ -479,7 +479,8 @@ benchmark_test() ->
             #{
                 <<"function">> => <<"fac">>,
                 <<"parameters">> => [5.0]
-            }
+            },
+			#{}
         ),
     Iterations =
         hb:benchmark(
@@ -513,7 +514,8 @@ state_export_and_restore_test() ->
                         <<"my_lib">> =>
                             #{ <<"device">> => <<"Test-Device@1.0">> }
                     }
-            }
+            },
+			#{}
         ),
     ?event({after_setup, Msg2}),
     % Compute a computation and export the state.
@@ -522,7 +524,7 @@ state_export_and_restore_test() ->
     {ok, State} = hb_ao:resolve(Msg3a, <<"snapshot">>, #{}),
     ?event({state_res, State}),
     % Restore the state without calling Init.
-    NewMsg1 = hb_maps:merge(Msg0, Extras#{ <<"snapshot">> => State }),
+    NewMsg1 = hb_maps:merge(Msg0, Extras#{ <<"snapshot">> => State }, #{}),
     ?assertEqual(
         {ok, [4]},
         hb_ao:resolve(NewMsg1, <<"compute/results/output">>, #{})
@@ -556,7 +558,8 @@ test_run_wasm(File, Func, Params, AdditionalMsg) ->
                 },
                 AdditionalMsg,
                 #{ hashpath => ignore }
-            )
+            ),
+			#{}
         ),
     ?event({after_setup, Msg2}),
     {ok, StateRes} = hb_ao:resolve(Msg2, <<"compute">>, #{}),

--- a/src/hb.erl
+++ b/src/hb.erl
@@ -196,9 +196,11 @@ topup(Node, Amount, Recipient, Wallet) ->
 wallet() ->
     wallet(hb_opts:get(priv_key_location)).
 wallet(Location) ->
+    wallet(Location, #{}).
+wallet(Location, Opts) ->
     case file:read_file_info(Location) of
         {ok, _} ->
-            ar_wallet:load_keyfile(Location);
+            ar_wallet:load_keyfile(Location, Opts);
         {error, _} -> 
             Res = ar_wallet:new_keyfile(?DEFAULT_KEY_TYPE, Location),
             ?event({created_new_keyfile, Location, address(Res)}),

--- a/src/hb.erl
+++ b/src/hb.erl
@@ -135,9 +135,9 @@ start_mainnet(Opts) ->
     io:format(
         "Started mainnet node at http://localhost:~p~n"
         "Operator: ~s~n",
-        [hb_maps:get(port, Opts), Address]
+        [hb_maps:get(port, Opts, undefined, Opts), Address]
     ),
-    <<"http://localhost:", (integer_to_binary(hb_maps:get(port, Opts)))/binary>>.
+    <<"http://localhost:", (integer_to_binary(hb_maps:get(port, Opts, undefined, Opts)))/binary>>.
 
 %%% @doc Start a server with a `simple-pay@1.0' pre-processor.
 start_simple_pay() ->
@@ -159,7 +159,7 @@ do_start_simple_pay(Opts) ->
         gun,
         os_mon
     ]),
-    Port = hb_maps:get(port, Opts),
+    Port = hb_maps:get(port, Opts, undefined, Opts),
     Processor =
         #{
             <<"device">> => <<"p4@1.0">>,

--- a/src/hb_ao.erl
+++ b/src/hb_ao.erl
@@ -95,7 +95,7 @@
 -module(hb_ao).
 %%% Main AO-Core API:
 -export([resolve/2, resolve/3, resolve_many/2]).
--export([normalize_key/1, normalize_key/2, normalize_keys/1]).
+-export([normalize_key/1, normalize_key/2, normalize_keys/1, normalize_keys/2]).
 -export([message_to_fun/3, message_to_device/2, load_device/2, find_exported_function/5]).
 -export([force_message/2]).
 %%% Shortcuts and tools:
@@ -224,11 +224,11 @@ resolve_stage(1, {as, DevID, Raw = #{ <<"path">> := ID }}, Msg2, Opts) when ?IS_
     % If the first message is an `as' with an ID, we should load the message and
     % apply the non-path elements of the sub-request to it.
     ?event(ao_core, {stage, 1, subresolving_with_load, {dev, DevID}, {id, ID}}, Opts),
-    RemMsg1 = hb_maps:without([<<"path">>], Raw),
+    RemMsg1 = hb_maps:without([<<"path">>], Raw, Opts),
     ?event(subresolution, {loading_message, {id, ID}, {params, RemMsg1}}, Opts),
     Msg1b = ensure_message_loaded(ID, Opts),
     ?event(subresolution, {loaded_message, {msg, Msg1b}}, Opts),
-    Msg1c = hb_maps:merge(Msg1b, RemMsg1),
+    Msg1c = hb_maps:merge(Msg1b, RemMsg1, Opts),
     ?event(subresolution, {merged_message, {msg, Msg1c}}, Opts),
     Msg1d = set(Msg1c, <<"device">>, DevID, Opts),
     ?event(subresolution, {loaded_parameterized_message, {msg, Msg1d}}, Opts),
@@ -266,14 +266,15 @@ resolve_stage(1, RawMsg1, Msg2Outer = #{ <<"path">> := {as, DevID, Msg2Inner} },
             Msg2Outer,
             if is_map(LoadedInner) -> LoadedInner;
             true -> #{ <<"path">> => LoadedInner }
-            end
+            end,
+			Opts
         ),
     subresolve(RawMsg1, DevID, Msg2, Opts);
 resolve_stage(1, Msg1, Msg2, Opts) when is_list(Msg1) ->
     % Normalize lists to numbered maps (base=1) if necessary.
     ?event(ao_core, {stage, 1, list_normalize}, Opts),
     resolve_stage(1,
-        normalize_keys(Msg1),
+        normalize_keys(Msg1, Opts),
         Msg2,
         Opts
     );
@@ -284,8 +285,8 @@ resolve_stage(1, RawMsg1, RawMsg2, Opts) ->
     % Normalize the path to a private key containing the list of remaining
     % keys to resolve.
     ?event(ao_core, {stage, 1, normalize}, Opts),
-    Msg1 = normalize_keys(RawMsg1),
-    Msg2 = normalize_keys(RawMsg2),
+    Msg1 = normalize_keys(RawMsg1, Opts),
+    Msg2 = normalize_keys(RawMsg2, Opts),
     resolve_stage(2, Msg1, Msg2, Opts);
 resolve_stage(2, Msg1, Msg2, Opts) ->
     ?event(ao_core, {stage, 2, cache_lookup}, Opts),
@@ -325,7 +326,7 @@ resolve_stage(4, Msg1, Msg2, Opts) ->
     % the `dev_process' device 'groups' all calls to the same process onto
     % calls to a single executor. By default, `{Msg1, Msg2}' is used as the
     % group name.
-    case hb_persistent:find_or_register(Msg1, Msg2, hb_maps:without(?TEMP_OPTS, Opts)) of
+    case hb_persistent:find_or_register(Msg1, Msg2, hb_maps:without(?TEMP_OPTS, Opts, Opts)) of
         {leader, ExecName} ->
             % We are the leader for this resolution. Continue to the next stage.
             case hb_opts:get(spawn_worker, false, Opts) of
@@ -385,7 +386,7 @@ resolve_stage(5, Msg1, Msg2, ExecName, Opts) ->
     % execute Msg2 on Msg1.
 	{ResolvedFunc, NewOpts} =
 		try
-            UserOpts = hb_maps:without(?TEMP_OPTS, Opts),
+            UserOpts = hb_maps:without(?TEMP_OPTS, Opts, Opts),
 			Key = hb_path:hd(Msg2, UserOpts),
 			% Try to load the device and get the function to call.
             ?event(
@@ -450,17 +451,17 @@ resolve_stage(6, Func, Msg1, Msg2, ExecName, Opts) ->
 	% Execution.
 	% First, determine the arguments to pass to the function.
 	% While calculating the arguments we unset the add_key option.
-	UserOpts1 = hb_maps:without(?TEMP_OPTS, Opts),
+	UserOpts1 = hb_maps:without(?TEMP_OPTS, Opts, Opts),
     % Unless the user has explicitly requested recursive spawning, we
     % unset the spawn_worker option so that we do not spawn a new worker
     % for every resulting execution.
     UserOpts2 =
-        case hb_maps:get(spawn_worker, UserOpts1, false) of
+        case hb_maps:get(spawn_worker, UserOpts1, false, Opts) of
             recursive -> UserOpts1;
-            _ -> hb_maps:remove(spawn_worker, UserOpts1)
+            _ -> hb_maps:remove(spawn_worker, UserOpts1, Opts)
         end,
 	Args =
-		case hb_maps:get(add_key, Opts, false) of
+		case hb_maps:get(add_key, Opts, false, Opts) of
 			false -> [Msg1, Msg2, UserOpts2];
 			Key -> [Key, Msg1, Msg2, UserOpts2]
 		end,
@@ -533,7 +534,7 @@ resolve_stage(7, Msg1, Msg2, {ok, Msg3}, ExecName, Opts) when is_map(Msg3) ->
                 end;
             reset ->
                 Priv = hb_private:from_message(Msg3),
-                {ok, Msg3#{ <<"priv">> => hb_maps:without([<<"hashpath">>], Priv) }};
+                {ok, Msg3#{ <<"priv">> => hb_maps:without([<<"hashpath">>], Priv, Opts) }};
             ignore ->
                 Priv = hb_private:from_message(Msg3),
                 if not is_map(Priv) ->
@@ -552,7 +553,7 @@ resolve_stage(7, Msg1, Msg2, {Status, Msg3}, ExecName, Opts) when is_map(Msg3) -
     Priv = hb_private:from_message(Msg3),
     resolve_stage(
         8, Msg1, Msg2,
-        {Status, Msg3#{ <<"priv">> => hb_maps:without([<<"hashpath">>], Priv) }},
+        {Status, Msg3#{ <<"priv">> => hb_maps:without([<<"hashpath">>], Priv, Opts) }},
         ExecName, Opts);
 resolve_stage(7, Msg1, Msg2, Res, ExecName, Opts) ->
     ?event(ao_core, {stage, 7, ExecName, non_map_result_skipping_hash_path}, Opts),
@@ -605,7 +606,7 @@ subresolve(RawMsg1, DevID, Req, Opts) ->
     Msg1b =
         case DevID of
             undefined -> Msg1;
-            _ -> set(Msg1, <<"device">>, DevID, hb_maps:without(?TEMP_OPTS, Opts))
+            _ -> set(Msg1, <<"device">>, DevID, hb_maps:without(?TEMP_OPTS, Opts, Opts))
         end,
     % If there is no path but there are elements to the request, we set these on
     % the base message. If there is a path, we do not modify the base message 
@@ -613,14 +614,14 @@ subresolve(RawMsg1, DevID, Req, Opts) ->
     case hb_path:from_message(request, Req) of
         undefined ->
             Msg1c =
-                case map_size(hb_maps:without([<<"path">>], Req)) of
+                case map_size(hb_maps:without([<<"path">>], Req, Opts)) of
                     0 -> Msg1b;
                     _ ->
                         set(
-                            Msg1b,
-                            hb_maps:without([<<"path">>], Req),
-                            Opts#{ force_message => false }
-                        )
+							Msg1b,
+							hb_maps:without([<<"path">>], Req, Opts),
+							Opts#{ force_message => false }
+						)
                 end,
             ?event(subresolution,
                 {subresolve_modified_base, Msg1c},
@@ -708,7 +709,7 @@ error_invalid_intermediate_status(Msg1, Msg2, Msg3, RemainingPath, Opts) ->
         #{
             <<"status">> => 422,
             <<"body">> => Msg3,
-            <<"key">> => hb_maps:get(<<"path">>, Msg2, <<"Key unknown.">>),
+            <<"key">> => hb_maps:get(<<"path">>, Msg2, <<"Key unknown.">>, Opts),
             <<"remaining-path">> => RemainingPath
         }
     }.
@@ -734,7 +735,7 @@ maybe_force_message({Status, Res}, Opts) ->
     end.
 
 force_message({Status, Res}, Opts) when is_list(Res) ->
-    force_message({Status, normalize_keys(Res)}, Opts);
+    force_message({Status, normalize_keys(Res, Opts)}, Opts);
 force_message({Status, Literal}, _Opts) when not is_map(Literal) ->
     ?event({force_message_from_literal, Literal}),
     {Status, #{ <<"ao-result">> => <<"body">>, <<"body">> => Literal }};
@@ -808,7 +809,8 @@ keys(Msg, Opts, keep) ->
             fun normalize_key/1,
             hb_maps:values(
                 normalize_keys(
-                    get(<<"keys">>, Msg, Opts)
+                    get(<<"keys">>, Msg, Opts),
+                    Opts
                 ),
                 Opts
             )
@@ -835,8 +837,8 @@ keys(Msg, Opts, remove) ->
 %% `set' works with maps and recursive paths while maintaining the appropriate
 %% `HashPath' for each step.
 set(RawMsg1, RawMsg2, Opts) when is_map(RawMsg2) ->
-    Msg1 = normalize_keys(RawMsg1),
-    Msg2 = hb_maps:without([<<"hashpath">>, <<"priv">>], normalize_keys(RawMsg2)),
+    Msg1 = normalize_keys(RawMsg1, Opts),
+    Msg2 = hb_maps:without([<<"hashpath">>, <<"priv">>], normalize_keys(RawMsg2, Opts), Opts),
     ?event(ao_internal, {set_called, {msg1, Msg1}, {msg2, Msg2}}, Opts),
     % Get the next key to set. 
     case keys(Msg2, internal_opts(Opts)) of
@@ -846,7 +848,7 @@ set(RawMsg1, RawMsg2, Opts) when is_map(RawMsg2) ->
             % getting via `maps' if it is not found.
             Val =
                 case get(Key, Msg2, internal_opts(Opts)) of
-                    not_found -> hb_maps:get(Key, Msg2);
+                    not_found -> hb_maps:get(Key, Msg2, undefined, Opts);
                     Body -> Body
                 end,
             ?event({got_val_to_set, {key, Key}, {val, Val}, {msg2, Msg2}}),
@@ -971,7 +973,7 @@ message_to_fun(Msg, Key, Opts) ->
 	Dev = message_to_device(Msg, Opts),
     Info = info(Dev, Msg, Opts),
     % Is the key exported by the device?
-    Exported = is_exported(Info, Key),
+    Exported = is_exported(Info, Key, Opts),
 	?event(
         ao_devices,
         {message_to_fun,
@@ -1061,20 +1063,20 @@ message_to_device(Msg, Opts) ->
 info_handler_to_fun(Handler, _Msg, _Key, _Opts) when is_function(Handler) ->
 	{add_key, Handler};
 info_handler_to_fun(HandlerMap, Msg, Key, Opts) ->
-	case hb_maps:find(exclude, HandlerMap) of
+	case hb_maps:find(exclude, HandlerMap, Opts) of
 		{ok, Exclude} ->
 			case lists:member(Key, Exclude) of
 				true ->
 					{ok, MsgWithoutDevice} =
-						dev_message:remove(Msg, #{ item => device }),
+						dev_message:remove(Msg, #{ item => device }, Opts),
 					message_to_fun(
 						MsgWithoutDevice#{ device => default_module() },
 						Key,
 						Opts
 					);
-				false -> {add_key, hb_maps:get(func, HandlerMap)}
+				false -> {add_key, hb_maps:get(func, HandlerMap, undefined, Opts)}
 			end;
-		error -> {add_key, hb_maps:get(func, HandlerMap)}
+		error -> {add_key, hb_maps:get(func, HandlerMap, undefined, Opts)}
 	end.
 
 %% @doc Find the function with the highest arity that has the given name, if it
@@ -1086,7 +1088,7 @@ info_handler_to_fun(HandlerMap, Msg, Key, Opts) ->
 %% the key using its literal value. If that fails, we cast the key to an atom
 %% and try again.
 find_exported_function(Msg, Dev, Key, MaxArity, Opts) when is_map(Dev) ->
-	case hb_maps:get(normalize_key(Key), normalize_keys(Dev), not_found) of
+	case hb_maps:get(normalize_key(Key), normalize_keys(Dev, Opts), not_found, Opts) of
 		not_found -> not_found;
 		Fun when is_function(Fun) ->
 			case erlang:fun_info(Fun, arity) of
@@ -1127,16 +1129,16 @@ find_exported_function(Msg, Mod, Key, Arity, Opts) ->
 %% given, so we check for it in both cases.
 is_exported(_Msg, _Dev, info, _Opts) -> true;
 is_exported(Msg, Dev, Key, Opts) ->
-	is_exported(info(Dev, Msg, Opts), Key).
-is_exported(_, info) -> true;
-is_exported(Info = #{ excludes := Excludes }, Key) ->
+	is_exported(info(Dev, Msg, Opts), Key, Opts).
+is_exported(_, info, _Opts) -> true;
+is_exported(Info = #{ excludes := Excludes }, Key, Opts) ->
     case lists:member(normalize_key(Key), lists:map(fun normalize_key/1, Excludes)) of
         true -> false;
-        false -> is_exported(hb_maps:remove(excludes, Info), Key)
+        false -> is_exported(hb_maps:remove(excludes, Info, Opts), Key, Opts)
     end;
-is_exported(#{ exports := Exports }, Key) ->
+is_exported(#{ exports := Exports }, Key, _Opts) ->
     lists:member(normalize_key(Key), lists:map(fun normalize_key/1, Exports));
-is_exported(_Info, _Key) -> true.
+is_exported(_Info, _Key, _Opts) -> true.
 
 %% @doc Convert a key to a binary in normalized form.
 normalize_key(Key) -> normalize_key(Key, #{}).
@@ -1158,14 +1160,19 @@ normalize_key(Key, _Opts) when is_list(Key) ->
     end.
 
 %% @doc Ensure that a message is processable by the AO-Core resolver: No lists.
-normalize_keys(Msg1) when is_list(Msg1) ->
-    normalize_keys(hb_maps:from_list(
-        lists:zip(
-            lists:seq(1, length(Msg1)),
-            Msg1
-        )
-    ));
-normalize_keys(Map) when is_map(Map) ->
+normalize_keys(Msg) -> normalize_keys(Msg, #{}).
+normalize_keys(Msg1, Opts) when is_list(Msg1) ->
+    normalize_keys(
+		hb_maps:from_list(
+        	lists:zip(
+            	lists:seq(1, length(Msg1)),
+            	Msg1
+			)
+        ),
+		Opts
+	);
+
+normalize_keys(Map, Opts) when is_map(Map) ->
     hb_maps:from_list(
         lists:map(
             fun({Key, Value}) when is_map(Value) ->
@@ -1173,10 +1180,10 @@ normalize_keys(Map) when is_map(Map) ->
             ({Key, Value}) ->
                 {hb_ao:normalize_key(Key), Value}
             end,
-            hb_maps:to_list(Map)
+            hb_maps:to_list(Map, Opts)
         )
     );
-normalize_keys(Other) -> Other.
+normalize_keys(Other, _Opts) -> Other.
 
 %% @doc Load a device module from its name or a message ID.
 %% Returns {ok, Executable} where Executable is the device module. On error,
@@ -1215,7 +1222,7 @@ load_device(ID, Opts) when ?IS_ID(ID) ->
 				false -> {error, device_signer_not_trusted};
 				true ->
                     ?event(device_load, {loading_device, {id, ID}}, Opts),
-					case hb_maps:get(<<"content-type">>, Msg, undefined) of
+					case hb_maps:get(<<"content-type">>, Msg, undefined, Opts) of
 						<<"application/beam">> ->
                             case verify_device_compatibility(Msg, Opts) of
                                 ok ->
@@ -1224,7 +1231,7 @@ load_device(ID, Opts) when ?IS_ID(ID) ->
                                             hb_maps:get(<<"module-name">>, Msg),
                                             new_atoms
                                         ),
-                                    case erlang:load_module(ModName, hb_maps:get(<<"body">>, Msg)) of
+                                    case erlang:load_module(ModName, hb_maps:get(<<"body">>, Msg, undefined, Opts)) of
                                         {module, _} ->
                                             {ok, ModName};
                                         {error, Reason} ->
@@ -1275,7 +1282,7 @@ verify_device_compatibility(Msg, Opts) ->
                 };
             (_) -> false
             end,
-            hb_maps:to_list(Msg)
+            hb_maps:to_list(Msg, Opts)
         ),
     ?event(device_load,
         {discerned_requirements,
@@ -1340,4 +1347,4 @@ internal_opts(Opts) ->
         cache_control => [<<"no-cache">>, <<"no-store">>],
         spawn_worker => false,
         await_inprogress => false
-    }).
+    }, Opts).

--- a/src/hb_ao_test_vectors.erl
+++ b/src/hb_ao_test_vectors.erl
@@ -167,7 +167,8 @@ exec_dummy_device(SigningWallet, Opts) ->
                     <<"requires-otp-release">> =>
                         hb_util:bin(erlang:system_info(otp_release)),
                     <<"body">> => Bin
-                }
+                },
+				Opts
             ),
             Opts
         ),
@@ -296,9 +297,9 @@ generate_device_with_keys_using_args() ->
             fun(State, Msg, Opts) ->
                 {ok,
                     <<
-                        (hb_maps:get(<<"state_key">>, State))/binary,
-                        (hb_maps:get(<<"msg_key">>, Msg))/binary,
-                        (hb_maps:get(<<"opts_key">>, Opts))/binary
+                        (hb_maps:get(<<"state_key">>, State, undefined, Opts))/binary,
+                        (hb_maps:get(<<"msg_key">>, Msg, undefined, Opts))/binary,
+                        (hb_maps:get(<<"opts_key">>, Opts, undefined, Opts))/binary
                     >>
                 }
             end
@@ -494,7 +495,7 @@ set_with_device_test(Opts) ->
                 #{
                     <<"set">> =>
                         fun(State, _Msg) ->
-                            Acc = hb_maps:get(<<"set_count">>, State, <<"">>),
+                            Acc = hb_maps:get(<<"set_count">>, State, <<"">>, Opts),
                             {ok,
                                 State#{
                                     <<"set_count">> => << Acc/binary, "." >>
@@ -577,7 +578,7 @@ deep_set_with_device_test(Opts) ->
                 % A device where the set function modifies the key
                 % and adds a modified flag.
                 {Key, Val} =
-                    hd(hb_maps:to_list(hb_maps:without([<<"path">>, <<"priv">>], Msg2))),
+                    hd(hb_maps:to_list(hb_maps:without([<<"path">>, <<"priv">>], Msg2, Opts), Opts)),
                 {ok, Msg1#{ Key => Val, <<"modified">> => true }}
             end
     },

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -107,12 +107,12 @@ ensure_loaded(Link = {link, ID, LinkOpts = #{ <<"lazy">> := true }}, Opts) ->
                     {link_opts, LinkOpts}
                 }
             ),
-            case hb_maps:get(<<"type">>, LinkOpts, undefined) of
+            case hb_maps:get(<<"type">>, LinkOpts, undefined, Opts) of
                 undefined -> LoadedMsg;
                 Type -> dev_codec_structured:decode_value(Type, LoadedMsg)
             end;
         not_found ->
-            throw({necessary_message_not_found, Link})
+            throw({necessary_message_not_found_b, Link})
     end;
 ensure_loaded(Msg, _Opts) when not ?IS_LINK(Msg) ->
     Msg.
@@ -300,7 +300,8 @@ calculate_all_ids(Msg, Opts) ->
     Commitments =
         hb_maps:without(
             [<<"priv">>],
-            hb_maps:get(<<"commitments">>, Msg, #{}, Opts)
+            hb_maps:get(<<"commitments">>, Msg, #{}, Opts),
+			Opts
         ),
     CommIDs = hb_maps:keys(Commitments, Opts),
     ?event({calculating_ids, {msg, Msg}, {commitments, Commitments}, {comm_ids, CommIDs}}),

--- a/src/hb_cache_render.erl
+++ b/src/hb_cache_render.erl
@@ -23,79 +23,80 @@ render(ToRender, StoreOrOpts) ->
 cache_path_to_dot(ToRender, StoreOrOpts) ->
     cache_path_to_dot(ToRender, #{}, StoreOrOpts).
 cache_path_to_dot(ToRender, RenderOpts, StoreOrOpts) ->
-    graph_to_dot(cache_path_to_graph(ToRender, RenderOpts, StoreOrOpts)).
+    graph_to_dot(cache_path_to_graph(ToRender, RenderOpts, StoreOrOpts), StoreOrOpts).
 
 %% @doc Main function to collect graph elements
 cache_path_to_graph(ToRender, GraphOpts, StoreOrOpts) when is_map(StoreOrOpts) ->
     Store = hb_opts:get(store, no_viable_store, StoreOrOpts),
-    cache_path_to_graph(ToRender, GraphOpts, Store);
-cache_path_to_graph(all, GraphOpts, Store) ->
+    cache_path_to_graph(ToRender, GraphOpts, Store, StoreOrOpts).
+cache_path_to_graph(all, GraphOpts, Store, Opts) ->
     {ok, Keys} = hb_store:list(Store, "/"),
-    cache_path_to_graph(Keys, GraphOpts, Store);
-cache_path_to_graph(InitPath, GraphOpts, Store) when is_binary(InitPath) ->
-    cache_path_to_graph([InitPath], GraphOpts, Store);
-cache_path_to_graph(RootKeys, GraphOpts, Store) ->
+    cache_path_to_graph(Store, GraphOpts, Keys, Opts);
+cache_path_to_graph(InitPath, GraphOpts, Store, Opts) when is_binary(InitPath) ->
+    {ok, Keys} = hb_store:list(Store, InitPath),
+    cache_path_to_graph(Store, GraphOpts, Keys, Opts);
+cache_path_to_graph(Store, GraphOpts, RootKeys, Opts) ->
     % Use a map to track nodes, arcs and visited paths (to avoid cycles)
     EmptyGraph = GraphOpts#{ nodes => #{}, arcs => #{}, visited => #{} },
     % Process all root keys and get the final graph
     lists:foldl(
-        fun(Key, Acc) -> traverse_store(Store, Key, undefined, Acc) end,
+        fun(Key, Acc) -> traverse_store(Store, Key, undefined, Acc, Opts) end,
         EmptyGraph,
         RootKeys
     ).
 
 %% @doc Traverse the store recursively to build the graph
-traverse_store(Store, Key, Parent, Graph) ->
+traverse_store(Store, Key, Parent, Graph, Opts) ->
     % Get the path and check if we've already visited it
     JoinedPath = hb_store:join(Key),
     ResolvedPath = hb_store:resolve(Store, Key),
     % Skip if we've already processed this node
-    case hb_maps:get(visited, Graph, #{}) of
+    case hb_maps:get(visited, Graph, #{}, Opts) of
         #{JoinedPath := _} -> Graph;
         _ ->
             % Mark as visited to avoid cycles
-            Graph1 = Graph#{visited => hb_maps:put(JoinedPath, true, hb_maps:get(visited, Graph, #{}))},
+            Graph1 = Graph#{visited => hb_maps:put(JoinedPath, true, hb_maps:get(visited, Graph, #{}, Opts), Opts)},
             % Process node based on its type
             case hb_store:type(Store, Key) of
                 simple -> 
-                    process_simple_node(Store, Key, Parent, ResolvedPath, JoinedPath, Graph1);
+                    process_simple_node(Store, Key, Parent, ResolvedPath, JoinedPath, Graph1, Opts);
                 composite -> 
-                    process_composite_node(Store, Key, Parent, ResolvedPath, JoinedPath, Graph1);
+                    process_composite_node(Store, Key, Parent, ResolvedPath, JoinedPath, Graph1, Opts);
                 _ -> 
                     Graph1
             end
     end.
 
 %% @doc Process a simple (leaf) node
-process_simple_node(Store, Key, Parent, ResolvedPath, JoinedPath, Graph) ->
+process_simple_node(_Store, _Key, Parent, ResolvedPath, JoinedPath, Graph, Opts) ->
     % Add the node to the graph
-    case hb_maps:get(render_data, Graph, true) of
+    case hb_maps:get(render_data, Graph, true, Opts) of
         false -> Graph;
         true ->
-            Graph1 = add_node(Graph, ResolvedPath, "lightblue"),
+            Graph1 = add_node(Graph, ResolvedPath, "lightblue", Opts),
             % If we have a parent, add an arc from parent to this node
             case Parent of
                 undefined -> Graph1;
                 ParentPath -> 
                     Label = extract_label(JoinedPath),
-                    add_arc(Graph1, ParentPath, ResolvedPath, Label)
+                    add_arc(Graph1, ParentPath, ResolvedPath, Label, Opts)
             end
     end.
 
 %% @doc Process a composite (directory) node
-process_composite_node(_Store, "data", _Parent, _ResolvedPath, _JoinedPath, Graph) ->
+process_composite_node(_Store, "data", _Parent, _ResolvedPath, _JoinedPath, Graph, _Opts) ->
     % Data is a special case: It contains every binary item in the store.
     % We don't need to render it.
     Graph;
-process_composite_node(Store, Key, Parent, ResolvedPath, JoinedPath, Graph) ->
+process_composite_node(Store, _Key, Parent, ResolvedPath, JoinedPath, Graph, Opts) ->
     % Add the node to the graph
-    Graph1 = add_node(Graph, ResolvedPath, "lightcoral"),
+    Graph1 = add_node(Graph, ResolvedPath, "lightcoral", Opts),
     % If we have a parent, add an arc from parent to this node
     Graph2 = case Parent of
         undefined -> Graph1;
         ParentPath -> 
             Label = extract_label(JoinedPath),
-            add_arc(Graph1, ParentPath, ResolvedPath, Label)
+            add_arc(Graph1, ParentPath, ResolvedPath, Label, Opts)
     end,
     % Process children recursively
     case hb_store:list(Store, ResolvedPath) of
@@ -103,7 +104,7 @@ process_composite_node(Store, Key, Parent, ResolvedPath, JoinedPath, Graph) ->
             lists:foldl(
                 fun(SubItem, Acc) ->
                     ChildKey = [ResolvedPath, SubItem],
-                    traverse_store(Store, ChildKey, ResolvedPath, Acc)
+                    traverse_store(Store, ChildKey, ResolvedPath, Acc, Opts)
                 end,
                 Graph2,
                 SubItems
@@ -112,15 +113,15 @@ process_composite_node(Store, Key, Parent, ResolvedPath, JoinedPath, Graph) ->
     end.
 
 %% @doc Add a node to the graph
-add_node(Graph, ID, Color) ->
-    Nodes = hb_maps:get(nodes, Graph, #{}),
-    Graph#{nodes => hb_maps:put(ID, {ID, Color}, Nodes)}.
+add_node(Graph, ID, Color, Opts) ->
+    Nodes = hb_maps:get(nodes, Graph, #{}, Opts),
+    Graph#{nodes => hb_maps:put(ID, {ID, Color}, Nodes, Opts)}.
 
 %% @doc Add an arc to the graph
-add_arc(Graph, From, To, Label) ->
+add_arc(Graph, From, To, Label, Opts) ->
     ?event({insert_arc, {id1, From}, {id2, To}, {label, Label}}),
-    Arcs = hb_maps:get(arcs, Graph, #{}),
-    Graph#{arcs => hb_maps:put({From, To, Label}, true, Arcs)}.
+    Arcs = hb_maps:get(arcs, Graph, #{}, Opts),
+    Graph#{arcs => hb_maps:put({From, To, Label}, true, Arcs, Opts)}.
 
 %% @doc Extract a label from a path
 extract_label(Path) ->
@@ -135,7 +136,7 @@ extract_label(Path) ->
     end.
 
 %% @doc Generate the DOT file from the graph
-graph_to_dot(Graph) ->
+graph_to_dot(Graph, Opts) ->
     % Create graph header
     Header = [
         <<"digraph filesystem {\n">>,
@@ -153,7 +154,8 @@ graph_to_dot(Graph) ->
             ]
         end,
         [],
-        hb_maps:get(nodes, Graph, #{})
+        hb_maps:get(nodes, Graph, #{}, Opts),
+		Opts
     ),
     % Create arcs section
     Arcs = hb_maps:fold(
@@ -167,7 +169,8 @@ graph_to_dot(Graph) ->
             ]
         end,
         [],
-        hb_maps:get(arcs, Graph, #{})
+        hb_maps:get(arcs, Graph, #{}, Opts),
+		Opts
     ),
     % Create graph footer
     Footer = <<"}\n">>,

--- a/src/hb_client.erl
+++ b/src/hb_client.erl
@@ -27,17 +27,18 @@ resolve(Node, Msg1, Msg2, Opts) ->
     ),
     hb_http:post(
         Node,
-        hb_maps:merge(prefix_keys(<<"1.">>, Msg1, Opts), TABM2),
+        hb_maps:merge(prefix_keys(<<"1.">>, Msg1, Opts), TABM2, Opts),
         Opts
     ).
 
 prefix_keys(Prefix, Message, Opts) ->
     hb_maps:fold(
         fun(Key, Val, Acc) ->
-            hb_maps:put(<<Prefix/binary, Key/binary>>, Val, Acc)
+            hb_maps:put(<<Prefix/binary, Key/binary>>, Val, Acc, Opts)
         end,
         #{},
-        hb_message:convert(Message, tabm, Opts)
+        hb_message:convert(Message, tabm, Opts),
+		Opts
     ).
 
 routes(Node, Opts) ->

--- a/src/hb_escape.erl
+++ b/src/hb_escape.erl
@@ -5,7 +5,7 @@
 %%% Subsequently, we encode all header keys to lowercase %-encoded URI-style
 %%% strings because transmission.
 -module(hb_escape).
--export([encode/1, decode/1, encode_keys/1, decode_keys/1]).
+-export([encode/1, decode/1, encode_keys/2, decode_keys/2]).
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
 
@@ -18,24 +18,24 @@ decode(Bin) when is_binary(Bin) ->
     list_to_binary(percent_unescape(binary_to_list(Bin))).
 
 %% @doc Return a message with all of its keys decoded.
-decode_keys(Msg) when is_map(Msg) ->
+decode_keys(Msg, Opts) when is_map(Msg) ->
     hb_maps:from_list(
         lists:map(
             fun({Key, Value}) -> {decode(Key), Value} end,
-            hb_maps:to_list(Msg)
+            hb_maps:to_list(Msg, Opts)
         )
     );
-decode_keys(Other) -> Other.
+decode_keys(Other, _Opts) -> Other.
 
 %% @doc URI encode keys in the base layer of a message. Does not recurse.
-encode_keys(Msg) when is_map(Msg) ->
+encode_keys(Msg, Opts) when is_map(Msg) ->
     hb_maps:from_list(
         lists:map(
             fun({Key, Value}) -> {encode(Key), Value} end,
-            hb_maps:to_list(Msg)
+            hb_maps:to_list(Msg, Opts)
         )
     );
-encode_keys(Other) -> Other.
+encode_keys(Other, _Opts) -> Other.
 
 %% @doc Escape a list of characters as a URI-encoded string.
 percent_escape([]) -> [];

--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -230,7 +230,7 @@ result_to_message(ExpectedID, Item, Opts) ->
                         % keys as committed fields.
                         ?event(warning, {gql_verify_failed, adding_trusted_fields, {tags, Tags}}),
                         Comms = hb_maps:get(<<"commitments">>, Structured, #{}, Opts),
-                        AttName = hd(hb_maps:keys(Comms)),
+                        AttName = hd(hb_maps:keys(Comms, Opts)),
                         Comm = hb_maps:get(AttName, Comms, not_found, Opts),
                         Structured#{
                             <<"commitments">> => #{
@@ -242,10 +242,11 @@ result_to_message(ExpectedID, Item, Opts) ->
                                                 ||
                                                     #{ <<"name">> := Name } <-
                                                         hb_maps:values(
-                                                            hb_ao:normalize_keys(Tags),
+                                                            hb_ao:normalize_keys(Tags, Opts),
                                                             Opts
                                                         )
-                                                ]
+                                                ],
+												Opts
                                             )
                                     }
                             }

--- a/src/hb_maps.erl
+++ b/src/hb_maps.erl
@@ -17,10 +17,11 @@
 %%% yourself from the inevitable issues that will arise from using this
 %%% module without understanding the full implications. You have been warned.
 -module(hb_maps).
--export([get/2, get/3, get/4, find/2, find/3, is_key/2, keys/1, keys/2, values/1, values/2]).
--export([put/3, map/2, map/3, filter/2, filter/3, filtermap/2, filtermap/3]).
--export([fold/3, fold/4, take/2, size/1]).
--export([merge/2, remove/2, with/2, without/2, update_with/3, update_with/4]).
+-export([is_key/2, is_key/3, keys/1, keys/2, values/1, values/2]).
+-export([map/2, map/3, filter/2, filter/3, filtermap/2, filtermap/3]).
+-export([fold/3, fold/4, take/2, take/3, size/1, size/2]).
+-export([merge/2, merge/3, remove/2, remove/3]).
+-export([with/2, with/3, without/2, without/3, update_with/3, update_with/4]).
 -export([from_list/1, to_list/1, to_list/2]).
 -include_lib("eunit/include/eunit.hrl").
 
@@ -30,10 +31,6 @@ get(Key, Map) ->
 
 -spec get(Key :: term(), Map :: map(), Default :: term()) -> term().
 get(Key, Map, Default) ->
-    %io:format(
-    %   standard_error, "get called without opts~n~p~n",
-    %   [try exit(1) catch _:_:St -> St end]
-    % ),
     get(Key, Map, Default, #{}).
 
 %% @doc Get a value from a map, resolving links as they are encountered in both
@@ -64,15 +61,30 @@ find(Key, Map, Opts) ->
 
 -spec put(Key :: term(), Value :: term(), Map :: map()) -> map().
 put(Key, Value, Map) ->
-    maps:put(Key, Value, hb_cache:ensure_loaded(Map)).
+	put(Key, Value, Map, #{}).
+
+-spec put(
+	Key :: term(),
+	Value :: term(),
+	Map :: map(),
+	Opts :: map()
+) -> map().
+put(Key, Value, Map, Opts) ->
+    maps:put(Key, Value, hb_cache:ensure_loaded(Map, Opts)).
 
 -spec is_key(Key :: term(), Map :: map()) -> boolean().
 is_key(Key, Map) ->
-    maps:is_key(Key, hb_cache:ensure_loaded(Map)).
+    is_key(Key, Map, #{}).
+
+-spec is_key(Key :: term(), Map :: map(), Opts :: map()) -> boolean().
+is_key(Key, Map, Opts) ->
+    maps:is_key(Key, hb_cache:ensure_loaded(Map, Opts)).
 
 -spec keys(Map :: map()) -> [term()].
 keys(Map) ->
-    maps:keys(hb_cache:ensure_loaded(Map)).
+	keys(Map, #{}).
+
+-spec keys(Map :: map(), Opts :: map()) -> [term()].
 keys(Map, Opts) ->
     maps:keys(hb_cache:ensure_loaded(Map, Opts)).
 
@@ -85,17 +97,17 @@ values(Map, Opts) ->
 
 -spec size(Map :: map()) -> non_neg_integer().
 size(Map) ->
-    maps:size(hb_cache:ensure_loaded(Map)).
+	size(Map, #{}).
+
+-spec size(Map :: map(), Opts :: map()) -> non_neg_integer().
+size(Map, Opts) ->
+    maps:size(hb_cache:ensure_loaded(Map, Opts)).
 
 -spec map(
     Fun :: fun((Key :: term(), Value :: term()) -> term()),
     Map :: map()
 ) -> map().
 map(Fun, Map) ->
-    % io:format(
-    %   standard_error, "map called without opts~n~p~n",
-    %   [try exit(1) catch _:_:St -> St end]
-    % ),
     map(Fun, Map, #{}).
 
 -spec map(
@@ -111,19 +123,35 @@ map(Fun, Map, Opts) ->
 
 -spec merge(Map1 :: map(), Map2 :: map()) -> map().
 merge(Map1, Map2) ->
-    maps:merge(hb_cache:ensure_loaded(Map1), hb_cache:ensure_loaded(Map2)).
+	merge(Map1, Map2, #{}).
+
+-spec merge(Map1 :: map(), Map2 :: map(), Opts :: map()) -> map().
+merge(Map1, Map2, Opts) ->
+    maps:merge(hb_cache:ensure_loaded(Map1, Opts), hb_cache:ensure_loaded(Map2, Opts)).
 
 -spec remove(Key :: term(), Map :: map()) -> map().
 remove(Key, Map) ->
-    maps:remove(Key, hb_cache:ensure_loaded(Map)).
+	remove(Key, Map, #{}).
+
+-spec remove(Key :: term(), Map :: map(), Opts :: map()) -> map().
+remove(Key, Map, Opts) ->
+    maps:remove(Key, hb_cache:ensure_loaded(Map, Opts)).
 
 -spec with(Keys :: [term()], Map :: map()) -> map().
 with(Keys, Map) ->
-    maps:with(Keys, hb_cache:ensure_loaded(Map)).
+	with(Keys, Map, #{}).
+
+-spec with(Keys :: [term()], Map :: map(), Opts :: map()) -> map().
+with(Keys, Map, Opts) ->
+    maps:with(Keys, hb_cache:ensure_loaded(Map, Opts)).
 
 -spec without(Keys :: [term()], Map :: map()) -> map().
 without(Keys, Map) ->
-    maps:without(Keys, hb_cache:ensure_loaded(Map)).
+	without(Keys, Map, #{}).
+
+-spec without(Keys :: [term()], Map :: map(), Opts :: map()) -> map().
+without(Keys, Map, Opts) ->
+    maps:without(Keys, hb_cache:ensure_loaded(Map, Opts)).
 
 -spec filter(
     Fun :: fun((Key :: term(), Value :: term()) -> boolean()),
@@ -189,7 +217,11 @@ fold(Fun, Acc, Map, Opts) ->
 
 -spec take(N :: non_neg_integer(), Map :: map()) -> map().
 take(N, Map) ->
-    maps:take(N, hb_cache:ensure_loaded(Map)).
+	take(N, Map, #{}).
+
+-spec take(N :: non_neg_integer(), Map :: map(), Opts :: map()) -> map().
+take(N, Map, Opts) ->
+    maps:take(N, hb_cache:ensure_loaded(Map, Opts)).
 
 -spec update_with(
     Key :: term(),
@@ -197,7 +229,7 @@ take(N, Map) ->
     Map :: map()
 ) -> map().
 update_with(Key, Fun, Map) ->
-    maps:update_with(Key, Fun, hb_cache:ensure_loaded(Map)).
+    update_with(Key, Fun, Map, #{}).
 
 -spec update_with(
     Key :: term(),
@@ -215,6 +247,8 @@ from_list(List) ->
 -spec to_list(Map :: map()) -> [{Key :: term(), Value :: term()}].
 to_list(Map) ->
     to_list(Map, #{}).
+
+-spec to_list(Map :: map(), Opts :: map()) -> [{Key :: term(), Value :: term()}].
 to_list(Map, Opts) ->
     maps:to_list(hb_cache:ensure_loaded(Map, Opts)).
 

--- a/src/hb_maps.erl
+++ b/src/hb_maps.erl
@@ -17,6 +17,8 @@
 %%% yourself from the inevitable issues that will arise from using this
 %%% module without understanding the full implications. You have been warned.
 -module(hb_maps).
+
+-export([get/2, get/3, get/4, put/3, put/4, find/2, find/3]).
 -export([is_key/2, is_key/3, keys/1, keys/2, values/1, values/2]).
 -export([map/2, map/3, filter/2, filter/3, filtermap/2, filtermap/3]).
 -export([fold/3, fold/4, take/2, take/3, size/1, size/2]).

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -57,7 +57,7 @@
 %%% interact with it are found in `hb_message_test_vectors.erl'.
 -module(hb_message).
 -export([id/1, id/2, id/3]).
--export([convert/3, convert/4, uncommitted/1, committed/3]).
+-export([convert/3, convert/4, uncommitted/1, uncommitted/2, committed/3]).
 -export([with_only_committers/2, with_only_committers/3]).
 -export([verify/1, verify/2, verify/3, commit/2, commit/3, signers/2, type/1, minimize/1]).
 -export([commitment/2, commitment/3, with_only_committed/2, is_signed_key/3]).

--- a/src/hb_router.erl
+++ b/src/hb_router.erl
@@ -8,9 +8,10 @@
 
 find(Type, ID) ->
     find(Type, ID, '_').
-
-find(Type, _ID, Address) ->
-    case hb_maps:get(Type, hb_opts:get(nodes), undefined) of
+find(Type, ID, Address) ->
+	find(Type, ID, Address, #{}).
+find(Type, _ID, Address, Opts) ->
+    case hb_maps:get(Type, hb_opts:get(nodes), undefined, Opts) of
         #{ Address := Node } -> {ok, Node};
         undefined -> {error, service_type_not_found}
     end.

--- a/src/hb_store_remote_node.erl
+++ b/src/hb_store_remote_node.erl
@@ -57,7 +57,7 @@ read(Opts = #{ <<"node">> := Node }, Key) ->
         {ok, Res} ->
             % returning the whole response to get the test-key
             % {ok, Msg} = hb_message:with_only_committed(Res),
-            Msg = hb_message:uncommitted(Res),
+            Msg = hb_message:uncommitted(Res, Opts),
             % ?event({read, {result, Msg}}),
             {ok, Msg};
         {error, _Err} ->

--- a/src/hb_test_utils.erl
+++ b/src/hb_test_utils.erl
@@ -24,7 +24,7 @@ suite_with_opts(Suite, OptsList) ->
     lists:filtermap(
         fun(OptSpec = #{ name := _Name, opts := Opts, desc := ODesc}) ->
             Store = hb_opts:get(store, hb_opts:get(store), Opts),
-            Skip = hb_maps:get(skip, OptSpec, []),
+            Skip = hb_maps:get(skip, OptSpec, [], Opts),
             case satisfies_requirements(OptSpec) of
                 true ->
                     {true, {foreach,

--- a/src/hb_util.erl
+++ b/src/hb_util.erl
@@ -7,7 +7,7 @@
 -export([find_value/2, find_value/3]).
 -export([deep_merge/3, number/1, list_to_numbered_map/1]).
 -export([is_ordered_list/2, message_to_ordered_list/1, message_to_ordered_list/2]).
--export([is_string_list/1, to_sorted_list/1, to_sorted_keys/1, to_sorted_keys/2]).
+-export([is_string_list/1, to_sorted_list/1, to_sorted_list/2, to_sorted_keys/1, to_sorted_keys/2]).
 -export([hd/1, hd/2, hd/3]).
 -export([remove_common/2, to_lower/1]).
 -export([maybe_throw/2]).
@@ -127,9 +127,11 @@ is_string_list(MaybeString) ->
 to_sorted_list(Msg) ->
     to_sorted_list(Msg, #{}).
 to_sorted_list(Msg, Opts) when is_map(Msg) ->
-    to_sorted_list(hb_maps:to_list(Msg, Opts), Opts);
+	to_sorted_list(hb_maps:to_list(Msg, Opts), Opts);
+to_sorted_list(Msg = [{_Key, _} | _], _Opts) when is_list(Msg) ->
+	lists:sort(fun({Key1, _}, {Key2, _}) -> Key1 < Key2 end, Msg);
 to_sorted_list(Msg, _Opts) when is_list(Msg) ->
-    lists:sort(fun({Key1, _}, {Key2, _}) -> Key1 < Key2 end, Msg).
+	lists:sort(fun(Key1, Key2) -> Key1 < Key2 end, Msg).
 
 %% @doc Given a map or KVList, return a deterministically ordered list of its keys.
 to_sorted_keys(Msg) ->


### PR DESCRIPTION
`Opts` became necessary for all `hb_maps` functions in a recent change.

Went through all calls to `hb_maps` functions. If `Opts` was available in the context, passed it into the function. Otherwise, determined whether or not `Opts` was necessary (ie, if the map could have links). If necessary, made available in context and passed in. 