### PR TITLE
impr: `scheduler@1.0/location` key

### DIFF
--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -126,8 +126,16 @@ new_server(RawNodeMsg) ->
         case dev_hook:on(<<"start">>, HookMsg, RawNodeMsgWithDefaults) of
             {ok, #{ <<"body">> := NodeMsgAfterHook }} -> NodeMsgAfterHook;
             Unexpected ->
-                ?event(http, {failed_to_start_server, {unexpected, Unexpected}}),
-                throw({failed_to_start_server, Unexpected})
+                ?event(http,
+                    {failed_to_start_server,
+                        {unexpected_hook_result, Unexpected}
+                    }
+                ),
+                throw(
+                    {failed_to_start_server,
+                        {unexpected_hook_result, Unexpected}
+                    }
+                )
         end,
     % Put server ID into node message so it's possible to update current server
     hb_http:start(),


### PR DESCRIPTION
Improves the interface for registering and retrieving scheduler-location records, including allowing nodes to notify others when their scheduler location is updated.

Additionally, the `dev_hook` interface has been updated to support requesting that the node sign requests before performing the hook execution, as well as the ability to have the result of the hook be discarded if preferred. Together, these two options make it significantly easier to integrate calls to non-hook-aware devices into hook calls.
