### PR TITLE
feat: handle ecdsa sigs

### DIFF
--- a/native/hb_keccak/hb_keccak.c
+++ b/native/hb_keccak/hb_keccak.c
@@ -1,0 +1,174 @@
+/** libkeccak-tiny
+ *
+ * A single-file implementation of SHA-3 and SHAKE.
+ *
+ * Implementor: David Leon Gil
+ * License: CC0, attribution kindly requested. Blame taken too,
+ * but not liability.
+ */
+#include "include/hb_keccak.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/******** The Keccak-f[1600] permutation ********/
+
+/*** Constants. ***/
+static const uint8_t rho[24] = \
+  { 1,  3,   6, 10, 15, 21,
+    28, 36, 45, 55,  2, 14,
+    27, 41, 56,  8, 25, 43,
+    62, 18, 39, 61, 20, 44};
+static const uint8_t pi[24] = \
+  {10,  7, 11, 17, 18, 3,
+    5, 16,  8, 21, 24, 4,
+   15, 23, 19, 13, 12, 2,
+   20, 14, 22,  9, 6,  1};
+static const uint64_t RC[24] = \
+  {1ULL, 0x8082ULL, 0x800000000000808aULL, 0x8000000080008000ULL,
+   0x808bULL, 0x80000001ULL, 0x8000000080008081ULL, 0x8000000000008009ULL,
+   0x8aULL, 0x88ULL, 0x80008009ULL, 0x8000000aULL,
+   0x8000808bULL, 0x800000000000008bULL, 0x8000000000008089ULL, 0x8000000000008003ULL,
+   0x8000000000008002ULL, 0x8000000000000080ULL, 0x800aULL, 0x800000008000000aULL,
+   0x8000000080008081ULL, 0x8000000000008080ULL, 0x80000001ULL, 0x8000000080008008ULL};
+
+/*** Helper macros to unroll the permutation. ***/
+#define rol(x, s) (((x) << s) | ((x) >> (64 - s)))
+#define REPEAT6(e) e e e e e e
+#define REPEAT24(e) REPEAT6(e e e e)
+#define REPEAT5(e) e e e e e
+#define FOR5(v, s, e) \
+  v = 0;            \
+  REPEAT5(e; v += s;)
+
+/*** Keccak-f[1600] ***/
+static inline void keccakf(void* state) {
+  uint64_t* a = (uint64_t*)state;
+  uint64_t b[5] = {0};
+  uint64_t t = 0;
+  uint8_t x, y;
+
+  for (int i = 0; i < 24; i++) {
+    // Theta
+    FOR5(x, 1,
+         b[x] = 0;
+         FOR5(y, 5,
+              b[x] ^= a[x + y]; ))
+    FOR5(x, 1,
+         FOR5(y, 5,
+              a[y + x] ^= b[(x + 4) % 5] ^ rol(b[(x + 1) % 5], 1); ))
+    // Rho and pi
+    t = a[1];
+    x = 0;
+    REPEAT24(b[0] = a[pi[x]];
+             a[pi[x]] = rol(t, rho[x]);
+             t = b[0];
+             x++; )
+    // Chi
+    FOR5(y,
+       5,
+       FOR5(x, 1,
+            b[x] = a[y + x];)
+       FOR5(x, 1,
+            a[y + x] = b[x] ^ ((~b[(x + 1) % 5]) & b[(x + 2) % 5]); ))
+    // Iota
+    a[0] ^= RC[i];
+  }
+}
+
+/******** The FIPS202-defined functions. ********/
+
+/*** Some helper macros. ***/
+
+#define _(S) do { S } while (0)
+#define FOR(i, ST, L, S) \
+  _(for (size_t i = 0; i < L; i += ST) { S; })
+#define mkapply_ds(NAME, S)                                          \
+  static inline void NAME(uint8_t* dst,                              \
+                          const uint8_t* src,                        \
+                          size_t len) {                              \
+    FOR(i, 1, len, S);                                               \
+  }
+#define mkapply_sd(NAME, S)                                          \
+  static inline void NAME(const uint8_t* src,                        \
+                          uint8_t* dst,                              \
+                          size_t len) {                              \
+    FOR(i, 1, len, S);                                               \
+  }
+
+mkapply_ds(xorin, dst[i] ^= src[i])  // xorin
+mkapply_sd(setout, dst[i] = src[i])  // setout
+
+#define P keccakf
+#define Plen 200
+
+// Fold P*F over the full blocks of an input.
+#define foldP(I, L, F) \
+  while (L >= rate) {  \
+    F(a, I, rate);     \
+    P(a);              \
+    I += rate;         \
+    L -= rate;         \
+  }
+
+/** The sponge-based hash construction. **/
+static inline int hash(uint8_t* out, size_t outlen,
+                       const uint8_t* in, size_t inlen,
+                       size_t rate, uint8_t delim) {
+  if ((out == NULL) || ((in == NULL) && inlen != 0) || (rate >= Plen)) {
+    return -1;
+  }
+  uint8_t a[Plen] = {0};
+  // Absorb input.
+  foldP(in, inlen, xorin);
+  // Xor in the DS and pad frame.
+  a[inlen] ^= delim;
+  a[rate - 1] ^= 0x80;
+  // Xor in the last block.
+  xorin(a, in, inlen);
+  // Apply P
+  P(a);
+  // Squeeze output.
+  foldP(out, outlen, setout);
+  setout(a, out, outlen);
+  memset(a, 0, 200);
+  return 0;
+}
+
+/*** Helper macros to define SHA3 and SHAKE instances. ***/
+#define defshake(bits)                                            \
+  int shake##bits(uint8_t* out, size_t outlen,                    \
+                  const uint8_t* in, size_t inlen) {              \
+    return hash(out, outlen, in, inlen, 200 - (bits / 4), 0x1f);  \
+  }
+
+
+#define defalgo(algoname, bits, pad)                              \
+  int algoname ## bits(uint8_t* out, size_t outlen,               \
+                  const uint8_t* in, size_t inlen) {              \
+    if (outlen > (bits/8)) {                                      \
+      return -1;                                                  \
+    }                                                             \
+    return hash(out, outlen, in, inlen, 200 - (bits / 4), pad);   \
+  }
+
+#define defsha3(bits)   defalgo(sha3_, bits, 0x06)
+#define defkeccak(bits) defalgo(keccak_, bits, 0x01)
+
+/*** FIPS202 SHAKE VOFs ***/
+defshake(128)
+defshake(256)
+
+/*** FIPS202 SHA3 FOFs ***/
+defsha3(224)
+defsha3(256)
+defsha3(384)
+defsha3(512)
+
+/*** ORIGINAL KECCAK SUBMISSION ***/
+defkeccak(224)
+defkeccak(256)
+defkeccak(384)
+defkeccak(512)

--- a/native/hb_keccak/hb_keccak_nif.c
+++ b/native/hb_keccak/hb_keccak_nif.c
@@ -1,0 +1,40 @@
+#include "erl_nif.h"
+#include "include/hb_keccak.h"
+#include <string.h>
+#include <stdlib.h>
+
+static ERL_NIF_TERM nif_sha3_256(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
+    ErlNifBinary input;
+    if (!enif_inspect_binary(env, argv[0], &input)) {
+        return enif_make_badarg(env);
+    }
+
+    uint8_t output[32];
+    sha3_256(output, 32, input.data, input.size);  // this is the actual C implementation
+
+    ERL_NIF_TERM result;
+    uint8_t* bin = enif_make_new_binary(env, 32, &result);
+    memcpy(bin, output, 32);
+    return result;
+}
+
+static ERL_NIF_TERM nif_keccak_256(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
+	ErlNifBinary input;
+    if (!enif_inspect_binary(env, argv[0], &input)) {
+        return enif_make_badarg(env);
+    }
+	uint8_t output[32];
+    keccak_256(output, 32, input.data, input.size);  
+
+    ERL_NIF_TERM result;
+    uint8_t* bin = enif_make_new_binary(env, 32, &result);
+    memcpy(bin, output, 32);
+    return result;
+}
+
+static ErlNifFunc nif_funcs[] = {
+    {"sha3_256", 1, nif_sha3_256},
+    {"keccak_256", 1, nif_keccak_256}
+};
+
+ERL_NIF_INIT(hb_keccak, nif_funcs, NULL, NULL, NULL, NULL)

--- a/native/hb_keccak/include/hb_keccak.h
+++ b/native/hb_keccak/include/hb_keccak.h
@@ -1,0 +1,23 @@
+#ifndef KECCAK_FIPS202_H
+#define KECCAK_FIPS202_H
+#define __STDC_WANT_LIB_EXT1__ 1
+#include <stdint.h>
+#include <stdlib.h>
+
+#define decshake(bits) \
+  int shake##bits(uint8_t*, size_t, const uint8_t*, size_t);
+
+#define decsha3(bits) \
+  int sha3_##bits(uint8_t*, size_t, const uint8_t*, size_t);
+
+#define deckeccak(bits) \
+  int keccak_##bits(uint8_t*, size_t, const uint8_t*, size_t);
+
+decshake(128)
+decshake(256)
+decsha3(224)
+decsha3(256)
+decsha3(384)
+decsha3(512)
+deckeccak(256)
+#endif

--- a/rebar.config
+++ b/rebar.config
@@ -53,6 +53,7 @@
 	{"(linux|darwin|solaris)", clean, "rm -rf \"${REBAR_ROOT_DIR}/_build\" \"${REBAR_ROOT_DIR}/priv\""},
 	{"(linux|darwin|solaris)", compile, "echo 'Post-compile hooks executed'"},
     { compile, "rm -f native/hb_beamr/*.o native/hb_beamr/*.d"},
+    { compile, "rm -f native/hb_keccak/*.o native/hb_keccak/*.d"},
     { compile, "mkdir -p priv/html"},
     { compile, "cp -R src/html/* priv/html"}
 ]}.
@@ -75,7 +76,11 @@
         "./native/hb_beamr/hb_driver.c",
         "./native/hb_beamr/hb_helpers.c",
         "./native/hb_beamr/hb_logging.c"
-    ]}
+    ]},
+	{"./priv/hb_keccak.so", [
+		"./native/hb_keccak/hb_keccak.c",
+		"./native/hb_keccak/hb_keccak_nif.c"
+	]}
 ]}.
 
 {deps, [

--- a/src/ar_wallet.erl
+++ b/src/ar_wallet.erl
@@ -57,14 +57,16 @@ verify({{rsa, PublicExpnt}, Pub}, Data, Sig, DigestType) when PublicExpnt =:= 65
 %% @doc Generate an address from a public key.
 to_address(Pubkey) ->
     to_address(Pubkey, ?DEFAULT_KEY_TYPE).
-to_address(PubKey, {rsa, 65537}) when bit_size(PubKey) == 256 ->
+to_address(PubKey, _) when bit_size(PubKey) == 256 ->
     %% Small keys are not secure, nobody is using them, the clause
     %% is for backwards-compatibility.
     PubKey;
-to_address({{_, _, PubKey}, {_, PubKey}}, {rsa, 65537}) ->
+to_address({{_, _, PubKey}, {_, PubKey}}, _) ->
     to_address(PubKey);
 to_address(PubKey, {rsa, 65537}) ->
-    to_rsa_address(PubKey).
+    to_rsa_address(PubKey);
+to_address(PubKey, {ecdsa, 256}) ->
+	to_ecdsa_address(PubKey).
 
 %% @doc Generate a new wallet public and private key, with a corresponding keyfile.
 %% The provided key is used as part of the file name.
@@ -193,6 +195,9 @@ to_rsa_address(PubKey) ->
 
 hash_address(PubKey) ->
     crypto:hash(sha256, PubKey).
+
+to_ecdsa_address(PubKey) ->
+	hb_keccak:key_to_ethereum_address(PubKey).
 
 %%%===================================================================
 %%% Private functions.

--- a/src/dev_codec_ans104.erl
+++ b/src/dev_codec_ans104.erl
@@ -274,7 +274,7 @@ do_from(RawTX) ->
                         }
                 end;
             _ ->
-                Address = hb_util:human_id(ar_wallet:to_address(TX#tx.owner)),
+                Address = hb_util:human_id(ar_wallet:to_address(TX#tx.owner, TX#tx.signature_type)),
                 WithoutBaseCommitment =
                     maps:without(
                         [

--- a/src/dev_json_iface.erl
+++ b/src/dev_json_iface.erl
@@ -133,12 +133,18 @@ message_to_json_struct(RawMsg, Features) ->
         end,
     Data = hb_ao:get(<<"data">>, {as, <<"message@1.0">>, MsgWithoutCommitments}, <<>>, #{}),
     Target = hb_ao:get(<<"target">>, {as, <<"message@1.0">>, MsgWithoutCommitments}, <<>>, #{}),
+	
+	% Ethereum addresses are already encoded
+	EncodedOwner = case byte_size(Owner) of
+		42 -> Owner;
+		_ -> hb_util:encode(Owner)
+	end,
     % Set "From" if From-Process is Tag or set with "Owner" address
     From =
         hb_ao:get(
             <<"from-process">>,
             {as, <<"message@1.0">>, MsgWithoutCommitments},
-            hb_util:encode(Owner),
+            EncodedOwner,
             #{}
         ),
     Sig = hb_ao:get(<<"signature">>, {as, <<"message@1.0">>, MsgWithoutCommitments}, <<>>, #{}),
@@ -147,7 +153,7 @@ message_to_json_struct(RawMsg, Features) ->
         % NOTE: In Arweave TXs, these are called "last_tx"
         <<"Anchor">> => Last,
         % NOTE: When sent to ao "Owner" is the wallet address
-        <<"Owner">> => hb_util:encode(Owner),
+        <<"Owner">> => EncodedOwner,
         <<"From">> => case ?IS_ID(From) of true -> safe_to_id(From); false -> From end,
         <<"Tags">> => prepare_tags(TABM),
         <<"Target">> => safe_to_id(Target),

--- a/src/hb_keccak.erl
+++ b/src/hb_keccak.erl
@@ -1,0 +1,86 @@
+-module(hb_keccak).
+-export([sha3_256/1]).
+-export([keccak_256/1]).
+-export([key_to_ethereum_address/1]).
+-include_lib("eunit/include/eunit.hrl").
+
+-on_load(init/0).
+
+-define(APPNAME, keccak).
+-define(LIBNAME, keccak_nif).
+
+%% NIF Initialization
+init() ->
+    SoName = filename:join([code:priv_dir(hb), "hb_keccak"]),
+    erlang:load_nif(SoName, 0).
+
+sha3_256(_Bin) ->
+    erlang:nif_error(not_loaded).
+
+keccak_256(_Bin) ->
+    erlang:nif_error(not_loaded).
+
+to_hex(Bin) when is_binary(Bin) ->
+	binary:encode_hex(Bin).
+
+key_to_ethereum_address(Key) when is_binary(Key) ->
+	<<_Prefix: 1/binary, NoCompressionByte/binary>> = Key,
+	Prefix = hb_util:to_hex(hb_keccak:keccak_256(NoCompressionByte)),
+	Last40 = binary:part(Prefix, byte_size(Prefix) - 40, 40),
+
+	Hash = hb_keccak:keccak_256(Last40),
+	HashHex = hb_util:to_hex(Hash),
+	
+	ChecksumAddress = hash_to_checksum_address(Last40, HashHex),
+	ChecksumAddress.
+
+hash_to_checksum_address(Last40, Hash) when
+	is_binary(Last40),
+	is_binary(Hash),
+	byte_size(Last40) =:= 40  ->
+
+	Checksummed = lists:zip(binary:bin_to_list(Last40), binary:bin_to_list(binary:part(Hash, 0, 40))),
+    Formatted = lists:map(fun({Char, H}) ->
+        case H >= $8 of
+            true -> string:to_upper([Char]);
+            false -> [Char]
+        end
+    end, Checksummed),
+	<<"0x", (list_to_binary(lists:append(Formatted)))/binary>>.
+
+%% Test functions
+keccak_256_test() ->
+	Input = <<"testing">>,
+	Expected = <<"5F16F4C7F149AC4F9510D9CF8CF384038AD348B3BCDC01915F95DE12DF9D1B02">>,
+	Actual = to_hex(hb_keccak:keccak_256(Input)),
+    ?assertEqual(Expected, Actual).
+
+keccak_256_key_test() ->
+	Input = <<"BAoixXds4JhW42pzlLb83B3-I21lX78j3Q7cPaoFiCjMgjYwYLDj-xL132J147ifZFwRBmzmEMC8eYAXzbRNWuA">>,
+	BinaryInput = hb_util:decode(Input),
+	<<_Prefix: 1/binary, NoCompressionByte/binary>> = BinaryInput,
+
+	Prefix = hb_keccak:keccak_256(NoCompressionByte),
+	PrefixHex = hb_util:to_hex(Prefix),
+	?assertEqual(PrefixHex, <<"12f9afe6abd38444cab38e8cb7b4360f7f6298de2e7a11009270f35f189bd77e">>),
+	
+	Last40 = binary:part(PrefixHex, byte_size(PrefixHex) - 40, 40),
+	?assertEqual(Last40, <<"b7b4360f7f6298de2e7a11009270f35f189bd77e">>),
+
+	Hash = hb_keccak:keccak_256(Last40),
+	HashHex = hb_util:to_hex(Hash),
+	
+	ChecksumAddress = hash_to_checksum_address(Last40, HashHex),
+	?assertEqual(ChecksumAddress, <<"0xb7B4360F7F6298dE2e7a11009270F35F189Bd77E">>).
+
+keccak_256_key_to_address_test() ->
+	Input = <<"BAoixXds4JhW42pzlLb83B3-I21lX78j3Q7cPaoFiCjMgjYwYLDj-xL132J147ifZFwRBmzmEMC8eYAXzbRNWuA">>,
+	ChecksumAddress = key_to_ethereum_address(hb_util:decode(Input)),
+	?assertEqual(ChecksumAddress, <<"0xb7B4360F7F6298dE2e7a11009270F35F189Bd77E">>).
+
+sha3_256_test() ->
+    %% "abc" => known SHA3-256 hash from NIST
+    Input = <<"testing">>,
+    Expected = <<"7F5979FB78F082E8B1C676635DB8795C4AC6FABA03525FB708CB5FD68FD40C5E">>,
+	Actual = to_hex(hb_keccak:sha3_256(Input)),
+    ?assertEqual(Expected, Actual).

--- a/src/hb_util.erl
+++ b/src/hb_util.erl
@@ -152,13 +152,18 @@ key_to_atom(Key, Mode) ->
 native_id(Bin) when is_binary(Bin) andalso byte_size(Bin) == 43 ->
     decode(Bin);
 native_id(Bin) when is_binary(Bin) andalso byte_size(Bin) == 32 ->
+    Bin;
+native_id(Bin) when is_binary(Bin) andalso byte_size(Bin) == 42 ->
     Bin.
 
 %% @doc Convert a native binary ID to a human readable ID. If the ID is already
-%% a human readable ID, it is returned as is.
+%% a human readable ID, it is returned as is. If it is an ethereum address, it
+%% is returned as is.
 human_id(Bin) when is_binary(Bin) andalso byte_size(Bin) == 32 ->
     encode(Bin);
 human_id(Bin) when is_binary(Bin) andalso byte_size(Bin) == 43 ->
+    Bin;
+human_id(Bin) when is_binary(Bin) andalso byte_size(Bin) == 42 ->
     Bin.
 
 %% @doc Return a short ID for the different types of IDs used in AO-Core.

--- a/src/include/hb.hrl
+++ b/src/include/hb.hrl
@@ -6,7 +6,7 @@
 -define(IS_EMPTY_MESSAGE(Msg), (map_size(Msg) == 0) orelse (map_size(Msg) == 1 andalso (is_map_key(priv, Msg) orelse is_map_key(<<"priv">>, Msg)))).
 %% @doc Macro usable in guards that validates whether a term is a
 %% human-readable ID encoding.
--define(IS_ID(X), (is_binary(X) andalso (byte_size(X) == 43 orelse byte_size(X) == 32))).
+-define(IS_ID(X), (is_binary(X) andalso (byte_size(X) == 42 orelse byte_size(X) == 43 orelse byte_size(X) == 32))).
 %% @doc List of special keys that are used in the AO-Core protocol.
 -define(AO_CORE_KEYS, [<<"path">>, <<"hashpath">>, <<"priv">>]).
 %% @doc Keys that can be regenerated losslessly.


### PR DESCRIPTION
Implements the `hb_keccak` NIF, which takes in ECDSA owner keys and translates them to Ethereum addresses