### PR TITLE
Refactor/replace ensure all loaded

### DIFF
--- a/src/dev_green_zone.erl
+++ b/src/dev_green_zone.erl
@@ -213,7 +213,7 @@ join(M1, M2, Opts) ->
     PeerID = hb_opts:get(<<"green_zone_peer_id">>, undefined, Opts),
     ?event(green_zone, {join_peer, PeerLocation, PeerID}),
     if (PeerLocation =:= undefined) or (PeerID =:= undefined) ->
-        validate_join(M1, M2, hb_cache:ensure_all_loaded(Opts, Opts));
+        validate_join(M1, M2, Opts);
     true ->
         join_peer(PeerLocation, PeerID, M1, M2, Opts)
     end.
@@ -420,10 +420,7 @@ join_peer(PeerLocation, PeerID, _M1, M2, InitOpts) ->
                 Opts
             ),
             % Create an committed join request using the wallet.
-            Req = hb_cache:ensure_all_loaded(
-                hb_message:commit(MergedReq, Wallet),
-                Opts
-            ),
+            Req = hb_message:commit(MergedReq, Wallet),
             ?event({join_req, {explicit, Req}}),
             ?event({verify_res, hb_message:verify(Req)}),
             % Log that the commitment report is being sent to the peer.
@@ -868,4 +865,3 @@ rsa_wallet_integration_test() ->
     ?assertEqual(PlainText, Decrypted),
     % Verify wallet structure
     ?assertEqual(KeyType, {rsa, 65537}).
-

--- a/src/dev_lookup.erl
+++ b/src/dev_lookup.erl
@@ -13,10 +13,10 @@ read(_M1, M2, Opts) ->
         {ok, RawRes} ->
             % We are sending the result over the wire, so make sure it is
             % fully loaded, to save the recipient latency.
-            Res = hb_cache:ensure_all_loaded(RawRes),
-            ?event({lookup_result, Res}),
+            ?event({lookup_result, RawRes}),
             case hb_ao:get(<<"accept">>, M2, Opts) of
                 <<"application/aos-2">> ->
+                    Res = hb_cache:ensure_all_loaded(RawRes),
                     Struct = dev_json_iface:message_to_json_struct(Res, Opts),
                     {ok,
                         #{
@@ -24,7 +24,7 @@ read(_M1, M2, Opts) ->
                             <<"content-type">> => <<"application/aos-2">>
                         }};
                 _ ->
-                    {ok, Res}
+                    {ok, RawRes}
             end;
         not_found ->
             ?event({lookup_not_found, ID}),
@@ -43,7 +43,7 @@ message_lookup_test() ->
     Msg = #{ <<"test-key">> => <<"test-value">>, <<"data">> => <<"test-data">> },
     {ok, ID} = hb_cache:write(Msg, #{}),
     {ok, RetrievedMsg} = read(#{}, #{ <<"target">> => ID }, #{}),
-    ?assertEqual(Msg, RetrievedMsg).
+    ?assert(hb_message:match(Msg, RetrievedMsg)).
 
 aos2_message_lookup_test() ->
     Msg = #{ <<"test-key">> => <<"test-value">>, <<"data">> => <<"test-data">> },

--- a/src/dev_lua_test_ledgers.erl
+++ b/src/dev_lua_test_ledgers.erl
@@ -213,8 +213,7 @@ balances(Prefix, ProcMsg, Opts) ->
 supply(ProcMsg, Opts) ->
     supply(now, ProcMsg, Opts).
 supply(Mode, ProcMsg, Opts) ->
-    Loaded = hb_cache:ensure_all_loaded(ProcMsg, Opts),
-    lists:sum(maps:values(balances(Mode, Loaded, Opts))).
+    lists:sum(maps:values(balances(Mode, ProcMsg, Opts))).
 
 %% @doc Calculate the supply of tokens in all sub-ledgers, from the balances of
 %% the root ledger.

--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -344,7 +344,7 @@ committed(Self, Req, Opts) ->
     % commitments are loaded.
     {ok, RawBase} =
         hb_message:find_target(
-            hb_cache:ensure_all_loaded(Self, Opts),
+            Self,
             Req,
             Opts
         ),

--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -210,7 +210,7 @@ handle_resolve(Req, Msgs, NodeMsg) ->
     TracePID = hb_opts:get(trace, no_tracer_set, NodeMsg),
     % Apply the pre-processor to the request.
     ?event({resolve_hook, Req, Msgs, NodeMsg}),
-    case resolve_hook(<<"request">>, Req, hb_cache:ensure_all_loaded(Msgs, NodeMsg), NodeMsg) of
+    case resolve_hook(<<"request">>, Req, Msgs, NodeMsg) of
         {ok, PreProcessedMsg} ->
             ?event({result_after_preprocessing, PreProcessedMsg}),
             AfterPreprocOpts = hb_http_server:get_opts(NodeMsg),

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -452,20 +452,18 @@ ensure_loaded(Msg1, Msg2, Opts) ->
                     % the public component of a message) into memory.
                     % Do not update the hashpath while we do this, and remove
                     % the snapshot key after we have normalized the message.
-                    LoadedSnapshotMsg = hb_cache:ensure_all_loaded(MaybeLoadedSnapshotMsg, Opts),
-                    LoadedSlot = hb_cache:ensure_all_loaded(MaybeLoadedSlot, Opts),
-                    ?event(compute, {loaded_state_checkpoint, ProcID, LoadedSlot}),
+                    ?event(compute, {loaded_state_checkpoint, ProcID, MaybeLoadedSlot}),
                     {ok, Normalized} =
                         run_as(
                             <<"execution">>,
-                            LoadedSnapshotMsg,
+                            MaybeLoadedSnapshotMsg,
                             normalize,
                             Opts#{ hashpath => ignore }
                         ),
                     NormalizedWithoutSnapshot = hb_maps:remove(<<"snapshot">>, Normalized, Opts),
                     ?event({loaded_state_checkpoint_result,
                         {proc_id, ProcID},
-                        {slot, LoadedSlot},
+                        {slot, MaybeLoadedSlot},
                         {after_normalization, NormalizedWithoutSnapshot}
                     }),
                     {ok, NormalizedWithoutSnapshot};

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -287,16 +287,15 @@ apply_routes(Msg, R, Opts) ->
 %% - `suffix': The suffix to add to the path.
 %% - `replace': A regex to replace in the path.
 apply_route(Msg, Route, Opts) ->
-    LoadedRoute = hb_cache:ensure_all_loaded(Route, Opts),
-    RouteOpts = hb_maps:get(<<"opts">>, LoadedRoute, #{}),
-    LoadedMsg = hb_cache:ensure_all_loaded(Msg, Opts),
+    % LoadedRoute = hb_cache:ensure_all_loaded(Route, Opts),
+    RouteOpts = hb_maps:get(<<"opts">>, Route, #{}),
     {ok, #{
         <<"opts">> => RouteOpts,
         <<"uri">> =>
             hb_util:ok(
                 do_apply_route(
-                    LoadedMsg,
-                    hb_maps:without([<<"opts">>], LoadedRoute, Opts),
+                    Msg,
+                    hb_maps:without([<<"opts">>], Route, Opts),
                     Opts
                 )
             )

--- a/src/dev_snp.erl
+++ b/src/dev_snp.erl
@@ -184,17 +184,15 @@ verify(M1, M2, NodeOpts) ->
 %% message ID), as well as the expected measurement (firmware, kernel, and VMSAs
 %% hashes).
 generate(_M1, _M2, Opts) ->
-    LoadedOpts = hb_cache:ensure_all_loaded(Opts, Opts),
-    ?event({generate_opts, {explicit, LoadedOpts}}),
-    Wallet = hb_opts:get(priv_wallet, no_viable_wallet, LoadedOpts),
+    Wallet = hb_opts:get(priv_wallet, no_viable_wallet, Opts),
     Address = hb_util:human_id(ar_wallet:to_address(Wallet)),
     % ?event({snp_wallet, Wallet}),
     % Remove the `priv*' keys from the options.
     {ok, PublicNodeMsgID} =
         dev_message:id(
-                NodeMsg = hb_private:reset(LoadedOpts),
+                NodeMsg = hb_private:reset(Opts),
                 #{ <<"committers">> => <<"none">> },
-                LoadedOpts
+                Opts
             ),
     RawPublicNodeMsgID = hb_util:native_id(PublicNodeMsgID),
     ?event({snp_node_msg, NodeMsg}),
@@ -204,7 +202,7 @@ generate(_M1, _M2, Opts) ->
     ?event({snp_address,  byte_size(Address)}),
     ReportData = generate_nonce(Address, RawPublicNodeMsgID),
     ?event({snp_report_data, byte_size(ReportData)}),
-    LocalHashes = hd(hb_opts:get(snp_trusted, [#{}], LoadedOpts)),
+    LocalHashes = hd(hb_opts:get(snp_trusted, [#{}], Opts)),
     ?event(snp_local_hashes, {explicit, LocalHashes}),
     {ok, ReportJSON} = dev_snp_nif:generate_attestation_report(ReportData, 1),
     ?event({snp_report_json, ReportJSON}),

--- a/src/dev_snp.erl
+++ b/src/dev_snp.erl
@@ -142,10 +142,7 @@ verify(M1, M2, NodeOpts) ->
                             fun atom_to_binary/1,
                             ?COMMITTED_PARAMETERS
                         ),
-                        hb_cache:ensure_all_loaded(
-                            hb_ao:get(<<"local-hashes">>, Msg, NodeOpts),
-                            NodeOpts
-                        )
+                        hb_maps:get(<<"local-hashes">>, Msg, NodeOpts)
                     )
                 )
             )

--- a/src/dev_stack.erl
+++ b/src/dev_stack.erl
@@ -97,20 +97,20 @@
 %%% In this example, the `device' key is mutated a number of times, but the
 %%% resulting HashPath remains correct and verifiable.
 -module(dev_stack).
--export([info/1, router/4, prefix/3, input_prefix/3, output_prefix/3]).
+-export([info/2, router/4, prefix/3, input_prefix/3, output_prefix/3]).
 %%% Test exports
 -export([generate_append_device/1]).
 -include_lib("eunit/include/eunit.hrl").
 
 -include("include/hb.hrl").
 
-info(Msg) ->
+info(Msg, Opts) ->
     hb_maps:merge(
         #{
             handler => fun router/4,
             excludes => [<<"set">>, <<"keys">>]
         },
-        case hb_maps:get(<<"stack-keys">>, Msg, not_found) of
+        case hb_maps:get(<<"stack-keys">>, Msg, not_found, Opts) of
             not_found -> #{};
             StackKeys -> #{ exports => StackKeys }
         end
@@ -166,7 +166,7 @@ router(Message1, Message2, Opts) ->
 %% 		keyInDevice executed on DeviceName against Msg1.
 transformer_message(Msg1, Opts) ->
 	?event({creating_transformer, {for, Msg1}}),
-    BaseInfo = info(Msg1),
+    BaseInfo = info(Msg1, Opts),
 	{ok, 
 		Msg1#{
 			<<"device">> => #{

--- a/src/hb_ao.erl
+++ b/src/hb_ao.erl
@@ -1459,7 +1459,7 @@ info(Msg, Opts) ->
     info(message_to_device(Msg, Opts), Msg, Opts).
 info(DevMod, Msg, Opts) ->
 	%?event({calculating_info, {dev, DevMod}, {msg, Msg}}),
-	case find_exported_function(Msg, DevMod, info, 1, Opts) of
+    case find_exported_function(Msg, DevMod, info, 2, Opts) of
 		{ok, Fun} ->
 			Res = apply(Fun, truncate_args(Fun, [Msg, Opts])),
 			% ?event({

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -734,13 +734,13 @@ find_target(Self, Req, Opts) ->
         cache_control => [<<"no-cache">>, <<"no-store">>]
     },
     {ok,
-        case hb_ao:get(<<"target">>, Req, <<"self">>, GetOpts) of
+        case hb_maps:get(<<"target">>, Req, <<"self">>, GetOpts) of
             <<"self">> -> Self;
             Key ->
-                hb_ao:get(
+                hb_maps:get(
                     Key,
                     Req,
-                    hb_ao:get(<<"body">>, Req, GetOpts),
+                    hb_maps:get(<<"body">>, Req, GetOpts),
                     GetOpts
                 )
         end


### PR DESCRIPTION
This PR aims to create remove unnecessary usage of `hb_cache:ensure_all_loaded` to uses `hb_maps:get` which underneath use `hb_cache:ensure_loaded` and allow to lazy load only the required links.