### PR TITLE
Fix: Enable genesis-wasm@1.0 device registration

### DIFF
--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -246,3 +246,6 @@ log_server_events([Remaining]) -> Remaining;
 log_server_events([Line | Rest]) ->
     ?event(genesis_wasm_server, {server_logged, Line}),
     log_server_events(Rest).
+
+devices() ->
+  [<<"genesis-wasm@1.0">>].


### PR DESCRIPTION
This patch resolves a `400 Bad Request` error that occurs when trying to use `aos` with the `genesis_wasm` device.

🔧 **What was added:**
Added a missing `devices/0` function in `src/dev_genesis_wasm.erl`:

```erlang
devices() ->
  [<<"genesis-wasm@1.0">>].