### PR TITLE
feat: add idempotent route registration and conditional mounting

### DIFF
--- a/src/dev_green_zone.erl
+++ b/src/dev_green_zone.erl
@@ -349,9 +349,13 @@ join_peer(PeerLocation, PeerID, _M1, M2, InitOpts) ->
 							},
                             hb_http_server:set_opts(NewOpts),
 							?event(successfully_joined_greenzone),
-                            
-                            % After successfully joining, try to mount encrypted volume
-                            try_mount_encrypted_volume(AESKey, NewOpts),
+							ShouldMount = hb_ao:get(<<"should_mount">>, M2, false, NewOpts),
+							case ShouldMount of
+								true ->
+									try_mount_encrypted_volume(AESKey, NewOpts);
+								false ->
+									?event(debug, <<"Not mounting encrypted volume.">>)
+							end,
 
                             {ok, #{ 
                                 <<"body">> => 


### PR DESCRIPTION
- Add register/3 function to dev_router supporting idempotent route registration with parameter validation and detailed error responses
- Make encrypted volume mounting conditional in dev_green_zone based on a should_mount flag
- Improve error messages for missing routes with structured responses including status codes

This improves node registration reliability by ensuring routes can only be registered once and provides better control over encrypted volume mounting during greenzone initialization.