### PR TITLE
Fix some issues regarding restarint persisted cron jobs

### DIFF
--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -427,7 +427,12 @@ get_opts(NodeMsg = #{ http_server := no_server_ref }) ->
     NodeMsg;
 get_opts(NodeMsg) ->
     ServerRef = hb_opts:get(http_server, no_server_ref, NodeMsg),
-    cowboy:get_env(ServerRef, node_msg, no_node_msg).
+    try cowboy:get_env(ServerRef, node_msg, no_node_msg)
+    catch error:badarg ->
+        % If the server is not yet started, might happen with dev_hook
+        % So we just return the original NodeMsg.
+        NodeMsg
+    end.
 
 set_default_opts(Opts) ->
     % Create a temporary opts map that does not include the defaults.


### PR DESCRIPTION
This PR aims to fix some issues to restart properly persisted cron jobs

To test the PR 
add the following config.flat
```
port: 10000
on/start/device: cron@1.0
on/start/path: normalize
on/start/hook/result: ignore
```

- Start a hyperbeam node. `HB_PRINT=dev_cron rebar3 shell`
- Start a cron job: `curl http://localhost:10000/~cron@1.0/every\?interval\=5-seconds\&cron-path\=/\~meta@1.0/info/address`
- Wait few seconds to see the job prompting to the console
- Stop the node
- Restart the node
- Wait few seconds to see the scheduled job re-prompting to the console