### PR TITLE
test: add tests for genesis wasm

### DIFF
--- a/src/hb_ao.erl
+++ b/src/hb_ao.erl
@@ -1267,6 +1267,7 @@ is_exported(_Info, _Key, _Opts) -> true.
 
 %% @doc Convert a key to a binary in normalized form.
 normalize_key(Key) -> normalize_key(Key, #{}).
+normalize_key(Key, _Opts) when ?IS_LINK(Key) -> normalize_key(hb_cache:ensure_loaded(Key, _Opts));
 normalize_key(Key, _Opts) when ?IS_ID(Key) -> Key;
 normalize_key(Key, _Opts) when is_binary(Key) ->
     hb_util:to_lower(Key);


### PR DESCRIPTION
Adds 4 tests for dev_genesis_wasm, including comparing results between wasm/genesis wasm and sending messages between genesis wasm processes.

Also, updates `hb_ao:normalize_key(Key)` to run ensure_loaded if Key is a link.