### PR TITLE
impr: `~push@1.0` supports user-requested depth for compute results

### DIFF
--- a/src/dev_codec_ans104.erl
+++ b/src/dev_codec_ans104.erl
@@ -24,7 +24,6 @@
 %%% encoded as fields in the TX record.
 -define(FORCED_TAG_FIELDS,
     [
-        <<"tags">>,
         <<"quantity">>,
         <<"manifest">>,
         <<"data_size">>,

--- a/src/dev_delegated_compute.erl
+++ b/src/dev_delegated_compute.erl
@@ -79,7 +79,7 @@ do_compute(ProcID, Msg2, Opts) ->
                 <<"relay-path">> =>
                     <<
                         "/result/",
-                        (integer_to_binary(Slot))/binary,
+                        (hb_util:bin(Slot))/binary,
                         "?process-id=",
                         ProcID/binary
                     >>,

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -888,7 +888,6 @@ do_get_remote_schedule(ProcID, LocalAssignments, From, To, Redirect, Opts) ->
     ?event({getting_remote_schedule, {node, {string, Node}}, {path, {string, Path}}}),
     case hb_http:get(Node, Path, Opts#{ http_client => httpc, protocol => http2 }) of
         {ok, Res} ->
-            ?event(push, {remote_schedule_result, {res, Res}}, Opts),
             case hb_util:int(hb_ao:get(<<"status">>, Res, 200, Opts)) of
                 200 ->
                     {ok, NormSched} = 

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -128,7 +128,7 @@ default_message() ->
         debug_print_trace => short, % `short' | `false'. Has performance impact.
         short_trace_len => 5,
         debug_metadata => true,
-        debug_ids => false,
+        debug_ids => true,
         debug_committers => false,
         debug_show_priv => false,
         snp_trusted => [],


### PR DESCRIPTION
Users may now request a `result-depth` along with `push` requests, allowing them to specify the depth to which the results of computations should be included in results given.

The effect of this is that the number of HTTP requests necessary for many (perhaps most?) uses of AO processes is cut in half. Rather than sending a request to schedule a result, then another to get the result, the user can simply `POST /procID/push` the message and receive the result. The effect of this is particularly pronounced, as _latency_ -- rather than execution speed -- is typically the bottleneck in creating 'snappy' user experiences with AO.

Additionally, this PR fixes two issues elsewhere in the codebase, on related codepaths:
1. An issue with the ANS-104 codecs that led to messages unnecessarily being converted into nested `Bundle-Maps`.
2. Additional type conversion was added to `~delegated-compute@1.0`, such that integration with a `~genesis-wasm@1.0` executor has improved fault tolerance.

All tests passing.