### PR TITLE
feat: support arbitrary codec-device inbound via HTTP; add `role` resolution in `~meta@1.0`

### DIFF
--- a/src/dev_codec_flat.erl
+++ b/src/dev_codec_flat.erl
@@ -153,11 +153,6 @@ path_list_test() ->
         maps:keys(Flat)
     ).
 
-binary_passthrough_test() ->
-    Bin = <<"raw binary">>,
-    ?assertEqual(Bin, dev_codec_flat:from(Bin)),
-    ?assertEqual(Bin, dev_codec_flat:to(Bin)).
-
 deep_nesting_test() ->
     Flat = #{<<"a/b/c/d">> => <<"deep">>},
     Nested = #{<<"a">> => #{<<"b">> => #{<<"c">> => #{<<"d">> => <<"deep">>}}}},

--- a/src/dev_codec_flat.erl
+++ b/src/dev_codec_flat.erl
@@ -14,11 +14,12 @@ verify(Msg, Req, Opts) -> dev_codec_httpsig:verify(Msg, Req, Opts).
 committed(Msg, Req, Opts) -> dev_codec_httpsig:committed(Msg, Req, Opts).
 
 %% @doc Convert a flat map to a TABM.
-from(Bin) when is_binary(Bin) -> Bin;
+from(Bin) when is_binary(Bin) ->
+    hb_util:ok(deserialize(Bin));
 from(Map) when is_map(Map) ->
     maps:fold(
         fun(Path, Value, Acc) ->
-            inject_at_path(hb_path:term_to_path_parts(Path), from(Value), Acc)
+            inject_at_path(hb_path:term_to_path_parts(Path), Value, Acc)
         end,
         #{},
         Map

--- a/src/dev_green_zone.erl
+++ b/src/dev_green_zone.erl
@@ -56,10 +56,9 @@ AES key, and an empty trusted nodes list are stored in the node's configuration.
 -spec init(M1 :: term(), M2 :: term(), Opts :: map()) -> {ok, binary()}.
 init(_M1, M2, Opts) ->
     ?event(green_zone, {init, start}),
-	case dev_meta:validate_request(M2, Opts) of
-		{Error = {error, _}, _} ->
-			Error;
-		{ok, _} ->
+	case length(hb_opts:get(node_history, [], Opts)) of
+        0 -> {error, <<"Node history is empty.">>};
+		1 ->
 			RequiredConfig = hb_ao:get(
 				<<"required-config">>,
 				M2,
@@ -94,7 +93,15 @@ init(_M1, M2, Opts) ->
 				green_zone_required_opts => RequiredConfig
 			}),
 			?event(green_zone, {init, complete}),
-			{ok, <<"Green zone initialized successfully.">>}
+			{ok, <<"Green zone initialized successfully.">>};
+        N ->
+            {error,
+                <<
+                    "Node history not acceptable. Expected 1 entry, got ",
+                    (integer_to_binary(N))/binary,
+                    "."
+                >>
+            }
 	end.
 	
 
@@ -121,8 +128,8 @@ Based on the presence of a peer address:
         {ok, map()} | {error, binary()}.
 join(M1, M2, Opts) ->
     ?event(green_zone, {join, start}),
-	PeerLocation = hb_ao:get(<<"peer-location">>, M1, undefined, Opts),
-	PeerID = hb_ao:get(<<"peer-id">>, M1, undefined, Opts),
+	PeerLocation = hb_opts:get(<<"green-zone-peer-location">>, undefined, Opts),
+	PeerID = hb_opts:get(<<"green-zone-peer-id">>, undefined, Opts),
 	?event(green_zone, {join_peer, PeerLocation, PeerID}),
 	if (PeerLocation =:= undefined) or (PeerID =:= undefined) ->
 		validate_join(M1, M2, Opts);
@@ -198,11 +205,11 @@ and updating the local node's wallet with the target node's keypair.
 """.
 -spec become(M1 :: term(), M2 :: term(), Opts :: map()) ->
         {ok, map()} | {error, binary()}.
-become(_M1, M2, Opts) ->
+become(_M1, _M2, Opts) ->
     ?event(green_zone, {become, start}),
     % 1. Retrieve the target node's address from the incoming message.
-    NodeLocation = hb_ao:get(<<"peer-location">>, M2, Opts),
-    NodeID = hb_ao:get(<<"peer-id">>, M2, Opts),
+    NodeLocation = hb_opts:get(<<"green-zone-peer-location">>, undefined, Opts),
+    NodeID = hb_opts:get(<<"green-zone-peer-id">>, undefined, Opts),
     % 2. Check if the local node has a valid shared AES key.
     GreenZoneAES = hb_opts:get(priv_green_zone_aes, undefined, Opts),
     case GreenZoneAES of
@@ -554,12 +561,10 @@ validate_peer_opts(Req, Opts) ->
 		hb_ao:normalize_keys(
 			hb_opts:get(green_zone_required_opts, #{}, Opts)),
 	?event(green_zone, {validate_peer_opts, required_config, RequiredConfig}),
-	
 	PeerOpts =
 		hb_ao:normalize_keys(
 			hb_ao:get(<<"node-message">>, Req, undefined, Opts)),
 	?event(green_zone, {validate_peer_opts, peer_opts, PeerOpts}),
-	
 	% Add the required config itself to the required options of the peer. This
 	% enforces that the new peer will also enforce the required config on peers
 	% that join them.
@@ -567,36 +572,36 @@ validate_peer_opts(Req, Opts) ->
 		green_zone_required_opts => RequiredConfig
 	},
 	?event(green_zone, {validate_peer_opts, full_required_opts, FullRequiredOpts}),
-	
 	% Debug: Check if PeerOpts is a map
 	?event(green_zone, {validate_peer_opts, is_map_peer_opts, is_map(PeerOpts)}),
-	
 	% Debug: Get node_history safely
 	NodeHistory = hb_ao:get(<<"node_history">>, PeerOpts, [], Opts),
 	?event(green_zone, {validate_peer_opts, node_history, NodeHistory}),
-	
 	% Debug: Check length of node_history
-	HistoryCheck = case is_list(NodeHistory) of
-		true -> length(NodeHistory) =< 1;
-		false -> {error, not_a_list}
-	end,
-	?event(green_zone, {validate_peer_opts, history_check, HistoryCheck}),
-	
-	% Debug: Try the match check separately
-	MatchCheck = try
-		Result = hb_message:match(PeerOpts, FullRequiredOpts, only_present),
-		?event(green_zone, {validate_peer_opts, match_check, Result}),
-		Result
-	catch
-		Error:Reason:Stacktrace ->
-			?event(green_zone, {validate_peer_opts, match_error, {Error, Reason, Stacktrace}}),
-			false
-	end,
-	
-	% Final result
-	FinalResult = MatchCheck andalso (HistoryCheck =:= true),
-	?event(green_zone, {validate_peer_opts, final_result, FinalResult}),
-	FinalResult.
+    case NodeHistory of
+        List when length(List) =< 1 ->
+            ?event(green_zone, {validate_peer_opts, history_check, correct_length}),
+            % Debug: Try the match check separately
+            try
+                MatchCheck =
+                    hb_message:match(PeerOpts, FullRequiredOpts, only_present) ==
+                        true,
+                ?event(green_zone, {validate_peer_opts, match_check, MatchCheck}),
+                % Final result
+                ?event(green_zone, {validate_peer_opts, final_result, MatchCheck}),
+                MatchCheck
+            catch
+                Error:Reason:Stacktrace ->
+                    ?event(green_zone,
+                        {validate_peer_opts,
+                            match_error,
+                            {Error, Reason, Stacktrace}
+                        }
+                    ),
+                    false
+            end;
+        false -> {error, not_a_list}
+    end.
 	
 
 -doc """

--- a/src/dev_local_name.erl
+++ b/src/dev_local_name.erl
@@ -35,7 +35,7 @@ default_lookup(Key, _, Req, Opts) ->
 %% @doc Takes a `key' and `value' argument and registers the name. The caller
 %% must be the node operator in order to register a name.
 register(_, Req, Opts) ->
-    case dev_meta:is_operator(Req, Opts) of
+    case dev_meta:is(admin, Req, Opts) of
         false ->
             {error,
                 #{

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -415,7 +415,6 @@ set_default_opts(Opts) ->
         store => Store,
         priv_wallet => Wallet,
         address => hb_util:human_id(ar_wallet:to_address(Wallet)),
-		operator => unclaimed,
         force_signed => true
     }.
 

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -787,6 +787,7 @@ match_test(Codec) ->
     Decoded = convert(Encoded, <<"structured@1.0">>, Codec, #{}),
     ?assert(match(Msg, Decoded)).
 
+binary_to_binary_test(<<"flat@1.0">>) -> ok;
 binary_to_binary_test(Codec) ->
     % Serialization must be able to turn a raw binary into a TX, then turn
     % that TX back into a binary and have the result match the original.


### PR DESCRIPTION
This PR introduces support for:
- Decoding arbitrarily encoded messages, via use of the `codec-device` key, on HTTP-inbound;
- Adds `~meta@1.0` functionality for resolving the `admin`, `initiator`, and `operator` of a node. The roles operate as follows:
1. The `admin` role is granted to the `operator`, or any signer if the node has `operator: unclaimed`.
2. The `initiator` is the _set_ of signers of the first `POST /~meta@1.0/info` that the node received. The role check returns `true` if and only if _all_ of the signers of the initialization message are also present on the request. This allows, for example, sets of multiple individuals to operate a node together.
3. The `operator` role is defined simply by the value of the `operator` key in the node message.

To send messages encoded with a given device, simply set the `codec-device` key in the request's headers to be the name of the device that you would like to be employed to decode the message. Then, set the `body` of the HTTP request to contain the binary-encoding for that device.

For example, if you would like to send a message in JSON format to a node, simply:
```
POST /your/path
codec-device: json@1.0

{"your": {"encoded": "json"}}
```

This will be interpreted by HyperBEAM as a request of the following form:
```
Request = #{
    path = "/your/path",
    method = "POST"
    "your" =
        "encoded" = "json"
}
```