### PR TITLE
feat: implement uniform request validation and improve security

### DIFF
--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -38,13 +38,15 @@
 %% so that it can be called only once.
 register(_M1, M2, Opts) ->
 	Registered = hb_opts:get(registered, false, Opts),
-	case Registered of
-	true ->
+	case { dev_meta:validate_request(M2, Opts), Registered } of
+	{Error = {error, _}, _} ->
+		Error;
+	{{ok, _}, true} ->
 		{ok, #{
 			<<"status">> => 208,
 			<<"message">> => <<"Node already registered.">>
 		}};
-	false ->
+	{{ok, _}, false} ->
 		RouterNode = hb_ao:get(<<"peer-location">>, M2, not_found, Opts),
 		Prefix = hb_ao:get(<<"prefix">>, M2, not_found, Opts),
 		Price = hb_ao:get(<<"price">>, M2, not_found, Opts),

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -415,6 +415,7 @@ set_default_opts(Opts) ->
         store => Store,
         priv_wallet => Wallet,
         address => hb_util:human_id(ar_wallet:to_address(Wallet)),
+		operator => unclaimed,
         force_signed => true
     }.
 

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -13,7 +13,7 @@
 %%% deterministic behavior impossible, the caller should fail the execution 
 %%% with a refusal to execute.
 -module(hb_opts).
--export([get/1, get/2, get/3, load/1, default_message/0, mimic_default_types/2]).
+-export([get/1, get/2, get/3, load/1, load_bin/1, default_message/0, mimic_default_types/2]).
 -include("include/hb.hrl").
 
 %% @doc The default configuration options of the hyperbeam node.
@@ -318,12 +318,14 @@ config_lookup(Key, Default) -> maps:get(Key, default_message(), Default).
 load(Path) ->
     case file:read_file(Path) of
         {ok, Bin} ->
-            try dev_codec_flat:deserialize(Bin) of
-                {ok, Map} -> {ok, mimic_default_types(Map, new_atoms)}
-            catch
-                error:B -> {error, B}
-            end;
+			load_bin(Bin);
         _ -> {error, not_found}
+    end.
+load_bin(Bin) ->
+    try dev_codec_flat:deserialize(Bin) of
+        {ok, Map} -> {ok, mimic_default_types(Map, new_atoms)}
+    catch
+        error:B -> {error, B}
     end.
 
 %% @doc Mimic the types of the default message for a given map.


### PR DESCRIPTION
This commit enhances security and consistency by:

1. Adding a centralized request validation mechanism in dev_meta:validate_request/2
2. Implementing signature verification for device initialization across green_zone, router, and SNP devices
3. Protecting sensitive data by stripping priv_wallet from node messages
4. Refactoring SNP device to use the trusted list structure instead of individual snp_hashes
5. Improving error handling with more descriptive messages
6. Setting operator to unclaimed by default in http_server
7. Adding utility function for binary data deserialization (load_bin)

These changes create a more secure initialization flow, ensuring only authorized users can modify critical device configuration.