### PR TITLE
Rewrite cron@1.0 device and add cache persistence

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -29,6 +29,11 @@
             {add, cowboy, [{erl_opts, [{d, 'COWBOY_QUICER', 1}]}]},
             {add, gun, [{erl_opts, [{d, 'GUN_QUICER', 1}]}]}
         ]}
+    ]},
+    {lua_cache, [
+        {erl_opts, [
+            {d, 'ENABLE_LUA_CACHE', true}
+        ]}
     ]}
 ]}.
 

--- a/scripts/cron.lua
+++ b/scripts/cron.lua
@@ -80,11 +80,29 @@ function compute(process, message, opts)
     
     -- Command dispatch
     if command == "put" then
-        return handle_put_command(process, message)
+        local ok, new_process_or_err = pcall(handle_put_command, process, message)
+        if not ok then
+            ao.event("debug_cron",
+                     { "error", "Error handling put command", error = new_process_or_err })
+            return process
+        end
+        return new_process_or_err
     elseif command == "remove" then
-        return handle_remove_command(process, message)
+        local ok, new_process_or_err = pcall(handle_remove_command, process, message)
+        if not ok then
+            ao.event("debug_cron",
+                     { "error", "Error handling remove command", error = new_process_or_err })
+            return process
+        end
+        return new_process_or_err
     elseif command == "clear" then
-        return handle_clear_command(process)
+        local ok, new_process_or_err = pcall(handle_clear_command, process)
+        if not ok then
+            ao.event("debug_cron",
+                     { "error", "Error handling clear command", error = new_process_or_err })
+            return process
+        end
+        return new_process_or_err
     else
         ao.event("debug_cron", { "error", "Unknown command received", command = command, command_body = message.body.body })
         return process

--- a/scripts/cron.lua
+++ b/scripts/cron.lua
@@ -1,40 +1,67 @@
 function compute(process, message, opts)
     -- Early return when no body is provided
     -- This handles the initial invocation during process setup
-    if not message.body or not message.body.body then
+    if not message or not message.body or not message.body.body then
+        ao.event("debug_cron", { "error", "Initial message structure invalid", raw_message_body = message.body })
         return process
     end
-    
+    local cmd_body = message.body.body
+
+    if not cmd_body.path or type(cmd_body.path) ~= "string" then
+        ao.event("debug_cron", { "error", "Command body missing or invalid 'path'", received_body = cmd_body })
+        return process 
+    end
+    local command = cmd_body.path
+    ao.event("debug_cron", { "compute command", command })
+
     -- Initialize crons table if it doesn't exist
     process.crons = process.crons or {}
-    
-    local command = message.body.body.path
-    ao.event("debug_cron", { "compute command", command })
-    
+
     if command == "put" then
+        if not cmd_body.task_id or type(cmd_body.task_id) ~= "string" then
+            ao.event("debug_cron", { "error", "Invalid 'put': missing/invalid task_id", command_body = cmd_body })
+            return process
+        end
+        if not cmd_body.data or type(cmd_body.data) ~= "table" then
+            ao.event("debug_cron", { "error", "Invalid 'put': missing/invalid data", command_body = cmd_body })
+            return process
+        end
         -- Standard addition to the cache with task_id
-        ao.event("debug_cron", { "adding task", message.body.body.task_id })
-        table.insert(process.crons, message.body)
+        ao.event("debug_cron", { "adding task", cmd_body.task_id })
+        table.insert(process.crons, cmd_body)
         
     elseif command == "remove" then
+        if not cmd_body.task_id or type(cmd_body.task_id) ~= "string" then
+            ao.event("debug_cron", { "error", "Invalid 'remove': missing/invalid task_id", command_body = cmd_body })
+            return process
+        end
         -- Remove an entry by task_id
-        local task_id = message.body.body.task_id
-        ao.event("debug_cron", { "removing task", task_id, "process.crons", process.crons })
-        
+        local task_id_to_remove = cmd_body.task_id
+        ao.event("debug_cron", { "removing task", task_id_to_remove, "crons_count_before", #process.crons })
+
         -- Find and remove the task with matching task_id
-        for i, job in ipairs(process.crons) do
-            if job.body and job.body.task_id == task_id then
+        local removed = false
+        for i = #process.crons, 1, -1 do
+            local job_wrapper = process.crons[i] -- This is the Erlang 'message.body' from the 'put'
+            if job_wrapper and job_wrapper.body and job_wrapper.body.body and job_wrapper.body.body.task_id == task_id_to_remove then
                 table.remove(process.crons, i)
-				ao.event("debug_cron", { "removed task", task_id, "process.crons", process.crons })
-                break
+                ao.event("debug_cron", { "removed task", task_id_to_remove, "crons_count_after", #process.crons })
+                removed = true
+                break 
             end
         end
+        if not removed then
+            ao.event("debug_cron", { "warn", "Task not found for removal", task_id = task_id_to_remove })
+       end
         
     elseif command == "clear" then
         -- Clear all entries
         ao.event("debug_cron", { "clearing all tasks" })
         process.crons = {}
 
+    else
+        ao.event("debug_cron", { "error", "Unknown command received", command = command, command_body = cmd_body })
+        return process 
     end
     
     return process

--- a/scripts/cron.lua
+++ b/scripts/cron.lua
@@ -1,0 +1,41 @@
+function compute(process, message, opts)
+    -- Early return when no body is provided
+    -- This handles the initial invocation during process setup
+    if not message.body or not message.body.body then
+        return process
+    end
+    
+    -- Initialize crons table if it doesn't exist
+    process.crons = process.crons or {}
+    
+    local command = message.body.body.path
+    ao.event("debug_cron", { "compute command", command })
+    
+    if command == "put" then
+        -- Standard addition to the cache with task_id
+        ao.event("debug_cron", { "adding task", message.body.body.task_id })
+        table.insert(process.crons, message.body)
+        
+    elseif command == "remove" then
+        -- Remove an entry by task_id
+        local task_id = message.body.body.task_id
+        ao.event("debug_cron", { "removing task", task_id, "process.crons", process.crons })
+        
+        -- Find and remove the task with matching task_id
+        for i, job in ipairs(process.crons) do
+            if job.body and job.body.task_id == task_id then
+                table.remove(process.crons, i)
+				ao.event("debug_cron", { "removed task", task_id, "process.crons", process.crons })
+                break
+            end
+        end
+        
+    elseif command == "clear" then
+        -- Clear all entries
+        ao.event("debug_cron", { "clearing all tasks" })
+        process.crons = {}
+
+    end
+    
+    return process
+end

--- a/scripts/cron.lua
+++ b/scripts/cron.lua
@@ -1,68 +1,106 @@
+local handle_put_command
+local handle_remove_command
+local handle_clear_command
+
+-- Helper functions for validation
+local validate_initial_message = function(message)
+    if not message or not message.body or not message.body.body then
+        return false, { "error", "Initial message structure invalid", raw_message_body = message.body }
+    end
+
+    return true
+end
+
+local validate_command_body = function(cmd_body)
+    if not cmd_body.path or type(cmd_body.path) ~= "string" then
+        return false, { "error", "Command body missing or invalid path", received_body = cmd_body }
+    end
+
+    return true
+end
+
+-- Command handlers
+local handle_put_command = function(process, cmd_body)
+    if not cmd_body.task_id or type(cmd_body.task_id) ~= "string" then
+        ao.event("debug_cron", { "error", "Invalid put: missing/invalid task_id", command_body = cmd_body })
+        return process
+    end
+
+    if not cmd_body.data or type(cmd_body.data) ~= "table" then
+        ao.event("debug_cron", { "error", "Invalid put: missing/invalid data", command_body = cmd_body })
+        return process
+    end
+
+    ao.event("debug_cron", { "adding task", cmd_body.task_id })
+    table.insert(process.crons, cmd_body) 
+    return process
+end
+
+local handle_remove_command = function(process, cmd_body)
+    if not cmd_body.task_id or type(cmd_body.task_id) ~= "string" then
+        ao.event("debug_cron", { "error", "Invalid remove: missing/invalid task_id", command_body = cmd_body })
+        return process
+    end
+
+    local task_id_to_remove = cmd_body.task_id
+    ao.event("debug_cron", { "removing task", task_id_to_remove, "crons_count_before", #process.crons })
+
+    local removed = false
+    for i = #process.crons, 1, -1 do
+        local job = process.crons[i] 
+        if job and job.task_id == task_id_to_remove then 
+            table.remove(process.crons, i)
+            ao.event("debug_cron", { "removed task", task_id_to_remove, "crons_count_after", #process.crons })
+            removed = true
+            break 
+        end
+    end
+
+    if not removed then
+         ao.event("debug_cron", { "warn", "Task not found for removal", task_id = task_id_to_remove })
+    end
+
+    return process
+end
+
+local handle_clear_command = function(process)
+    ao.event("debug_cron", { "clearing all tasks" })
+    process.crons = nil 
+    collectgarbage() 
+    process.crons = {}
+    return process
+end
+
 function compute(process, message, opts)
     -- Early return when no body is provided
     -- This handles the initial invocation during process setup
-    if not message or not message.body or not message.body.body then
-        ao.event("debug_cron", { "error", "Initial message structure invalid", raw_message_body = message.body })
+    -- Validation of the initial message
+    local is_valid, validation_error_details = validate_initial_message(message)
+    if not is_valid then
+        ao.event("debug_cron", validation_error_details)
         return process
     end
-    local cmd_body = message.body.body
 
-    if not cmd_body.path or type(cmd_body.path) ~= "string" then
-        ao.event("debug_cron", { "error", "Command body missing or invalid 'path'", received_body = cmd_body })
-        return process 
+    local cmd_body = message.body.body
+    is_valid, validation_error_details = validate_command_body(cmd_body)
+    if not is_valid then
+        ao.event("debug_cron", validation_error_details)
+        return process
     end
+
     local command = cmd_body.path
     ao.event("debug_cron", { "compute command", command })
-
     -- Initialize crons table if it doesn't exist
     process.crons = process.crons or {}
-
+    -- Command processing
     if command == "put" then
-        if not cmd_body.task_id or type(cmd_body.task_id) ~= "string" then
-            ao.event("debug_cron", { "error", "Invalid 'put': missing/invalid task_id", command_body = cmd_body })
-            return process
-        end
-        if not cmd_body.data or type(cmd_body.data) ~= "table" then
-            ao.event("debug_cron", { "error", "Invalid 'put': missing/invalid data", command_body = cmd_body })
-            return process
-        end
-        -- Standard addition to the cache with task_id
-        ao.event("debug_cron", { "adding task", cmd_body.task_id })
-        table.insert(process.crons, cmd_body)
-        
+        return handle_put_command(process, cmd_body)     
     elseif command == "remove" then
-        if not cmd_body.task_id or type(cmd_body.task_id) ~= "string" then
-            ao.event("debug_cron", { "error", "Invalid 'remove': missing/invalid task_id", command_body = cmd_body })
-            return process
-        end
-        -- Remove an entry by task_id
-        local task_id_to_remove = cmd_body.task_id
-        ao.event("debug_cron", { "removing task", task_id_to_remove, "crons_count_before", #process.crons })
-
-        -- Find and remove the task with matching task_id
-        local removed = false
-        for i = #process.crons, 1, -1 do
-            local job_wrapper = process.crons[i] -- This is the Erlang 'message.body' from the 'put'
-            if job_wrapper and job_wrapper.body and job_wrapper.body.body and job_wrapper.body.body.task_id == task_id_to_remove then
-                table.remove(process.crons, i)
-                ao.event("debug_cron", { "removed task", task_id_to_remove, "crons_count_after", #process.crons })
-                removed = true
-                break 
-            end
-        end
-        if not removed then
-            ao.event("debug_cron", { "warn", "Task not found for removal", task_id = task_id_to_remove })
-       end
-        
+        return handle_remove_command(process, cmd_body)
     elseif command == "clear" then
-        -- Clear all entries
-        ao.event("debug_cron", { "clearing all tasks" })
-        process.crons = {}
-
+        return handle_clear_command(process)
     else
         ao.event("debug_cron", { "error", "Unknown command received", command = command, command_body = cmd_body })
         return process 
     end
-    
-    return process
 end

--- a/scripts/cron.lua
+++ b/scripts/cron.lua
@@ -45,19 +45,21 @@ local handle_remove_command = function(process, cmd_body)
     local task_id_to_remove = cmd_body.task_id
     ao.event("debug_cron", { "removing task", task_id_to_remove, "crons_count_before", #process.crons })
 
-    local removed = false
-    for i = #process.crons, 1, -1 do
-        local job = process.crons[i] 
-        if job and job.task_id == task_id_to_remove then 
-            table.remove(process.crons, i)
-            ao.event("debug_cron", { "removed task", task_id_to_remove, "crons_count_after", #process.crons })
-            removed = true
-            break 
+    -- Find the index of the task to remove.
+    local idx_to_remove = nil
+    for i, job in ipairs(process.crons) do
+        if job.task_id == task_id_to_remove then
+            idx_to_remove = i
+            break
         end
     end
-
-    if not removed then
-         ao.event("debug_cron", { "warn", "Task not found for removal", task_id = task_id_to_remove })
+    
+    -- If an index is found, remove the task. Otherwise, log a warning.
+    if idx_to_remove then
+        table.remove(process.crons, idx_to_remove)
+        ao.event("debug_cron", { "removed task", task_id_to_remove, "crons_count_after", #process.crons })
+    else
+        ao.event("debug_cron", { "warn", "Task not found for removal", task_id = task_id_to_remove })
     end
 
     return process

--- a/scripts/lua-cache-test.lua
+++ b/scripts/lua-cache-test.lua
@@ -4,6 +4,9 @@
 -- @param map_to_write The Lua table/map to write
 -- @return The result table from ao.cache_write (e.g., { status = "ok", value = "id_string" })
 function write_test(map_to_write)
+    if map_to_write == nil then
+        return { status = "error", reason = "map_to_write is nil" }
+    end
 	ao.event("cache_test_lua", {"test_write called", {map=map_to_write}})
 	-- ao.cache_write now returns multiple values in Lua (status, value_or_reason)
 	-- based on the Erlang list [Status, ValueOrReason]
@@ -23,6 +26,9 @@ end
 -- @param id_or_path The ID or path string
 -- @return The result table from ao.cache_read (e.g., { status = "ok", value = map } or {status="not_found"})
 function read_test(id_or_path)
+    if id_or_path == nil then
+        return { status = "error", reason = "id_or_path is nil" }
+    end
 	ao.event("cache_test_lua", {"test_read called", {id=id_or_path}})
 	-- ao.cache_read returns multiple values (status, value_or_reason)
 	-- OR just one value ('not_found')
@@ -39,4 +45,19 @@ function read_test(id_or_path)
 	  -- Error case: status="error", value_or_reason=ReasonMap
 	  return { status = status, reason = value_or_reason }
 	end
+end
+
+-- Test the cache functions
+function test_cache()
+    -- Test writing a map
+    local map_to_write = {
+        test_key = "test_value"
+    }
+    local result = write_test(map_to_write)
+    ao.event("cache_test_lua", {"test_write result", {result=result}})
+
+    -- Test reading the map
+    local id_or_path = result.value
+    local read_result = read_test(id_or_path)
+    ao.event("cache_test_lua", {"test_read result", {result=read_result}})
 end

--- a/scripts/lua-cache-test.lua
+++ b/scripts/lua-cache-test.lua
@@ -1,0 +1,42 @@
+--- Test functions for ao.cache.* bindings
+--- 
+-- Writes a map using ao.cache_write
+-- @param map_to_write The Lua table/map to write
+-- @return The result table from ao.cache_write (e.g., { status = "ok", value = "id_string" })
+function write_test(map_to_write)
+	ao.event("cache_test_lua", {"test_write called", {map=map_to_write}})
+	-- ao.cache_write now returns multiple values in Lua (status, value_or_reason)
+	-- based on the Erlang list [Status, ValueOrReason]
+	local status, value_or_reason = ao.cache_write(map_to_write)
+	ao.event("cache_test_lua", {"test_write raw result", {status=status, value_or_reason=value_or_reason}})
+  
+	if status == "ok" then
+	  -- On success, value_or_reason is the ID
+	  return { status = status, value = value_or_reason }
+	else
+	  -- On error, value_or_reason is the ReasonMap
+	  return { status = status, reason = value_or_reason }
+	end
+end
+  
+-- Reads data using ao.cache_read
+-- @param id_or_path The ID or path string
+-- @return The result table from ao.cache_read (e.g., { status = "ok", value = map } or {status="not_found"})
+function read_test(id_or_path)
+	ao.event("cache_test_lua", {"test_read called", {id=id_or_path}})
+	-- ao.cache_read returns multiple values (status, value_or_reason)
+	-- OR just one value ('not_found')
+	local status, value_or_reason = ao.cache_read(id_or_path)
+	ao.event("cache_test_lua", {"test_read raw result", {status=status, value_or_reason=value_or_reason}})
+  
+	if status == "ok" then
+	   -- Success case: value_or_reason holds the actual data
+	  return { status = status, value = value_or_reason }
+	elseif status == "not_found" then
+	  -- Not found case: Erlang returned [not_found], so Lua receives status="not_found", value_or_reason=nil
+	  return { status = status }
+	else
+	  -- Error case: status="error", value_or_reason=ReasonMap
+	  return { status = status, reason = value_or_reason }
+	end
+end

--- a/src/dev_cron.erl
+++ b/src/dev_cron.erl
@@ -1,14 +1,16 @@
 %%% @doc A device that inserts new messages into the schedule to allow processes
 %%% to passively 'call' themselves without user interaction.
 -module(dev_cron).
--export([once/3, every/3, stop/3, info/1, info/3]).
+-export([list/3, once/3, every/3, stop/3, info/1, info/3]).
+-export([normalize/3]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 %% @doc Exported function for getting device info.
 info(_) -> 
-	#{ exports => [info, once, every, stop] }.
+	#{ exports => [info, once, every, stop, add, load, normalize] }.
 
+%% @doc Exported function for granting a description of the device.
 info(_Msg1, _Msg2, _Opts) ->
 	InfoBody = #{
 		<<"description">> => <<"Cron device for scheduling messages">>,
@@ -17,10 +19,164 @@ info(_Msg1, _Msg2, _Opts) ->
 			<<"info">> => <<"Get device info">>,
 			<<"once">> => <<"Schedule a one-time message">>,
 			<<"every">> => <<"Schedule a recurring message">>,
-			<<"stop">> => <<"Stop a scheduled task {task}">>
+			<<"stop">> => <<"Stop a scheduled task {task}">>,
+			<<"list">> => <<"List all registered cron tasks">>,
+			<<"normalize">> => <<"Boostrap cron jobs from cache">>
 		}
 	},
 	{ok, #{<<"status">> => 200, <<"body">> => InfoBody}}.
+
+
+%% @doc Modify a given node message to include the cron process.
+cron_opts(Opts) ->
+    {ok, Script} = file:read_file("scripts/cron.lua"),
+    CronProcDef = #{
+        <<"device">> => <<"process@1.0">>,
+        <<"execution-device">> => <<"lua@5.3a">>,
+        <<"function">> => <<"compute">>,
+        <<"module">> => #{
+            <<"content-type">> => <<"application/lua">>,
+            <<"body">> => Script
+        }
+    },
+    ?event({debug_cron_opts, {cron_process_def, CronProcDef}}),
+    Opts#{
+        node_processes =>
+            (hb_opts:get(node_processes, #{}, Opts))#{
+                <<"cron">> => CronProcDef
+            }
+    }.
+
+%% @doc Normalize the cron jobs from cache by attempting to restart them.
+normalize(Msg1, _Msg2, Opts) ->
+	?event({normalize_cron_jobs_start}),
+    CronOpts = cron_opts(Opts),
+    case cache_list(CronOpts) of
+		{ok, Crons} -> 
+			?event({normalize_cron_jobs_loaded, {count, length(Crons)}}),
+            {Successes, Errors} = process_cached_jobs(Crons, Msg1, CronOpts),
+            NumSuccess = length(Successes),
+            ErrorDetails = Errors,
+            ?event({normalize_cron_jobs_finished, 
+				{success_or_existing, NumSuccess}, 
+				{errors, length(ErrorDetails)}, 
+				{error_details, ErrorDetails}}),
+			{ok, #{
+				<<"restarted_or_existing">> => NumSuccess, 
+				<<"errors">> => ErrorDetails
+			}};
+		{error, Reason} ->
+			 ?event({normalize_cron_jobs_load_error, {error, Reason}}),
+             {error, Reason}
+	end.
+
+%% Helper function to process the list of cached cron jobs
+process_cached_jobs(Crons, Msg1, CronOpts) ->
+    Results = lists:map(
+        fun(Job) -> 
+            process_single_job(Job, Msg1, CronOpts)
+        end, Crons
+    ),
+    lists:partition(
+		fun({ok, _}) -> true; 
+		(_) -> false end, 
+		Results).
+
+%% Helper function to process a single cached job entry
+process_single_job(Job, Msg1, CronOpts) ->
+    case extract_job_details(Job) of
+        {ok, DetailsMap} ->
+            case reconstruct_original_msg(DetailsMap) of
+                {ok, OriginalMsg} ->
+                    attempt_job_restart(DetailsMap, OriginalMsg, Msg1, CronOpts);
+                {error, Reason} ->
+                    TaskId = maps:get(task_id, DetailsMap, unknown),
+                    {error, {TaskId, Reason}}
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% Helper function to extract and validate details from a raw cache job entry
+extract_job_details(Job) ->
+    Body = maps:get(<<"body">>, Job, #{}),
+    TaskId = maps:get(<<"task_id">>, Body, undefined),
+    AugmentedData = maps:get(<<"data">>, Body, #{}),
+    Type = maps:get(<<"type">>, AugmentedData, undefined),
+    Interval = maps:get(<<"interval">>, AugmentedData, undefined),
+    WorkerMsg = maps:get(<<"worker_msg">>, AugmentedData, #{}),
+    if TaskId == undefined orelse Type == undefined orelse not is_map(WorkerMsg) orelse WorkerMsg == #{} ->
+        ?event({normalize_skipping_invalid_job, {reason, invalid_structure}, {raw_job, Job}}),
+        {error, {unknown_task_id, invalid_job_structure}};
+       true ->
+            {ok, #{ task_id => TaskId, type => Type, interval => Interval, worker_msg => WorkerMsg }}
+    end.
+
+%% Helper function to reconstruct the original message for once/every from cached details
+reconstruct_original_msg(DetailsMap) ->
+    #{ task_id := TaskId, type := Type, interval := Interval, worker_msg := WorkerMsg } = DetailsMap,
+    TargetPath = maps:get(<<"path">>, WorkerMsg, undefined),
+    if TargetPath == undefined ->
+        ?event({normalize_skipping_no_target_path, {task_id, TaskId}, {worker_msg, WorkerMsg}}),
+        {error, no_target_path};
+       true ->
+            OtherParams = maps:remove(<<"path">>, WorkerMsg),
+            OriginalMsg0 = maps:put(<<"cron-path">>, TargetPath, OtherParams),
+            OriginalMsg1 = case Type of
+                               <<"every">> when Interval =/= null andalso Interval =/= undefined -> 
+                                   maps:put(<<"interval">>, Interval, OriginalMsg0);
+                               _ -> OriginalMsg0
+                           end,
+            OriginalMsgPath = <<"/~cron@1.0/", Type/binary>>,
+            OriginalMsg = maps:put(<<"path">>, OriginalMsgPath, OriginalMsg1),
+            {ok, OriginalMsg}
+    end.
+
+%% Helper function to attempt the restart of a single job
+attempt_job_restart(DetailsMap, OriginalMsg, Msg1, CronOpts) ->
+    #{ task_id := TaskId, type := Type } = DetailsMap,
+    %?event({normalize_attempting_restart, {task_id, TaskId}, {type, Type}, {original_msg_preview, OriginalMsg#{ 
+    %     commitments => commitments
+    % }}}),
+    case Type of
+        <<"once">> -> 
+            case once(Msg1, OriginalMsg, CronOpts) of
+                {ok, ReturnedId} -> 
+                     % Success if original ID matches OR a new ID was returned (idempotency handled)
+                    ?event({normalize_once_success, {task_id, TaskId}, {returned_id, ReturnedId}}),
+                    {ok, TaskId};
+                Error -> 
+                    ?event({normalize_once_error, {task_id, TaskId}, {error, Error}}),
+                    {error, {TaskId, Error}}
+            end;
+        <<"every">> -> 
+            case every(Msg1, OriginalMsg, CronOpts) of
+                 {ok, ReturnedId} -> 
+                     % Success if original ID matches OR a new ID was returned (idempotency handled)
+                    ?event({normalize_every_success, {task_id, TaskId}, {returned_id, ReturnedId}}),
+                    {ok, TaskId};
+                Error -> 
+                    ?event({normalize_every_error, {task_id, TaskId}, {error, Error}}),
+                    {error, {TaskId, Error}}
+            end;
+        _ ->
+            ?event({normalize_unknown_type, {task_id, TaskId}, {type, Type}}),
+            {error, {TaskId, unknown_type}}
+    end.
+
+%% @doc List all registered cron tasks.
+list(_, _, Opts) ->
+    CronOpts = cron_opts(Opts),
+    ?event({list_cron_jobs_start, {cron_opts, CronOpts}}),
+    case cache_list(CronOpts) of
+        {ok, Crons} ->
+            ?event({list_cron_jobs_success, {crons, Crons}}),
+            {ok, #{<<"crons">> => Crons}};
+        {error, Reason} ->
+            ?event({list_cron_jobs_error, {error, Reason}}),
+            {error, Reason}
+    end.
+
 
 %% @doc Exported function for scheduling a one-time message.
 once(_Msg1, Msg2, Opts) ->
@@ -36,9 +192,28 @@ once(_Msg1, Msg2, Opts) ->
                     maps:put(<<"path">>, CronPath, Msg2)
                 ),
 			Name = {<<"cron@1.0">>, ReqMsgID},
-			Pid = spawn(fun() -> once_worker(CronPath, ModifiedMsg2, Opts) end),
-			hb_name:register(Name, Pid),
-			{ok, ReqMsgID}
+			case hb_name:lookup(Name) of
+				Pid when is_pid(Pid) ->
+					% Process already registered, return existing TaskID
+					?event({once_already_registered, {task_id, ReqMsgID}, {pid, Pid}}),
+					{ok, ReqMsgID};
+				undefined ->
+					% Process not found, spawn and register
+					Pid = spawn(fun() -> once_worker(CronPath, ModifiedMsg2, Opts) end),
+					hb_name:register(Name, Pid),
+					% Define the data structure for the cache
+					MinimalAugmentedData = #{ 
+						<<"type">> => <<"once">>,
+						<<"interval">> => null, % No interval for 'once'
+						<<"worker_msg">> => ModifiedMsg2 
+					},
+					% Cache the augmented task data
+					{ok, PutResult} = cache_put(ReqMsgID, MinimalAugmentedData, cron_opts(Opts)),
+					?event({once_cache_put_result, {result, PutResult}}),
+					% {ok, Crons} = cache_list(cron_opts(Opts)),
+					% ?event({once_cron_cache_load_test_crons, {crons, Crons}}),
+					{ok, ReqMsgID}
+			end
 	end.
 
 %% @doc Internal function for scheduling a one-time message.
@@ -85,20 +260,37 @@ every(_Msg1, Msg2, Opts) ->
                         maps:remove(<<"interval">>, Msg2)
                     ),
 				TracePID = hb_tracer:start_trace(),
-				Pid =
-                    spawn(
-                        fun() ->
-                            every_worker_loop(
-                                CronPath,
-                                ModifiedMsg2,
-                                Opts#{ trace => TracePID },
-                                IntervalMillis
-                            )
-                        end
-                    ),
 				Name = {<<"cron@1.0">>, ReqMsgID},
-				hb_name:register(Name, Pid),
-				{ok, ReqMsgID}
+				case hb_name:lookup(Name) of
+					Pid when is_pid(Pid) ->
+						% Process already registered, return existing TaskID
+						?event({every_already_registered, {task_id, ReqMsgID}, {pid, Pid}}),
+						{ok, ReqMsgID};
+					undefined ->
+						% Process not found, spawn and register
+						Pid =
+		                    spawn(
+		                        fun() ->
+		                            every_worker_loop(
+		                                CronPath,
+		                                ModifiedMsg2,
+		                                Opts#{ trace => TracePID },
+		                                IntervalMillis
+		                            )
+		                        end
+		                    ),
+						hb_name:register(Name, Pid),
+						% Define the data structure for the cache
+						MinimalAugmentedData = #{ 
+							<<"type">> => <<"every">>,
+							<<"interval">> => IntervalString,
+							<<"worker_msg">> => ModifiedMsg2 
+						},
+						% Cache the augmented task data
+						{ok, PutResult} = cache_put(ReqMsgID, MinimalAugmentedData, cron_opts(Opts)),
+						?event({every_cache_put_result, {result, PutResult}}),
+						{ok, ReqMsgID}
+				end
 			catch
 				error:{invalid_time_unit, Unit} ->
                     {error, <<"Invalid time unit: ", Unit/binary>>};
@@ -108,35 +300,6 @@ every(_Msg1, Msg2, Opts) ->
 					{error, {<<"Error parsing interval">>, Reason}}
 			end
 	end.
-
-%% @doc Exported function for stopping a scheduled task.
-stop(_Msg1, Msg2, Opts) ->
-	case hb_ao:get(<<"task">>, Msg2, Opts) of
-		not_found ->
-			{error, <<"No task ID found in message.">>};
-		TaskID ->
-			Name = {<<"cron@1.0">>, TaskID},
-			case hb_name:lookup(Name) of
-				Pid when is_pid(Pid) ->
-					?event({cron_stopping_task, {task_id, TaskID}, {pid, Pid}}),
-					exit(Pid, kill),
-					hb_name:unregister(Name),
-					{ok, #{<<"status">> => 200, <<"body">> => #{
-						<<"message">> => <<"Task stopped successfully">>,
-						<<"task_id">> => TaskID
-					}}};
-				undefined ->
-					{error, <<"Task not found.">>};
-				Error ->
-					?event({cron_stop_lookup_error, {task_id, TaskID}, {error, Error}}),
-					{error, #{
-                        <<"error">> =>
-                            <<"Failed to lookup task or unexpected result">>,
-                            <<"details">> => Error
-                    }}
-			end
-	end.
-
 every_worker_loop(CronPath, Req, Opts, IntervalMillis) ->
 	ReqSingleton = Req#{ <<"path">> => CronPath },
 	?event(
@@ -161,6 +324,37 @@ every_worker_loop(CronPath, Req, Opts, IntervalMillis) ->
 	timer:sleep(IntervalMillis),
 	every_worker_loop(CronPath, Req, Opts, IntervalMillis).
 
+
+%% @doc Exported function for stopping a scheduled task.
+stop(_Msg1, Msg2, Opts) ->
+	case hb_ao:get(<<"task">>, Msg2, Opts) of
+		not_found ->
+			{error, <<"No task ID found in message.">>};
+		TaskID ->
+			Name = {<<"cron@1.0">>, TaskID},
+			case hb_name:lookup(Name) of
+				Pid when is_pid(Pid) ->
+					?event({cron_stopping_task, {task_id, TaskID}, {pid, Pid}}),
+					exit(Pid, kill),
+					hb_name:unregister(Name),
+					{ok, RemoveResult} = cache_remove(TaskID, cron_opts(Opts)),
+					?event({stop_cache_remove_result, {result, RemoveResult}}),
+					{ok, #{<<"status">> => 200, <<"body">> => #{
+						<<"message">> => <<"Task stopped successfully">>,
+						<<"task_id">> => TaskID
+					}}};
+				undefined ->
+					{error, <<"Task not found.">>};
+				Error ->
+					?event({cron_stop_lookup_error, {task_id, TaskID}, {error, Error}}),
+					{error, #{
+                        <<"error">> =>
+                            <<"Failed to lookup task or unexpected result">>,
+                            <<"details">> => Error
+                    }}
+			end
+	end.
+
 %% @doc Parse a time string into milliseconds.
 parse_time(BinString) ->
 	[AmountStr, UnitStr] = binary:split(BinString, <<"-">>),
@@ -175,11 +369,144 @@ parse_time(BinString) ->
 		_ -> throw({error, invalid_time_unit, UnitStr})
 	end.
 
-%%% Tests
 
+%% Cache functions and helpers
+%% @doc Helper function to send commands to the cron process
+send_cron_command(Command, Body, Opts) ->
+    SampleMsg = [
+        #{ <<"device">> => <<"node-process@1.0">> },
+        <<"cron">>,
+        #{
+            <<"path">> => <<"schedule">>,
+            <<"method">> => <<"POST">>,
+            <<"body">> =>
+                hb_message:commit(
+                    #{
+                        <<"path">> => <<"compute">>,
+                        <<"body">> => Body#{<<"path">> => Command}
+                    },
+                    Opts
+                )
+        }
+    ],
+    Result = hb_ao:resolve_many(SampleMsg, Opts),
+    ?event({cron_command_result, {command, Command}, {result, Result}}),
+    Result.
+
+%% @doc Put a value in the cache with the specified task ID
+%% Returns {ok, TaskId} on success
+cache_put(TaskId, AugmentedData, Opts) ->
+	?event({cache_put_start, {task_id, TaskId}, {augmented_data, AugmentedData}}),
+    send_cron_command(
+		<<"put">>,
+		#{ 
+			<<"task_id">> => TaskId,
+        	<<"data">> => AugmentedData % Pass the augmented data map
+    	},
+		Opts
+	),
+	{ok, TaskId}.
+
+%% @doc Get a value from the cache by task ID
+%% Returns {ok, Value} if found, {error, not_found} otherwise
+cache_get(TaskId, Opts) ->
+    AllJobs = hb_ao:get(
+        << "cron/now/crons" >>,
+        #{ <<"device">> => <<"node-process@1.0">> },
+        Opts
+    ),
+    find_job_by_task_id(AllJobs, TaskId).
+
+%% @doc Remove a value from the cache by task ID
+%% Returns {ok, removed} if successful
+cache_remove(TaskId, Opts) ->
+    send_cron_command(
+		<<"remove">>, 
+		#{
+        	<<"task_id">> => TaskId
+    	}, 
+	Opts),
+{ok, removed}.
+
+cache_list(Opts) ->
+	?event({cache_list_OG_start}),
+	SampleMsg = [
+		#{ <<"device">> => <<"node-process@1.0">> },
+		<<"cron">>,
+		#{ 
+			<<"path">> => <<"now/crons">>, 
+			<<"method">> => <<"GET">> 
+		}
+	],
+	{ok, Result} = hb_ao:resolve_many(SampleMsg, Opts),
+	CronData = hb_ao:get(<<"crons">>, Result, #{}),
+	?event({cache_list_cron_data, {cron_data, CronData}}),
+    case is_list(CronData) of
+        true -> {ok, CronData};
+        false -> {error, CronData}
+    end.
+
+%% @doc Clear all values from the cache
+%% Returns {ok, cleared} on success
+cache_clear(Opts) ->
+    send_cron_command(<<"clear">>, #{}, Opts),
+    {ok, cleared}.
+
+%% @doc Helper function to find a job by task ID in a list of jobs
+find_job_by_task_id([], _) ->
+    {error, not_found};
+
+find_job_by_task_id([Job|Rest], TaskId) ->
+	?event({find_job_by_task_id, {job, Job}, {task_id, TaskId}}),
+    case hb_ao:get(<<"body/task_id">>, Job, #{}) of
+        TaskId -> 
+            JobData = hb_ao:get(<<"body/data">>, Job, #{}),
+            ?event({found_job_by_task_id_job_data, {job_data, JobData}}),
+            {ok, JobData};
+        _ -> find_job_by_task_id(Rest, TaskId)
+    end.
+
+
+%%%
+%%% Cron device tests
+%%%
+% Helper functions to generate test opts
+generate_test_opts() ->
+	{ok, Script} = file:read_file("scripts/cron.lua"),
+	generate_test_opts(#{
+		<<"cron">> => #{
+			<<"device">> => <<"process@1.0">>,
+			<<"execution-device">> => <<"lua@5.3a">>,
+			<<"scheduler-device">> => <<"scheduler@1.0">>,
+			<<"module">> => #{
+				<<"content-type">> => <<"application/lua">>,
+				<<"body">> => Script
+			}
+		}
+	}).
+generate_test_opts(Defs) ->
+#{
+	store =>
+		[
+			#{
+				<<"store-module">> => hb_store_fs,
+				<<"prefix">> =>
+					<<
+						"cache-TEST-",
+						(integer_to_binary(os:system_time(millisecond)))/binary
+					>>
+			}
+		],
+	node_processes => Defs,
+	priv_wallet => ar_wallet:new()
+}.
+
+%% @doc This test verifies that a one-time task can be stopped by
+%% calling the stop function with the task ID.
 stop_once_test() ->
+	Opts = generate_test_opts(),
 	% Start a new node
-	Node = hb_http_server:start_node(),
+	Node = hb_http_server:start_node(Opts),
 	% Set up a standard test worker (even though delay doesn't use its state)
 	TestWorkerPid = spawn(fun test_worker/0),
 	TestWorkerNameId = hb_util:human_id(crypto:strong_rand_bytes(32)),
@@ -208,7 +535,6 @@ stop_once_test() ->
 	timer:sleep(100),
 	% Verify process termination
 	?assertNot(erlang:is_process_alive(OncePid), "Process not killed by stop"),
-	
 	% Call stop again to verify 404 response
 	{error, <<"Task not found.">>} = hb_http:get(Node, OnceStopPath, #{}).
 
@@ -216,8 +542,9 @@ stop_once_test() ->
 %% @doc This test verifies that a recurring task can be stopped by
 %% calling the stop function with the task ID.
 stop_every_test() ->
+	Opts = generate_test_opts(),
 	% Start a new node
-	Node = hb_http_server:start_node(),
+	Node = hb_http_server:start_node(Opts),
 	% Set up a test worker process to hold state (counter)
 	TestWorkerPid = spawn(fun test_worker/0),
 	TestWorkerNameId = hb_util:human_id(crypto:strong_rand_bytes(32)),
@@ -261,8 +588,9 @@ stop_every_test() ->
 
 %% @doc This test verifies that a one-time task can be scheduled and executed.
 once_executed_test() ->
+	Opts = generate_test_opts(),
 	% start a new node 
-	Node = hb_http_server:start_node(),
+	Node = hb_http_server:start_node(Opts),
 	% spawn a worker on the new node that calls test_worker/0 which inits
     % test_worker/1 with a state of undefined
 	PID = spawn(fun test_worker/0),
@@ -275,7 +603,10 @@ once_executed_test() ->
 			"&cron-path=/~test-device@1.0/update_state">>,
 	% this should call the worker via the test device
 	% the test device should look up the worker via the id given 
-	{ok, _ReqMsgId} = hb_http:get(Node, UrlPath, #{}),
+	{ok, ReqMsgId1} = hb_http:get(Node, UrlPath, #{}),
+	% Call again to test idempotency
+	{ok, ReqMsgId2} = hb_http:get(Node, UrlPath, #{}),
+	?assertEqual(ReqMsgId1, ReqMsgId2, "Second call should return the same Task ID"),
 	% wait for the request to be processed
 	timer:sleep(1000),
 	% send a message to the worker to get the state
@@ -293,7 +624,8 @@ once_executed_test() ->
 
 %% @doc This test verifies that a recurring task can be scheduled and executed.
 every_worker_loop_test() ->
-	Node = hb_http_server:start_node(),
+	Opts = generate_test_opts(),
+	Node = hb_http_server:start_node(Opts),
 	PID = spawn(fun test_worker/0),
 	ID = hb_util:human_id(crypto:strong_rand_bytes(32)),
 	hb_name:register({<<"test">>, ID}, PID),
@@ -301,8 +633,12 @@ every_worker_loop_test() ->
 		"&interval=500-milliseconds",
 		"&cron-path=/~test-device@1.0/increment_counter">>,
 	?event({'cron:every:test:sendUrl', {url_path, UrlPath}}),
-	{ok, ReqMsgId} = hb_http:get(Node, UrlPath, #{}),
-	?event({'cron:every:test:get_done', {req_id, ReqMsgId}}),
+	{ok, ReqMsgId1} = hb_http:get(Node, UrlPath, #{}),
+	?event({'cron:every:test:get_done', {req_id, ReqMsgId1}}),
+	% Call again to test idempotency
+	{ok, ReqMsgId2} = hb_http:get(Node, UrlPath, #{}),
+	?assertEqual(ReqMsgId1, ReqMsgId2, "Second call should return the same Task ID"),
+	?event({'cron:every:test:idempotency_check_done', {req_id, ReqMsgId2}}),
 	timer:sleep(1500),
 	PID ! {get, self()},
 	% receive the state from the worker
@@ -315,7 +651,89 @@ every_worker_loop_test() ->
 		?event({'cron:every:test:timeout', {pid, PID}, {lookup_result, FinalLookup}}),
 		throw({test_timeout_waiting_for_state, {id, ID}})
 	end.
-	
+
+%% @doc Test that verifies a one-time job is added to 
+%% the cron cache and can be loaded via the load endpoint
+once_cron_cache_load_test() ->
+    Opts = generate_test_opts(),
+    % Start a new node with test options
+    Node = hb_http_server:start_node(Opts),
+    % Create a test worker
+    PID = spawn(fun test_worker/0),
+    ID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    hb_name:register({<<"test">>, ID}, PID),
+    % Create a "once" task
+    UrlPath = <<"/~cron@1.0/once?test-id=", ID/binary,
+              "&cron-path=/~test-device@1.0/update_state">>,
+    {ok, ReqMsgId} = hb_http:get(Node, UrlPath, #{}),
+    ?event({once_load_test_created, {task_id, ReqMsgId}}),
+    % Wait for the task to be processed
+    timer:sleep(1000),
+	% Use the cache list function to retrieve cron jobs
+	{ok, Crons} = cache_list(Opts),
+	?event({once_cron_cache_load_test_crons, {crons, Crons}}),
+    % % Use the load function to retrieve cron jobs
+	{ok, LoadedCrons} = hb_ao:resolve_many(
+        hb_singleton:from(#{
+            <<"path">> => <<"/~cron@1.0/load">>
+        }),
+        Opts
+    ),
+    ?event({once_load_test_loaded, {loaded_crons, LoadedCrons}}),
+    % Extract the list of cron jobs from the result map
+    CronsList = hb_ao:get(<<"crons">>, LoadedCrons, #{}),
+    ?event({once_load_test_extracted, {crons_list, CronsList}}),
+    % Verify the task is in the loaded list
+    ?assertMatch({ok, _}, find_job_by_task_id(CronsList, ReqMsgId)),
+    ?event({'once_load_test_done'}).
+
+%% @doc Test that verifies a recurring job is added to
+%% the cron cache and can be loaded via cache_list.
+every_cron_cache_load_test() ->
+    Opts = generate_test_opts(),
+    % Start a new node with test options
+    Node = hb_http_server:start_node(Opts),
+    % Create a test worker
+    PID = spawn(fun test_worker/0),
+    ID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    hb_name:register({<<"test">>, ID}, PID),
+    % Create an "every" task
+    UrlPath = <<"/~cron@1.0/every?test-id=", ID/binary,
+              "&interval=500-milliseconds", % Specify interval
+              "&cron-path=/~test-device@1.0/increment_counter">>, % Specify target path
+    {ok, ReqMsgId} = hb_http:get(Node, UrlPath, #{}),
+    ?event({every_load_test_created, {task_id, ReqMsgId}}),
+    % Wait for the task to be processed and added to the cache
+    timer:sleep(100), % Short sleep just to ensure cache_put completes
+    % Use the cache list function to retrieve cron jobs
+    {ok, Crons} = cache_list(Opts),
+    ?event({every_cron_cache_load_test_crons, {crons, Crons}}),
+    % Verify the task is in the loaded list
+    ?assertMatch({ok, _}, find_job_by_task_id(Crons, ReqMsgId)),
+    ?event({'every_load_test_done'}).
+
+cron_device_load_test() ->
+	% this test checks whether the cron load function returns 
+	% the correct data
+	Opts = generate_test_opts(),
+	Node = hb_http_server:start_node(Opts),
+	TaskId = <<"load-test-task-id">>,
+	TestData = #{<<"key">> => <<"value">>, <<"timestamp">> => os:system_time(millisecond)},
+	{ok, _PutResult} = cache_put(TaskId, TestData, Opts),
+	TaskId2 = <<"load-test-task-id-2">>,
+	TestData2 = #{<<"key">> => <<"value-2">>, <<"timestamp">> => os:system_time(millisecond)},
+	{ok, _PutResult2} = cache_put(TaskId2, TestData2, Opts),
+	UrlPath = <<"/~cron@1.0/load">>,
+	{ok, LoadedCrons} = hb_http:get(Node, UrlPath, #{}),
+	CronsList = hb_ao:get(<<"crons">>, LoadedCrons, #{}),
+	{ok, RetrievedData} = find_job_by_task_id(CronsList, TaskId),
+	{ok, RetrievedData2} = find_job_by_task_id(CronsList, TaskId2),
+	CleanedData = maps:remove(<<"priv">>, RetrievedData),
+	CleanedData2 = maps:remove(<<"priv">>, RetrievedData2),
+	?assertEqual(TestData, CleanedData),
+	?assertEqual(TestData2, CleanedData2),
+	?event({'cache_load_test_done'}).
+
 %% @doc This is a helper function that is used to test the cron device.
 %% It is used to increment a counter and update the state of the worker.
 test_worker() -> test_worker(#{count => 0}).
@@ -332,3 +750,217 @@ test_worker(State) ->
 			Pid ! {state, State},
 			test_worker(State)
 	end.
+
+
+% Cache test framework for cron.lua via the node-process devices
+cache_put_test() ->
+	Opts = generate_test_opts(),
+	TaskId = <<"test-task-id">>,
+	TestData = #{<<"key">> => <<"value">>, <<"timestamp">> => os:system_time(millisecond)},
+	% Put the data in the cache
+	{ok, PutResult} = cache_put(TaskId, TestData, Opts),
+	?event({cache_put_test_result, {task_id, TaskId}, {result, PutResult}}),
+	?assertEqual(TaskId, PutResult),
+	timer:sleep(100),
+	% Verify the data was stored by retrieving the crons list
+	StoredData = hb_ao:get(
+		<<"cron/now/crons">>,
+		#{ <<"device">> => <<"node-process@1.0">> },
+		Opts
+	),
+	?event({cache_put_test_stored_data, {stored_data, StoredData}}),
+	% % Verify we can find our task in the stored data
+	{ok, RetrievedData} = find_job_by_task_id(StoredData, TaskId),
+	CleanedData = maps:remove(<<"priv">>, RetrievedData),
+	?event({cache_put_test_retrieved, {retrieved_data, CleanedData}}),
+	?assertEqual(TestData, CleanedData),
+	?event({'cache_put_test_done'}).
+
+%% @doc Test the cache_remove function
+cache_remove_test() ->
+    Opts = generate_test_opts(),
+    TaskId = <<"test-remove-task-id">>,
+    TestData = #{<<"key">> => <<"value-to-remove">>, <<"timestamp">> => os:system_time(millisecond)},
+    % First put the data in the cache
+    {ok, PutResult} = cache_put(TaskId, TestData, Opts),
+    ?event({cache_remove_test_put, {task_id, TaskId}, {result, PutResult}}),
+    ?assertEqual(TaskId, PutResult),
+    timer:sleep(100),
+    % Verify the data was stored
+    StoredData = hb_ao:get(
+        <<"cron/now/crons">>,
+        #{ <<"device">> => <<"node-process@1.0">> },
+        Opts
+    ),
+    ?event({cache_remove_test_stored, {stored_data, StoredData}}),
+    % Verify we can find our task
+    {ok, RetrievedData} = find_job_by_task_id(StoredData, TaskId),
+    ?event({cache_remove_test_retrieved, {retrieved_data, RetrievedData}}),
+    CleanedData = maps:remove(<<"priv">>, RetrievedData),
+    ?assertEqual(TestData, CleanedData),
+    % Now remove the data
+    {ok, RemoveResult} = cache_remove(TaskId, Opts),
+    ?event({cache_remove_test_remove, {result, RemoveResult}}),
+    ?assertEqual(removed, RemoveResult),
+    timer:sleep(100),
+    % Verify the data was removed
+    UpdatedData = hb_ao:get(
+        <<"cron/now/crons">>,
+        #{ <<"device">> => <<"node-process@1.0">> },
+        Opts
+    ),
+    ?event({cache_remove_test_after, {updated_data, UpdatedData}}),
+    % Verify the task is no longer found
+    NotFoundResult = find_job_by_task_id(UpdatedData, TaskId),
+    ?assertEqual({error, not_found}, NotFoundResult),
+    ?event({'cache_remove_test_done'}).
+
+%% @doc Test the cache_list function
+cache_list_test() ->
+    Opts = generate_test_opts(),
+    % Create a few task IDs and test data
+    TaskId1 = <<"test-list-task-1">>,
+    TaskId2 = <<"test-list-task-2">>,
+    TestData1 = #{<<"key">> => <<"value-1">>, <<"timestamp">> => os:system_time(millisecond)},
+    TestData2 = #{<<"key">> => <<"value-2">>, <<"timestamp">> => os:system_time(millisecond)},
+    % Clear any existing data first (for test isolation)
+    {ok, _} = cache_clear(Opts),
+    timer:sleep(100),
+    % Put the test data in the cache
+    {ok, PutResult1} = cache_put(TaskId1, TestData1, Opts),
+    {ok, PutResult2} = cache_put(TaskId2, TestData2, Opts),
+    ?event({cache_list_test_put, {task_id1, TaskId1}, {task_id2, TaskId2}}),
+    ?assertEqual(TaskId1, PutResult1),
+    ?assertEqual(TaskId2, PutResult2),
+    timer:sleep(100),
+    % List all values in the cache
+    {ok, AllJobs} = cache_list(Opts),
+    ?event({cache_list_test_all_jobs, {all_jobs, AllJobs}}),
+    % Verify we can find both tasks in the list
+    {ok, RetrievedData1} = find_job_by_task_id(AllJobs, TaskId1),
+    {ok, RetrievedData2} = find_job_by_task_id(AllJobs, TaskId2),
+    % Clean the data for comparison
+    CleanedData1 = maps:remove(<<"priv">>, RetrievedData1),
+    CleanedData2 = maps:remove(<<"priv">>, RetrievedData2),
+    % Verify the data matches
+    ?assertEqual(TestData1, CleanedData1),
+    ?assertEqual(TestData2, CleanedData2),
+    % Verify the list length
+    ?assertEqual(2, length(AllJobs)),
+    ?event({'cache_list_test_done'}).
+
+%% @doc Test the cache_clear function
+cache_clear_test() ->
+    Opts = generate_test_opts(),
+    % Create test data
+    TaskId1 = <<"test-clear-task-1">>,
+    TaskId2 = <<"test-clear-task-2">>,
+    TestData1 = #{<<"key">> => <<"value-to-clear-1">>, <<"timestamp">> => os:system_time(millisecond)},
+    TestData2 = #{<<"key">> => <<"value-to-clear-2">>, <<"timestamp">> => os:system_time(millisecond)},
+    % Add data to the cache
+    {ok, PutResult1} = cache_put(TaskId1, TestData1, Opts),
+    {ok, PutResult2} = cache_put(TaskId2, TestData2, Opts),
+    ?event({cache_clear_test_put, {task_id1, TaskId1}, {task_id2, TaskId2}}),
+    ?assertEqual(TaskId1, PutResult1),
+    ?assertEqual(TaskId2, PutResult2),
+    timer:sleep(100),
+    % Verify the data was stored
+    {ok, AllJobsBefore} = cache_list(Opts),
+    ?event({cache_clear_test_before, {all_jobs, AllJobsBefore}}),
+    ?assert(length(AllJobsBefore) >= 2),
+    % Clear the cache
+    {ok, ClearResult} = cache_clear(Opts),
+    ?event({cache_clear_test_clear, {result, ClearResult}}),
+    ?assertEqual(cleared, ClearResult),
+    timer:sleep(100),
+    % Verify the cache is empty
+    {ok, AllJobsAfter} = cache_list(Opts),
+    ?event({cache_clear_test_after, {all_jobs, AllJobsAfter}}),
+    ?assertEqual(0, length(AllJobsAfter)),
+    ?event({'cache_clear_test_done'}).
+
+%% @doc Test the cache_get function
+cache_get_test() ->
+    Opts = generate_test_opts(),
+    TaskId = <<"test-get-task-id">>,
+    TestData = #{<<"key">> => <<"value-to-get">>, <<"timestamp">> => os:system_time(millisecond)},
+    % First put the data in the cache
+    {ok, PutResult} = cache_put(TaskId, TestData, Opts),
+    ?event({cache_get_test_put, {task_id, TaskId}, {result, PutResult}}),
+    ?assertEqual(TaskId, PutResult),
+    timer:sleep(100),
+    % Get the data from the cache
+    {ok, RetrievedData} = cache_get(TaskId, Opts),
+    ?event({cache_get_test_retrieved, {retrieved_data, RetrievedData}}),
+    % Clean the data for comparison
+    CleanedData = maps:remove(<<"priv">>, RetrievedData),
+    % Verify the data matches
+    ?assertEqual(TestData, CleanedData),
+    % Test getting a non-existent task
+    NonExistentResult = cache_get(<<"non-existent-task">>, Opts),
+    ?assertEqual({error, not_found}, NonExistentResult),
+    ?event({'cache_get_test_done'}).
+
+normalize_test() ->
+    Opts = generate_test_opts(),
+    Node = hb_http_server:start_node(Opts),
+    % Setup test worker
+    PID = spawn(fun test_worker/0),
+    ID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    hb_name:register({<<"test">>, ID}, PID),
+    % Create a once job
+    OnceUrlPath = <<"/~cron@1.0/once?test-id=", ID/binary,
+                   "&cron-path=/~test-device@1.0/update_state">>,
+    {ok, _OnceTaskId} = hb_http:get(Node, OnceUrlPath, #{}),
+    ?event({'normalize_test_once_created'}),
+    % Create an every job
+    EveryUrlPath = <<"/~cron@1.0/every?test-id=", ID/binary,
+                    "&interval=1000-milliseconds", % Use a reasonable interval
+                    "&cron-path=/~test-device@1.0/increment_counter">>,
+    {ok, _EveryTaskId} = hb_http:get(Node, EveryUrlPath, #{}),
+    ?event({'normalize_test_every_created'}),
+    timer:sleep(100), 
+    NormalizeUrlPath = <<"/~cron@1.0/normalize">>,
+    ?event({'normalize_test_calling_normalize', {url, NormalizeUrlPath}}),
+    {ok, NormalizeResult} = hb_http:get(Node, NormalizeUrlPath, #{}),
+    ?event({'normalize_test_normalize_result', {result, NormalizeResult}}),
+    ?assertMatch(#{ 
+        <<"status">> := 200,
+        <<"restarted_or_existing">> := _,
+        <<"errors">> := _
+    }, NormalizeResult),
+    ?event({'normalize_test_done'}).
+
+start_hook_normalize_test() ->
+	Opts = generate_test_opts(),
+	Node = hb_http_server:start_node(Opts),
+	?event({start_hook_normalize_test}),
+	% schedule a once job
+	PID = spawn(fun test_worker/0),
+    ID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    hb_name:register({<<"test">>, ID}, PID),
+	OnceUrlPath = <<"/~cron@1.0/once?test-id=", ID/binary,
+                   "&cron-path=/~test-device@1.0/update_state">>,
+    {ok, _OnceTaskId} = hb_http:get(Node, OnceUrlPath, #{}),
+	?event({start_hook_normalize_test, once_created}),
+	% stop the node.
+	Res = hb_http_server:stop_node(Opts),
+	?event({start_hook_normalize_test, node_stopped, Res}),
+	HookNodeOpts = maps:merge(Opts, #{
+		on => #{
+			<<"start">> => #{
+				<<"device">> => <<"cron@1.0">>,
+				<<"path">> => <<"normalize">>,
+				<<"hook">> => #{ <<"result">> => <<"ignore">> }
+			}
+		}
+	}),
+	% ?event({start_hook_normalize_test, hook_node_opts, HookNodeOpts}),
+	HookNode = hb_http_server:start_node(HookNodeOpts),
+	% ?event({start_hook_normalize_test, hook_node_started, HookNode}),
+	timer:sleep(100),
+	% check the cron cache list
+	{ok, Crons} = cache_list(HookNodeOpts),
+	% verify we can find the once job in the crons list after node start
+	?assertMatch({ok, _}, find_job_by_task_id(Crons, _OnceTaskId)),
+	?event({start_hook_normalize_test, test_end}).

--- a/src/dev_cron.erl
+++ b/src/dev_cron.erl
@@ -429,7 +429,7 @@ cache_remove(TaskId, Opts) ->
 {ok, removed}.
 
 cache_list(Opts) ->
-	?event({cache_list_OG_start}),
+	?event({cache_list_start}),
 	SampleMsg = [
 		#{ <<"device">> => <<"node-process@1.0">> },
 		<<"cron">>,
@@ -684,7 +684,9 @@ once_cron_cache_list_test() ->
     CronsList = hb_ao:get(<<"crons">>, LoadedCrons, #{}),
     ?event({once_load_test_extracted, {crons_list, CronsList}}),
     % Verify the task is in the loaded list
-    ?assertMatch({ok, _}, find_job_by_task_id(CronsList, ReqMsgId)),
+    Res = find_job_by_task_id(CronsList, ReqMsgId),
+    ?event({once_load_test_job, {res, Res}}),
+    ?assertMatch({ok, _}, Res),
     ?event({'once_load_test_done'}).
 
 %% @doc Test that verifies a recurring job is added to
@@ -713,7 +715,7 @@ every_cron_cache_list_test() ->
     ?event({'every_load_test_done'}).
 
 cron_device_load_test() ->
-	% this test checks whether the cron load function returns 
+	% This test checks whether the cron load function returns 
 	% the correct data
 	Opts = generate_test_opts(),
 	Node = hb_http_server:start_node(Opts),

--- a/src/dev_lua_lib.erl
+++ b/src/dev_lua_lib.erl
@@ -185,9 +185,7 @@ event([Group, Event], ExecState, Opts) ->
     ?event(Group, Event),
     {[<<"ok">>], ExecState}.
 
-%% ===================================================================
 %% Lua Cache Functions Wrappers
-%% ===================================================================
 
 %% @doc Wrapper for hb_cache:write/2 (structured message version).
 %% Expects Lua call: ao.cache_write(message_map, opts?)

--- a/src/dev_lua_lib.erl
+++ b/src/dev_lua_lib.erl
@@ -15,7 +15,10 @@
 %%% Library functions. Each exported function is _automatically_ added to the
 %%% Lua environment, except for the `install/3' function, which is used to
 %%% install the library in the first place.
--export([resolve/3, set/3, event/3, install/3, cache_write/3, cache_read/3]).
+-export([resolve/3, set/3, event/3, install/3]).
+-ifdef(ENABLE_LUA_CACHE).
+-export([cache_write/3, cache_read/3]).
+-endif.
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -185,6 +188,9 @@ event([Group, Event], ExecState, Opts) ->
     ?event(Group, Event),
     {[<<"ok">>], ExecState}.
 
+
+-ifdef(ENABLE_LUA_CACHE). 
+
 %% Lua Cache Functions Wrappers
 
 %% @doc Wrapper for hb_cache:write/2 (structured message version).
@@ -281,3 +287,5 @@ lua_ao_cache_write_read_test() ->
 	?assertEqual(<<"ok">>, Status),
 	?assertEqual(TestMap, maps:remove(<<"priv">>, RetrievedValueMap)),
     ok.
+
+-endif.

--- a/src/dev_node_process.erl
+++ b/src/dev_node_process.erl
@@ -187,11 +187,15 @@ lookup_execute_test() ->
         {ok, #{ <<"slot">> := 1 }},
         Res1
     ),
+	?event({lookup_execute_test_result, {res1, Res1}}),
+	Res2 = hb_ao:get(
+		<< ?TEST_NAME/binary, "/now/results/output/body" >>,
+		#{ <<"device">> => <<"node-process@1.0">> },
+		Opts
+	),
+	?event({lookup_execute_test_result2, {res2, Res2}}),
     ?assertMatch(
         42,
-        hb_ao:get(
-            << ?TEST_NAME/binary, "/now/results/output/body" >>,
-            #{ <<"device">> => <<"node-process@1.0">> },
-            Opts
-        )
-    ).
+        Res2
+    ),
+	?event({lookup_execute_test_done}).

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -416,6 +416,13 @@ set_opts(Request, Opts) ->
     },
     {set_opts(FinalOpts), FinalOpts}.
 
+
+%% hb_http_server/start_node/1 executes a start hook before cowboy is 
+%% listening. This means there is no valid http_server ref in node_opts.
+%% When we run dev_cron/normalize as part of a start hook, it spawns
+%% workers using the original NodeMsg, which does not contain a valid
+%% http_server ref. This can crash the cowboy:get_env. To solve for this,
+%% we return the original NodeMsg when no Cowboy listener is attached.
 get_opts(NodeMsg = #{ http_server := no_server_ref }) ->
     NodeMsg;
 get_opts(NodeMsg) ->

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -416,6 +416,8 @@ set_opts(Request, Opts) ->
     },
     {set_opts(FinalOpts), FinalOpts}.
 
+get_opts(NodeMsg = #{ http_server := no_server_ref }) ->
+    NodeMsg;
 get_opts(NodeMsg) ->
     ServerRef = hb_opts:get(http_server, no_server_ref, NodeMsg),
     cowboy:get_env(ServerRef, node_msg, no_node_msg).

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -11,7 +11,7 @@
 %%% the execution parameters of all downstream requests to be controlled.
 -module(hb_http_server).
 -export([start/0, start/1, allowed_methods/2, init/2, set_opts/1, set_opts/2, get_opts/1]).
--export([start_node/0, start_node/1, set_default_opts/1]).
+-export([start_node/0, start_node/1, set_default_opts/1, stop_node/1]).
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
 
@@ -95,6 +95,7 @@ start() ->
         }
     ).
 start(Opts) ->
+	
     application:ensure_all_started([
         kernel,
         stdlib,
@@ -108,7 +109,10 @@ start(Opts) ->
     hb:init(),
     BaseOpts = set_default_opts(Opts),
     {ok, Listener, _Port} = new_server(BaseOpts),
+	
     {ok, Listener}.
+
+
 
 %% @doc Trigger the creation of a new HTTP server node. Accepts a `NodeMsg'
 %% message, which is used to configure the server. This function executed the
@@ -475,6 +479,15 @@ start_node(Opts) ->
     {ok, _Listener, Port} = new_server(ServerOpts),
     <<"http://localhost:", (integer_to_binary(Port))/binary, "/">>.
 
+stop_node(Opts) ->
+	?event(http, {node_stopping, Opts}),
+	application:stop(ranch),
+	application:stop(cowboy),
+	% application:stop(gun),
+	% application:stop(inets),
+	?event(http, {node_stopped, Opts}),
+	<<"node stopped">>.
+	
 %%% Tests
 %%% The following only covering the HTTP server initialization process. For tests
 %%% of HTTP server requests/responses, see `hb_http.erl'.


### PR DESCRIPTION
## Introduce Cron Device and Cache Persistence

This PR introduces a complete rewrite of the device, `dev_cron`, enabling scheduled message execution for processes on HyperBEAM.

*   Allows processes to trigger actions at specified intervals or once.
*   Tasks can be scheduled via HTTP GET requests to the cron device.
    *   **Example (one-time task):** `GET /~cron@1.0/once?cron-path=/~my-device@1.0/my-action&param1=value1`
    *   **Example (recurring task):** `GET /~cron@1.0/every?interval=5-minutes&cron-path=/~my-device@1.0/another-action`
*   Cron jobs are now persisted. Upon node restart, a `normalize` function attempts to re-establish active cron jobs from this persisted state.
*   The cron device utilizes a cache (backed by a Lua process via `dev_node_process`) to store scheduled job information.
*   To enable persistence of cron jobs across node restarts, the node configuration *must* define a hook for the `cron` node process.

```
% In node opts (config.flat) add the following
#{
        on => #{
            <<"start">> => #{
                <<"device">> => <<"cron@1.0">>,
                <<"path">> => <<"normalize">>,
                <<"hook">> => #{ <<"result">> => <<"ignore">> } % Or handle the result as needed
            }
        }
    }
```

## Tests
All tests for devices / files in this PR pass.

## TBD
- We should make the cron config set by default 


## Tasks
- [x] `cron.lua` script that powers `cron~node-process@1.0/resolve` with a compute function to handle functionality
- [x] cron cache supports commands: put (individual task), remove (individual task), clear (all tasks from cache)
- [x] helper functions for `dev_cron` for `cache_put`, `cache_remove`, `cache_list` and `cache_clear`
- [x] test harness and unit tests for all above functionality
- [x] integrated cache functions into once, every and stop
- [x] a new exported load function on `cron@1.0` to load existing cron jobs from cache in the event of node reboot
- [x] test harness for cache functionality working in once, every and stop
- [x] (wip) persistence of cron cache to file system see PR 263
- [x] add a guard to once/every so that repeated same id is detected and return early vs forking more processes
- [x] - implement a normalize key to cron node-process that wil list the cached cron and reinvoke once or every 
- [x] have the execution device implement the normalize key if present for that device/node-process
