### PR TITLE
feat(router/green-zone): support multiple route registrations and improve identity handling

### DIFF
--- a/src/dev_green_zone.erl
+++ b/src/dev_green_zone.erl
@@ -381,9 +381,22 @@ finalize_become(KeyResp, NodeLocation, NodeID, GreenZoneAES, Opts) ->
             priv_wallet => GreenZoneWallet
         }
     },
-    ok = hb_http_server:set_opts(Opts#{
-        identities => UpdatedIdentities
-    }),
+    NewOpts =         
+        maps:without(
+            [
+                <<"green_zone_peer_location">>,
+                <<"green_zone_peer_id">>,
+                green_zone_peer_location,
+                green_zone_peer_id
+            ],
+            Opts#{
+                identities => UpdatedIdentities,
+                <<"green_zone_peer_location">> => unset,
+                <<"green_zone_peer_id">> => unset
+            }
+        ),
+    ?event(green_zone, {become, new_opts, {explicit, NewOpts}}),
+    ok = hb_http_server:set_opts(NewOpts),
     % Print the updated wallet address
     Wallet = hb_opts:get(priv_wallet, undefined, Opts),
     ?event(green_zone,


### PR DESCRIPTION
### **Description**

This PR introduces improvements to the `dev_router` and `dev_green_zone` modules to enhance identity management and support multiple route registrations with better debug behavior and clarity.

---

### 🔄 `src/dev_green_zone.erl`

* ✅ Logs additional context in `join/3`, including whether a `green-zone` identity is present.
* ✅ Correctly falls back to the `priv_wallet` if no `green-zone` identity exists.
* ✅ Enhances `finalize_become/5` with consistent formatting and safer option updates.

---

### 🔄 `src/dev_router.erl`

* ✅ Updates the `router_registration_opts` schema in `info/3` to reflect list-based input.
* ✅ Refactors `register/3` to support **multiple router registration messages** via a `list` of `router_registration_opts` entries.
* ✅ Adds robust pattern handling for both single map and list input for route registration.
* ✅ Wraps registration per entry in a `lists:foreach/2` loop, ensuring each is independently processed and logged.
