### PR TITLE
fix: using trusted instead of snp_hashes

### DIFF
--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -64,7 +64,7 @@ register(_M1, _M2, Opts) ->
                         #{}, 
                         #{ 
                             priv_wallet => hb:wallet(), 
-                            snp_hashes => hb_opts:get(snp_hashes, #{}, Opts)
+                            trusted => hb_opts:get(trusted, [], Opts)
                         }
                     ),
                     ?event(debug_register, {attestion, Attestion}),


### PR DESCRIPTION
Replaced snp_hashes with the trusted in the opts passed to generating the attestation report.

NOTE: This is needed now because we removed snp_hashes in replace of trusted[1]