### PR TITLE
fix: encoding issue when calling local scheduler

### DIFF
--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -1,3 +1,4 @@
+%%% @doc A simple scheduler scheme for AO.
 %%% This device expects a message of the form:
 %%%     Process: `#{ id, Scheduler: #{ Authority } }'
 %%% <pre>

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -1,4 +1,3 @@
-%%% @doc A simple scheduler scheme for AO.
 %%% This device expects a message of the form:
 %%%     Process: `#{ id, Scheduler: #{ Authority } }'
 %%% <pre>
@@ -1314,7 +1313,7 @@ generate_local_schedule(Format, ProcID, From, To, Opts) ->
     % Determine and apply the formatting function to use for generation 
     % of the response, based on the `Accept' header.
     FormatterFun =
-        case Format of
+        case uri_string:percent_decode(Format) of
             <<"application/aos-2">> ->
                 fun dev_scheduler_formats:assignments_to_aos2/4;
             _ ->


### PR DESCRIPTION
This pr fixed the encoding uri format for the application/aos-2 setting.


