### PR TITLE
feat: expose `build` information on `~meta@1.0/build`.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -39,6 +39,9 @@
 {overrides, []}.
 
 {pre_hooks, [
+    {compile, "bash -c \"echo '-define(HB_BUILD_COMMIT, <<\\\"$(git rev-parse HEAD)\\\">>).\n' > ${REBAR_ROOT_DIR}/_build/hb_buildinfo.hrl\""},
+    {compile, "bash -c \"echo '-define(HB_BUILD_COMMIT_SHORT, <<\\\"$(git rev-parse --short HEAD)\\\">>).\n' >> ${REBAR_ROOT_DIR}/_build/hb_buildinfo.hrl\""},
+    {compile, "bash -c \"echo '-define(HB_BUILD_TIME, $(date +%s)).\n' >> ${REBAR_ROOT_DIR}/_build/hb_buildinfo.hrl\""},
 	{compile, "make -C \"${REBAR_ROOT_DIR}\" wamr"}
 ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -39,8 +39,8 @@
 {overrides, []}.
 
 {pre_hooks, [
-    {compile, "bash -c \"echo '-define(HB_BUILD_COMMIT, <<\\\"$(git rev-parse HEAD)\\\">>).\n' > ${REBAR_ROOT_DIR}/_build/hb_buildinfo.hrl\""},
-    {compile, "bash -c \"echo '-define(HB_BUILD_COMMIT_SHORT, <<\\\"$(git rev-parse --short HEAD)\\\">>).\n' >> ${REBAR_ROOT_DIR}/_build/hb_buildinfo.hrl\""},
+    {compile, "bash -c \"echo '-define(HB_BUILD_SOURCE, <<\\\"$(git rev-parse HEAD)\\\">>).\n' > ${REBAR_ROOT_DIR}/_build/hb_buildinfo.hrl\""},
+    {compile, "bash -c \"echo '-define(HB_BUILD_SOURCE_SHORT, <<\\\"$(git rev-parse --short HEAD)\\\">>).\n' >> ${REBAR_ROOT_DIR}/_build/hb_buildinfo.hrl\""},
     {compile, "bash -c \"echo '-define(HB_BUILD_TIME, $(date +%s)).\n' >> ${REBAR_ROOT_DIR}/_build/hb_buildinfo.hrl\""},
 	{compile, "make -C \"${REBAR_ROOT_DIR}\" wamr"}
 ]}.

--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -7,10 +7,11 @@
 %%% resolver. Additionally, a post-processor can be set, which is executed after
 %%% the AO-Core resolver has returned a result.
 -module(dev_meta).
--export([info/1, info/3, handle/2, adopt_node_message/2, is/2, is/3]).
-%%% Public API
+-export([info/1, info/3, build/3, handle/2, adopt_node_message/2, is/2, is/3]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
+%%% Include the auto-generated build info header file.
+-include_lib("_build/hb_buildinfo.hrl").
 
 %% @doc Ensure that the helper function `adopt_node_message/2' is not exported.
 %% The naming of this method carefully avoids a clash with the exported `info/3'
@@ -21,7 +22,26 @@
 %% info call will match the three-argument version of the function. If in the 
 %% future the `request' is added as an argument to AO-Core's internal `info'
 %% function, we will need to find a different approach.
-info(_) -> #{ exports => [info] }.
+info(_) -> #{ exports => [info, build] }.
+
+%% @doc Emits the version number and commit hash of the HyperBEAM node source,
+%% if available.
+%% 
+%% We include the short hash separately, as the length of this hash may change in
+%% the future, depending on the git version/config used to build the node.
+%% Subsequently, rather than embedding the `git-short-hash-length', for the
+%% avoidance of doubt, we include the short hash separately, as well as its long
+%% hash.
+build(_, _, _NodeMsg) ->
+    {ok,
+        #{
+            <<"node">> => <<"HyperBEAM">>,
+            <<"version">> => ?HYPERBEAM_VERSION,
+            <<"commit">> => ?HB_BUILD_COMMIT,
+            <<"commit-short">> => ?HB_BUILD_COMMIT_SHORT,
+            <<"build-time">> => ?HB_BUILD_TIME
+        }
+    }.
 
 %% @doc Normalize and route messages downstream based on their path. Messages
 %% with a `Meta' key are routed to the `handle_meta/2' function, while all

--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -37,8 +37,8 @@ build(_, _, _NodeMsg) ->
         #{
             <<"node">> => <<"HyperBEAM">>,
             <<"version">> => ?HYPERBEAM_VERSION,
-            <<"commit">> => ?HB_BUILD_COMMIT,
-            <<"commit-short">> => ?HB_BUILD_COMMIT_SHORT,
+            <<"source">> => ?HB_BUILD_SOURCE,
+            <<"source-short">> => ?HB_BUILD_SOURCE_SHORT,
             <<"build-time">> => ?HB_BUILD_TIME
         }
     }.
@@ -646,3 +646,27 @@ modify_request_test() ->
         }),
     {ok, Res} = hb_http:get(Node, <<"/added">>, #{}),
     ?assertEqual(<<"value">>, Res).
+
+%% @doc Test that version information is available and returned correctly.
+buildinfo_test() ->
+    Node = hb_http_server:start_node(#{}),
+    ?assertEqual(
+        {ok, <<"HyperBEAM">>},
+        hb_http:get(Node, <<"/~meta@1.0/build/node">>, #{})
+    ),
+    ?assertEqual(
+        {ok, ?HYPERBEAM_VERSION},
+        hb_http:get(Node, <<"/~meta@1.0/build/version">>, #{})
+    ),
+    ?assertEqual(
+        {ok, ?HB_BUILD_SOURCE},
+        hb_http:get(Node, <<"/~meta@1.0/build/source">>, #{})
+    ),
+    ?assertEqual(
+        {ok, ?HB_BUILD_SOURCE_SHORT},
+        hb_http:get(Node, <<"/~meta@1.0/build/source-short">>, #{})
+    ),
+    ?assertEqual(
+        {ok, ?HB_BUILD_TIME},
+        hb_http:get(Node, <<"/~meta@1.0/build/build-time">>, #{})
+    ).


### PR DESCRIPTION
This allows us to track the versions of HyperBEAM that different nodes in the network are executing. Additionally, as the build information is exposed through an AO-Core device (`~meta@1.0`) this response is itself attested by the node's key. This opens options for varied types of enforcement depending on correctness.
