### PR TITLE
fix(snp): convert trusted configuration from map to list structure

### DIFF
--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -694,16 +694,18 @@ dynamic_router_test() ->
     {ok, Script} = file:read_file("scripts/dynamic-router.lua"),
     Run = hb_util:bin(rand:uniform(1337)),
     Node = hb_http_server:start_node(Opts = #{
-		trusted => #{
-			vcpus => 1,
-			vcpu_type => 5, 
-			vmm_type => 1,
-			guest_features => 1,
-			firmware => <<"b8c5d4082d5738db6b0fb0294174992738645df70c44cdecf7fad3a62244b788e7e408c582ee48a74b289f3acec78510">>,
-			kernel => <<"69d0cd7d13858e4fcef6bc7797aebd258730f215bc5642c4ad8e4b893cc67576">>,
-			initrd => <<"da6dffff50373e1d393bf92cb9b552198b1930068176a046dda4e23bb725b3bb">>,
-			append => <<"aaf13c9ed2e821ea8c82fcc7981c73a14dc2d01c855f09262d42090fa0424422">>
-		},
+		trusted => [
+			#{
+				vcpus => 1,
+				vcpu_type => 5, 
+				vmm_type => 1,
+				guest_features => 1,
+				firmware => <<"b8c5d4082d5738db6b0fb0294174992738645df70c44cdecf7fad3a62244b788e7e408c582ee48a74b289f3acec78510">>,
+				kernel => <<"69d0cd7d13858e4fcef6bc7797aebd258730f215bc5642c4ad8e4b893cc67576">>,
+				initrd => <<"da6dffff50373e1d393bf92cb9b552198b1930068176a046dda4e23bb725b3bb">>,
+				append => <<"aaf13c9ed2e821ea8c82fcc7981c73a14dc2d01c855f09262d42090fa0424422">>
+			}
+		],
         store => [
             #{
                 <<"store-module">> => hb_store_fs,
@@ -716,8 +718,7 @@ dynamic_router_test() ->
         },
         route_provider => #{
             <<"path">> =>
-                RouteProvider =
-                    <<"/router~node-process@1.0/compute/routes~message@1.0">>
+				<<"/router~node-process@1.0/compute/routes~message@1.0">>
         },
         node_processes => #{
             <<"router">> => #{
@@ -783,7 +784,7 @@ dynamic_router_test() ->
     {Status, NodeRoutes} = hb_http:get(Node, <<"/router~node-process@1.0/now">>, #{}),
     ?event(debug_dynrouter, {got_node_routes, NodeRoutes}),
 	% Meta info is a part of the exempt routes. Make sure this returns our address
-    {ok, Res} = hb_http:get(Node, <<"/~meta@1.0/info/address">>, Opts),
+    {ok, _Res} = hb_http:get(Node, <<"/~meta@1.0/info/address">>, Opts),
 	% ?assertEqual(hb_util:human_id(ar_wallet:to_address(hb_opts:get(priv_wallet, not_found, Opts))), Res),
 	% {Status, _} = hb_http:get(Node, <<"/RhguwWmQJ-wWCXhRH_NtTDHRRgfCqNDZckXtJK52zKs~process@1.0/compute&slot=1">>, Opts),
     ?assertEqual(ok, Status).

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -130,7 +130,7 @@ default_message() ->
         debug_ids => false,
         debug_committers => false,
         debug_show_priv => false,
-		trusted => #{},
+		trusted => [],
         routes => [
             #{
                 % Routes for the genesis-wasm device to use a local CU, if requested.


### PR DESCRIPTION
This change refactors the SNP validation system to support multiple trusted configurations by consistently using lists of maps instead of single maps:

- Convert all trusted configuration structures from maps to lists of maps
- Update SNP trusted validation logic to check against multiple configurations
- Fix init function to properly append new configurations to existing list
- Update default configuration in hb_opts.erl to use empty list instead of map

This enables more flexible SEV-SNP validation by allowing multiple trusted measurement configurations to be stored simultaneously.