### PR TITLE
impr: pass `Opts` during `format` flow

### DIFF
--- a/src/dev_hyperbuddy.erl
+++ b/src/dev_hyperbuddy.erl
@@ -69,21 +69,25 @@ format(Base, Req, Opts) ->
     {ok,
         #{
             <<"body">> =>
-                    hb_util:bin(
-                        hb_message:format(
-                            #{
-                                <<"base">> =>
-                                    maps:without(
-                                        [<<"device">>],
-                                        hb_private:reset(LoadedBase)),
-                                <<"request">> =>
-                                    maps:without(
-                                        [<<"path">>],
-                                        hb_private:reset(LoadedReq)
-                                    )
-                            }
-                        )
+                hb_util:bin(
+                    hb_message:format(
+                        #{
+                            <<"base">> =>
+                                maps:without(
+                                    [<<"device">>],
+                                    hb_private:reset(LoadedBase)),
+                            <<"request">> =>
+                                maps:without(
+                                    [<<"path">>],
+                                    hb_private:reset(LoadedReq)
+                                )
+                        },
+                        Opts#{
+                            linkify_mode => discard,
+                            cache_control => [<<"no-cache">>, <<"no-store">>]
+                        }
                     )
+                )
         }
     }.
 

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -45,7 +45,7 @@ start() ->
                 Loaded
             )
         ),
-    FormattedConfig = hb_util:debug_fmt(MergedConfig, 2),
+    FormattedConfig = hb_util:debug_fmt(MergedConfig, MergedConfig, 2),
     io:format("~n"
         "===========================================================~n"
         "==    ██╗  ██╗██╗   ██╗██████╗ ███████╗██████╗           ==~n"

--- a/src/hb_link.erl
+++ b/src/hb_link.erl
@@ -150,7 +150,7 @@ format(Link) -> format(Link, #{}).
 format(Link, Opts) ->
     case hb_opts:get(debug_resolve_links, false, Opts) of
         true ->
-            try hb_message:format(hb_cache:ensure_all_loaded(Link))
+            try hb_message:format(hb_cache:ensure_all_loaded(Link, Opts), Opts)
             catch
                 _:_ -> << "!UNRESOLVABLE! ", (format_unresolved(Link))/binary >>
             end;


### PR DESCRIPTION
This PR ensures that the `Opts` of the present evaluation are used+enforced throughout the formatting flow. It is a simple change but has two direct benefits:
- Ensures that calls to `~hyperbuddy@1.0/format` are 'read only' (not caching results directly; and
- Resolutions of linked elements during formatting utilize the correct cache.