### PR TITLE
Add notify@1.0 device

### DIFF
--- a/docs/devices/notify-at-1-0.md
+++ b/docs/devices/notify-at-1-0.md
@@ -1,0 +1,187 @@
+# Device: ~notify@1.0
+
+## Overview
+
+The [`~notify@1.0`](../resources/source-code/dev_notify.md) device provides real-time event streaming capabilities for HyperBEAM, enabling clients to subscribe to specific events and receive notifications via HTTP/3 Server-Sent Events (SSE) streams.
+
+## Use Cases
+
+*   **Real-time monitoring**: Subscribe to AO process events as they occur
+*   **Event-driven applications**: Build reactive applications that respond to process state changes
+*   **Performance monitoring**: Track events efficiently with high-throughput architecture
+*   **Custom filtering**: Use flexible templates to receive only relevant events
+
+## Core Architecture
+
+The notify device operates using a separate long-running **notification manager process** for optimal performance. This architecture ensures:
+
+*   **Asynchronous processing**: Events are dispatched without blocking the main request flow
+*   **High throughput**: Dedicated process handles event matching and distribution
+*   **Fault isolation**: Event processing failures don't affect other operations
+*   **Resource efficiency**: Centralized ETS table management for fast lookups
+
+## Core Functions (Keys)
+
+### `info`
+
+Provides information about the notification device capabilities and endpoints.
+
+*   **`GET /~notify@1.0/info`**
+    *   **Action:** Returns device metadata including available paths and version information.
+    *   **Response:** JSON object describing the device's capabilities.
+
+### `stream` (Primary API)
+
+Creates a real-time HTTP/3 streaming connection for receiving events. **This is the main method for most use cases.**
+
+*   **`GET /~notify@1.0/stream`**
+    *   **Action:** Establishes a Server-Sent Events (SSE) connection for real-time event delivery. Automatically registers the listener when the connection is established.
+    *   **Query Parameters:** 
+        *   `template`: Event matching pattern (map or regex)
+    *   **Response:** HTTP/3 stream with `Content-Type: text/event-stream`
+    *   **Headers:** Includes CORS headers and cache-control directives for web compatibility
+
+**Stream URL Examples:**
+```
+GET /~notify@1.0/stream?template={"device":"process@1.0"}
+GET /~notify@1.0/stream?template=/.*compute.*/
+```
+
+**Template Types:**
+*   **Map Templates**: Structured message matching using key-value pairs
+*   **Regex Templates**: Path-based pattern matching using regular expressions
+
+**Map Template Example:**
+```json
+GET /~notify@1.0/stream?template={"device":"process@1.0","action":"compute"}
+```
+
+**Regex Template Example:**
+```json
+GET /~notify@1.0/stream?template="/.*process.*/.*/.*"
+```
+
+### `register` (For Persistent Use Cases)
+
+Registers a new event listener with a specific template for event matching. **Use this for persistent subscriptions that need to survive across multiple stream connections or for programmatic subscription management.**
+
+*   **`POST /~notify@1.0/register`**
+    *   **Action:** Creates a persistent event subscription using the provided template and stream identifier.
+    *   **Request Body:** Must contain `template` (event pattern) and `stream` (stream identifier) fields.
+    *   **Response:** Success confirmation or error message.
+    *   **Use Cases:** Pre-registration, batch registration, persistent subscriptions, programmatic management
+
+**Registration Example:**
+```json
+{
+  "template": {
+    "device": "process@1.0",
+    "action": "compute"
+  },
+  "stream": "persistent-stream-001"
+}
+```
+
+### `unregister` (For Persistent Use Cases)
+
+Removes an existing persistent event listener registration.
+
+*   **`POST /~notify@1.0/unregister`**
+    *   **Action:** Removes the persistent listener associated with the specified template.
+    *   **Request Body:** Must contain the `template` field matching the original registration.
+    *   **Response:** Success confirmation or error message.
+    *   **Use Cases:** Cleanup of persistent subscriptions, programmatic subscription management
+
+### `dispatch`
+
+Dispatches events to registered listeners (typically called internally by the system).
+
+*   **`POST /~notify@1.0/dispatch`**
+    *   **Action:** Processes an event and sends it to all matching registered listeners.
+    *   **Request Body:** Event data to be matched against registered templates.
+    *   **Response:** Dispatch confirmation.
+    *   **Note:** This is primarily used internally by `hb_persistent:notify/4` for automatic event triggering.
+
+## Template System
+
+The notify device supports two types of templates for flexible event filtering:
+
+### Map Templates
+
+Structured templates that match against message fields using exact key-value matching.
+
+```erlang
+Template = #{
+    <<"device">> => <<"process@1.0">>,
+    <<"action">> => <<"compute">>,
+    <<"status">> => <<"completed">>
+}
+```
+
+**Matching Logic:**
+*   All specified keys must be present in the event
+*   All specified values must match exactly
+*   Events can contain additional keys (partial matching allowed)
+
+### Regex Templates
+
+Path-based templates that match against the event's `path` field using regular expressions.
+
+```erlang
+Template = <<"/processes/.*/compute/.*">>
+```
+
+**Matching Logic:**
+*   Event's `path` field is extracted (defaults to `"/"` if not present)
+*   Regex pattern is applied to the path string
+*   Match succeeds if the pattern matches any part of the path
+
+## Event Flow
+
+1. **Registration**: Client registers listener with template via `/register` endpoint
+2. **Template Storage**: Template is validated and stored in ETS table with stream process ID
+3. **Event Trigger**: AO process completes operation, triggering `hb_persistent:notify/4`
+4. **Event Dispatch**: Notification manager receives event and checks against all templates
+5. **Template Matching**: Event is tested against each registered template
+6. **Event Delivery**: Matching events are sent to appropriate stream processes
+7. **HTTP Streaming**: Events are delivered to clients via Server-Sent Events format
+
+## Integration with HyperBEAM
+
+The notify device integrates seamlessly with HyperBEAM's persistence layer:
+
+*   **Automatic Startup**: Notification manager starts automatically when `notify_device` is configured in `hb_opts.erl`
+*   **Event Integration**: `hb_persistent:notify/4` automatically dispatches events to the notification manager
+*   **Configuration**: Enable via `notify_device` option in node configuration
+*   **Performance**: Uses ETS tables for O(1) listener lookups and efficient event dispatching
+
+## Configuration
+
+To enable the notify device, configure it in your HyperBEAM node:
+
+```erlang
+% In hb_opts.erl or config file
+notify_device => #{
+    <<"name">> => <<"notify@1.0">>,
+    <<"module">> => dev_notify
+}
+```
+
+The notification manager will start automatically during application startup when this configuration is present.
+
+## Performance Characteristics
+
+*   **Lookup Performance**: O(1) listener lookup via ETS named tables
+*   **Dispatch Performance**: O(n) where n = number of registered listeners
+*   **Memory Usage**: Linear with number of active listeners and templates
+*   **Concurrency**: Parallel event processing using short-lived worker processes
+
+## Error Handling
+
+The notify device implements comprehensive error handling:
+
+*   **Template Validation**: Templates are validated at registration time to fail fast
+*   **Dead Process Cleanup**: Automatic cleanup of terminated listener processes during dispatch
+*   **Graceful Degradation**: Individual listener failures don't affect other listeners
+
+[notify module](../resources/source-code/dev_notify.md)

--- a/docs/devices/notify-at-1-0.md
+++ b/docs/devices/notify-at-1-0.md
@@ -32,10 +32,10 @@ Provides information about the notification device capabilities and endpoints.
 
 ### `stream` (Primary API)
 
-Creates a real-time HTTP/3 streaming connection for receiving events. **This is the main method for most use cases.**
+Creates a real-time HTTP/3 streaming connection for receiving events. **This is the main method for event subscriptions.**
 
 *   **`GET /~notify@1.0/stream`**
-    *   **Action:** Establishes a Server-Sent Events (SSE) connection for real-time event delivery. Automatically registers the listener when the connection is established.
+    *   **Action:** Establishes a Server-Sent Events (SSE) connection for real-time event delivery. The connection automatically registers itself as a listener when established.
     *   **Query Parameters:** 
         *   `template`: Event matching pattern (map or regex)
     *   **Response:** HTTP/3 stream with `Content-Type: text/event-stream`
@@ -60,37 +60,6 @@ GET /~notify@1.0/stream?template={"device":"process@1.0","action":"compute"}
 ```json
 GET /~notify@1.0/stream?template="/.*process.*/.*/.*"
 ```
-
-### `register` (For Persistent Use Cases)
-
-Registers a new event listener with a specific template for event matching. **Use this for persistent subscriptions that need to survive across multiple stream connections or for programmatic subscription management.**
-
-*   **`POST /~notify@1.0/register`**
-    *   **Action:** Creates a persistent event subscription using the provided template and stream identifier.
-    *   **Request Body:** Must contain `template` (event pattern) and `stream` (stream identifier) fields.
-    *   **Response:** Success confirmation or error message.
-    *   **Use Cases:** Pre-registration, batch registration, persistent subscriptions, programmatic management
-
-**Registration Example:**
-```json
-{
-  "template": {
-    "device": "process@1.0",
-    "action": "compute"
-  },
-  "stream": "persistent-stream-001"
-}
-```
-
-### `unregister` (For Persistent Use Cases)
-
-Removes an existing persistent event listener registration.
-
-*   **`POST /~notify@1.0/unregister`**
-    *   **Action:** Removes the persistent listener associated with the specified template.
-    *   **Request Body:** Must contain the `template` field matching the original registration.
-    *   **Response:** Success confirmation or error message.
-    *   **Use Cases:** Cleanup of persistent subscriptions, programmatic subscription management
 
 ### `dispatch`
 
@@ -138,7 +107,7 @@ Template = <<"/processes/.*/compute/.*">>
 
 ## Event Flow
 
-1. **Registration**: Client registers listener with template via `/register` endpoint
+1. **Stream Connection**: Client establishes streaming connection via `/stream` endpoint with template
 2. **Template Storage**: Template is validated and stored in ETS table with stream process ID
 3. **Event Trigger**: AO process completes operation, triggering `hb_persistent:notify/4`
 4. **Event Dispatch**: Notification manager receives event and checks against all templates

--- a/src/dev_notify.erl
+++ b/src/dev_notify.erl
@@ -35,37 +35,64 @@ info(_Msg1, _Msg2, _Opts) ->
     },
     {ok, #{<<"status">> => 200, <<"body">> => InfoBody}}.
 
-%% @doc Register a new event listener
+%% @doc Register a new event listener with template/spec support
 register(StateMsg, InputMsg, Opts) ->
     ?event(notify, {register_listener, InputMsg}),
-    case hb_ao:get(<<"pattern">>, InputMsg, Opts) of
+    
+    % Extract template specification (supports both map and regex templates)
+    TemplateResult = case hb_ao:get(<<"template">>, InputMsg, Opts) of
         not_found ->
-            {error, <<"No pattern specified for event registration">>};
-        Pattern ->
+            % Fallback to legacy pattern field for compatibility
+            case hb_ao:get(<<"pattern">>, InputMsg, Opts) of
+                not_found -> {error, <<"No template or pattern specified">>};
+                Pattern -> {ok, Pattern}
+            end;
+        TemplateSpec -> {ok, TemplateSpec}
+    end,
+    
+    case TemplateResult of
+        {error, Reason} -> {error, Reason};
+        {ok, ExtractedTemplate} ->
             case hb_ao:get(<<"stream">>, InputMsg, Opts) of
                 not_found ->
                     {error, <<"No stream specified for event registration">>};
                 Stream ->
-                    % Register the pattern and stream in the state
-                    NewState = maps:put(
-                        {pattern, Pattern},
-                        Stream,
-                        maps:get(<<"listeners">>, StateMsg, #{})
-                    ),
-                    {ok, StateMsg#{<<"listeners">> => NewState}}
+                    % Validate template specification
+                    case validate_template(ExtractedTemplate, Opts) of
+                        {ok, ValidatedTemplate} ->
+                            % Register the template and stream in the state
+                            NewState = maps:put(
+                                {template, ValidatedTemplate},
+                                Stream,
+                                maps:get(<<"listeners">>, StateMsg, #{})
+                            ),
+                            {ok, StateMsg#{<<"listeners">> => NewState}};
+                        {error, ValidationError} ->
+                            {error, ValidationError}
+                    end
             end
     end.
 
-%% @doc Unregister an event listener
+%% @doc Unregister an event listener (supports both template and legacy pattern)
 unregister(StateMsg, InputMsg, Opts) ->
     ?event(notify, {unregister_listener, InputMsg}),
-    case hb_ao:get(<<"pattern">>, InputMsg, Opts) of
+    
+    % Extract template or pattern for removal
+    TemplateResult = case hb_ao:get(<<"template">>, InputMsg, Opts) of
         not_found ->
-            {error, <<"No pattern specified for event unregistration">>};
-        Pattern ->
-            % Remove the pattern from the state
+            case hb_ao:get(<<"pattern">>, InputMsg, Opts) of
+                not_found -> {error, <<"No template or pattern specified">>};
+                Pattern -> {ok, Pattern}
+            end;
+        TemplateSpec -> {ok, TemplateSpec}
+    end,
+    
+    case TemplateResult of
+        {error, Reason} -> {error, Reason};
+        {ok, ExtractedTemplate} ->
+            % Remove the template from the state
             Listeners = maps:get(<<"listeners">>, StateMsg, #{}),
-            NewState = maps:remove({pattern, Pattern}, Listeners),
+            NewState = maps:remove({template, ExtractedTemplate}, Listeners),
             {ok, StateMsg#{<<"listeners">> => NewState}}
     end.
 
@@ -91,8 +118,13 @@ dispatch(_StateMsg, InputMsg, Opts) ->
 stream(_StateMsg, InputMsg, Opts) ->
     ?event(notify, {start_stream, InputMsg}),
     
-    % Extract pattern for filtering events
-    Pattern = hb_ao:get(<<"pattern">>, InputMsg, <<"*">>, Opts),
+    % Extract template for filtering events (supports both map and regex templates)
+    Template = case hb_ao:get(<<"template">>, InputMsg, Opts) of
+        not_found ->
+            % Fallback to pattern field for legacy compatibility
+            hb_ao:get(<<"pattern">>, InputMsg, <<".*">>, Opts); % Default regex matches all
+        TemplateSpec -> TemplateSpec
+    end,
     
     % Create streaming response headers
     Headers = #{
@@ -103,7 +135,7 @@ stream(_StateMsg, InputMsg, Opts) ->
     },
     
     % Start the streaming response
-    StreamingBody = create_streaming_body(Pattern, Opts),
+    StreamingBody = create_streaming_body(Template, Opts),
     
     {ok, #{
         <<"status">> => 200,
@@ -113,7 +145,7 @@ stream(_StateMsg, InputMsg, Opts) ->
     }}.
 
 %% @doc Create a streaming body function that keeps the connection open
-create_streaming_body(Pattern, Opts) ->
+create_streaming_body(Template, Opts) ->
     fun(Req) ->
         % Initialize streaming response
         Req2 = cowboy_req:stream_reply(200, #{
@@ -123,27 +155,39 @@ create_streaming_body(Pattern, Opts) ->
             <<"access-control-allow-origin">> => <<"*">>
         }, Req),
         
-        % Register this stream for notifications
-        StreamId = make_ref(),
-        register_stream(StreamId, Pattern, Req2, Opts),
-        
-        % Send initial connection message
-        InitialMessage = hb_util:encode(#{
-            <<"type">> => <<"connection">>,
-            <<"message">> => <<"Connected to notification stream">>,
-            <<"pattern">> => Pattern,
-            <<"timestamp">> => erlang:system_time(millisecond)
-        }),
-        cowboy_req:stream_body([<<"data: ">>, InitialMessage, <<"\n\n">>], nofin, Req2),
-        
-        % Keep connection alive and handle cleanup
-        stream_loop(StreamId, Req2, Opts),
+        % Validate template before registering
+        case validate_template(Template, Opts) of
+            {ok, ValidatedTemplate} ->
+                % Register this stream for notifications
+                StreamId = make_ref(),
+                register_stream(StreamId, ValidatedTemplate, Req2, Opts),
+                
+                % Send initial connection message
+                InitialMessage = hb_util:encode(#{
+                    <<"type">> => <<"connection">>,
+                    <<"message">> => <<"Connected to notification stream">>,
+                    <<"template">> => ValidatedTemplate,
+                    <<"timestamp">> => erlang:system_time(millisecond)
+                }),
+                cowboy_req:stream_body([<<"data: ">>, InitialMessage, <<"\n\n">>], nofin, Req2),
+                
+                % Keep connection alive and handle cleanup
+                stream_loop(StreamId, Req2, Opts);
+            {error, ValidationError} ->
+                % Send error message and close stream
+                ErrorMessage = hb_util:encode(#{
+                    <<"type">> => <<"error">>,
+                    <<"message">> => ValidationError,
+                    <<"timestamp">> => erlang:system_time(millisecond)
+                }),
+                cowboy_req:stream_body([<<"data: ">>, ErrorMessage, <<"\n\n">>], fin, Req2)
+        end,
         
         {ok, Req2}
     end.
 
 %% @doc Register a streaming connection for receiving notifications
-register_stream(StreamId, Pattern, _Req, _Opts) ->
+register_stream(StreamId, Template, _Req, _Opts) ->
     % Ensure notification manager is running
     start_notification_manager(),
     
@@ -153,8 +197,8 @@ register_stream(StreamId, Pattern, _Req, _Opts) ->
             ?event(notify, {manager_not_available, {stream_id, StreamId}});
         ManagerPid ->
             StreamPid = self(),
-            ManagerPid ! {register_listener, Pattern, StreamPid, StreamId},
-            ?event(notify, {stream_registered_with_manager, {stream_id, StreamId}, {pattern, Pattern}})
+            ManagerPid ! {register_listener, Template, StreamPid, StreamId},
+            ?event(notify, {stream_registered_with_manager, {stream_id, StreamId}, {template, Template}})
     end.
 
 %% @doc Keep the streaming connection alive and handle events
@@ -191,6 +235,57 @@ unregister_stream(StreamId) ->
             ManagerPid ! {unregister_listener, StreamId},
             ?event(notify, {stream_unregistered_from_manager, {stream_id, StreamId}})
     end.
+
+%% ============================================================================
+%% Template Validation and Matching
+%% ============================================================================
+
+%% @doc Validate a template specification (map template or regex pattern)
+validate_template(Template, _Opts) when is_map(Template) ->
+    % Map templates are used for message structure matching
+    % Validate that it's a proper map with at least one key
+    case maps:size(Template) of
+        0 -> {error, <<"Template cannot be empty">>};
+        _ -> {ok, Template}
+    end;
+validate_template(Template, _Opts) when is_binary(Template) ->
+    % Binary templates are treated as regex patterns for path matching
+    try 
+        % Test if the regex compiles properly
+        case re:compile(Template) of
+            {ok, _} -> {ok, Template};
+            {error, Reason} -> {error, iolist_to_binary(io_lib:format("Invalid regex: ~p", [Reason]))}
+        end
+    catch
+        _:_ -> {error, <<"Invalid regex template">>}
+    end;
+validate_template(Template, _Opts) ->
+    {error, iolist_to_binary(io_lib:format("Template must be a map or binary, got: ~p", [Template]))}.
+
+%% @doc Enhanced template matching using router's template system
+template_matches(Event, Template, _Opts) when is_map(Template) ->
+    % Use message structure matching (similar to dev_router:template_matches)
+    case hb_message:match(Template, Event, primary) of
+        {value_mismatch, _Key, _Val1, _Val2} -> false;
+        true -> true;
+        _Other -> false
+    end;
+template_matches(Event, Template, Opts) when is_binary(Template) ->
+    % Use regex path matching
+    EventPath = case hb_ao:get(<<"path">>, Event, Opts) of
+        not_found -> <<"/">>;
+        Path -> Path
+    end,
+    try 
+        case re:run(EventPath, Template) of
+            nomatch -> false;
+            _ -> true
+        end
+    catch
+        _:_ -> false
+    end;
+template_matches(_Event, _Template, _Opts) ->
+    false.
 
 %% ============================================================================
 %% Notification Manager Process
@@ -241,10 +336,10 @@ notification_manager_loop(State) ->
             handle_event_dispatch(Event, Opts),
             notification_manager_loop(State);
             
-        {register_listener, Pattern, StreamPid, Ref} ->
-            % Register a new listener
-            ets:insert(notification_listeners, {Pattern, StreamPid, Ref}),
-            ?event(notify, {listener_registered, {pattern, Pattern}, {stream, StreamPid}, {ref, Ref}}),
+        {register_listener, Template, StreamPid, Ref} ->
+            % Register a new listener with template
+            ets:insert(notification_listeners, {Template, StreamPid, Ref}),
+            ?event(notify, {listener_registered, {template, Template}, {stream, StreamPid}, {ref, Ref}}),
             notification_manager_loop(State);
             
         {unregister_listener, Ref} ->
@@ -279,18 +374,18 @@ handle_event_dispatch(Event, Opts) ->
     
     % Spawn short-lived worker processes for actual dispatching
     % This keeps the manager process responsive
-    lists:foreach(fun({Pattern, StreamPid, Ref}) ->
+    lists:foreach(fun({Template, StreamPid, Ref}) ->
         spawn(fun() -> 
-            try_dispatch_to_listener(Pattern, StreamPid, Ref, Event, Opts)
+            try_dispatch_to_listener(Template, StreamPid, Ref, Event, Opts)
         end)
     end, AllListeners).
 
-%% @doc Try to dispatch an event to a specific listener if pattern matches
-try_dispatch_to_listener(Pattern, StreamPid, Ref, Event, _Opts) ->
+%% @doc Try to dispatch an event to a specific listener if template matches
+try_dispatch_to_listener(Template, StreamPid, Ref, Event, Opts) ->
     try
-        case hb_message:match(Event, Pattern) of
+        case template_matches(Event, Template, Opts) of
             true ->
-                ?event(notify, {matched_pattern, {pattern, Pattern}, {ref, Ref}}),
+                ?event(notify, {matched_template, {template, Template}, {ref, Ref}}),
                 % Send event to the stream process
                 case is_process_alive(StreamPid) of
                     true ->
@@ -302,10 +397,53 @@ try_dispatch_to_listener(Pattern, StreamPid, Ref, Event, _Opts) ->
                         ?event(notify, {dead_stream_cleaned, {stream, StreamPid}})
                 end;
             false ->
-                % Pattern didn't match, no action needed
+                % Template didn't match, no action needed
                 ok
         end
     catch
         Class:Reason ->
-            ?event(notify, {dispatch_error, {class, Class}, {reason, Reason}, {pattern, Pattern}})
-    end. 
+            ?event(notify, {dispatch_error, {class, Class}, {reason, Reason}, {template, Template}})
+    end.
+
+%% ============================================================================
+%% Tests
+%% ============================================================================
+
+%% @doc Test template validation
+template_validation_test() ->
+    % Valid map template
+    ?assertEqual({ok, #{ <<"device">> => <<"test">> }}, 
+                 validate_template(#{ <<"device">> => <<"test">> }, #{})),
+    
+    % Valid regex template  
+    ?assertEqual({ok, <<"/.*/test">>}, 
+                 validate_template(<<"/.*/test">>, #{})),
+    
+    % Invalid empty map
+    ?assertMatch({error, _}, validate_template(#{}, #{})),
+    
+    % Invalid regex
+    ?assertMatch({error, _}, validate_template(<<"[invalid">>, #{})),
+    
+    % Invalid type
+    ?assertMatch({error, _}, validate_template(123, #{})).
+
+%% @doc Test template matching
+template_matching_test() ->
+    % Map template matching
+    MapTemplate = #{ <<"device">> => <<"process@1.0">> },
+    
+    Event1 = #{ <<"device">> => <<"process@1.0">>, <<"path">> => <<"/compute">> },
+    ?assertEqual(true, template_matches(Event1, MapTemplate, #{})),
+    
+    Event2 = #{ <<"device">> => <<"message@1.0">>, <<"path">> => <<"/compute">> },
+    ?assertEqual(false, template_matches(Event2, MapTemplate, #{})),
+    
+    % Regex template matching
+    RegexTemplate = <<"/.*process.*/.*">>,
+    
+    Event3 = #{ <<"path">> => <<"/test/process@1.0/compute">> },
+    ?assertEqual(true, template_matches(Event3, RegexTemplate, #{})),
+    
+    Event4 = #{ <<"path">> => <<"/test/message@1.0/compute">> },
+    ?assertEqual(false, template_matches(Event4, RegexTemplate, #{})). 

--- a/src/dev_notify.erl
+++ b/src/dev_notify.erl
@@ -465,16 +465,16 @@ notification_manager_loop(State) ->
 %% @doc Handle event dispatch by matching against registered listeners
 handle_event_dispatch(Event, Opts) ->
     try
-        % Get all registered listeners using new key structure
-        AllListeners = ets:tab2list(notification_listeners),
-        
-        % Spawn short-lived worker processes for actual dispatching
-        % This keeps the manager process responsive
-        lists:foreach(fun({{Template, StreamPid}, Ref}) ->
+        % Use ets:foldl instead of tab2list to avoid copying entire table
+        % This eliminates memory allocation overhead for large listener tables
+        ets:foldl(fun({{Template, StreamPid}, Ref}, Acc) ->
+            % Spawn short-lived worker processes for actual dispatching
+            % This keeps the manager process responsive
             spawn(fun() -> 
                 try_dispatch_to_listener(Template, StreamPid, Ref, Event, Opts)
-            end)
-        end, AllListeners)
+            end),
+            Acc
+        end, ok, notification_listeners)
     catch
         _:_ ->
             % Table might not exist, ignore

--- a/src/dev_notify.erl
+++ b/src/dev_notify.erl
@@ -1,0 +1,104 @@
+%%% @doc A device that provides real-time notifications for AO process events.
+%%% It integrates with the existing event system (hb_event) and allows clients
+%%% to subscribe to specific events using HTTP/3 streams.
+-module(dev_notify).
+-export([info/1, info/3, dispatch/3, register/3, unregister/3]).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%% @doc Device API information
+info(_) ->
+    #{
+        exports => [info, dispatch, register, unregister],
+        variant => <<"Notify/1.0">>
+    }.
+
+%% @doc HTTP info response providing information about this device
+info(_Msg1, _Msg2, _Opts) ->
+    InfoBody = #{
+        <<"description">> => <<"Notification device for real-time event streaming">>,
+        <<"version">> => <<"1.0">>,
+        <<"paths">> => #{
+            <<"info">> => <<"Get device info">>,
+            <<"dispatch">> => <<"Dispatch an event to registered listeners">>,
+            <<"register">> => <<"Register a new event listener">>,
+            <<"unregister">> => <<"Unregister an event listener">>
+        }
+    },
+    {ok, #{<<"status">> => 200, <<"body">> => InfoBody}}.
+
+%% @doc Register a new event listener
+register(StateMsg, InputMsg, Opts) ->
+    ?event(notify, {register_listener, InputMsg}),
+    case hb_ao:get(<<"pattern">>, InputMsg, Opts) of
+        not_found ->
+            {error, <<"No pattern specified for event registration">>};
+        Pattern ->
+            case hb_ao:get(<<"stream">>, InputMsg, Opts) of
+                not_found ->
+                    {error, <<"No stream specified for event registration">>};
+                Stream ->
+                    % Register the pattern and stream in the state
+                    NewState = maps:put(
+                        {pattern, Pattern},
+                        Stream,
+                        maps:get(<<"listeners">>, StateMsg, #{})
+                    ),
+                    {ok, StateMsg#{<<"listeners">> => NewState}}
+            end
+    end.
+
+%% @doc Unregister an event listener
+unregister(StateMsg, InputMsg, Opts) ->
+    ?event(notify, {unregister_listener, InputMsg}),
+    case hb_ao:get(<<"pattern">>, InputMsg, Opts) of
+        not_found ->
+            {error, <<"No pattern specified for event unregistration">>};
+        Pattern ->
+            % Remove the pattern from the state
+            Listeners = maps:get(<<"listeners">>, StateMsg, #{}),
+            NewState = maps:remove({pattern, Pattern}, Listeners),
+            {ok, StateMsg#{<<"listeners">> => NewState}}
+    end.
+
+%% @doc Dispatch an event to registered listeners
+dispatch(StateMsg, InputMsg, Opts) ->
+    ?event(notify, {dispatch_event, InputMsg}),
+    Listeners = maps:get(<<"listeners">>, StateMsg, #{}),
+    
+    % Spawn a worker process for non-blocking dispatch
+    spawn(fun() ->
+        dispatch_to_listeners(InputMsg, Listeners, Opts)
+    end),
+    
+    {ok, <<"OK">>}.
+
+%% @doc Internal function to dispatch events to matching listeners
+dispatch_to_listeners(Event, Listeners, Opts) ->
+    maps:fold(
+        fun({pattern, Pattern}, Stream, _) ->
+            case hb_message:match(Event, Pattern) of
+                true ->
+                    ?event(notify, {matched_pattern, Pattern, Event}),
+                    % Use Cowboy's http/3 push to send the event
+                    push_event(Stream, Event, Opts);
+                false ->
+                    ok
+            end
+        end,
+        ok,
+        Listeners
+    ).
+
+%% @doc Push an event to a stream using Cowboy's http/3 push
+push_event(Stream, Event, Opts) ->
+    try
+        % Convert event to JSON
+        EventJson = json:encode(Event),
+        % Push the event to the stream
+        cowboy_req:push(Stream, EventJson, Opts)
+    catch
+        Class:Reason ->
+            ?event(notify, {push_error, {Class, Reason}}),
+            ok
+    end. 

--- a/src/dev_notify.erl
+++ b/src/dev_notify.erl
@@ -1,52 +1,53 @@
 %%% @doc A device that provides real-time notifications for AO process events.
 %%% It integrates with the existing event system (hb_event) and allows clients
 %%% to subscribe to specific events using HTTP/3 streams.
-%%% 
+%%%
 %%% Uses a long-running notification manager process to handle high-frequency
 %%% message matching and dispatching efficiently.
 -module(dev_notify).
+
 -export([info/1, info/3, dispatch/3, register/3, unregister/3, stream/3]).
 -export([start_notification_manager/0, stop_notification_manager/0]).
--export([notification_manager_loop/1]).
+
 -include("include/hb.hrl").
+
 -include_lib("eunit/include/eunit.hrl").
 
 -define(NOTIFICATION_MANAGER, hb_notification_manager).
 
 %% @doc Device API information
 info(_) ->
-    #{
-        exports => [info, dispatch, register, unregister, stream],
-        variant => <<"Notify/1.0">>
-    }.
+    #{exports => [info, dispatch, register, unregister, stream], variant => <<"Notify/1.0">>}.
 
 %% @doc HTTP info response providing information about this device
 info(_Msg1, _Msg2, _Opts) ->
-    InfoBody = #{
-        <<"description">> => <<"Notification device for real-time event streaming">>,
-        <<"version">> => <<"1.0">>,
-        <<"paths">> => #{
-            <<"info">> => <<"Get device info">>,
-            <<"dispatch">> => <<"Dispatch an event to registered listeners">>,
-            <<"register">> => <<"Register a new event listener">>,
-            <<"unregister">> => <<"Unregister an event listener">>,
-            <<"stream">> => <<"Start a streaming connection for real-time events">>
-        }
-    },
+    InfoBody =
+        #{<<"description">> => <<"Notification device for real-time event streaming">>,
+          <<"version">> => <<"1.0">>,
+          <<"paths">> =>
+              #{<<"info">> => <<"Get device info">>,
+                <<"dispatch">> => <<"Dispatch an event to registered listeners">>,
+                <<"register">> => <<"Register a new event listener">>,
+                <<"unregister">> => <<"Unregister an event listener">>,
+                <<"stream">> => <<"Start a streaming connection for real-time events">>}},
     {ok, #{<<"status">> => 200, <<"body">> => InfoBody}}.
 
 %% @doc Register a new event listener with template/spec support
 register(StateMsg, InputMsg, Opts) ->
     ?event(notify, {register_listener, InputMsg}),
-    
+
     % Extract template specification (supports both map and regex templates)
-    TemplateResult = case hb_ao:get(<<"template">>, InputMsg, Opts) of
-        not_found -> {error, <<"No template specified">>};
-        TemplateSpec -> {ok, TemplateSpec}
-    end,
-    
+    TemplateResult =
+        case hb_ao:get(<<"template">>, InputMsg, Opts) of
+            not_found ->
+                {error, <<"No template specified">>};
+            TemplateSpec ->
+                {ok, TemplateSpec}
+        end,
+
     case TemplateResult of
-        {error, Reason} -> {error, Reason};
+        {error, Reason} ->
+            {error, Reason};
         {ok, ExtractedTemplate} ->
             case hb_ao:get(<<"stream">>, InputMsg, Opts) of
                 not_found ->
@@ -56,11 +57,10 @@ register(StateMsg, InputMsg, Opts) ->
                     case validate_template(ExtractedTemplate, Opts) of
                         {ok, ValidatedTemplate} ->
                             % Register the template and stream in the state
-                            NewState = maps:put(
-                                {template, ValidatedTemplate},
-                                Stream,
-                                maps:get(<<"listeners">>, StateMsg, #{})
-                            ),
+                            NewState =
+                                maps:put({template, ValidatedTemplate},
+                                         Stream,
+                                         maps:get(<<"listeners">>, StateMsg, #{})),
                             {ok, StateMsg#{<<"listeners">> => NewState}};
                         {error, ValidationError} ->
                             {error, ValidationError}
@@ -71,15 +71,19 @@ register(StateMsg, InputMsg, Opts) ->
 %% @doc Unregister an event listener (supports both template and legacy pattern)
 unregister(StateMsg, InputMsg, Opts) ->
     ?event(notify, {unregister_listener, InputMsg}),
-    
+
     % Extract template for removal
-    TemplateResult = case hb_ao:get(<<"template">>, InputMsg, Opts) of
-        not_found -> {error, <<"No template specified">>};
-        TemplateSpec -> {ok, TemplateSpec}
-    end,
-    
+    TemplateResult =
+        case hb_ao:get(<<"template">>, InputMsg, Opts) of
+            not_found ->
+                {error, <<"No template specified">>};
+            TemplateSpec ->
+                {ok, TemplateSpec}
+        end,
+
     case TemplateResult of
-        {error, Reason} -> {error, Reason};
+        {error, Reason} ->
+            {error, Reason};
         {ok, ExtractedTemplate} ->
             % Validate template to get the same format as register function
             case validate_template(ExtractedTemplate, Opts) of
@@ -109,8 +113,10 @@ find_matching_key(_TargetTemplate, []) ->
     not_found;
 find_matching_key(TargetTemplate, [{template, StoredTemplate} | Rest]) ->
     case templates_match(TargetTemplate, StoredTemplate) of
-        true -> {template, StoredTemplate};
-        false -> find_matching_key(TargetTemplate, Rest)
+        true ->
+            {template, StoredTemplate};
+        false ->
+            find_matching_key(TargetTemplate, Rest)
     end;
 find_matching_key(TargetTemplate, [_OtherKey | Rest]) ->
     find_matching_key(TargetTemplate, Rest).
@@ -118,13 +124,16 @@ find_matching_key(TargetTemplate, [_OtherKey | Rest]) ->
 %% @doc Check if two templates are equivalent
 templates_match(Template1, Template2) when is_binary(Template1), is_binary(Template2) ->
     Template1 =:= Template2;
-templates_match({compiled_regex, _CompiledRegex1, OriginalPattern1}, {compiled_regex, _CompiledRegex2, OriginalPattern2}) ->
+templates_match({compiled_regex, _CompiledRegex1, OriginalPattern1},
+                {compiled_regex, _CompiledRegex2, OriginalPattern2}) ->
     % Compare original patterns for compiled regex templates
     OriginalPattern1 =:= OriginalPattern2;
-templates_match({compiled_regex, _CompiledRegex, OriginalPattern}, Template) when is_binary(Template) ->
+templates_match({compiled_regex, _CompiledRegex, OriginalPattern}, Template)
+    when is_binary(Template) ->
     % Compare compiled regex with binary template
     OriginalPattern =:= Template;
-templates_match(Template, {compiled_regex, _CompiledRegex, OriginalPattern}) when is_binary(Template) ->
+templates_match(Template, {compiled_regex, _CompiledRegex, OriginalPattern})
+    when is_binary(Template) ->
     % Compare binary template with compiled regex
     Template =:= OriginalPattern;
 templates_match(Template1, Template2) when is_map(Template1), is_map(Template2) ->
@@ -146,7 +155,7 @@ extract_essential_template(Template) ->
 %% @doc Dispatch an event to registered listeners via the notification manager
 dispatch(_StateMsg, InputMsg, Opts) ->
     ?event(notify, {dispatch_event, InputMsg}),
-    
+
     % Send event to the long-running notification manager process
     case whereis(?NOTIFICATION_MANAGER) of
         undefined ->
@@ -164,75 +173,72 @@ dispatch(_StateMsg, InputMsg, Opts) ->
 %% @doc Start a streaming connection for real-time event notifications
 stream(_StateMsg, InputMsg, Opts) ->
     ?event(notify, {start_stream, InputMsg}),
-    
+
     % Extract template for filtering events (supports both map and regex templates)
     Template = hb_ao:get(<<"template">>, InputMsg, <<".*">>, Opts),
-    
+
     % Create streaming response headers
-    Headers = #{
-        <<"content-type">> => <<"application/json">>,
-        <<"cache-control">> => <<"no-cache">>,
-        <<"connection">> => <<"keep-alive">>,
-        <<"access-control-allow-origin">> => <<"*">>
-    },
-    
+    Headers =
+        #{<<"content-type">> => <<"application/json">>,
+          <<"cache-control">> => <<"no-cache">>,
+          <<"connection">> => <<"keep-alive">>,
+          <<"access-control-allow-origin">> => <<"*">>},
+
     % Start the streaming response
     StreamingBody = create_streaming_body(Template, Opts),
-    
-    {ok, #{
-        <<"status">> => 200,
-        <<"headers">> => Headers,
-        <<"body">> => StreamingBody,
-        <<"streaming">> => true
-    }}.
+
+    {ok,
+     #{<<"status">> => 200,
+       <<"headers">> => Headers,
+       <<"body">> => StreamingBody,
+       <<"streaming">> => true}}.
 
 %% @doc Create a streaming body function that keeps the connection open
 create_streaming_body(Template, Opts) ->
     fun(Req) ->
-        % Initialize streaming response
-        Req2 = cowboy_req:stream_reply(200, #{
-            <<"content-type">> => <<"text/event-stream">>,
-            <<"cache-control">> => <<"no-cache">>,
-            <<"connection">> => <<"keep-alive">>,
-            <<"access-control-allow-origin">> => <<"*">>
-        }, Req),
-        
-        % Validate template before registering
-        case validate_template(Template, Opts) of
-            {ok, ValidatedTemplate} ->
-                % Register this stream for notifications
-                StreamId = make_ref(),
-                register_stream(StreamId, ValidatedTemplate, Req2, Opts),
-                
-                % Send initial connection message
-                InitialMessage = hb_util:encode(#{
-                    <<"type">> => <<"connection">>,
-                    <<"message">> => <<"Connected to notification stream">>,
-                    <<"template">> => ValidatedTemplate,
-                    <<"timestamp">> => erlang:system_time(millisecond)
-                }),
-                cowboy_req:stream_body([<<"data: ">>, InitialMessage, <<"\n\n">>], nofin, Req2),
-                
-                % Keep connection alive and handle cleanup
-                stream_loop(StreamId, Req2, Opts);
-            {error, ValidationError} ->
-                % Send error message and close stream
-                ErrorMessage = hb_util:encode(#{
-                    <<"type">> => <<"error">>,
-                    <<"message">> => ValidationError,
-                    <<"timestamp">> => erlang:system_time(millisecond)
-                }),
-                cowboy_req:stream_body([<<"data: ">>, ErrorMessage, <<"\n\n">>], fin, Req2)
-        end,
-        
-        {ok, Req2}
+       % Initialize streaming response
+       Req2 =
+           cowboy_req:stream_reply(200,
+                                   #{<<"content-type">> => <<"text/event-stream">>,
+                                     <<"cache-control">> => <<"no-cache">>,
+                                     <<"connection">> => <<"keep-alive">>,
+                                     <<"access-control-allow-origin">> => <<"*">>},
+                                   Req),
+
+       % Validate template before registering
+       case validate_template(Template, Opts) of
+           {ok, ValidatedTemplate} ->
+               % Register this stream for notifications
+               StreamId = make_ref(),
+               register_stream(StreamId, ValidatedTemplate, Req2, Opts),
+
+               % Send initial connection message
+               InitialMessage =
+                   hb_util:encode(#{<<"type">> => <<"connection">>,
+                                    <<"message">> => <<"Connected to notification stream">>,
+                                    <<"template">> => ValidatedTemplate,
+                                    <<"timestamp">> => erlang:system_time(millisecond)}),
+               cowboy_req:stream_body([<<"data: ">>, InitialMessage, <<"\n\n">>], nofin, Req2),
+
+               % Keep connection alive and handle cleanup
+               stream_loop(StreamId, Req2, Opts);
+           {error, ValidationError} ->
+               % Send error message and close stream
+               ErrorMessage =
+                   hb_util:encode(#{<<"type">> => <<"error">>,
+                                    <<"message">> => ValidationError,
+                                    <<"timestamp">> => erlang:system_time(millisecond)}),
+               cowboy_req:stream_body([<<"data: ">>, ErrorMessage, <<"\n\n">>], fin, Req2)
+       end,
+
+       {ok, Req2}
     end.
 
 %% @doc Register a streaming connection for receiving notifications
 register_stream(StreamId, Template, _Req, _Opts) ->
     % Ensure notification manager is running
     start_notification_manager(),
-    
+
     % Register with the notification manager
     case whereis(?NOTIFICATION_MANAGER) of
         undefined ->
@@ -240,7 +246,8 @@ register_stream(StreamId, Template, _Req, _Opts) ->
         ManagerPid ->
             StreamPid = self(),
             ManagerPid ! {register_listener, Template, StreamPid, StreamId},
-            ?event(notify, {stream_registered_with_manager, {stream_id, StreamId}, {template, Template}})
+            ?event(notify,
+                   {stream_registered_with_manager, {stream_id, StreamId}, {template, Template}})
     end.
 
 %% @doc Keep the streaming connection alive and handle events
@@ -259,10 +266,9 @@ stream_loop(StreamId, Req, Opts) ->
             stream_loop(StreamId, Req, Opts)
     after 30000 -> % 30 second keepalive
         % Send keepalive message
-        KeepaliveMsg = hb_util:encode(#{
-            <<"type">> => <<"keepalive">>,
-            <<"timestamp">> => erlang:system_time(millisecond)
-        }),
+        KeepaliveMsg =
+            hb_util:encode(#{<<"type">> => <<"keepalive">>,
+                             <<"timestamp">> => erlang:system_time(millisecond)}),
         cowboy_req:stream_body([<<"data: ">>, KeepaliveMsg, <<"\n\n">>], nofin, Req),
         stream_loop(StreamId, Req, Opts)
     end.
@@ -287,58 +293,79 @@ validate_template(Template, _Opts) when is_map(Template) ->
     % Map templates are used for message structure matching
     % Validate that it's a proper map with at least one key
     case maps:size(Template) of
-        0 -> {error, <<"Template cannot be empty">>};
-        _ -> {ok, Template}
+        0 ->
+            {error, <<"Template cannot be empty">>};
+        _ ->
+            {ok, Template}
     end;
 validate_template(Template, _Opts) when is_binary(Template) ->
     % Binary templates are treated as regex patterns for path matching
     % Compile the regex once for efficiency
-    try 
+    try
         case re:compile(Template) of
-            {ok, CompiledRegex} -> {ok, {compiled_regex, CompiledRegex, Template}};
-            {error, Reason} -> {error, iolist_to_binary(io_lib:format("Invalid regex: ~p", [Reason]))}
+            {ok, CompiledRegex} ->
+                {ok, {compiled_regex, CompiledRegex, Template}};
+            {error, Reason} ->
+                {error, iolist_to_binary(io_lib:format("Invalid regex: ~p", [Reason]))}
         end
     catch
-        _:_ -> {error, <<"Invalid regex template">>}
+        _:_ ->
+            {error, <<"Invalid regex template">>}
     end;
 validate_template(Template, _Opts) ->
-    {error, iolist_to_binary(io_lib:format("Template must be a map or binary, got: ~p", [Template]))}.
+    {error,
+     iolist_to_binary(io_lib:format("Template must be a map or binary, got: ~p", [Template]))}.
 
 %% @doc Enhanced template matching using router's template system
 template_matches(Event, Template, _Opts) when is_map(Template) ->
     % Use message structure matching (similar to dev_router:template_matches)
     case hb_message:match(Template, Event, primary) of
-        {value_mismatch, _Key, _Val1, _Val2} -> false;
-        true -> true;
-        _Other -> false
+        {value_mismatch, _Key, _Val1, _Val2} ->
+            false;
+        true ->
+            true;
+        _Other ->
+            false
     end;
 template_matches(Event, {compiled_regex, CompiledRegex, _OriginalPattern}, Opts) ->
     % Use pre-compiled regex for efficient path matching
-    EventPath = case hb_ao:get(<<"path">>, Event, Opts) of
-        not_found -> <<"/">>;
-        Path -> Path
-    end,
-    try 
+    EventPath =
+        case hb_ao:get(<<"path">>, Event, Opts) of
+            not_found ->
+                <<"/">>;
+            Path ->
+                Path
+        end,
+    try
         case re:run(EventPath, CompiledRegex) of
-            nomatch -> false;
-            _ -> true
+            nomatch ->
+                false;
+            _ ->
+                true
         end
     catch
-        _:_ -> false
+        _:_ ->
+            false
     end;
 template_matches(Event, Template, Opts) when is_binary(Template) ->
     % Fallback for legacy binary templates (compile on-the-fly)
-    EventPath = case hb_ao:get(<<"path">>, Event, Opts) of
-        not_found -> <<"/">>;
-        Path -> Path
-    end,
-    try 
+    EventPath =
+        case hb_ao:get(<<"path">>, Event, Opts) of
+            not_found ->
+                <<"/">>;
+            Path ->
+                Path
+        end,
+    try
         case re:run(EventPath, Template) of
-            nomatch -> false;
-            _ -> true
+            nomatch ->
+                false;
+            _ ->
+                true
         end
     catch
-        _:_ -> false
+        _:_ ->
+            false
     end;
 template_matches(_Event, _Template, _Opts) ->
     false.
@@ -352,30 +379,38 @@ start_notification_manager() ->
     case whereis(?NOTIFICATION_MANAGER) of
         undefined ->
             % Start the manager process
-            ManagerPid = spawn_link(fun() -> 
-                try register(?NOTIFICATION_MANAGER, self()) of
-                    true ->
-                        % Initialize ETS table for fast listener lookups
-                        case ets:info(notification_listeners) of
-                            undefined ->
-                                ets:new(notification_listeners, [named_table, public, set, {read_concurrency, true}]);
-                            _ -> ok
-                        end,
-                        ?event(notify, {notification_manager_started, self()}),
-                        notification_manager_loop(#{})
-                catch
-                    error:badarg ->
-                        % Someone else registered already, exit quietly
-                        exit(already_registered)
-                end
-            end),
+            ManagerPid =
+                spawn_link(fun() ->
+                              try register(?NOTIFICATION_MANAGER, self()) of
+                                  true ->
+                                      % Initialize ETS table for fast listener lookups
+                                      case ets:info(notification_listeners) of
+                                          undefined ->
+                                              ets:new(notification_listeners,
+                                                      [named_table,
+                                                       public,
+                                                       set,
+                                                       {read_concurrency, true}]);
+                                          _ -> ok
+                                      end,
+                                      ?event(notify, {notification_manager_started, self()}),
+                                      notification_manager_loop(#{})
+                              catch
+                                  error:badarg ->
+                                      % Someone else registered already, exit quietly
+                                      exit(already_registered)
+                              end
+                           end),
             % Give the process a moment to register
             timer:sleep(10),
             % Check if it actually got registered
             case whereis(?NOTIFICATION_MANAGER) of
-                ManagerPid -> {ok, ManagerPid};
-                OtherPid when is_pid(OtherPid) -> {already_started, OtherPid};
-                undefined -> {error, registration_failed}
+                ManagerPid ->
+                    {ok, ManagerPid};
+                OtherPid when is_pid(OtherPid) ->
+                    {already_started, OtherPid};
+                undefined ->
+                    {error, registration_failed}
             end;
         Pid ->
             {already_started, Pid}
@@ -384,29 +419,45 @@ start_notification_manager() ->
 %% @doc Stop the notification manager process
 stop_notification_manager() ->
     case whereis(?NOTIFICATION_MANAGER) of
-        undefined -> ok;
+        undefined ->
+            ok;
         Pid ->
             % First unregister to prevent new registrations
-            try unregister(?NOTIFICATION_MANAGER) catch _:_ -> ok end,
-            
+            try
+                unregister(?NOTIFICATION_MANAGER)
+            catch
+                _:_ ->
+                    ok
+            end,
+
             % Send stop signal
             Pid ! stop,
-            
+
             % Wait for process to die with timeout
             Ref = monitor(process, Pid),
             receive
-                {'DOWN', Ref, process, Pid, _Reason} -> ok
+                {'DOWN', Ref, process, Pid, _Reason} ->
+                    ok
             after 100 ->
                 exit(Pid, kill),
-                receive {'DOWN', Ref, process, Pid, _} -> ok after 50 -> ok end
+                receive
+                    {'DOWN', Ref, process, Pid, _} ->
+                        ok
+                after 50 ->
+                    ok
+                end
             end,
-            
+
             % Clean up ETS table if it still exists
             case ets:info(notification_listeners) of
-                undefined -> ok;
-                _ -> 
-                    try ets:delete(notification_listeners)
-                    catch _:_ -> ok
+                undefined ->
+                    ok;
+                _ ->
+                    try
+                        ets:delete(notification_listeners)
+                    catch
+                        _:_ ->
+                            ok
                     end
             end,
             ok
@@ -420,42 +471,42 @@ notification_manager_loop(State) ->
             % This keeps the work minimal to avoid blocking
             handle_event_dispatch(Event, Opts),
             notification_manager_loop(State);
-            
         {register_listener, Template, StreamPid, Ref} ->
             % Register a new listener with template using new key structure
             % Key is {{Template, StreamPid}, Ref} to ensure deduplication by {Template, StreamPid}
             ets:insert(notification_listeners, {{Template, StreamPid}, Ref}),
-            ?event(notify, {listener_registered, {template, Template}, {stream, StreamPid}, {ref, Ref}}),
+            ?event(notify,
+                   {listener_registered, {template, Template}, {stream, StreamPid}, {ref, Ref}}),
             notification_manager_loop(State);
-            
         {unregister_listener, Ref} ->
             % Remove listener by reference using new key structure
-            ets:match_delete(notification_listeners, {'_', Ref}),
+            % Key structure is {{Template, StreamPid}, Ref}
+            ets:match_delete(notification_listeners, {{'_', '_'}, Ref}),
             ?event(notify, {listener_unregistered, {ref, Ref}}),
             notification_manager_loop(State);
-            
         {get_stats} ->
             % Return statistics about registered listeners
-            Stats = #{
-                total_listeners => ets:info(notification_listeners, size),
-                manager_pid => self(),
-                state => State
-            },
+            Stats =
+                #{total_listeners => ets:info(notification_listeners, size),
+                  manager_pid => self(),
+                  state => State},
             ?event(notify, {manager_stats, Stats}),
             notification_manager_loop(State);
-            
         stop ->
             ?event(notify, {notification_manager_stopping, self()}),
             % Clean up ETS table before exiting
             case ets:info(notification_listeners) of
-                undefined -> ok;
-                _ -> 
-                    try ets:delete(notification_listeners)
-                    catch _:_ -> ok
+                undefined ->
+                    ok;
+                _ ->
+                    try
+                        ets:delete(notification_listeners)
+                    catch
+                        _:_ ->
+                            ok
                     end
             end,
             ok;
-            
         Msg ->
             ?event(notify, {unexpected_message, Msg}),
             notification_manager_loop(State)
@@ -467,13 +518,14 @@ handle_event_dispatch(Event, Opts) ->
         % Use ets:foldl instead of tab2list to avoid copying entire table
         % This eliminates memory allocation overhead for large listener tables
         ets:foldl(fun({{Template, StreamPid}, Ref}, Acc) ->
-            % Spawn short-lived worker processes for actual dispatching
-            % This keeps the manager process responsive
-            spawn(fun() -> 
-                try_dispatch_to_listener(Template, StreamPid, Ref, Event, Opts)
-            end),
-            Acc
-        end, ok, notification_listeners)
+                     % Spawn short-lived worker processes for actual dispatching
+                     % This keeps the manager process responsive
+                     spawn(fun() -> try_dispatch_to_listener(Template, StreamPid, Ref, Event, Opts)
+                           end),
+                     Acc
+                  end,
+                  ok,
+                  notification_listeners)
     catch
         _:_ ->
             % Table might not exist, ignore
@@ -512,27 +564,27 @@ try_dispatch_to_listener(Template, StreamPid, Ref, Event, Opts) ->
 %% @doc Test template validation
 template_validation_test() ->
     % Valid map template
-    MapTemplate = #{ <<"device">> => <<"test">> },
+    MapTemplate = #{<<"device">> => <<"test">>},
     MapResult = validate_template(MapTemplate, #{}),
     ?event(debug, {map_template_validation, {input, MapTemplate}, {result, MapResult}}),
-    ?assertEqual({ok, #{ <<"device">> => <<"test">> }}, MapResult),
-    
-    % Valid regex template  
+    ?assertEqual({ok, #{<<"device">> => <<"test">>}}, MapResult),
+
+    % Valid regex template
     RegexTemplate = <<"/.*/test">>,
     RegexResult = validate_template(RegexTemplate, #{}),
     ?event(debug, {regex_template_validation, {input, RegexTemplate}, {result, RegexResult}}),
     ?assertMatch({ok, {compiled_regex, _, <<"/.*/test">>}}, RegexResult),
-    
+
     % Invalid empty map
     EmptyResult = validate_template(#{}, #{}),
     ?event(debug, {empty_map_validation, {result, EmptyResult}}),
     ?assertMatch({error, _}, EmptyResult),
-    
+
     % Invalid regex
     InvalidRegexResult = validate_template(<<"[invalid">>, #{}),
     ?event(debug, {invalid_regex_validation, {result, InvalidRegexResult}}),
     ?assertMatch({error, _}, InvalidRegexResult),
-    
+
     % Invalid type
     InvalidTypeResult = validate_template(123, #{}),
     ?event(debug, {invalid_type_validation, {result, InvalidTypeResult}}),
@@ -541,29 +593,33 @@ template_validation_test() ->
 %% @doc Test template matching
 template_matching_test() ->
     % Map template matching
-    MapTemplate = #{ <<"device">> => <<"process@1.0">> },
-    
-    Event1 = #{ <<"device">> => <<"process@1.0">>, <<"path">> => <<"/compute">> },
+    MapTemplate = #{<<"device">> => <<"process@1.0">>},
+
+    Event1 = #{<<"device">> => <<"process@1.0">>, <<"path">> => <<"/compute">>},
     Match1 = template_matches(Event1, MapTemplate, #{}),
-    ?event(debug, {map_template_match, {template, MapTemplate}, {event, Event1}, {result, Match1}}),
+    ?event(debug,
+           {map_template_match, {template, MapTemplate}, {event, Event1}, {result, Match1}}),
     ?assertEqual(true, Match1),
-    
-    Event2 = #{ <<"device">> => <<"message@1.0">>, <<"path">> => <<"/compute">> },
+
+    Event2 = #{<<"device">> => <<"message@1.0">>, <<"path">> => <<"/compute">>},
     Match2 = template_matches(Event2, MapTemplate, #{}),
-    ?event(debug, {map_template_no_match, {template, MapTemplate}, {event, Event2}, {result, Match2}}),
+    ?event(debug,
+           {map_template_no_match, {template, MapTemplate}, {event, Event2}, {result, Match2}}),
     ?assertEqual(false, Match2),
-    
+
     % Regex template matching
     RegexTemplate = <<"/.*process.*/.*">>,
-    
-    Event3 = #{ <<"path">> => <<"/test/process@1.0/compute">> },
+
+    Event3 = #{<<"path">> => <<"/test/process@1.0/compute">>},
     Match3 = template_matches(Event3, RegexTemplate, #{}),
-    ?event(debug, {regex_template_match, {template, RegexTemplate}, {event, Event3}, {result, Match3}}),
+    ?event(debug,
+           {regex_template_match, {template, RegexTemplate}, {event, Event3}, {result, Match3}}),
     ?assertEqual(true, Match3),
-    
-    Event4 = #{ <<"path">> => <<"/test/message@1.0/compute">> },
+
+    Event4 = #{<<"path">> => <<"/test/message@1.0/compute">>},
     Match4 = template_matches(Event4, RegexTemplate, #{}),
-    ?event(debug, {regex_template_no_match, {template, RegexTemplate}, {event, Event4}, {result, Match4}}),
+    ?event(debug,
+           {regex_template_no_match, {template, RegexTemplate}, {event, Event4}, {result, Match4}}),
     ?assertEqual(false, Match4).
 
 %% @doc Test notification manager process lifecycle
@@ -573,7 +629,7 @@ notification_manager_test() ->
     ?event(debug, {manager_initial_state, InitialState}),
     stop_notification_manager(),
     timer:sleep(50),
-    
+
     % Start manager
     StartResult = start_notification_manager(),
     ?event(debug, {manager_start_result, StartResult}),
@@ -581,7 +637,7 @@ notification_manager_test() ->
     ?assert(is_process_alive(ManagerPid)),
     ?assertEqual(ManagerPid, whereis(?NOTIFICATION_MANAGER)),
     ?event(debug, {manager_started_successfully, {pid, ManagerPid}}),
-    
+
     % Stop manager
     ?event(debug, {stopping_manager}),
     stop_notification_manager(),
@@ -596,42 +652,40 @@ event_dispatch_test() ->
     % Ensure clean state
     stop_notification_manager(),
     timer:sleep(50),
-    
+
     start_notification_manager(),
     ManagerPid = whereis(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
-    
+
     % Create a test stream process
     TestPid = self(),
-    StreamPid = spawn(fun() ->
-        receive 
-            {notify_event, Event} -> TestPid ! {received_event, Event}
-        after 1000 -> TestPid ! timeout
-        end
-    end),
-    
+    StreamPid =
+        spawn(fun() ->
+                 receive
+                     {notify_event, Event} -> TestPid ! {received_event, Event}
+                 after 1000 -> TestPid ! timeout
+                 end
+              end),
+
     % Register listener with map template
-    MapTemplate = #{ <<"device">> => <<"process@1.0">> },
+    MapTemplate = #{<<"device">> => <<"process@1.0">>},
     Ref1 = make_ref(),
-    ?event(debug, {registering_listener, {template, MapTemplate}, {stream_pid, StreamPid}, {ref, Ref1}}),
+    ?event(debug,
+           {registering_listener, {template, MapTemplate}, {stream_pid, StreamPid}, {ref, Ref1}}),
     ManagerPid ! {register_listener, MapTemplate, StreamPid, Ref1},
-    
+
     % Create test events
-    MatchingEvent = #{
-        <<"device">> => <<"process@1.0">>,
-        <<"action">> => <<"compute">>,
-        <<"data">> => <<"test">>
-    },
-    
-    NonMatchingEvent = #{
-        <<"device">> => <<"message@1.0">>,
-        <<"action">> => <<"compute">>
-    },
-    
+    MatchingEvent =
+        #{<<"device">> => <<"process@1.0">>,
+          <<"action">> => <<"compute">>,
+          <<"data">> => <<"test">>},
+
+    NonMatchingEvent = #{<<"device">> => <<"message@1.0">>, <<"action">> => <<"compute">>},
+
     % Dispatch matching event
     ?event(debug, {dispatching_matching_event, MatchingEvent}),
     ManagerPid ! {dispatch_event, MatchingEvent, #{}},
-    
+
     % Should receive the event
     receive
         {received_event, ReceivedEvent} ->
@@ -641,11 +695,11 @@ event_dispatch_test() ->
         ?event(debug, {timeout_on_matching_event}),
         ?assert(false, "Should have received matching event")
     end,
-    
+
     % Dispatch non-matching event
     ?event(debug, {dispatching_non_matching_event, NonMatchingEvent}),
     ManagerPid ! {dispatch_event, NonMatchingEvent, #{}},
-    
+
     % Should not receive anything (timeout expected)
     receive
         {received_event, UnexpectedEvent} ->
@@ -655,7 +709,7 @@ event_dispatch_test() ->
         ?event(debug, {expected_timeout_on_non_matching_event}),
         ok % Expected timeout
     end,
-    
+
     stop_notification_manager().
 
 %% @doc Test integration with hb_persistent notification
@@ -663,69 +717,72 @@ integration_test() ->
     % Ensure clean state
     stop_notification_manager(),
     timer:sleep(50),
-    
+
     % Test the integration point with hb_persistent
     GroupName = <<"test-group">>,
-    Msg2 = #{ <<"path">> => <<"/test">>, <<"data">> => <<"request">> },
-    Msg3 = #{ <<"result">> => <<"success">>, <<"timestamp">> => erlang:system_time(millisecond) },
-    Opts = #{ notify_device => <<"notify@1.0">> },
-    
+    Msg2 = #{<<"path">> => <<"/test">>, <<"data">> => <<"request">>},
+    Msg3 =
+        #{<<"result">> => <<"success">>, <<"timestamp">> => erlang:system_time(millisecond)},
+    Opts = #{notify_device => <<"notify@1.0">>},
+
     % Start notification manager
     start_notification_manager(),
     ManagerPid = whereis(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
-    
+
     % This should call our dispatch function
     hb_persistent:dispatch_to_notify_device(GroupName, Msg2, Msg3, Opts),
     timer:sleep(50),
-    
+
     % Manager should still be running (no crashes)
     ?assert(is_process_alive(ManagerPid)),
-    
+
     stop_notification_manager().
 
 %% @doc Test device registration and unregistration functions
 device_registration_test() ->
     StateMsg = #{<<"listeners">> => #{}},
     ?event(debug, {initial_state, StateMsg}),
-    
+
     % Test successful registration with map template
-    InputMsg1 = #{
-        <<"template">> => #{ <<"device">> => <<"test@1.0">> },
-        <<"stream">> => <<"test-stream">>
-    },
+    InputMsg1 =
+        #{<<"template">> => #{<<"device">> => <<"test@1.0">>}, <<"stream">> => <<"test-stream">>},
     ?event(debug, {registering_map_template, InputMsg1}),
-    
+
     {ok, NewState1} = register(StateMsg, InputMsg1, #{}),
     Listeners1 = maps:get(<<"listeners">>, NewState1),
-    ?event(debug, {after_map_registration, {listeners_count, maps:size(Listeners1)}, {keys, maps:keys(Listeners1)}}),
+    ?event(debug,
+           {after_map_registration,
+            {listeners_count, maps:size(Listeners1)},
+            {keys, maps:keys(Listeners1)}}),
     ?assertEqual(1, maps:size(Listeners1)),
-    
+
     % Test registration with regex template
-    InputMsg2 = #{
-        <<"template">> => <<"/.*test.*/.*">>,
-        <<"stream">> => <<"test-stream-2">>
-    },
-    
+    InputMsg2 = #{<<"template">> => <<"/.*test.*/.*">>, <<"stream">> => <<"test-stream-2">>},
+
     {ok, NewState2} = register(NewState1, InputMsg2, #{}),
     Listeners2 = maps:get(<<"listeners">>, NewState2),
     ?assertEqual(2, maps:size(Listeners2)),
-    
-    
+
     % Test unregistration - unregister the first template we added
-    UnregMsg = #{
-        <<"template">> => #{ <<"device">> => <<"test@1.0">> }
-    },
-    
-    ?event(debug, {before_unregister, {listeners_count, maps:size(maps:get(<<"listeners">>, NewState2))}}),
+    UnregMsg = #{<<"template">> => #{<<"device">> => <<"test@1.0">>}},
+
+    ?event(debug,
+           {before_unregister,
+            {listeners_count,
+             maps:size(
+                 maps:get(<<"listeners">>, NewState2))}}),
     {ok, NewState3} = unregister(NewState2, UnregMsg, #{}),
     Listeners3 = maps:get(<<"listeners">>, NewState3),
-    ?event(debug, {after_unregister, {listeners_count, maps:size(Listeners3)}, {keys, maps:keys(Listeners3)}}),
+    ?event(debug,
+           {after_unregister,
+            {listeners_count, maps:size(Listeners3)},
+            {keys, maps:keys(Listeners3)}}),
     ?assertEqual(1, maps:size(Listeners3)), % Should have 1 left (regex)
-    
+
     % Verify the correct template was removed
-    ?assertNot(maps:is_key({template, #{ <<"device">> => <<"test@1.0">> }}, Listeners3)),
-    
+    ?assertNot(maps:is_key({template, #{<<"device">> => <<"test@1.0">>}}, Listeners3)),
+
     % Test error cases
     ?assertMatch({error, _}, register(StateMsg, #{}, #{})),
     ?assertMatch({error, _}, register(StateMsg, #{<<"template">> => #{}}, #{})),
@@ -736,32 +793,32 @@ listener_registration_test() ->
     % Ensure clean state
     stop_notification_manager(),
     timer:sleep(50),
-    
+
     % Start manager
     start_notification_manager(),
     ManagerPid = whereis(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
-    
+
     % Register a listener
-    Template = #{ <<"device">> => <<"message@1.0">> },
+    Template = #{<<"device">> => <<"message@1.0">>},
     StreamPid = spawn(fun() -> receive _ -> ok end end),
     Ref = make_ref(),
-    
+
     ManagerPid ! {register_listener, Template, StreamPid, Ref},
     timer:sleep(10), % Allow registration to process
-    
+
     % Check listener is registered
     AllListeners = ets:tab2list(notification_listeners),
     ?assert(lists:member({{Template, StreamPid}, Ref}, AllListeners)),
-    
+
     % Unregister listener
     ManagerPid ! {unregister_listener, Ref},
     timer:sleep(10), % Allow unregistration to process
-    
+
     % Check listener is removed
     AllListeners2 = ets:tab2list(notification_listeners),
     ?assertNot(lists:member({{Template, StreamPid}, Ref}, AllListeners2)),
-    
+
     stop_notification_manager().
 
 %% @doc Test regex template matching in event dispatch
@@ -769,47 +826,48 @@ regex_dispatch_test() ->
     % Ensure clean state
     stop_notification_manager(),
     timer:sleep(50),
-    
+
     start_notification_manager(),
     ManagerPid = whereis(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
-    
+
     % Create test stream process
     TestPid = self(),
-    StreamPid = spawn(fun() ->
-        receive 
-            {notify_event, Event} -> TestPid ! {received_event, Event}
-        after 1000 -> TestPid ! timeout
-        end
-    end),
-    
+    StreamPid =
+        spawn(fun() ->
+                 receive
+                     {notify_event, Event} -> TestPid ! {received_event, Event}
+                 after 1000 -> TestPid ! timeout
+                 end
+              end),
+
     % Register listener with regex template
     RegexTemplate = <<"/.*process.*/.*">>,
     Ref = make_ref(),
     ManagerPid ! {register_listener, RegexTemplate, StreamPid, Ref},
-    
+
     % Test matching path
-    MatchingEvent = #{ <<"path">> => <<"/test/process@1.0/compute">> },
+    MatchingEvent = #{<<"path">> => <<"/test/process@1.0/compute">>},
     ManagerPid ! {dispatch_event, MatchingEvent, #{}},
-    
+
     receive
         {received_event, ReceivedEvent} ->
             ?assertEqual(MatchingEvent, ReceivedEvent)
     after 500 ->
         ?assert(false, "Should have received matching event")
     end,
-    
+
     % Test non-matching path
-    NonMatchingEvent = #{ <<"path">> => <<"/test/message@1.0/compute">> },
+    NonMatchingEvent = #{<<"path">> => <<"/test/message@1.0/compute">>},
     ManagerPid ! {dispatch_event, NonMatchingEvent, #{}},
-    
+
     receive
         {received_event, _} ->
             ?assert(false, "Should not have received non-matching event")
     after 100 ->
         ok % Expected timeout
     end,
-    
+
     stop_notification_manager().
 
 %% @doc Test dispatch function
@@ -817,83 +875,83 @@ dispatch_function_test() ->
     % Ensure clean state
     stop_notification_manager(),
     timer:sleep(50),
-    
+
     % Start manager for testing
     start_notification_manager(),
-    
+
     % Test dispatch with valid input
-    InputMsg = #{
-        <<"event">> => #{ <<"test">> => <<"data">> },
-        <<"timestamp">> => erlang:system_time(millisecond)
-    },
-    
+    InputMsg =
+        #{<<"event">> => #{<<"test">> => <<"data">>},
+          <<"timestamp">> => erlang:system_time(millisecond)},
+
     Result = dispatch(#{}, InputMsg, #{}),
     ?assertEqual({ok, <<"OK">>}, Result),
-    
+
     stop_notification_manager().
 
 %% @doc Test stream function
 stream_function_test() ->
     % Test stream creation with valid template
-    InputMsg1 = #{
-        <<"template">> => #{ <<"device">> => <<"test@1.0">> }
-    },
-    
+    InputMsg1 = #{<<"template">> => #{<<"device">> => <<"test@1.0">>}},
+
     {ok, Result1} = stream(#{}, InputMsg1, #{}),
     ?assertEqual(200, maps:get(<<"status">>, Result1)),
     ?assertEqual(true, maps:get(<<"streaming">>, Result1)),
     ?assert(maps:is_key(<<"headers">>, Result1)),
     ?assert(maps:is_key(<<"body">>, Result1)),
-    
+
     % Test with regex template
-    InputMsg2 = #{
-        <<"template">> => <<"/.*test.*/.*">>
-    },
-    
+    InputMsg2 = #{<<"template">> => <<"/.*test.*/.*">>},
+
     {ok, Result2} = stream(#{}, InputMsg2, #{}),
     ?assertEqual(200, maps:get(<<"status">>, Result2)).
-    
 
 %% @doc Test dead process cleanup
 dead_process_cleanup_test() ->
     % Ensure clean state
     stop_notification_manager(),
     timer:sleep(50),
-    
+
     start_notification_manager(),
     ManagerPid = whereis(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
-    
+
     % Create and register a process, then kill it
     DeadPid = spawn(fun() -> ok end),
     timer:sleep(10), % Ensure process dies
     ?assertNot(is_process_alive(DeadPid)),
     ?event(debug, {created_dead_process, {pid, DeadPid}, {alive, is_process_alive(DeadPid)}}),
-    
-    Template = #{ <<"device">> => <<"message@1.0">> },
+
+    Template = #{<<"device">> => <<"message@1.0">>},
     Ref = make_ref(),
-    
+
     % Register the dead process
     ?event(debug, {registering_dead_process, {template, Template}, {dead_pid, DeadPid}}),
     ManagerPid ! {register_listener, Template, DeadPid, Ref},
     timer:sleep(10),
-    
+
     % Verify it's in the table
     AllListeners = ets:tab2list(notification_listeners),
-    ?event(debug, {listeners_before_cleanup, {count, length(AllListeners)}, {has_dead_process, lists:member({{Template, DeadPid}, Ref}, AllListeners)}}),
+    ?event(debug,
+           {listeners_before_cleanup,
+            {count, length(AllListeners)},
+            {has_dead_process, lists:member({{Template, DeadPid}, Ref}, AllListeners)}}),
     ?assert(lists:member({{Template, DeadPid}, Ref}, AllListeners)),
-    
+
     % Dispatch an event that matches
-    Event = #{ <<"device">> => <<"message@1.0">> },
+    Event = #{<<"device">> => <<"message@1.0">>},
     ?event(debug, {dispatching_to_dead_process, Event}),
     ManagerPid ! {dispatch_event, Event, #{}},
     timer:sleep(50), % Allow cleanup to happen
-    
+
     % Dead process should be cleaned up
     AllListeners2 = ets:tab2list(notification_listeners),
-    ?event(debug, {listeners_after_cleanup, {count, length(AllListeners2)}, {dead_process_removed, not lists:member({{Template, DeadPid}, Ref}, AllListeners2)}}),
+    ?event(debug,
+           {listeners_after_cleanup,
+            {count, length(AllListeners2)},
+            {dead_process_removed, not lists:member({{Template, DeadPid}, Ref}, AllListeners2)}}),
     ?assertNot(lists:member({{Template, DeadPid}, Ref}, AllListeners2)),
-    
+
     stop_notification_manager().
 
 %% @doc Test concurrent dispatching
@@ -901,46 +959,49 @@ concurrent_dispatch_test() ->
     % Ensure clean state
     stop_notification_manager(),
     timer:sleep(50),
-    
+
     start_notification_manager(),
     ManagerPid = whereis(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
-    
+
     % Create multiple test processes
     TestPid = self(),
     NumStreams = 5,
-    
-    StreamPids = lists:map(fun(N) ->
-        spawn(fun() ->
-            receive 
-                {notify_event, Event} -> 
-                    TestPid ! {received_event, N, Event}
-            after 1000 -> 
-                TestPid ! {timeout, N}
-            end
-        end)
-    end, lists:seq(1, NumStreams)),
-    
+
+    StreamPids =
+        lists:map(fun(N) ->
+                     spawn(fun() ->
+                              receive
+                                  {notify_event, Event} -> TestPid ! {received_event, N, Event}
+                              after 1000 -> TestPid ! {timeout, N}
+                              end
+                           end)
+                  end,
+                  lists:seq(1, NumStreams)),
+
     % Register all with the same template
-    Template = #{ <<"type">> => <<"broadcast">> },
+    Template = #{<<"type">> => <<"broadcast">>},
     lists:foreach(fun({_N, Pid}) ->
-        ManagerPid ! {register_listener, Template, Pid, make_ref()}
-    end, lists:zip(lists:seq(1, NumStreams), StreamPids)),
-    
+                     ManagerPid ! {register_listener, Template, Pid, make_ref()}
+                  end,
+                  lists:zip(
+                      lists:seq(1, NumStreams), StreamPids)),
+
     timer:sleep(20), % Allow registrations to process
-    
+
     % Dispatch one event
-    Event = #{ <<"type">> => <<"broadcast">>, <<"message">> => <<"hello">> },
+    Event = #{<<"type">> => <<"broadcast">>, <<"message">> => <<"hello">>},
     ManagerPid ! {dispatch_event, Event, #{}},
-    
+
     % All streams should receive the event
     ReceivedCount = receive_events(NumStreams, 0),
     ?assertEqual(NumStreams, ReceivedCount),
-    
+
     stop_notification_manager().
 
 %% Helper function for concurrent test
-receive_events(0, Count) -> Count;
+receive_events(0, Count) ->
+    Count;
 receive_events(Remaining, Count) ->
     receive
         {received_event, _N, _Event} ->
@@ -954,24 +1015,20 @@ receive_events(Remaining, Count) ->
 %% @doc Test template validation edge cases
 template_validation_edge_cases_test() ->
     % Test deeply nested map template
-    NestedTemplate = #{
-        <<"device">> => <<"test@1.0">>,
-        <<"data">> => #{
-            <<"nested">> => #{
-                <<"value">> => <<"deep">>
-            }
-        }
-    },
+    NestedTemplate =
+        #{<<"device">> => <<"test@1.0">>,
+          <<"data">> => #{<<"nested">> => #{<<"value">> => <<"deep">>}}},
     ?assertEqual({ok, NestedTemplate}, validate_template(NestedTemplate, #{})),
-    
+
     % Test complex regex patterns
     ComplexRegex = <<"^/(test|prod)/process@[0-9]+\\.[0-9]+/.+$">>,
-    ?assertMatch({ok, {compiled_regex, _, ComplexRegex}}, validate_template(ComplexRegex, #{})),
-    
+    ?assertMatch({ok, {compiled_regex, _, ComplexRegex}},
+                 validate_template(ComplexRegex, #{})),
+
     % Test unicode in templates
-    UnicodeTemplate = #{ <<"message">> => <<"Hello 世界">> },
+    UnicodeTemplate = #{<<"message">> => <<"Hello 世界">>},
     ?assertEqual({ok, UnicodeTemplate}, validate_template(UnicodeTemplate, #{})),
-    
+
     % Test very long regex
     LongRegex = iolist_to_binary(lists:duplicate(1000, "a")),
     ?assertMatch({ok, {compiled_regex, _, LongRegex}}, validate_template(LongRegex, #{})).
@@ -979,26 +1036,25 @@ template_validation_edge_cases_test() ->
 %% @doc Test message matching edge cases
 message_matching_edge_cases_test() ->
     % Test partial map matching
-    Template = #{ <<"device">> => <<"message@1.0">> },
-    Event = #{
-        <<"device">> => <<"message@1.0">>,
-        <<"extra">> => <<"field">>,
-        <<"more">> => #{ <<"nested">> => <<"data">> }
-    },
+    Template = #{<<"device">> => <<"message@1.0">>},
+    Event =
+        #{<<"device">> => <<"message@1.0">>,
+          <<"extra">> => <<"field">>,
+          <<"more">> => #{<<"nested">> => <<"data">>}},
     ?assertEqual(true, template_matches(Event, Template, #{})),
-    
+
     % Test case sensitivity
-    CaseTemplate = #{ <<"Device">> => <<"Message@1.0">> },
-    CaseEvent = #{ <<"device">> => <<"message@1.0">> },
+    CaseTemplate = #{<<"Device">> => <<"Message@1.0">>},
+    CaseEvent = #{<<"device">> => <<"message@1.0">>},
     ?assertEqual(false, template_matches(CaseEvent, CaseTemplate, #{})),
-    
+
     % Test missing path in regex matching
     RegexTemplate = <<"/test.*">>,
-    EventWithoutPath = #{ <<"device">> => <<"message@1.0">> },
+    EventWithoutPath = #{<<"device">> => <<"message@1.0">>},
     ?assertEqual(false, template_matches(EventWithoutPath, RegexTemplate, #{})),
-    
+
     % Test empty path
-    EventWithEmptyPath = #{ <<"path">> => <<"">> },
+    EventWithEmptyPath = #{<<"path">> => <<"">>},
     ?assertEqual(false, template_matches(EventWithEmptyPath, RegexTemplate, #{})).
 
 %% @doc Test error handling and recovery
@@ -1006,27 +1062,27 @@ error_handling_test() ->
     % Ensure clean state
     stop_notification_manager(),
     timer:sleep(50),
-    
+
     start_notification_manager(),
     ManagerPid = whereis(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
-    
+
     % Test invalid template in dispatch (should not crash manager)
     InvalidTemplate = invalid_template_atom,
     TestPid = spawn(fun() -> receive _ -> ok end end),
     Ref = make_ref(),
-    
+
     % Register invalid template (insert directly to bypass validation)
     ets:insert(notification_listeners, {{InvalidTemplate, TestPid}, Ref}),
-    
+
     % Dispatch event - should handle error gracefully
-    Event = #{ <<"test">> => <<"data">> },
+    Event = #{<<"test">> => <<"data">>},
     ManagerPid ! {dispatch_event, Event, #{}},
     timer:sleep(50),
-    
+
     % Manager should still be alive
     ?assert(is_process_alive(ManagerPid)),
-    
+
     stop_notification_manager().
 
 %% @doc Performance test for high-frequency events
@@ -1034,190 +1090,191 @@ performance_test() ->
     % Ensure clean state
     stop_notification_manager(),
     timer:sleep(50),
-    
+
     start_notification_manager(),
     ManagerPid = whereis(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
-    
+
     % Register a listener
-    Template = #{ <<"type">> => <<"perf-test">> },
-    TestPid = spawn(fun() ->
-        receive_loop(0)
-    end),
+    Template = #{<<"type">> => <<"perf-test">>},
+    TestPid = spawn(fun() -> receive_loop(0) end),
     Ref = make_ref(),
     ManagerPid ! {register_listener, Template, TestPid, Ref},
     timer:sleep(10),
-    
+
     % Send many events quickly
     NumEvents = 100,
     StartTime = erlang:system_time(microsecond),
-    
+
     lists:foreach(fun(N) ->
-        Event = #{
-            <<"type">> => <<"perf-test">>,
-            <<"sequence">> => N,
-            <<"timestamp">> => erlang:system_time(millisecond)
-        },
-        ManagerPid ! {dispatch_event, Event, #{}}
-    end, lists:seq(1, NumEvents)),
-    
+                     Event =
+                         #{<<"type">> => <<"perf-test">>,
+                           <<"sequence">> => N,
+                           <<"timestamp">> => erlang:system_time(millisecond)},
+                     ManagerPid ! {dispatch_event, Event, #{}}
+                  end,
+                  lists:seq(1, NumEvents)),
+
     EndTime = erlang:system_time(microsecond),
     Duration = EndTime - StartTime,
-    
+
     ?event(notify, {performance_test, {events, NumEvents}, {duration_us, Duration}}),
-    
+
     % Should handle 100 events quickly (< 100ms)
     ?assert(Duration < 100000, "Performance test took too long"),
-    
-    stop_notification_manager().
 
+    stop_notification_manager().
 
 %% @doc Benchmark test to measure handle_event_dispatch performance directly
 handle_event_dispatch_benchmark_test() ->
     % Ensure clean state
     stop_notification_manager(),
     timer:sleep(50),
-    
+
     start_notification_manager(),
     ManagerPid = whereis(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
-    
+
     % Register many listeners to create realistic load
     NumListeners = 10000,
-    TestEvent = #{
-        <<"service">> => <<"benchmark">>,
-        <<"action">> => <<"test">>,
-        <<"data">> => <<"benchmark_payload">>
-    },
-    
+    TestEvent =
+        #{<<"service">> => <<"benchmark">>,
+          <<"action">> => <<"test">>,
+          <<"data">> => <<"benchmark_payload">>},
+
     % Create listeners with different templates for realistic scenario
     lists:foreach(fun(N) ->
-        Template = case N rem 4 of
-            0 -> #{ <<"service">> => <<"benchmark">> };  % Will match
-            1 -> #{ <<"service">> => <<"other">> };      % Won't match
-            2 -> #{ <<"action">> => <<"test">> };        % Will match  
-            3 -> #{ <<"type">> => <<"different">> }      % Won't match
-        end,
-        StreamPid = spawn(fun() -> 
-            receive stop -> ok after 10000 -> ok end 
-        end),
-        Ref = make_ref(),
-        ManagerPid ! {register_listener, Template, StreamPid, Ref}
-    end, lists:seq(1, NumListeners)),
-    
+                     Template =
+                         case N rem 4 of
+                             0 -> #{<<"service">> => <<"benchmark">>};  % Will match
+                             1 -> #{<<"service">> => <<"other">>};      % Won't match
+                             2 -> #{<<"action">> => <<"test">>};        % Will match
+                             3 -> #{<<"type">> => <<"different">>}      % Won't match
+                         end,
+                     StreamPid = spawn(fun() -> receive stop -> ok after 10000 -> ok end end),
+                     Ref = make_ref(),
+                     ManagerPid ! {register_listener, Template, StreamPid, Ref}
+                  end,
+                  lists:seq(1, NumListeners)),
+
     timer:sleep(100), % Allow registrations to process
-    
+
     % Verify listeners are registered
     ListenerCount = ets:info(notification_listeners, size),
     ?event(notify, {benchmark_setup, {listeners_registered, ListenerCount}}),
     ?assertEqual(NumListeners, ListenerCount),
-    
+
     % Benchmark current handle_event_dispatch implementation
     NumIterations = 100,
-    Times = lists:map(fun(_) ->
-        StartTime = erlang:system_time(microsecond),
-        
-        % Call handle_event_dispatch directly (this is what we're optimizing)
-        handle_event_dispatch(TestEvent, #{}),
-        
-        EndTime = erlang:system_time(microsecond),
-        EndTime - StartTime
-    end, lists:seq(1, NumIterations)),
-    
+    Times =
+        lists:map(fun(_) ->
+                     StartTime = erlang:system_time(microsecond),
+
+                     % Call handle_event_dispatch directly (this is what we're optimizing)
+                     handle_event_dispatch(TestEvent, #{}),
+
+                     EndTime = erlang:system_time(microsecond),
+                     EndTime - StartTime
+                  end,
+                  lists:seq(1, NumIterations)),
+
     % Calculate statistics
     TotalTime = lists:sum(Times),
     MinTime = lists:min(Times),
     MaxTime = lists:max(Times),
     AvgTime = TotalTime div NumIterations,
-    
+
     % Calculate how many processes were spawned per call
     % (This will be listeners that match × 1 since we spawn one process per match)
     MatchingListeners = NumListeners div 2, % Roughly half should match our test event
     ProcessesPerCall = MatchingListeners,
     TotalProcessesSpawned = ProcessesPerCall * NumIterations,
-    
-    ?event(notify_benchmark, {handle_event_dispatch_benchmark, 
-        {listeners, NumListeners},
-        {matching_listeners_estimate, MatchingListeners},
-        {iterations, NumIterations},
-        {total_time_us, TotalTime},
-        {avg_time_us, AvgTime},
-        {min_time_us, MinTime},
-        {max_time_us, MaxTime},
-        {processes_spawned_per_call, ProcessesPerCall},
-        {total_processes_spawned, TotalProcessesSpawned},
-        {calls_per_second, (NumIterations * 1000000) div TotalTime}
-    }),
-    
+
+    ?event(notify_benchmark,
+           {handle_event_dispatch_benchmark,
+            {listeners, NumListeners},
+            {matching_listeners_estimate, MatchingListeners},
+            {iterations, NumIterations},
+            {total_time_us, TotalTime},
+            {avg_time_us, AvgTime},
+            {min_time_us, MinTime},
+            {max_time_us, MaxTime},
+            {processes_spawned_per_call, ProcessesPerCall},
+            {total_processes_spawned, TotalProcessesSpawned},
+            {calls_per_second, NumIterations * 1000000 div TotalTime}}),
+
     % Performance assertions
     ?assert(AvgTime > 0, "Benchmark should take measurable time"),
     ?assert(TotalProcessesSpawned > 0, "Should spawn processes for matching listeners"),
-    
+
     % Log current performance baseline for comparison with foldl implementation
-    EventsPerSecond = (NumIterations * 1000000) div TotalTime,
+    EventsPerSecond = NumIterations * 1000000 div TotalTime,
     MicrosecondsPerEvent = AvgTime,
-    
-    ?event(notify_benchmark, {current_tab2list_baseline,
-        {events_per_second, EventsPerSecond},
-        {microseconds_per_event, MicrosecondsPerEvent},
-        {microseconds_per_listener, AvgTime div NumListeners},
-        {table_copying_overhead, "tab2list_copies_entire_table"}
-    }),
-    
+
+    ?event(notify_benchmark,
+           {current_tab2list_baseline,
+            {events_per_second, EventsPerSecond},
+            {microseconds_per_event, MicrosecondsPerEvent},
+            {microseconds_per_listener, AvgTime div NumListeners},
+            {table_copying_overhead, "tab2list_copies_entire_table"}}),
+
     stop_notification_manager().
 
 %% @doc Test handle_event_dispatch performance under different listener loads
 scaling_benchmark_test() ->
     % Test how performance degrades as listener count increases
     ListenerCounts = [100, 500, 1000, 2000, 10000],
-    Results = lists:map(fun(NumListeners) ->
-        benchmark_with_listener_count(NumListeners)
-    end, ListenerCounts),
-    
+    Results =
+        lists:map(fun(NumListeners) -> benchmark_with_listener_count(NumListeners) end,
+                  ListenerCounts),
+
     ?event(notify_benchmark, {scaling_benchmark_results, Results}),
-    
+
     % Performance should degrade linearly (or better) with listener count
     % If it degrades quadratically, that's a bad sign
     lists:foreach(fun({ListenerCount, AvgTimeUs}) ->
-        % Very rough check - average time should be reasonable
-        ReasonableTimeUs = ListenerCount * 10, % 10us per listener is reasonable
-        ?assert(AvgTimeUs < ReasonableTimeUs * 2, 
-            io_lib:format("Performance too slow for ~p listeners: ~pus", [ListenerCount, AvgTimeUs]))
-    end, Results).
+                     % Very rough check - average time should be reasonable
+                     ReasonableTimeUs = ListenerCount * 10, % 10us per listener is reasonable
+                     ?assert(AvgTimeUs < ReasonableTimeUs * 2,
+                             io_lib:format("Performance too slow for ~p listeners: ~pus",
+                                           [ListenerCount, AvgTimeUs]))
+                  end,
+                  Results).
 
 %% Helper function for scaling benchmark
 benchmark_with_listener_count(NumListeners) ->
     stop_notification_manager(),
     timer:sleep(50),
-    
+
     start_notification_manager(),
     ManagerPid = whereis(?NOTIFICATION_MANAGER),
-    
+
     % Register listeners
     lists:foreach(fun(N) ->
-        Template = #{ <<"test">> => <<"scaling">>, <<"id">> => integer_to_binary(N rem 10) },
-        StreamPid = spawn(fun() -> receive stop -> ok after 5000 -> ok end end),
-        Ref = make_ref(),
-        ManagerPid ! {register_listener, Template, StreamPid, Ref}
-    end, lists:seq(1, NumListeners)),
-    
+                     Template =
+                         #{<<"test">> => <<"scaling">>, <<"id">> => integer_to_binary(N rem 10)},
+                     StreamPid = spawn(fun() -> receive stop -> ok after 5000 -> ok end end),
+                     Ref = make_ref(),
+                     ManagerPid ! {register_listener, Template, StreamPid, Ref}
+                  end,
+                  lists:seq(1, NumListeners)),
+
     timer:sleep(50),
-    
+
     % Benchmark handle_event_dispatch
-    TestEvent = #{ <<"test">> => <<"scaling">>, <<"data">> => <<"test">> },
+    TestEvent = #{<<"test">> => <<"scaling">>, <<"data">> => <<"test">>},
     NumIterations = 50,
-    
+
     StartTime = erlang:system_time(microsecond),
-    lists:foreach(fun(_) ->
-        handle_event_dispatch(TestEvent, #{})
-    end, lists:seq(1, NumIterations)),
+    lists:foreach(fun(_) -> handle_event_dispatch(TestEvent, #{}) end,
+                  lists:seq(1, NumIterations)),
     EndTime = erlang:system_time(microsecond),
-    
+
     TotalTime = EndTime - StartTime,
     AvgTime = TotalTime div NumIterations,
-    
+
     stop_notification_manager(),
-    
+
     {NumListeners, AvgTime}.
 
 %% @doc Test memory pressure with large listener counts
@@ -1234,83 +1291,87 @@ memory_pressure_test_impl() ->
     % Ensure clean state
     stop_notification_manager(),
     timer:sleep(50),
-    
+
     start_notification_manager(),
     ManagerPid = whereis(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
-    
+
     % Register many listeners
     NumListeners = 5000,  % Large number to stress memory
-    
+
     ?event(notify_benchmark, {memory_test_start, {registering_listeners, NumListeners}}),
-    
+
     lists:foreach(fun(N) ->
-        Template = #{ 
-            <<"service">> => <<"memory-test">>,
-            <<"instance">> => integer_to_binary(N rem 100), % Some variety
-            <<"id">> => integer_to_binary(N)
-        },
-        StreamPid = spawn(fun() -> 
-            receive stop -> ok after 30000 -> ok end 
-        end),
-        Ref = make_ref(),
-        ManagerPid ! {register_listener, Template, StreamPid, Ref},
-        
-        % Add small delay every 100 registrations to avoid overwhelming
-        case N rem 100 of
-            0 -> timer:sleep(1);
-            _ -> ok
-        end
-    end, lists:seq(1, NumListeners)),
-    
+                     Template =
+                         #{<<"service">> => <<"memory-test">>,
+                           <<"instance">> => integer_to_binary(N rem 100), % Some variety
+                           <<"id">> => integer_to_binary(N)},
+                     StreamPid = spawn(fun() -> receive stop -> ok after 30000 -> ok end end),
+                     Ref = make_ref(),
+                     ManagerPid ! {register_listener, Template, StreamPid, Ref},
+
+                     % Add small delay every 100 registrations to avoid overwhelming
+                     case N rem 100 of
+                         0 -> timer:sleep(1);
+                         _ -> ok
+                     end
+                  end,
+                  lists:seq(1, NumListeners)),
+
     timer:sleep(200), % Allow registrations to process
-    
+
     % Get memory stats before test
     MemBefore = erlang:memory(total),
     ProcessCountBefore = erlang:system_info(process_count),
-    
+
     % Send events that will trigger many process spawns
     NumEvents = 5,
     StartTime = erlang:system_time(microsecond),
-    
+
     lists:foreach(fun(N) ->
-        Event = #{
-            <<"service">> => <<"memory-test">>,
-            <<"event_id">> => N,
-            <<"data">> => <<"large_event_payload_to_increase_memory_pressure">>
-        },
-        ManagerPid ! {dispatch_event, Event, #{}}
-    end, lists:seq(1, NumEvents)),
-    
+                     Event =
+                         #{<<"service">> => <<"memory-test">>,
+                           <<"event_id">> => N,
+                           <<"data">> => <<"large_event_payload_to_increase_memory_pressure">>},
+                     ManagerPid ! {dispatch_event, Event, #{}}
+                  end,
+                  lists:seq(1, NumEvents)),
+
     % Wait for processing (increased to allow process spawns to complete)
     timer:sleep(1000),
-    
+
     EndTime = erlang:system_time(microsecond),
     Duration = EndTime - StartTime,
-    
+
     % Get memory stats after test
     MemAfter = erlang:memory(total),
     ProcessCountAfter = erlang:system_info(process_count),
-    
+
     % Calculate metrics
     ExpectedProcessSpawns = NumListeners * NumEvents,
     MemoryIncrease = MemAfter - MemBefore,
     ProcessIncrease = ProcessCountAfter - ProcessCountBefore,
-    
-    ?event(notify_benchmark, {memory_pressure_results,
-        {listeners, NumListeners},
-        {events, NumEvents},
-        {duration_us, Duration},
-        {expected_process_spawns, ExpectedProcessSpawns},
-        {memory_increase_bytes, MemoryIncrease},
-        {process_count_increase, ProcessIncrease},
-        {memory_per_spawn_bytes, case ExpectedProcessSpawns of 0 -> 0; _ -> MemoryIncrease div ExpectedProcessSpawns end}
-    }),
-    
+
+    ?event(notify_benchmark,
+           {memory_pressure_results,
+            {listeners, NumListeners},
+            {events, NumEvents},
+            {duration_us, Duration},
+            {expected_process_spawns, ExpectedProcessSpawns},
+            {memory_increase_bytes, MemoryIncrease},
+            {process_count_increase, ProcessIncrease},
+            {memory_per_spawn_bytes,
+             case ExpectedProcessSpawns of
+                 0 ->
+                     0;
+                 _ ->
+                     MemoryIncrease div ExpectedProcessSpawns
+             end}}),
+
     % Performance should not be terrible even with many listeners
     MaxReasonableTime = 5000000, % 5 seconds
     ?assert(Duration < MaxReasonableTime, "Memory pressure test took too long"),
-    
+
     stop_notification_manager().
 
 receive_loop(Count) ->
@@ -1326,43 +1387,48 @@ duplicate_listener_registration_test() ->
     % Ensure clean state
     stop_notification_manager(),
     timer:sleep(50),
-    
+
     start_notification_manager(),
     ManagerPid = whereis(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
-    
+
     % Create test stream process that counts events
     TestPid = self(),
-    StreamPid = spawn(fun() ->
-        duplicate_event_counter(0)
-    end),
-    
+    StreamPid = spawn(fun() -> duplicate_event_counter(0) end),
+
     % Register the same template and stream multiple times
-    Template = #{ <<"device">> => <<"duplicate-test@1.0">> },
+    Template = #{<<"device">> => <<"duplicate-test@1.0">>},
     Ref1 = make_ref(),
     Ref2 = make_ref(),
     Ref3 = make_ref(),
-    
-    ?event(debug, {registering_duplicate_listeners, {template, Template}, {stream_pid, StreamPid}}),
+
+    ?event(debug,
+           {registering_duplicate_listeners, {template, Template}, {stream_pid, StreamPid}}),
     ManagerPid ! {register_listener, Template, StreamPid, Ref1},
     ManagerPid ! {register_listener, Template, StreamPid, Ref2},
     ManagerPid ! {register_listener, Template, StreamPid, Ref3},
     timer:sleep(20), % Allow registrations to process
-    
+
     % Check how many entries are in the ETS table
     AllListeners = ets:tab2list(notification_listeners),
-    MatchingListeners = [L || {{T, P}, _R} = L <- AllListeners, T =:= Template, P =:= StreamPid],
-    ?event(debug, {duplicate_registrations_found, {count, length(MatchingListeners)}, {entries, MatchingListeners}}),
-    
+    MatchingListeners =
+        [L || {{T, P}, _R} = L <- AllListeners, T =:= Template, P =:= StreamPid],
+    ?event(debug,
+           {duplicate_registrations_found,
+            {count, length(MatchingListeners)},
+            {entries, MatchingListeners}}),
+
     % This test will FAIL with current implementation - showing the bug
     % The same {Template, StreamPid} should only be registered once
-    ?assertEqual(1, length(MatchingListeners), "Same template/stream should only be registered once"),
-    
+    ?assertEqual(1,
+                 length(MatchingListeners),
+                 "Same template/stream should only be registered once"),
+
     % Dispatch one event
-    Event = #{ <<"device">> => <<"duplicate-test@1.0">>, <<"message">> => <<"test">> },
+    Event = #{<<"device">> => <<"duplicate-test@1.0">>, <<"message">> => <<"test">>},
     ManagerPid ! {dispatch_event, Event, #{}},
     timer:sleep(50),
-    
+
     % Stream should receive the event only once
     StreamPid ! {get_count, TestPid},
     receive
@@ -1372,7 +1438,7 @@ duplicate_listener_registration_test() ->
     after 500 ->
         ?assert(false, "Should have received event count")
     end,
-    
+
     stop_notification_manager().
 
 %% Helper process that counts duplicate events
@@ -1393,50 +1459,62 @@ multiple_registration_scenarios_test() ->
     % Ensure clean state
     stop_notification_manager(),
     timer:sleep(50),
-    
+
     start_notification_manager(),
     ManagerPid = whereis(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
-    
+
     % Scenario 1: Same template, same stream, different refs
-    Template1 = #{ <<"type">> => <<"scenario1">> },
+    Template1 = #{<<"type">> => <<"scenario1">>},
     Stream1 = spawn(fun() -> receive _ -> ok end end),
-    
+
     ManagerPid ! {register_listener, Template1, Stream1, make_ref()},
     ManagerPid ! {register_listener, Template1, Stream1, make_ref()},
     timer:sleep(10),
-    
-    Listeners1 = [L || {{T, P}, _R} = L <- ets:tab2list(notification_listeners), T =:= Template1, P =:= Stream1],
+
+    Listeners1 =
+        [L
+         || {{T, P}, _R} = L <- ets:tab2list(notification_listeners),
+            T =:= Template1,
+            P =:= Stream1],
     ?event(debug, {scenario1_duplicates, {count, length(Listeners1)}}),
     % Same template/stream should only be registered once
-    ?assertEqual(1, length(Listeners1), "Same template/stream should only be registered once"),
-    
+    ?assertEqual(1,
+                 length(Listeners1),
+                 "Same template/stream should only be registered once"),
+
     % Scenario 2: Same template, different streams (should be allowed)
-    Template2 = #{ <<"type">> => <<"scenario2">> },
+    Template2 = #{<<"type">> => <<"scenario2">>},
     Stream2A = spawn(fun() -> receive _ -> ok end end),
     Stream2B = spawn(fun() -> receive _ -> ok end end),
-    
+
     ManagerPid ! {register_listener, Template2, Stream2A, make_ref()},
     ManagerPid ! {register_listener, Template2, Stream2B, make_ref()},
     timer:sleep(10),
-    
-    Listeners2 = [L || {{T, _P}, _R} = L <- ets:tab2list(notification_listeners), T =:= Template2],
+
+    Listeners2 =
+        [L || {{T, _P}, _R} = L <- ets:tab2list(notification_listeners), T =:= Template2],
     ?event(debug, {scenario2_different_streams, {count, length(Listeners2)}}),
-    ?assertEqual(2, length(Listeners2), "Different streams with same template should be allowed"),
-    
+    ?assertEqual(2,
+                 length(Listeners2),
+                 "Different streams with same template should be allowed"),
+
     % Scenario 3: Different templates, same stream (should be allowed)
-    Template3A = #{ <<"type">> => <<"scenario3a">> },
-    Template3B = #{ <<"type">> => <<"scenario3b">> },
+    Template3A = #{<<"type">> => <<"scenario3a">>},
+    Template3B = #{<<"type">> => <<"scenario3b">>},
     Stream3 = spawn(fun() -> receive _ -> ok end end),
-    
+
     ManagerPid ! {register_listener, Template3A, Stream3, make_ref()},
     ManagerPid ! {register_listener, Template3B, Stream3, make_ref()},
     timer:sleep(10),
-    
-    Listeners3 = [L || {{_T, P}, _R} = L <- ets:tab2list(notification_listeners), P =:= Stream3],
+
+    Listeners3 =
+        [L || {{_T, P}, _R} = L <- ets:tab2list(notification_listeners), P =:= Stream3],
     ?event(debug, {scenario3_different_templates, {count, length(Listeners3)}}),
-    ?assertEqual(2, length(Listeners3), "Same stream with different templates should be allowed"),
-    
+    ?assertEqual(2,
+                 length(Listeners3),
+                 "Same stream with different templates should be allowed"),
+
     stop_notification_manager().
 
 %% @doc Test event duplication with multiple registrations
@@ -1444,30 +1522,28 @@ event_duplication_test() ->
     % Ensure clean state
     stop_notification_manager(),
     timer:sleep(50),
-    
+
     start_notification_manager(),
     ManagerPid = whereis(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
-    
+
     % Create counting process
     TestPid = self(),
-    CounterPid = spawn(fun() ->
-        event_duplication_counter(0, TestPid)
-    end),
-    
+    CounterPid = spawn(fun() -> event_duplication_counter(0, TestPid) end),
+
     % Register the same listener 3 times (showing the bug)
-    Template = #{ <<"event">> => <<"duplication-test">> },
+    Template = #{<<"event">> => <<"duplication-test">>},
     ManagerPid ! {register_listener, Template, CounterPid, make_ref()},
     ManagerPid ! {register_listener, Template, CounterPid, make_ref()},
     ManagerPid ! {register_listener, Template, CounterPid, make_ref()},
     timer:sleep(20),
-    
+
     % Dispatch one event
-    Event = #{ <<"event">> => <<"duplication-test">>, <<"data">> => <<"single event">> },
+    Event = #{<<"event">> => <<"duplication-test">>, <<"data">> => <<"single event">>},
     ?event(debug, {dispatching_single_event, Event}),
     ManagerPid ! {dispatch_event, Event, #{}},
     timer:sleep(50),
-    
+
     % Check how many times the event was received
     CounterPid ! {report_count, TestPid},
     receive
@@ -1478,7 +1554,7 @@ event_duplication_test() ->
     after 500 ->
         ?assert(false, "Should have received count report")
     end,
-    
+
     stop_notification_manager().
 
 %% Helper for event duplication test
@@ -1499,20 +1575,20 @@ notification_manager_manual_start_test() ->
     % Ensure clean state
     stop_notification_manager(),
     timer:sleep(100),
-    
+
     % Verify no manager is running
     ?assertEqual(undefined, whereis(?NOTIFICATION_MANAGER)),
-    
+
     % Start manager manually
     {ok, ManagerPid} = start_notification_manager(),
-    
+
     % Verify manager started successfully
     ?assertNotEqual(undefined, ManagerPid),
     ?assert(is_process_alive(ManagerPid)),
     ?assertEqual(ManagerPid, whereis(?NOTIFICATION_MANAGER)),
-    
+
     ?event(debug, {manual_start_test_completed, {manager_pid, ManagerPid}}),
-    
+
     stop_notification_manager().
 
 %% @doc Test multiple start attempts return already_started
@@ -1520,20 +1596,20 @@ notification_manager_multiple_start_test() ->
     % Clean state
     stop_notification_manager(),
     timer:sleep(50),
-    
+
     % Manually start manager first
     {ok, ManualPid} = start_notification_manager(),
     ?assert(is_process_alive(ManualPid)),
-    
+
     % Try to start again (should return already_started)
     StartResult = start_notification_manager(),
     ?assertEqual({already_started, ManualPid}, StartResult),
-    
+
     % Should still be the same process
     CurrentPid = whereis(?NOTIFICATION_MANAGER),
     ?assertEqual(ManualPid, CurrentPid),
     ?assert(is_process_alive(CurrentPid)),
-    
+
     stop_notification_manager().
 
 %% @doc Test manual start handles conflicts gracefully
@@ -1541,36 +1617,36 @@ notification_manager_manual_start_conflict_test() ->
     % Clean state thoroughly
     stop_notification_manager(),
     timer:sleep(100),
-    
+
     % Ensure no process is registered
     ?assertEqual(undefined, whereis(?NOTIFICATION_MANAGER)),
-    
+
     % Create a conflicting process with the same name
     TestPid = self(),
-    ConflictPid = spawn(fun() ->
-        try register(?NOTIFICATION_MANAGER, self()) of
-            true ->
-                TestPid ! {conflict_registered, self()},
-                receive stop -> ok after 10000 -> ok end
-        catch
-            error:badarg ->
-                TestPid ! {conflict_failed, self()}
-        end
-    end),
-    
+    ConflictPid =
+        spawn(fun() ->
+                 try register(?NOTIFICATION_MANAGER, self()) of
+                     true ->
+                         TestPid ! {conflict_registered, self()},
+                         receive stop -> ok after 10000 -> ok end
+                 catch
+                     error:badarg -> TestPid ! {conflict_failed, self()}
+                 end
+              end),
+
     % Wait for registration result
     receive
         {conflict_registered, ConflictPid} ->
             % Verify the conflict process is registered
             ?assertEqual(ConflictPid, whereis(?NOTIFICATION_MANAGER)),
-            
+
             % Try manual start (should return already_started)
             StartResult = start_notification_manager(),
             ?assertEqual({already_started, ConflictPid}, StartResult),
-            
+
             % The original conflict process should still be there
             ?assertEqual(ConflictPid, whereis(?NOTIFICATION_MANAGER)),
-            
+
             % Clean up
             ConflictPid ! stop,
             timer:sleep(50);
@@ -1580,10 +1656,10 @@ notification_manager_manual_start_conflict_test() ->
     after 1000 ->
         ?assert(false, "Conflict process failed to register")
     end,
-    
+
     % Ensure clean state
     stop_notification_manager(),
-    
+
     % Now start should work
     {ok, _NewPid} = start_notification_manager(),
     stop_notification_manager().
@@ -1593,49 +1669,49 @@ notification_manager_manager_restart_test() ->
     % Test simulates stopping and restarting the manager
     stop_notification_manager(),
     timer:sleep(50),
-    
+
     % Verify clean state
     ?assertEqual(undefined, whereis(?NOTIFICATION_MANAGER)),
-    
+
     % Start the manager manually
     {ok, FirstPid} = start_notification_manager(),
     timer:sleep(50),
-    
+
     % Verify manager started
     ?assertEqual(FirstPid, whereis(?NOTIFICATION_MANAGER)),
     ?assertNotEqual(undefined, FirstPid),
     ?assert(is_process_alive(FirstPid)),
-    
+
     % Register a test listener to verify functionality
-    TestTemplate = #{ <<"test">> => <<"restart">> },
+    TestTemplate = #{<<"test">> => <<"restart">>},
     TestStreamPid = spawn(fun() -> receive _ -> ok end end),
     TestRef = make_ref(),
-    
+
     FirstPid ! {register_listener, TestTemplate, TestStreamPid, TestRef},
     timer:sleep(10),
-    
+
     % Verify listener is registered
     Listeners = ets:tab2list(notification_listeners),
     ?assert(lists:member({{TestTemplate, TestStreamPid}, TestRef}, Listeners)),
-    
+
     % Stop manager and restart
     stop_notification_manager(),
     timer:sleep(50),
-    
-    % Start again 
+
+    % Start again
     {ok, SecondPid} = start_notification_manager(),
     timer:sleep(50),
-    
+
     % Verify new manager started (should be different PID)
     ?assertEqual(SecondPid, whereis(?NOTIFICATION_MANAGER)),
     ?assertNotEqual(undefined, SecondPid),
     ?assert(is_process_alive(SecondPid)),
     ?assertNotEqual(FirstPid, SecondPid),
-    
+
     % ETS table should be recreated (empty)
     NewListeners = ets:tab2list(notification_listeners),
     ?assertEqual([], NewListeners),
-    
+
     stop_notification_manager().
 
 %% @doc Test ETS table initialization and ownership
@@ -1643,34 +1719,34 @@ notification_manager_ets_initialization_test() ->
     % Ensure clean state
     stop_notification_manager(),
     timer:sleep(50),
-    
+
     % Start manager manually
     {ok, ManagerPid} = start_notification_manager(),
     timer:sleep(50),
-    
+
     ?assertNotEqual(undefined, ManagerPid),
     ?assert(is_process_alive(ManagerPid)),
-    
+
     % Verify ETS table exists and has correct properties
     TableInfo = ets:info(notification_listeners),
     ?assertNotEqual(undefined, TableInfo),
-    
+
     % Verify table properties
     ?assertEqual(set, ets:info(notification_listeners, type)),
     ?assertEqual(true, ets:info(notification_listeners, named_table)),
-    
+
     % Most importantly: verify the ETS table is owned by the manager process
     % This is the critical fix - table should be owned by manager, not caller
     ETSOwner = ets:info(notification_listeners, owner),
     ?assertEqual(ManagerPid, ETSOwner),
-    
+
     % Test basic ETS operations work
     InitialSize = ets:info(notification_listeners, size),
     TestKey = {{test_template, test_pid}, test_ref},
     ets:insert(notification_listeners, TestKey),
     ?assertEqual(InitialSize + 1, ets:info(notification_listeners, size)),
     ?assert(ets:member(notification_listeners, element(1, TestKey))),
-    
+
     % Clean up test data
     ets:delete(notification_listeners, element(1, TestKey)),
     ?assertEqual(InitialSize, ets:info(notification_listeners, size)).
@@ -1680,41 +1756,45 @@ notification_manager_concurrent_start_test() ->
     % Clean state
     stop_notification_manager(),
     timer:sleep(50),
-    
+
     TestPid = self(),
     NumConcurrentCalls = 5,
-    
+
     % Spawn multiple processes that all try to start the manager
-    ConcurrentPids = lists:map(fun(N) ->
-        spawn(fun() ->
-            % Random small delay to increase chance of race conditions
-            timer:sleep(rand:uniform(50)),
-            Result = start_notification_manager(),
-            ManagerPid = whereis(?NOTIFICATION_MANAGER),
-            TestPid ! {concurrent_result, N, Result, ManagerPid}
-        end)
-    end, lists:seq(1, NumConcurrentCalls)),
-    
+    ConcurrentPids =
+        lists:map(fun(N) ->
+                     spawn(fun() ->
+                              % Random small delay to increase chance of race conditions
+                              timer:sleep(
+                                  rand:uniform(50)),
+                              Result = start_notification_manager(),
+                              ManagerPid = whereis(?NOTIFICATION_MANAGER),
+                              TestPid ! {concurrent_result, N, Result, ManagerPid}
+                           end)
+                  end,
+                  lists:seq(1, NumConcurrentCalls)),
+
     % Collect all results
-    Results = lists:map(fun(_) ->
-        receive
-            {concurrent_result, N, Result, ManagerPid} ->
-                {N, Result, ManagerPid}
-        after 5000 ->
-            {timeout, timeout, undefined}
-        end
-    end, ConcurrentPids),
-    
+    Results =
+        lists:map(fun(_) ->
+                     receive
+                         {concurrent_result, N, Result, ManagerPid} -> {N, Result, ManagerPid}
+                     after 5000 -> {timeout, timeout, undefined}
+                     end
+                  end,
+                  ConcurrentPids),
+
     ?event(debug, {concurrent_start_results, Results}),
-    
+
     % Should get one {ok, Pid} and rest {already_started, Pid}
     OkResults = [R || {_N, R, _Pid} <- Results, element(1, R) =:= ok],
-    AlreadyStartedResults = [R || {_N, R, _Pid} <- Results, element(1, R) =:= already_started],
-    
+    AlreadyStartedResults =
+        [R || {_N, R, _Pid} <- Results, element(1, R) =:= already_started],
+
     % Should have exactly one ok result and rest already_started
     ?assertEqual(1, length(OkResults)),
     ?assertEqual(NumConcurrentCalls - 1, length(AlreadyStartedResults)),
-    
+
     % All should see the same manager PID
     ManagerPids = [Pid || {_N, _Result, Pid} <- Results, Pid =/= undefined],
     case ManagerPids of
@@ -1722,9 +1802,7 @@ notification_manager_concurrent_start_test() ->
             ?assert(false, "No manager PIDs found");
         [FirstPid | Rest] ->
             % All should be the same PID
-            lists:foreach(fun(Pid) ->
-                ?assertEqual(FirstPid, Pid)
-            end, Rest)
+            lists:foreach(fun(Pid) -> ?assertEqual(FirstPid, Pid) end, Rest)
     end,
-    
+
     stop_notification_manager().

--- a/src/dev_notify.erl
+++ b/src/dev_notify.erl
@@ -1077,4 +1077,177 @@ receive_loop(Count) ->
             receive_loop(Count + 1)
     after 10 ->
         exit({received_count, Count})
+    end.
+
+%% @doc Test duplicate listener registration bug
+duplicate_listener_registration_test() ->
+    % Ensure clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    start_notification_manager(),
+    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ?assert(is_process_alive(ManagerPid)),
+    
+    % Create test stream process that counts events
+    TestPid = self(),
+    StreamPid = spawn(fun() ->
+        duplicate_event_counter(0)
+    end),
+    
+    % Register the same template and stream multiple times
+    Template = #{ <<"device">> => <<"duplicate-test@1.0">> },
+    Ref1 = make_ref(),
+    Ref2 = make_ref(),
+    Ref3 = make_ref(),
+    
+    ?event(debug, {registering_duplicate_listeners, {template, Template}, {stream_pid, StreamPid}}),
+    ManagerPid ! {register_listener, Template, StreamPid, Ref1},
+    ManagerPid ! {register_listener, Template, StreamPid, Ref2},
+    ManagerPid ! {register_listener, Template, StreamPid, Ref3},
+    timer:sleep(20), % Allow registrations to process
+    
+    % Check how many entries are in the ETS table
+    AllListeners = ets:tab2list(notification_listeners),
+    MatchingListeners = [L || {T, P, _R} = L <- AllListeners, T =:= Template, P =:= StreamPid],
+    ?event(debug, {duplicate_registrations_found, {count, length(MatchingListeners)}, {entries, MatchingListeners}}),
+    
+    % This test will FAIL with current implementation - showing the bug
+    % The same {Template, StreamPid} should only be registered once
+    ?assertEqual(1, length(MatchingListeners), "Same template/stream should only be registered once"),
+    
+    % Dispatch one event
+    Event = #{ <<"device">> => <<"duplicate-test@1.0">>, <<"message">> => <<"test">> },
+    ManagerPid ! {dispatch_event, Event, #{}},
+    timer:sleep(50),
+    
+    % Stream should receive the event only once
+    StreamPid ! {get_count, TestPid},
+    receive
+        {event_count, Count} ->
+            ?event(debug, {event_count_received, Count}),
+            ?assertEqual(1, Count, "Event should be received only once, not duplicated")
+    after 500 ->
+        ?assert(false, "Should have received event count")
+    end,
+    
+    stop_notification_manager().
+
+%% Helper process that counts duplicate events
+duplicate_event_counter(Count) ->
+    receive
+        {notify_event, Event} ->
+            ?event(debug, {duplicate_counter_received_event, {count, Count + 1}, {event, Event}}),
+            duplicate_event_counter(Count + 1);
+        {get_count, ReplyPid} ->
+            ReplyPid ! {event_count, Count},
+            duplicate_event_counter(Count)
+    after 1000 ->
+        exit({final_count, Count})
+    end.
+
+%% @doc Test multiple registration attempts with different scenarios
+multiple_registration_scenarios_test() ->
+    % Ensure clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    start_notification_manager(),
+    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ?assert(is_process_alive(ManagerPid)),
+    
+    % Scenario 1: Same template, same stream, different refs
+    Template1 = #{ <<"type">> => <<"scenario1">> },
+    Stream1 = spawn(fun() -> receive _ -> ok end end),
+    
+    ManagerPid ! {register_listener, Template1, Stream1, make_ref()},
+    ManagerPid ! {register_listener, Template1, Stream1, make_ref()},
+    timer:sleep(10),
+    
+    Listeners1 = [L || {T, P, _R} = L <- ets:tab2list(notification_listeners), T =:= Template1, P =:= Stream1],
+    ?event(debug, {scenario1_duplicates, {count, length(Listeners1)}}),
+    % Same template/stream should only be registered once
+    ?assertEqual(1, length(Listeners1), "Same template/stream should only be registered once"),
+    
+    % Scenario 2: Same template, different streams (should be allowed)
+    Template2 = #{ <<"type">> => <<"scenario2">> },
+    Stream2A = spawn(fun() -> receive _ -> ok end end),
+    Stream2B = spawn(fun() -> receive _ -> ok end end),
+    
+    ManagerPid ! {register_listener, Template2, Stream2A, make_ref()},
+    ManagerPid ! {register_listener, Template2, Stream2B, make_ref()},
+    timer:sleep(10),
+    
+    Listeners2 = [L || {T, _P, _R} = L <- ets:tab2list(notification_listeners), T =:= Template2],
+    ?event(debug, {scenario2_different_streams, {count, length(Listeners2)}}),
+    ?assertEqual(2, length(Listeners2), "Different streams with same template should be allowed"),
+    
+    % Scenario 3: Different templates, same stream (should be allowed)
+    Template3A = #{ <<"type">> => <<"scenario3a">> },
+    Template3B = #{ <<"type">> => <<"scenario3b">> },
+    Stream3 = spawn(fun() -> receive _ -> ok end end),
+    
+    ManagerPid ! {register_listener, Template3A, Stream3, make_ref()},
+    ManagerPid ! {register_listener, Template3B, Stream3, make_ref()},
+    timer:sleep(10),
+    
+    Listeners3 = [L || {_T, P, _R} = L <- ets:tab2list(notification_listeners), P =:= Stream3],
+    ?event(debug, {scenario3_different_templates, {count, length(Listeners3)}}),
+    ?assertEqual(2, length(Listeners3), "Same stream with different templates should be allowed"),
+    
+    stop_notification_manager().
+
+%% @doc Test event duplication with multiple registrations
+event_duplication_test() ->
+    % Ensure clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    start_notification_manager(),
+    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ?assert(is_process_alive(ManagerPid)),
+    
+    % Create counting process
+    TestPid = self(),
+    CounterPid = spawn(fun() ->
+        event_duplication_counter(0, TestPid)
+    end),
+    
+    % Register the same listener 3 times (showing the bug)
+    Template = #{ <<"event">> => <<"duplication-test">> },
+    ManagerPid ! {register_listener, Template, CounterPid, make_ref()},
+    ManagerPid ! {register_listener, Template, CounterPid, make_ref()},
+    ManagerPid ! {register_listener, Template, CounterPid, make_ref()},
+    timer:sleep(20),
+    
+    % Dispatch one event
+    Event = #{ <<"event">> => <<"duplication-test">>, <<"data">> => <<"single event">> },
+    ?event(debug, {dispatching_single_event, Event}),
+    ManagerPid ! {dispatch_event, Event, #{}},
+    timer:sleep(50),
+    
+    % Check how many times the event was received
+    CounterPid ! {report_count, TestPid},
+    receive
+        {duplicate_count, ReceivedCount} ->
+            ?event(debug, {event_received_count, ReceivedCount}),
+            % Event should be received only once, not duplicated
+            ?assertEqual(1, ReceivedCount, "Event should be received only once, not duplicated")
+    after 500 ->
+        ?assert(false, "Should have received count report")
+    end,
+    
+    stop_notification_manager().
+
+%% Helper for event duplication test
+event_duplication_counter(Count, TestPid) ->
+    receive
+        {notify_event, Event} ->
+            ?event(debug, {duplication_counter_event, {count, Count + 1}, {event, Event}}),
+            event_duplication_counter(Count + 1, TestPid);
+        {report_count, ReplyPid} ->
+            ReplyPid ! {duplicate_count, Count},
+            event_duplication_counter(Count, TestPid)
+    after 1000 ->
+        TestPid ! {final_duplicate_count, Count}
     end. 

--- a/src/dev_notify.erl
+++ b/src/dev_notify.erl
@@ -351,17 +351,16 @@ template_matches(_Event, _Template, _Opts) ->
 start_notification_manager() ->
     case whereis(?NOTIFICATION_MANAGER) of
         undefined ->
-            % Initialize ETS table for fast listener lookups
-            case ets:info(notification_listeners) of
-                undefined ->
-                    ets:new(notification_listeners, [named_table, public, set, {read_concurrency, true}]);
-                _ -> ok
-            end,
-            
             % Start the manager process
             ManagerPid = spawn_link(fun() -> 
                 try register(?NOTIFICATION_MANAGER, self()) of
                     true ->
+                        % Initialize ETS table for fast listener lookups
+                        case ets:info(notification_listeners) of
+                            undefined ->
+                                ets:new(notification_listeners, [named_table, public, set, {read_concurrency, true}]);
+                            _ -> ok
+                        end,
                         ?event(notify, {notification_manager_started, self()}),
                         notification_manager_loop(#{})
                 catch
@@ -1493,4 +1492,239 @@ event_duplication_counter(Count, TestPid) ->
             event_duplication_counter(Count, TestPid)
     after 1000 ->
         TestPid ! {final_duplicate_count, Count}
-    end. 
+    end.
+
+%% @doc Test manual notification manager startup
+notification_manager_manual_start_test() ->
+    % Ensure clean state
+    stop_notification_manager(),
+    timer:sleep(100),
+    
+    % Verify no manager is running
+    ?assertEqual(undefined, whereis(?NOTIFICATION_MANAGER)),
+    
+    % Start manager manually
+    {ok, ManagerPid} = start_notification_manager(),
+    
+    % Verify manager started successfully
+    ?assertNotEqual(undefined, ManagerPid),
+    ?assert(is_process_alive(ManagerPid)),
+    ?assertEqual(ManagerPid, whereis(?NOTIFICATION_MANAGER)),
+    
+    ?event(debug, {manual_start_test_completed, {manager_pid, ManagerPid}}),
+    
+    stop_notification_manager().
+
+%% @doc Test multiple start attempts return already_started
+notification_manager_multiple_start_test() ->
+    % Clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    % Manually start manager first
+    {ok, ManualPid} = start_notification_manager(),
+    ?assert(is_process_alive(ManualPid)),
+    
+    % Try to start again (should return already_started)
+    StartResult = start_notification_manager(),
+    ?assertEqual({already_started, ManualPid}, StartResult),
+    
+    % Should still be the same process
+    CurrentPid = whereis(?NOTIFICATION_MANAGER),
+    ?assertEqual(ManualPid, CurrentPid),
+    ?assert(is_process_alive(CurrentPid)),
+    
+    stop_notification_manager().
+
+%% @doc Test manual start handles conflicts gracefully
+notification_manager_manual_start_conflict_test() ->
+    % Clean state thoroughly
+    stop_notification_manager(),
+    timer:sleep(100),
+    
+    % Ensure no process is registered
+    ?assertEqual(undefined, whereis(?NOTIFICATION_MANAGER)),
+    
+    % Create a conflicting process with the same name
+    TestPid = self(),
+    ConflictPid = spawn(fun() ->
+        try register(?NOTIFICATION_MANAGER, self()) of
+            true ->
+                TestPid ! {conflict_registered, self()},
+                receive stop -> ok after 10000 -> ok end
+        catch
+            error:badarg ->
+                TestPid ! {conflict_failed, self()}
+        end
+    end),
+    
+    % Wait for registration result
+    receive
+        {conflict_registered, ConflictPid} ->
+            % Verify the conflict process is registered
+            ?assertEqual(ConflictPid, whereis(?NOTIFICATION_MANAGER)),
+            
+            % Try manual start (should return already_started)
+            StartResult = start_notification_manager(),
+            ?assertEqual({already_started, ConflictPid}, StartResult),
+            
+            % The original conflict process should still be there
+            ?assertEqual(ConflictPid, whereis(?NOTIFICATION_MANAGER)),
+            
+            % Clean up
+            ConflictPid ! stop,
+            timer:sleep(50);
+        {conflict_failed, ConflictPid} ->
+            % Name was already taken, just start normally
+            {ok, _} = start_notification_manager()
+    after 1000 ->
+        ?assert(false, "Conflict process failed to register")
+    end,
+    
+    % Ensure clean state
+    stop_notification_manager(),
+    
+    % Now start should work
+    {ok, _NewPid} = start_notification_manager(),
+    stop_notification_manager().
+
+%% @doc Test manager restart after stop/start cycle
+notification_manager_manager_restart_test() ->
+    % Test simulates stopping and restarting the manager
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    % Verify clean state
+    ?assertEqual(undefined, whereis(?NOTIFICATION_MANAGER)),
+    
+    % Start the manager manually
+    {ok, FirstPid} = start_notification_manager(),
+    timer:sleep(50),
+    
+    % Verify manager started
+    ?assertEqual(FirstPid, whereis(?NOTIFICATION_MANAGER)),
+    ?assertNotEqual(undefined, FirstPid),
+    ?assert(is_process_alive(FirstPid)),
+    
+    % Register a test listener to verify functionality
+    TestTemplate = #{ <<"test">> => <<"restart">> },
+    TestStreamPid = spawn(fun() -> receive _ -> ok end end),
+    TestRef = make_ref(),
+    
+    FirstPid ! {register_listener, TestTemplate, TestStreamPid, TestRef},
+    timer:sleep(10),
+    
+    % Verify listener is registered
+    Listeners = ets:tab2list(notification_listeners),
+    ?assert(lists:member({{TestTemplate, TestStreamPid}, TestRef}, Listeners)),
+    
+    % Stop manager and restart
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    % Start again 
+    {ok, SecondPid} = start_notification_manager(),
+    timer:sleep(50),
+    
+    % Verify new manager started (should be different PID)
+    ?assertEqual(SecondPid, whereis(?NOTIFICATION_MANAGER)),
+    ?assertNotEqual(undefined, SecondPid),
+    ?assert(is_process_alive(SecondPid)),
+    ?assertNotEqual(FirstPid, SecondPid),
+    
+    % ETS table should be recreated (empty)
+    NewListeners = ets:tab2list(notification_listeners),
+    ?assertEqual([], NewListeners),
+    
+    stop_notification_manager().
+
+%% @doc Test ETS table initialization and ownership
+notification_manager_ets_initialization_test() ->
+    % Ensure clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    % Start manager manually
+    {ok, ManagerPid} = start_notification_manager(),
+    timer:sleep(50),
+    
+    ?assertNotEqual(undefined, ManagerPid),
+    ?assert(is_process_alive(ManagerPid)),
+    
+    % Verify ETS table exists and has correct properties
+    TableInfo = ets:info(notification_listeners),
+    ?assertNotEqual(undefined, TableInfo),
+    
+    % Verify table properties
+    ?assertEqual(set, ets:info(notification_listeners, type)),
+    ?assertEqual(true, ets:info(notification_listeners, named_table)),
+    
+    % Most importantly: verify the ETS table is owned by the manager process
+    % This is the critical fix - table should be owned by manager, not caller
+    ETSOwner = ets:info(notification_listeners, owner),
+    ?assertEqual(ManagerPid, ETSOwner),
+    
+    % Test basic ETS operations work
+    InitialSize = ets:info(notification_listeners, size),
+    TestKey = {{test_template, test_pid}, test_ref},
+    ets:insert(notification_listeners, TestKey),
+    ?assertEqual(InitialSize + 1, ets:info(notification_listeners, size)),
+    ?assert(ets:member(notification_listeners, element(1, TestKey))),
+    
+    % Clean up test data
+    ets:delete(notification_listeners, element(1, TestKey)),
+    ?assertEqual(InitialSize, ets:info(notification_listeners, size)).
+
+%% @doc Test concurrent manager start attempts
+notification_manager_concurrent_start_test() ->
+    % Clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    TestPid = self(),
+    NumConcurrentCalls = 5,
+    
+    % Spawn multiple processes that all try to start the manager
+    ConcurrentPids = lists:map(fun(N) ->
+        spawn(fun() ->
+            % Random small delay to increase chance of race conditions
+            timer:sleep(rand:uniform(50)),
+            Result = start_notification_manager(),
+            ManagerPid = whereis(?NOTIFICATION_MANAGER),
+            TestPid ! {concurrent_result, N, Result, ManagerPid}
+        end)
+    end, lists:seq(1, NumConcurrentCalls)),
+    
+    % Collect all results
+    Results = lists:map(fun(_) ->
+        receive
+            {concurrent_result, N, Result, ManagerPid} ->
+                {N, Result, ManagerPid}
+        after 5000 ->
+            {timeout, timeout, undefined}
+        end
+    end, ConcurrentPids),
+    
+    ?event(debug, {concurrent_start_results, Results}),
+    
+    % Should get one {ok, Pid} and rest {already_started, Pid}
+    OkResults = [R || {_N, R, _Pid} <- Results, element(1, R) =:= ok],
+    AlreadyStartedResults = [R || {_N, R, _Pid} <- Results, element(1, R) =:= already_started],
+    
+    % Should have exactly one ok result and rest already_started
+    ?assertEqual(1, length(OkResults)),
+    ?assertEqual(NumConcurrentCalls - 1, length(AlreadyStartedResults)),
+    
+    % All should see the same manager PID
+    ManagerPids = [Pid || {_N, _Result, Pid} <- Results, Pid =/= undefined],
+    case ManagerPids of
+        [] ->
+            ?assert(false, "No manager PIDs found");
+        [FirstPid | Rest] ->
+            % All should be the same PID
+            lists:foreach(fun(Pid) ->
+                ?assertEqual(FirstPid, Pid)
+            end, Rest)
+    end,
+    
+    stop_notification_manager().

--- a/src/dev_notify.erl
+++ b/src/dev_notify.erl
@@ -118,6 +118,15 @@ find_matching_key(TargetTemplate, [_OtherKey | Rest]) ->
 %% @doc Check if two templates are equivalent
 templates_match(Template1, Template2) when is_binary(Template1), is_binary(Template2) ->
     Template1 =:= Template2;
+templates_match({compiled_regex, _CompiledRegex1, OriginalPattern1}, {compiled_regex, _CompiledRegex2, OriginalPattern2}) ->
+    % Compare original patterns for compiled regex templates
+    OriginalPattern1 =:= OriginalPattern2;
+templates_match({compiled_regex, _CompiledRegex, OriginalPattern}, Template) when is_binary(Template) ->
+    % Compare compiled regex with binary template
+    OriginalPattern =:= Template;
+templates_match(Template, {compiled_regex, _CompiledRegex, OriginalPattern}) when is_binary(Template) ->
+    % Compare binary template with compiled regex
+    Template =:= OriginalPattern;
 templates_match(Template1, Template2) when is_map(Template1), is_map(Template2) ->
     % For map templates, we need to compare the core fields, ignoring metadata
     % Extract the essential template fields
@@ -283,10 +292,10 @@ validate_template(Template, _Opts) when is_map(Template) ->
     end;
 validate_template(Template, _Opts) when is_binary(Template) ->
     % Binary templates are treated as regex patterns for path matching
+    % Compile the regex once for efficiency
     try 
-        % Test if the regex compiles properly
         case re:compile(Template) of
-            {ok, _} -> {ok, Template};
+            {ok, CompiledRegex} -> {ok, {compiled_regex, CompiledRegex, Template}};
             {error, Reason} -> {error, iolist_to_binary(io_lib:format("Invalid regex: ~p", [Reason]))}
         end
     catch
@@ -303,8 +312,22 @@ template_matches(Event, Template, _Opts) when is_map(Template) ->
         true -> true;
         _Other -> false
     end;
+template_matches(Event, {compiled_regex, CompiledRegex, _OriginalPattern}, Opts) ->
+    % Use pre-compiled regex for efficient path matching
+    EventPath = case hb_ao:get(<<"path">>, Event, Opts) of
+        not_found -> <<"/">>;
+        Path -> Path
+    end,
+    try 
+        case re:run(EventPath, CompiledRegex) of
+            nomatch -> false;
+            _ -> true
+        end
+    catch
+        _:_ -> false
+    end;
 template_matches(Event, Template, Opts) when is_binary(Template) ->
-    % Use regex path matching
+    % Fallback for legacy binary templates (compile on-the-fly)
     EventPath = case hb_ao:get(<<"path">>, Event, Opts) of
         not_found -> <<"/">>;
         Path -> Path
@@ -498,7 +521,7 @@ template_validation_test() ->
     RegexTemplate = <<"/.*/test">>,
     RegexResult = validate_template(RegexTemplate, #{}),
     ?event(debug, {regex_template_validation, {input, RegexTemplate}, {result, RegexResult}}),
-    ?assertEqual({ok, <<"/.*/test">>}, RegexResult),
+    ?assertMatch({ok, {compiled_regex, _, <<"/.*/test">>}}, RegexResult),
     
     % Invalid empty map
     EmptyResult = validate_template(#{}, #{}),
@@ -943,7 +966,7 @@ template_validation_edge_cases_test() ->
     
     % Test complex regex patterns
     ComplexRegex = <<"^/(test|prod)/process@[0-9]+\\.[0-9]+/.+$">>,
-    ?assertEqual({ok, ComplexRegex}, validate_template(ComplexRegex, #{})),
+    ?assertMatch({ok, {compiled_regex, _, ComplexRegex}}, validate_template(ComplexRegex, #{})),
     
     % Test unicode in templates
     UnicodeTemplate = #{ <<"message">> => <<"Hello 世界">> },
@@ -951,7 +974,7 @@ template_validation_edge_cases_test() ->
     
     % Test very long regex
     LongRegex = iolist_to_binary(lists:duplicate(1000, "a")),
-    ?assertEqual({ok, LongRegex}, validate_template(LongRegex, #{})).
+    ?assertMatch({ok, {compiled_regex, _, LongRegex}}, validate_template(LongRegex, #{})).
 
 %% @doc Test message matching edge cases
 message_matching_edge_cases_test() ->

--- a/src/dev_notify.erl
+++ b/src/dev_notify.erl
@@ -71,22 +71,8 @@ dispatch(_StateMsg, InputMsg, Opts) ->
             % Send event to the long-running notification manager process
             case hb_name:lookup(?NOTIFICATION_MANAGER) of
                 undefined ->
-                    % Manager not started, try to start it via the device
-                    spawn(fun() ->
-                             try
-                                 start_notification_manager(),
-                                 case hb_name:lookup(?NOTIFICATION_MANAGER) of
-                                     undefined -> ?event({notify_manager_start_failed, InputMsg});
-                                     ManagerPid -> ManagerPid ! {dispatch_event, InputMsg, Opts}
-                                 end
-                             catch
-                                 Class:Reason ->
-                                     ?event({notify_dispatch_error,
-                                             {class, Class},
-                                             {reason, Reason}})
-                             end
-                          end),
-                    {ok, <<"Starting notification manager">>};
+                    % Manager not started, return error instead of trying to start
+                    {error, <<"Notification manager not available">>};
                 ManagerPid ->
                     % Send directly to manager process (minimal overhead)
                     ManagerPid ! {dispatch_event, InputMsg, Opts},
@@ -163,10 +149,7 @@ create_streaming_body(Template, Opts) ->
 
 %% @doc Register a streaming connection for receiving notifications
 register_stream(StreamId, Template, _Req, _Opts) ->
-    % Ensure notification manager is running
-    start_notification_manager(),
-
-    % Register with the notification manager
+    % Register with the notification manager (no longer automatically starts)
     case hb_name:lookup(?NOTIFICATION_MANAGER) of
         undefined ->
             ?event(notify, {manager_not_available, {stream_id, StreamId}});
@@ -671,22 +654,25 @@ dispatch_function_test() ->
     stop_notification_manager(),
     timer:sleep(50),
 
-    % Start manager for testing
-    start_notification_manager(),
-
     % Test dispatch with valid input
     InputMsg =
         #{<<"event">> => #{<<"test">> => <<"data">>},
           <<"timestamp">> => erlang:system_time(millisecond)},
 
     % Test with no notify device configured (should return appropriate message)
-    Result1 = dispatch(#{}, InputMsg, #{}),
+    OptsWithoutNotify = #{notify_device => undefined},
+    Result1 = dispatch(#{}, InputMsg, OptsWithoutNotify),
     ?assertEqual({ok, <<"No notify device configured">>}, Result1),
 
-    % Test with notify device configured
+    % Test with notify device configured but no manager running (should return error)
     OptsWithNotify = #{notify_device => <<"notify@1.0">>},
     Result2 = dispatch(#{}, InputMsg, OptsWithNotify),
-    ?assertEqual({ok, <<"OK">>}, Result2),
+    ?assertEqual({error, <<"Notification manager not available">>}, Result2),
+
+    % Start manager and test successful dispatch
+    start_notification_manager(),
+    Result3 = dispatch(#{}, InputMsg, OptsWithNotify),
+    ?assertEqual({ok, <<"OK">>}, Result3),
 
     stop_notification_manager().
 
@@ -1350,6 +1336,40 @@ notification_manager_concurrent_start_test() ->
 
     stop_notification_manager().
 
+%% @doc Test that the start_manager hook function works correctly
+start_manager_hook_test() ->
+    % Ensure clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+
+    % Verify manager is not running
+    ?assertEqual(undefined, hb_name:lookup(?NOTIFICATION_MANAGER)),
+
+    % Test with notify_device undefined (should not start manager)
+    HookMsg1 = #{<<"body">> => #{notify_device => undefined}},
+    {ok, HookMsg1} = start_manager(#{}, HookMsg1, #{}),
+    ?assertEqual(undefined, hb_name:lookup(?NOTIFICATION_MANAGER)),
+
+    % Test with notify_device configured (should start manager)
+    HookMsg2 = #{<<"body">> => #{notify_device => <<"notify@1.0">>}},
+    {ok, UpdatedHookMsg} = start_manager(#{}, HookMsg2, #{}),
+    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
+    ?assertNotEqual(undefined, ManagerPid),
+    ?assert(is_process_alive(ManagerPid)),
+    
+    % Verify that the hook message was updated with on-notify registration
+    UpdatedBody = maps:get(<<"body">>, UpdatedHookMsg),
+    OnHooks = maps:get(on, UpdatedBody),
+    ?assert(maps:is_key(<<"on-notify">>, OnHooks)),
+
+    % Test idempotent behavior (calling again should not create new manager)
+    {ok, _UpdatedHookMsg2} = start_manager(#{}, UpdatedHookMsg, #{}),
+    ManagerPid2 = hb_name:lookup(?NOTIFICATION_MANAGER),
+    ?assertEqual(ManagerPid, ManagerPid2), % Same PID
+
+    stop_notification_manager().
+
+
 %% @doc Benchmark test to measure handle_event_dispatch performance directly
 handle_event_dispatch_benchmark_test() ->
     % Ensure clean state
@@ -1606,32 +1626,3 @@ receive_loop(Count) ->
     after 10 ->
         exit({received_count, Count})
     end.
-
-%% @doc Test that the start_manager hook function works correctly
-start_manager_hook_test() ->
-    % Ensure clean state
-    stop_notification_manager(),
-    timer:sleep(50),
-
-    % Verify manager is not running
-    ?assertEqual(undefined, hb_name:lookup(?NOTIFICATION_MANAGER)),
-
-    % Test with notify_device undefined (should not start manager)
-    HookMsg1 = #{<<"body">> => #{notify_device => undefined}},
-    {ok, HookMsg1} = start_manager(#{}, HookMsg1, #{}),
-    ?assertEqual(undefined, hb_name:lookup(?NOTIFICATION_MANAGER)),
-
-    % Test with notify_device configured (should start manager)
-    HookMsg2 = #{<<"body">> => #{notify_device => <<"notify@1.0">>}},
-    {ok, HookMsg2} = start_manager(#{}, HookMsg2, #{}),
-    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
-    ?assertNotEqual(undefined, ManagerPid),
-    ?assert(is_process_alive(ManagerPid)),
-
-    % Test idempotent behavior (calling again should not create new manager)
-    {ok, HookMsg2} = start_manager(#{}, HookMsg2, #{}),
-    ManagerPid2 = hb_name:lookup(?NOTIFICATION_MANAGER),
-    ?assertEqual(ManagerPid, ManagerPid2), % Same PID
-
-    stop_notification_manager().
-

--- a/src/dev_notify.erl
+++ b/src/dev_notify.erl
@@ -354,7 +354,7 @@ start_notification_manager() ->
             % Initialize ETS table for fast listener lookups
             case ets:info(notification_listeners) of
                 undefined ->
-                    ets:new(notification_listeners, [named_table, public, bag, {read_concurrency, true}]);
+                    ets:new(notification_listeners, [named_table, public, set, {read_concurrency, true}]);
                 _ -> ok
             end,
             
@@ -423,14 +423,15 @@ notification_manager_loop(State) ->
             notification_manager_loop(State);
             
         {register_listener, Template, StreamPid, Ref} ->
-            % Register a new listener with template
-            ets:insert(notification_listeners, {Template, StreamPid, Ref}),
+            % Register a new listener with template using new key structure
+            % Key is {{Template, StreamPid}, Ref} to ensure deduplication by {Template, StreamPid}
+            ets:insert(notification_listeners, {{Template, StreamPid}, Ref}),
             ?event(notify, {listener_registered, {template, Template}, {stream, StreamPid}, {ref, Ref}}),
             notification_manager_loop(State);
             
         {unregister_listener, Ref} ->
-            % Remove listener by reference
-            ets:match_delete(notification_listeners, {'_', '_', Ref}),
+            % Remove listener by reference using new key structure
+            ets:match_delete(notification_listeners, {'_', Ref}),
             ?event(notify, {listener_unregistered, {ref, Ref}}),
             notification_manager_loop(State);
             
@@ -464,12 +465,12 @@ notification_manager_loop(State) ->
 %% @doc Handle event dispatch by matching against registered listeners
 handle_event_dispatch(Event, Opts) ->
     try
-        % Get all registered listeners
+        % Get all registered listeners using new key structure
         AllListeners = ets:tab2list(notification_listeners),
         
         % Spawn short-lived worker processes for actual dispatching
         % This keeps the manager process responsive
-        lists:foreach(fun({Template, StreamPid, Ref}) ->
+        lists:foreach(fun({{Template, StreamPid}, Ref}) ->
             spawn(fun() -> 
                 try_dispatch_to_listener(Template, StreamPid, Ref, Event, Opts)
             end)
@@ -492,8 +493,8 @@ try_dispatch_to_listener(Template, StreamPid, Ref, Event, Opts) ->
                         StreamPid ! {notify_event, Event},
                         ?event(notify, {event_sent, {stream, StreamPid}, {ref, Ref}});
                     false ->
-                        % Clean up dead process
-                        ets:match_delete(notification_listeners, {'_', StreamPid, '_'}),
+                        % Clean up dead process using new key structure
+                        ets:match_delete(notification_listeners, {{'_', StreamPid}, '_'}),
                         ?event(notify, {dead_stream_cleaned, {stream, StreamPid}})
                 end;
             false ->
@@ -752,7 +753,7 @@ listener_registration_test() ->
     
     % Check listener is registered
     AllListeners = ets:tab2list(notification_listeners),
-    ?assert(lists:member({Template, StreamPid, Ref}, AllListeners)),
+    ?assert(lists:member({{Template, StreamPid}, Ref}, AllListeners)),
     
     % Unregister listener
     ManagerPid ! {unregister_listener, Ref},
@@ -760,7 +761,7 @@ listener_registration_test() ->
     
     % Check listener is removed
     AllListeners2 = ets:tab2list(notification_listeners),
-    ?assertNot(lists:member({Template, StreamPid, Ref}, AllListeners2)),
+    ?assertNot(lists:member({{Template, StreamPid}, Ref}, AllListeners2)),
     
     stop_notification_manager().
 
@@ -880,8 +881,8 @@ dead_process_cleanup_test() ->
     
     % Verify it's in the table
     AllListeners = ets:tab2list(notification_listeners),
-    ?event(debug, {listeners_before_cleanup, {count, length(AllListeners)}, {has_dead_process, lists:member({Template, DeadPid, Ref}, AllListeners)}}),
-    ?assert(lists:member({Template, DeadPid, Ref}, AllListeners)),
+    ?event(debug, {listeners_before_cleanup, {count, length(AllListeners)}, {has_dead_process, lists:member({{Template, DeadPid}, Ref}, AllListeners)}}),
+    ?assert(lists:member({{Template, DeadPid}, Ref}, AllListeners)),
     
     % Dispatch an event that matches
     Event = #{ <<"device">> => <<"message@1.0">> },
@@ -891,8 +892,8 @@ dead_process_cleanup_test() ->
     
     % Dead process should be cleaned up
     AllListeners2 = ets:tab2list(notification_listeners),
-    ?event(debug, {listeners_after_cleanup, {count, length(AllListeners2)}, {dead_process_removed, not lists:member({Template, DeadPid, Ref}, AllListeners2)}}),
-    ?assertNot(lists:member({Template, DeadPid, Ref}, AllListeners2)),
+    ?event(debug, {listeners_after_cleanup, {count, length(AllListeners2)}, {dead_process_removed, not lists:member({{Template, DeadPid}, Ref}, AllListeners2)}}),
+    ?assertNot(lists:member({{Template, DeadPid}, Ref}, AllListeners2)),
     
     stop_notification_manager().
 
@@ -1017,7 +1018,7 @@ error_handling_test() ->
     Ref = make_ref(),
     
     % Register invalid template (insert directly to bypass validation)
-    ets:insert(notification_listeners, {InvalidTemplate, TestPid, Ref}),
+    ets:insert(notification_listeners, {{InvalidTemplate, TestPid}, Ref}),
     
     % Dispatch event - should handle error gracefully
     Event = #{ <<"test">> => <<"data">> },
@@ -1109,7 +1110,7 @@ duplicate_listener_registration_test() ->
     
     % Check how many entries are in the ETS table
     AllListeners = ets:tab2list(notification_listeners),
-    MatchingListeners = [L || {T, P, _R} = L <- AllListeners, T =:= Template, P =:= StreamPid],
+    MatchingListeners = [L || {{T, P}, _R} = L <- AllListeners, T =:= Template, P =:= StreamPid],
     ?event(debug, {duplicate_registrations_found, {count, length(MatchingListeners)}, {entries, MatchingListeners}}),
     
     % This test will FAIL with current implementation - showing the bug
@@ -1164,7 +1165,7 @@ multiple_registration_scenarios_test() ->
     ManagerPid ! {register_listener, Template1, Stream1, make_ref()},
     timer:sleep(10),
     
-    Listeners1 = [L || {T, P, _R} = L <- ets:tab2list(notification_listeners), T =:= Template1, P =:= Stream1],
+    Listeners1 = [L || {{T, P}, _R} = L <- ets:tab2list(notification_listeners), T =:= Template1, P =:= Stream1],
     ?event(debug, {scenario1_duplicates, {count, length(Listeners1)}}),
     % Same template/stream should only be registered once
     ?assertEqual(1, length(Listeners1), "Same template/stream should only be registered once"),
@@ -1178,7 +1179,7 @@ multiple_registration_scenarios_test() ->
     ManagerPid ! {register_listener, Template2, Stream2B, make_ref()},
     timer:sleep(10),
     
-    Listeners2 = [L || {T, _P, _R} = L <- ets:tab2list(notification_listeners), T =:= Template2],
+    Listeners2 = [L || {{T, _P}, _R} = L <- ets:tab2list(notification_listeners), T =:= Template2],
     ?event(debug, {scenario2_different_streams, {count, length(Listeners2)}}),
     ?assertEqual(2, length(Listeners2), "Different streams with same template should be allowed"),
     
@@ -1191,7 +1192,7 @@ multiple_registration_scenarios_test() ->
     ManagerPid ! {register_listener, Template3B, Stream3, make_ref()},
     timer:sleep(10),
     
-    Listeners3 = [L || {_T, P, _R} = L <- ets:tab2list(notification_listeners), P =:= Stream3],
+    Listeners3 = [L || {{_T, P}, _R} = L <- ets:tab2list(notification_listeners), P =:= Stream3],
     ?event(debug, {scenario3_different_templates, {count, length(Listeners3)}}),
     ?assertEqual(2, length(Listeners3), "Same stream with different templates should be allowed"),
     

--- a/src/dev_notify.erl
+++ b/src/dev_notify.erl
@@ -712,33 +712,6 @@ event_dispatch_test() ->
 
     stop_notification_manager().
 
-%% @doc Test integration with hb_persistent notification
-integration_test() ->
-    % Ensure clean state
-    stop_notification_manager(),
-    timer:sleep(50),
-
-    % Test the integration point with hb_persistent
-    GroupName = <<"test-group">>,
-    Msg2 = #{<<"path">> => <<"/test">>, <<"data">> => <<"request">>},
-    Msg3 =
-        #{<<"result">> => <<"success">>, <<"timestamp">> => erlang:system_time(millisecond)},
-    Opts = #{notify_device => <<"notify@1.0">>},
-
-    % Start notification manager
-    start_notification_manager(),
-    ManagerPid = whereis(?NOTIFICATION_MANAGER),
-    ?assert(is_process_alive(ManagerPid)),
-
-    % This should call our dispatch function
-    hb_persistent:dispatch_to_notify_device(GroupName, Msg2, Msg3, Opts),
-    timer:sleep(50),
-
-    % Manager should still be running (no crashes)
-    ?assert(is_process_alive(ManagerPid)),
-
-    stop_notification_manager().
-
 %% @doc Test device registration and unregistration functions
 device_registration_test() ->
     StateMsg = #{<<"listeners">> => #{}},

--- a/src/dev_notify.erl
+++ b/src/dev_notify.erl
@@ -1,12 +1,13 @@
 %%% @doc A device that provides real-time notifications for AO process events.
 %%% It integrates with the existing event system (hb_event) and allows clients
-%%% to subscribe to specific events using HTTP/3 streams.
+%%% to subscribe to specific events using HTTP/3 streams. Registration happens
+%%% automatically when clients establish streaming connections.
 %%%
 %%% Uses a long-running notification manager process to handle high-frequency
 %%% message matching and dispatching efficiently.
 -module(dev_notify).
 
--export([info/1, info/3, dispatch/3, register/3, unregister/3, stream/3]).
+-export([info/1, info/3, dispatch/3, stream/3]).
 -export([start_notification_manager/0, stop_notification_manager/0]).
 
 -include("include/hb.hrl").
@@ -17,7 +18,7 @@
 
 %% @doc Device API information
 info(_) ->
-    #{exports => [info, dispatch, register, unregister, stream], variant => <<"Notify/1.0">>}.
+    #{exports => [info, dispatch, stream], variant => <<"Notify/1.0">>}.
 
 %% @doc HTTP info response providing information about this device
 info(_Msg1, _Msg2, _Opts) ->
@@ -27,130 +28,11 @@ info(_Msg1, _Msg2, _Opts) ->
           <<"paths">> =>
               #{<<"info">> => <<"Get device info">>,
                 <<"dispatch">> => <<"Dispatch an event to registered listeners">>,
-                <<"register">> => <<"Register a new event listener">>,
-                <<"unregister">> => <<"Unregister an event listener">>,
                 <<"stream">> => <<"Start a streaming connection for real-time events">>}},
     {ok, #{<<"status">> => 200, <<"body">> => InfoBody}}.
 
-%% @doc Register a new event listener with template/spec support
-register(StateMsg, InputMsg, Opts) ->
-    ?event(notify, {register_listener, InputMsg}),
 
-    % Extract template specification (supports both map and regex templates)
-    TemplateResult =
-        case hb_ao:get(<<"template">>, InputMsg, Opts) of
-            not_found ->
-                {error, <<"No template specified">>};
-            TemplateSpec ->
-                {ok, TemplateSpec}
-        end,
 
-    case TemplateResult of
-        {error, Reason} ->
-            {error, Reason};
-        {ok, ExtractedTemplate} ->
-            case hb_ao:get(<<"stream">>, InputMsg, Opts) of
-                not_found ->
-                    {error, <<"No stream specified for event registration">>};
-                Stream ->
-                    % Validate template specification
-                    case validate_template(ExtractedTemplate, Opts) of
-                        {ok, ValidatedTemplate} ->
-                            % Register the template and stream in the state
-                            NewState =
-                                maps:put({template, ValidatedTemplate},
-                                         Stream,
-                                         maps:get(<<"listeners">>, StateMsg, #{})),
-                            {ok, StateMsg#{<<"listeners">> => NewState}};
-                        {error, ValidationError} ->
-                            {error, ValidationError}
-                    end
-            end
-    end.
-
-%% @doc Unregister an event listener (supports both template and legacy pattern)
-unregister(StateMsg, InputMsg, Opts) ->
-    ?event(notify, {unregister_listener, InputMsg}),
-
-    % Extract template for removal
-    TemplateResult =
-        case hb_ao:get(<<"template">>, InputMsg, Opts) of
-            not_found ->
-                {error, <<"No template specified">>};
-            TemplateSpec ->
-                {ok, TemplateSpec}
-        end,
-
-    case TemplateResult of
-        {error, Reason} ->
-            {error, Reason};
-        {ok, ExtractedTemplate} ->
-            % Validate template to get the same format as register function
-            case validate_template(ExtractedTemplate, Opts) of
-                {ok, ValidatedTemplate} ->
-                    % Find and remove the matching template from state
-                    Listeners = maps:get(<<"listeners">>, StateMsg, #{}),
-                    % We need to find the key that matches our template, accounting for message processing
-                    MatchingKey = find_matching_template_key(ValidatedTemplate, Listeners),
-                    case MatchingKey of
-                        not_found ->
-                            {error, <<"Template not found in listeners">>};
-                        Key ->
-                            NewState = maps:remove(Key, Listeners),
-                            {ok, StateMsg#{<<"listeners">> => NewState}}
-                    end;
-                {error, ValidationError} ->
-                    {error, ValidationError}
-            end
-    end.
-
-%% @doc Find the template key that matches our target template
-find_matching_template_key(TargetTemplate, Listeners) ->
-    Keys = maps:keys(Listeners),
-    find_matching_key(TargetTemplate, Keys).
-
-find_matching_key(_TargetTemplate, []) ->
-    not_found;
-find_matching_key(TargetTemplate, [{template, StoredTemplate} | Rest]) ->
-    case templates_match(TargetTemplate, StoredTemplate) of
-        true ->
-            {template, StoredTemplate};
-        false ->
-            find_matching_key(TargetTemplate, Rest)
-    end;
-find_matching_key(TargetTemplate, [_OtherKey | Rest]) ->
-    find_matching_key(TargetTemplate, Rest).
-
-%% @doc Check if two templates are equivalent
-templates_match(Template1, Template2) when is_binary(Template1), is_binary(Template2) ->
-    Template1 =:= Template2;
-templates_match({compiled_regex, _CompiledRegex1, OriginalPattern1},
-                {compiled_regex, _CompiledRegex2, OriginalPattern2}) ->
-    % Compare original patterns for compiled regex templates
-    OriginalPattern1 =:= OriginalPattern2;
-templates_match({compiled_regex, _CompiledRegex, OriginalPattern}, Template)
-    when is_binary(Template) ->
-    % Compare compiled regex with binary template
-    OriginalPattern =:= Template;
-templates_match(Template, {compiled_regex, _CompiledRegex, OriginalPattern})
-    when is_binary(Template) ->
-    % Compare binary template with compiled regex
-    Template =:= OriginalPattern;
-templates_match(Template1, Template2) when is_map(Template1), is_map(Template2) ->
-    % For map templates, we need to compare the core fields, ignoring metadata
-    % Extract the essential template fields
-    Essential1 = extract_essential_template(Template1),
-    Essential2 = extract_essential_template(Template2),
-    Essential1 =:= Essential2;
-templates_match(_Template1, _Template2) ->
-    false.
-
-%% @doc Extract essential template fields, removing HyperBEAM metadata
-extract_essential_template(Template) when is_map(Template) ->
-    % Remove priv and other metadata keys, keep only the core template fields
-    maps:without([<<"priv">>, <<"id">>, <<"unsigned_id">>, <<"hashpath">>], Template);
-extract_essential_template(Template) ->
-    Template.
 
 %% @doc Dispatch an event to registered listeners via the notification manager
 dispatch(_StateMsg, InputMsg, Opts) ->
@@ -712,54 +594,6 @@ event_dispatch_test() ->
 
     stop_notification_manager().
 
-%% @doc Test device registration and unregistration functions
-device_registration_test() ->
-    StateMsg = #{<<"listeners">> => #{}},
-    ?event(debug, {initial_state, StateMsg}),
-
-    % Test successful registration with map template
-    InputMsg1 =
-        #{<<"template">> => #{<<"device">> => <<"test@1.0">>}, <<"stream">> => <<"test-stream">>},
-    ?event(debug, {registering_map_template, InputMsg1}),
-
-    {ok, NewState1} = register(StateMsg, InputMsg1, #{}),
-    Listeners1 = maps:get(<<"listeners">>, NewState1),
-    ?event(debug,
-           {after_map_registration,
-            {listeners_count, maps:size(Listeners1)},
-            {keys, maps:keys(Listeners1)}}),
-    ?assertEqual(1, maps:size(Listeners1)),
-
-    % Test registration with regex template
-    InputMsg2 = #{<<"template">> => <<"/.*test.*/.*">>, <<"stream">> => <<"test-stream-2">>},
-
-    {ok, NewState2} = register(NewState1, InputMsg2, #{}),
-    Listeners2 = maps:get(<<"listeners">>, NewState2),
-    ?assertEqual(2, maps:size(Listeners2)),
-
-    % Test unregistration - unregister the first template we added
-    UnregMsg = #{<<"template">> => #{<<"device">> => <<"test@1.0">>}},
-
-    ?event(debug,
-           {before_unregister,
-            {listeners_count,
-             maps:size(
-                 maps:get(<<"listeners">>, NewState2))}}),
-    {ok, NewState3} = unregister(NewState2, UnregMsg, #{}),
-    Listeners3 = maps:get(<<"listeners">>, NewState3),
-    ?event(debug,
-           {after_unregister,
-            {listeners_count, maps:size(Listeners3)},
-            {keys, maps:keys(Listeners3)}}),
-    ?assertEqual(1, maps:size(Listeners3)), % Should have 1 left (regex)
-
-    % Verify the correct template was removed
-    ?assertNot(maps:is_key({template, #{<<"device">> => <<"test@1.0">>}}, Listeners3)),
-
-    % Test error cases
-    ?assertMatch({error, _}, register(StateMsg, #{}, #{})),
-    ?assertMatch({error, _}, register(StateMsg, #{<<"template">> => #{}}, #{})),
-    ?assertMatch({error, _}, unregister(StateMsg, #{}, #{})).
 
 %% @doc Test listener registration and unregistration
 listener_registration_test() ->

--- a/src/dev_notify.erl
+++ b/src/dev_notify.erl
@@ -90,11 +90,58 @@ unregister(StateMsg, InputMsg, Opts) ->
     case TemplateResult of
         {error, Reason} -> {error, Reason};
         {ok, ExtractedTemplate} ->
-            % Remove the template from the state
-            Listeners = maps:get(<<"listeners">>, StateMsg, #{}),
-            NewState = maps:remove({template, ExtractedTemplate}, Listeners),
-            {ok, StateMsg#{<<"listeners">> => NewState}}
+            % Validate template to get the same format as register function
+            case validate_template(ExtractedTemplate, Opts) of
+                {ok, ValidatedTemplate} ->
+                    % Find and remove the matching template from state
+                    Listeners = maps:get(<<"listeners">>, StateMsg, #{}),
+                    % We need to find the key that matches our template, accounting for message processing
+                    MatchingKey = find_matching_template_key(ValidatedTemplate, Listeners),
+                    case MatchingKey of
+                        not_found ->
+                            {error, <<"Template not found in listeners">>};
+                        Key ->
+                            NewState = maps:remove(Key, Listeners),
+                            {ok, StateMsg#{<<"listeners">> => NewState}}
+                    end;
+                {error, ValidationError} ->
+                    {error, ValidationError}
+            end
     end.
+
+%% @doc Find the template key that matches our target template
+find_matching_template_key(TargetTemplate, Listeners) ->
+    Keys = maps:keys(Listeners),
+    find_matching_key(TargetTemplate, Keys).
+
+find_matching_key(_TargetTemplate, []) ->
+    not_found;
+find_matching_key(TargetTemplate, [{template, StoredTemplate} | Rest]) ->
+    case templates_match(TargetTemplate, StoredTemplate) of
+        true -> {template, StoredTemplate};
+        false -> find_matching_key(TargetTemplate, Rest)
+    end;
+find_matching_key(TargetTemplate, [_OtherKey | Rest]) ->
+    find_matching_key(TargetTemplate, Rest).
+
+%% @doc Check if two templates are equivalent
+templates_match(Template1, Template2) when is_binary(Template1), is_binary(Template2) ->
+    Template1 =:= Template2;
+templates_match(Template1, Template2) when is_map(Template1), is_map(Template2) ->
+    % For map templates, we need to compare the core fields, ignoring metadata
+    % Extract the essential template fields
+    Essential1 = extract_essential_template(Template1),
+    Essential2 = extract_essential_template(Template2),
+    Essential1 =:= Essential2;
+templates_match(_Template1, _Template2) ->
+    false.
+
+%% @doc Extract essential template fields, removing HyperBEAM metadata
+extract_essential_template(Template) when is_map(Template) ->
+    % Remove priv and other metadata keys, keep only the core template fields
+    maps:without([<<"priv">>, <<"id">>, <<"unsigned_id">>, <<"hashpath">>], Template);
+extract_essential_template(Template) ->
+    Template.
 
 %% @doc Dispatch an event to registered listeners via the notification manager
 dispatch(_StateMsg, InputMsg, Opts) ->
@@ -304,11 +351,24 @@ start_notification_manager() ->
             
             % Start the manager process
             ManagerPid = spawn_link(fun() -> 
-                register(?NOTIFICATION_MANAGER, self()),
-                ?event(notify, {notification_manager_started, self()}),
-                notification_manager_loop(#{})
+                try register(?NOTIFICATION_MANAGER, self()) of
+                    true ->
+                        ?event(notify, {notification_manager_started, self()}),
+                        notification_manager_loop(#{})
+                catch
+                    error:badarg ->
+                        % Someone else registered already, exit quietly
+                        exit(already_registered)
+                end
             end),
-            {ok, ManagerPid};
+            % Give the process a moment to register
+            timer:sleep(10),
+            % Check if it actually got registered
+            case whereis(?NOTIFICATION_MANAGER) of
+                ManagerPid -> {ok, ManagerPid};
+                OtherPid when is_pid(OtherPid) -> {already_started, OtherPid};
+                undefined -> {error, registration_failed}
+            end;
         Pid ->
             {already_started, Pid}
     end.
@@ -318,11 +378,28 @@ stop_notification_manager() ->
     case whereis(?NOTIFICATION_MANAGER) of
         undefined -> ok;
         Pid ->
+            % First unregister to prevent new registrations
+            try unregister(?NOTIFICATION_MANAGER) catch _:_ -> ok end,
+            
+            % Send stop signal
             Pid ! stop,
-            % Clean up ETS table
+            
+            % Wait for process to die with timeout
+            Ref = monitor(process, Pid),
+            receive
+                {'DOWN', Ref, process, Pid, _Reason} -> ok
+            after 100 ->
+                exit(Pid, kill),
+                receive {'DOWN', Ref, process, Pid, _} -> ok after 50 -> ok end
+            end,
+            
+            % Clean up ETS table if it still exists
             case ets:info(notification_listeners) of
                 undefined -> ok;
-                _ -> ets:delete(notification_listeners)
+                _ -> 
+                    try ets:delete(notification_listeners)
+                    catch _:_ -> ok
+                    end
             end,
             ok
     end.
@@ -360,6 +437,14 @@ notification_manager_loop(State) ->
             
         stop ->
             ?event(notify, {notification_manager_stopping, self()}),
+            % Clean up ETS table before exiting
+            case ets:info(notification_listeners) of
+                undefined -> ok;
+                _ -> 
+                    try ets:delete(notification_listeners)
+                    catch _:_ -> ok
+                    end
+            end,
             ok;
             
         Msg ->
@@ -369,16 +454,22 @@ notification_manager_loop(State) ->
 
 %% @doc Handle event dispatch by matching against registered listeners
 handle_event_dispatch(Event, Opts) ->
-    % Get all registered listeners
-    AllListeners = ets:tab2list(notification_listeners),
-    
-    % Spawn short-lived worker processes for actual dispatching
-    % This keeps the manager process responsive
-    lists:foreach(fun({Template, StreamPid, Ref}) ->
-        spawn(fun() -> 
-            try_dispatch_to_listener(Template, StreamPid, Ref, Event, Opts)
-        end)
-    end, AllListeners).
+    try
+        % Get all registered listeners
+        AllListeners = ets:tab2list(notification_listeners),
+        
+        % Spawn short-lived worker processes for actual dispatching
+        % This keeps the manager process responsive
+        lists:foreach(fun({Template, StreamPid, Ref}) ->
+            spawn(fun() -> 
+                try_dispatch_to_listener(Template, StreamPid, Ref, Event, Opts)
+            end)
+        end, AllListeners)
+    catch
+        _:_ ->
+            % Table might not exist, ignore
+            ok
+    end.
 
 %% @doc Try to dispatch an event to a specific listener if template matches
 try_dispatch_to_listener(Template, StreamPid, Ref, Event, Opts) ->
@@ -412,21 +503,31 @@ try_dispatch_to_listener(Template, StreamPid, Ref, Event, Opts) ->
 %% @doc Test template validation
 template_validation_test() ->
     % Valid map template
-    ?assertEqual({ok, #{ <<"device">> => <<"test">> }}, 
-                 validate_template(#{ <<"device">> => <<"test">> }, #{})),
+    MapTemplate = #{ <<"device">> => <<"test">> },
+    MapResult = validate_template(MapTemplate, #{}),
+    ?event(debug, {map_template_validation, {input, MapTemplate}, {result, MapResult}}),
+    ?assertEqual({ok, #{ <<"device">> => <<"test">> }}, MapResult),
     
     % Valid regex template  
-    ?assertEqual({ok, <<"/.*/test">>}, 
-                 validate_template(<<"/.*/test">>, #{})),
+    RegexTemplate = <<"/.*/test">>,
+    RegexResult = validate_template(RegexTemplate, #{}),
+    ?event(debug, {regex_template_validation, {input, RegexTemplate}, {result, RegexResult}}),
+    ?assertEqual({ok, <<"/.*/test">>}, RegexResult),
     
     % Invalid empty map
-    ?assertMatch({error, _}, validate_template(#{}, #{})),
+    EmptyResult = validate_template(#{}, #{}),
+    ?event(debug, {empty_map_validation, {result, EmptyResult}}),
+    ?assertMatch({error, _}, EmptyResult),
     
     % Invalid regex
-    ?assertMatch({error, _}, validate_template(<<"[invalid">>, #{})),
+    InvalidRegexResult = validate_template(<<"[invalid">>, #{}),
+    ?event(debug, {invalid_regex_validation, {result, InvalidRegexResult}}),
+    ?assertMatch({error, _}, InvalidRegexResult),
     
     % Invalid type
-    ?assertMatch({error, _}, validate_template(123, #{})).
+    InvalidTypeResult = validate_template(123, #{}),
+    ?event(debug, {invalid_type_validation, {result, InvalidTypeResult}}),
+    ?assertMatch({error, _}, InvalidTypeResult).
 
 %% @doc Test template matching
 template_matching_test() ->
@@ -434,16 +535,553 @@ template_matching_test() ->
     MapTemplate = #{ <<"device">> => <<"process@1.0">> },
     
     Event1 = #{ <<"device">> => <<"process@1.0">>, <<"path">> => <<"/compute">> },
-    ?assertEqual(true, template_matches(Event1, MapTemplate, #{})),
+    Match1 = template_matches(Event1, MapTemplate, #{}),
+    ?event(debug, {map_template_match, {template, MapTemplate}, {event, Event1}, {result, Match1}}),
+    ?assertEqual(true, Match1),
     
     Event2 = #{ <<"device">> => <<"message@1.0">>, <<"path">> => <<"/compute">> },
-    ?assertEqual(false, template_matches(Event2, MapTemplate, #{})),
+    Match2 = template_matches(Event2, MapTemplate, #{}),
+    ?event(debug, {map_template_no_match, {template, MapTemplate}, {event, Event2}, {result, Match2}}),
+    ?assertEqual(false, Match2),
     
     % Regex template matching
     RegexTemplate = <<"/.*process.*/.*">>,
     
     Event3 = #{ <<"path">> => <<"/test/process@1.0/compute">> },
-    ?assertEqual(true, template_matches(Event3, RegexTemplate, #{})),
+    Match3 = template_matches(Event3, RegexTemplate, #{}),
+    ?event(debug, {regex_template_match, {template, RegexTemplate}, {event, Event3}, {result, Match3}}),
+    ?assertEqual(true, Match3),
     
     Event4 = #{ <<"path">> => <<"/test/message@1.0/compute">> },
-    ?assertEqual(false, template_matches(Event4, RegexTemplate, #{})). 
+    Match4 = template_matches(Event4, RegexTemplate, #{}),
+    ?event(debug, {regex_template_no_match, {template, RegexTemplate}, {event, Event4}, {result, Match4}}),
+    ?assertEqual(false, Match4).
+
+%% @doc Test notification manager process lifecycle
+notification_manager_test() ->
+    % Ensure clean state
+    InitialState = whereis(?NOTIFICATION_MANAGER),
+    ?event(debug, {manager_initial_state, InitialState}),
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    % Start manager
+    StartResult = start_notification_manager(),
+    ?event(debug, {manager_start_result, StartResult}),
+    {ok, ManagerPid} = StartResult,
+    ?assert(is_process_alive(ManagerPid)),
+    ?assertEqual(ManagerPid, whereis(?NOTIFICATION_MANAGER)),
+    ?event(debug, {manager_started_successfully, {pid, ManagerPid}}),
+    
+    % Stop manager
+    ?event(debug, {stopping_manager}),
+    stop_notification_manager(),
+    % Wait a bit for cleanup
+    timer:sleep(100),
+    FinalState = whereis(?NOTIFICATION_MANAGER),
+    ?event(debug, {manager_final_state, FinalState}),
+    ?assertEqual(undefined, FinalState).
+
+%% @doc Test event dispatching with template matching
+event_dispatch_test() ->
+    % Ensure clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    start_notification_manager(),
+    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ?assert(is_process_alive(ManagerPid)),
+    
+    % Create a test stream process
+    TestPid = self(),
+    StreamPid = spawn(fun() ->
+        receive 
+            {notify_event, Event} -> TestPid ! {received_event, Event}
+        after 1000 -> TestPid ! timeout
+        end
+    end),
+    
+    % Register listener with map template
+    MapTemplate = #{ <<"device">> => <<"process@1.0">> },
+    Ref1 = make_ref(),
+    ?event(debug, {registering_listener, {template, MapTemplate}, {stream_pid, StreamPid}, {ref, Ref1}}),
+    ManagerPid ! {register_listener, MapTemplate, StreamPid, Ref1},
+    
+    % Create test events
+    MatchingEvent = #{
+        <<"device">> => <<"process@1.0">>,
+        <<"action">> => <<"compute">>,
+        <<"data">> => <<"test">>
+    },
+    
+    NonMatchingEvent = #{
+        <<"device">> => <<"message@1.0">>,
+        <<"action">> => <<"compute">>
+    },
+    
+    % Dispatch matching event
+    ?event(debug, {dispatching_matching_event, MatchingEvent}),
+    ManagerPid ! {dispatch_event, MatchingEvent, #{}},
+    
+    % Should receive the event
+    receive
+        {received_event, ReceivedEvent} ->
+            ?event(debug, {received_matching_event, ReceivedEvent}),
+            ?assertEqual(MatchingEvent, ReceivedEvent)
+    after 500 ->
+        ?event(debug, {timeout_on_matching_event}),
+        ?assert(false, "Should have received matching event")
+    end,
+    
+    % Dispatch non-matching event
+    ?event(debug, {dispatching_non_matching_event, NonMatchingEvent}),
+    ManagerPid ! {dispatch_event, NonMatchingEvent, #{}},
+    
+    % Should not receive anything (timeout expected)
+    receive
+        {received_event, UnexpectedEvent} ->
+            ?event(debug, {unexpected_event_received, UnexpectedEvent}),
+            ?assert(false, "Should not have received non-matching event")
+    after 100 ->
+        ?event(debug, {expected_timeout_on_non_matching_event}),
+        ok % Expected timeout
+    end,
+    
+    stop_notification_manager().
+
+%% @doc Test integration with hb_persistent notification
+integration_test() ->
+    % Ensure clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    % Test the integration point with hb_persistent
+    GroupName = <<"test-group">>,
+    Msg2 = #{ <<"path">> => <<"/test">>, <<"data">> => <<"request">> },
+    Msg3 = #{ <<"result">> => <<"success">>, <<"timestamp">> => erlang:system_time(millisecond) },
+    Opts = #{ notify_device => <<"notify@1.0">> },
+    
+    % Start notification manager
+    start_notification_manager(),
+    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ?assert(is_process_alive(ManagerPid)),
+    
+    % This should call our dispatch function
+    hb_persistent:dispatch_to_notify_device(GroupName, Msg2, Msg3, Opts),
+    timer:sleep(50),
+    
+    % Manager should still be running (no crashes)
+    ?assert(is_process_alive(ManagerPid)),
+    
+    stop_notification_manager().
+
+%% @doc Test device registration and unregistration functions
+device_registration_test() ->
+    StateMsg = #{<<"listeners">> => #{}},
+    ?event(debug, {initial_state, StateMsg}),
+    
+    % Test successful registration with map template
+    InputMsg1 = #{
+        <<"template">> => #{ <<"device">> => <<"test@1.0">> },
+        <<"stream">> => <<"test-stream">>
+    },
+    ?event(debug, {registering_map_template, InputMsg1}),
+    
+    {ok, NewState1} = register(StateMsg, InputMsg1, #{}),
+    Listeners1 = maps:get(<<"listeners">>, NewState1),
+    ?event(debug, {after_map_registration, {listeners_count, maps:size(Listeners1)}, {keys, maps:keys(Listeners1)}}),
+    ?assertEqual(1, maps:size(Listeners1)),
+    
+    % Test registration with regex template
+    InputMsg2 = #{
+        <<"template">> => <<"/.*test.*/.*">>,
+        <<"stream">> => <<"test-stream-2">>
+    },
+    
+    {ok, NewState2} = register(NewState1, InputMsg2, #{}),
+    Listeners2 = maps:get(<<"listeners">>, NewState2),
+    ?assertEqual(2, maps:size(Listeners2)),
+    
+    % Test legacy pattern field
+    InputMsg3 = #{
+        <<"pattern">> => #{ <<"action">> => <<"test">> },
+        <<"stream">> => <<"test-stream-3">>
+    },
+    
+    {ok, NewState3} = register(NewState2, InputMsg3, #{}),
+    Listeners3 = maps:get(<<"listeners">>, NewState3),
+    ?assertEqual(3, maps:size(Listeners3)),
+    
+    % Test unregistration - unregister the first template we added
+    UnregMsg = #{
+        <<"template">> => #{ <<"device">> => <<"test@1.0">> }
+    },
+    
+    ?event(debug, {before_unregister, {listeners_count, maps:size(maps:get(<<"listeners">>, NewState3))}}),
+    {ok, NewState4} = unregister(NewState3, UnregMsg, #{}),
+    Listeners4 = maps:get(<<"listeners">>, NewState4),
+    ?event(debug, {after_unregister, {listeners_count, maps:size(Listeners4)}, {keys, maps:keys(Listeners4)}}),
+    ?assertEqual(2, maps:size(Listeners4)), % Should have 2 left (regex + pattern)
+    
+    % Verify the correct template was removed
+    ?assertNot(maps:is_key({template, #{ <<"device">> => <<"test@1.0">> }}, Listeners4)),
+    
+    % Test error cases
+    ?assertMatch({error, _}, register(StateMsg, #{}, #{})),
+    ?assertMatch({error, _}, register(StateMsg, #{<<"template">> => #{}}, #{})),
+    ?assertMatch({error, _}, unregister(StateMsg, #{}, #{})).
+
+%% @doc Test listener registration and unregistration
+listener_registration_test() ->
+    % Ensure clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    % Start manager
+    start_notification_manager(),
+    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ?assert(is_process_alive(ManagerPid)),
+    
+    % Register a listener
+    Template = #{ <<"device">> => <<"message@1.0">> },
+    StreamPid = spawn(fun() -> receive _ -> ok end end),
+    Ref = make_ref(),
+    
+    ManagerPid ! {register_listener, Template, StreamPid, Ref},
+    timer:sleep(10), % Allow registration to process
+    
+    % Check listener is registered
+    AllListeners = ets:tab2list(notification_listeners),
+    ?assert(lists:member({Template, StreamPid, Ref}, AllListeners)),
+    
+    % Unregister listener
+    ManagerPid ! {unregister_listener, Ref},
+    timer:sleep(10), % Allow unregistration to process
+    
+    % Check listener is removed
+    AllListeners2 = ets:tab2list(notification_listeners),
+    ?assertNot(lists:member({Template, StreamPid, Ref}, AllListeners2)),
+    
+    stop_notification_manager().
+
+%% @doc Test regex template matching in event dispatch
+regex_dispatch_test() ->
+    % Ensure clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    start_notification_manager(),
+    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ?assert(is_process_alive(ManagerPid)),
+    
+    % Create test stream process
+    TestPid = self(),
+    StreamPid = spawn(fun() ->
+        receive 
+            {notify_event, Event} -> TestPid ! {received_event, Event}
+        after 1000 -> TestPid ! timeout
+        end
+    end),
+    
+    % Register listener with regex template
+    RegexTemplate = <<"/.*process.*/.*">>,
+    Ref = make_ref(),
+    ManagerPid ! {register_listener, RegexTemplate, StreamPid, Ref},
+    
+    % Test matching path
+    MatchingEvent = #{ <<"path">> => <<"/test/process@1.0/compute">> },
+    ManagerPid ! {dispatch_event, MatchingEvent, #{}},
+    
+    receive
+        {received_event, ReceivedEvent} ->
+            ?assertEqual(MatchingEvent, ReceivedEvent)
+    after 500 ->
+        ?assert(false, "Should have received matching event")
+    end,
+    
+    % Test non-matching path
+    NonMatchingEvent = #{ <<"path">> => <<"/test/message@1.0/compute">> },
+    ManagerPid ! {dispatch_event, NonMatchingEvent, #{}},
+    
+    receive
+        {received_event, _} ->
+            ?assert(false, "Should not have received non-matching event")
+    after 100 ->
+        ok % Expected timeout
+    end,
+    
+    stop_notification_manager().
+
+%% @doc Test dispatch function
+dispatch_function_test() ->
+    % Ensure clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    % Start manager for testing
+    start_notification_manager(),
+    
+    % Test dispatch with valid input
+    InputMsg = #{
+        <<"event">> => #{ <<"test">> => <<"data">> },
+        <<"timestamp">> => erlang:system_time(millisecond)
+    },
+    
+    Result = dispatch(#{}, InputMsg, #{}),
+    ?assertEqual({ok, <<"OK">>}, Result),
+    
+    stop_notification_manager().
+
+%% @doc Test stream function
+stream_function_test() ->
+    % Test stream creation with valid template
+    InputMsg1 = #{
+        <<"template">> => #{ <<"device">> => <<"test@1.0">> }
+    },
+    
+    {ok, Result1} = stream(#{}, InputMsg1, #{}),
+    ?assertEqual(200, maps:get(<<"status">>, Result1)),
+    ?assertEqual(true, maps:get(<<"streaming">>, Result1)),
+    ?assert(maps:is_key(<<"headers">>, Result1)),
+    ?assert(maps:is_key(<<"body">>, Result1)),
+    
+    % Test with regex template
+    InputMsg2 = #{
+        <<"template">> => <<"/.*test.*/.*">>
+    },
+    
+    {ok, Result2} = stream(#{}, InputMsg2, #{}),
+    ?assertEqual(200, maps:get(<<"status">>, Result2)),
+    
+    % Test with legacy pattern
+    InputMsg3 = #{
+        <<"pattern">> => #{ <<"action">> => <<"compute">> }
+    },
+    
+    {ok, Result3} = stream(#{}, InputMsg3, #{}),
+    ?assertEqual(200, maps:get(<<"status">>, Result3)).
+
+%% @doc Test dead process cleanup
+dead_process_cleanup_test() ->
+    % Ensure clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    start_notification_manager(),
+    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ?assert(is_process_alive(ManagerPid)),
+    
+    % Create and register a process, then kill it
+    DeadPid = spawn(fun() -> ok end),
+    timer:sleep(10), % Ensure process dies
+    ?assertNot(is_process_alive(DeadPid)),
+    ?event(debug, {created_dead_process, {pid, DeadPid}, {alive, is_process_alive(DeadPid)}}),
+    
+    Template = #{ <<"device">> => <<"message@1.0">> },
+    Ref = make_ref(),
+    
+    % Register the dead process
+    ?event(debug, {registering_dead_process, {template, Template}, {dead_pid, DeadPid}}),
+    ManagerPid ! {register_listener, Template, DeadPid, Ref},
+    timer:sleep(10),
+    
+    % Verify it's in the table
+    AllListeners = ets:tab2list(notification_listeners),
+    ?event(debug, {listeners_before_cleanup, {count, length(AllListeners)}, {has_dead_process, lists:member({Template, DeadPid, Ref}, AllListeners)}}),
+    ?assert(lists:member({Template, DeadPid, Ref}, AllListeners)),
+    
+    % Dispatch an event that matches
+    Event = #{ <<"device">> => <<"message@1.0">> },
+    ?event(debug, {dispatching_to_dead_process, Event}),
+    ManagerPid ! {dispatch_event, Event, #{}},
+    timer:sleep(50), % Allow cleanup to happen
+    
+    % Dead process should be cleaned up
+    AllListeners2 = ets:tab2list(notification_listeners),
+    ?event(debug, {listeners_after_cleanup, {count, length(AllListeners2)}, {dead_process_removed, not lists:member({Template, DeadPid, Ref}, AllListeners2)}}),
+    ?assertNot(lists:member({Template, DeadPid, Ref}, AllListeners2)),
+    
+    stop_notification_manager().
+
+%% @doc Test concurrent dispatching
+concurrent_dispatch_test() ->
+    % Ensure clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    start_notification_manager(),
+    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ?assert(is_process_alive(ManagerPid)),
+    
+    % Create multiple test processes
+    TestPid = self(),
+    NumStreams = 5,
+    
+    StreamPids = lists:map(fun(N) ->
+        spawn(fun() ->
+            receive 
+                {notify_event, Event} -> 
+                    TestPid ! {received_event, N, Event}
+            after 1000 -> 
+                TestPid ! {timeout, N}
+            end
+        end)
+    end, lists:seq(1, NumStreams)),
+    
+    % Register all with the same template
+    Template = #{ <<"type">> => <<"broadcast">> },
+    lists:foreach(fun({_N, Pid}) ->
+        ManagerPid ! {register_listener, Template, Pid, make_ref()}
+    end, lists:zip(lists:seq(1, NumStreams), StreamPids)),
+    
+    timer:sleep(20), % Allow registrations to process
+    
+    % Dispatch one event
+    Event = #{ <<"type">> => <<"broadcast">>, <<"message">> => <<"hello">> },
+    ManagerPid ! {dispatch_event, Event, #{}},
+    
+    % All streams should receive the event
+    ReceivedCount = receive_events(NumStreams, 0),
+    ?assertEqual(NumStreams, ReceivedCount),
+    
+    stop_notification_manager().
+
+%% Helper function for concurrent test
+receive_events(0, Count) -> Count;
+receive_events(Remaining, Count) ->
+    receive
+        {received_event, _N, _Event} ->
+            receive_events(Remaining - 1, Count + 1);
+        {timeout, _N} ->
+            receive_events(Remaining - 1, Count)
+    after 500 ->
+        Count
+    end.
+
+%% @doc Test template validation edge cases
+template_validation_edge_cases_test() ->
+    % Test deeply nested map template
+    NestedTemplate = #{
+        <<"device">> => <<"test@1.0">>,
+        <<"data">> => #{
+            <<"nested">> => #{
+                <<"value">> => <<"deep">>
+            }
+        }
+    },
+    ?assertEqual({ok, NestedTemplate}, validate_template(NestedTemplate, #{})),
+    
+    % Test complex regex patterns
+    ComplexRegex = <<"^/(test|prod)/process@[0-9]+\\.[0-9]+/.+$">>,
+    ?assertEqual({ok, ComplexRegex}, validate_template(ComplexRegex, #{})),
+    
+    % Test unicode in templates
+    UnicodeTemplate = #{ <<"message">> => <<"Hello 世界">> },
+    ?assertEqual({ok, UnicodeTemplate}, validate_template(UnicodeTemplate, #{})),
+    
+    % Test very long regex
+    LongRegex = iolist_to_binary(lists:duplicate(1000, "a")),
+    ?assertEqual({ok, LongRegex}, validate_template(LongRegex, #{})).
+
+%% @doc Test message matching edge cases
+message_matching_edge_cases_test() ->
+    % Test partial map matching
+    Template = #{ <<"device">> => <<"message@1.0">> },
+    Event = #{
+        <<"device">> => <<"message@1.0">>,
+        <<"extra">> => <<"field">>,
+        <<"more">> => #{ <<"nested">> => <<"data">> }
+    },
+    ?assertEqual(true, template_matches(Event, Template, #{})),
+    
+    % Test case sensitivity
+    CaseTemplate = #{ <<"Device">> => <<"Message@1.0">> },
+    CaseEvent = #{ <<"device">> => <<"message@1.0">> },
+    ?assertEqual(false, template_matches(CaseEvent, CaseTemplate, #{})),
+    
+    % Test missing path in regex matching
+    RegexTemplate = <<"/test.*">>,
+    EventWithoutPath = #{ <<"device">> => <<"message@1.0">> },
+    ?assertEqual(false, template_matches(EventWithoutPath, RegexTemplate, #{})),
+    
+    % Test empty path
+    EventWithEmptyPath = #{ <<"path">> => <<"">> },
+    ?assertEqual(false, template_matches(EventWithEmptyPath, RegexTemplate, #{})).
+
+%% @doc Test error handling and recovery
+error_handling_test() ->
+    % Ensure clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    start_notification_manager(),
+    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ?assert(is_process_alive(ManagerPid)),
+    
+    % Test invalid template in dispatch (should not crash manager)
+    InvalidTemplate = invalid_template_atom,
+    TestPid = spawn(fun() -> receive _ -> ok end end),
+    Ref = make_ref(),
+    
+    % Register invalid template (insert directly to bypass validation)
+    ets:insert(notification_listeners, {InvalidTemplate, TestPid, Ref}),
+    
+    % Dispatch event - should handle error gracefully
+    Event = #{ <<"test">> => <<"data">> },
+    ManagerPid ! {dispatch_event, Event, #{}},
+    timer:sleep(50),
+    
+    % Manager should still be alive
+    ?assert(is_process_alive(ManagerPid)),
+    
+    stop_notification_manager().
+
+%% @doc Performance test for high-frequency events
+performance_test() ->
+    % Ensure clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    start_notification_manager(),
+    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ?assert(is_process_alive(ManagerPid)),
+    
+    % Register a listener
+    Template = #{ <<"type">> => <<"perf-test">> },
+    TestPid = spawn(fun() ->
+        receive_loop(0)
+    end),
+    Ref = make_ref(),
+    ManagerPid ! {register_listener, Template, TestPid, Ref},
+    timer:sleep(10),
+    
+    % Send many events quickly
+    NumEvents = 100,
+    StartTime = erlang:system_time(microsecond),
+    
+    lists:foreach(fun(N) ->
+        Event = #{
+            <<"type">> => <<"perf-test">>,
+            <<"sequence">> => N,
+            <<"timestamp">> => erlang:system_time(millisecond)
+        },
+        ManagerPid ! {dispatch_event, Event, #{}}
+    end, lists:seq(1, NumEvents)),
+    
+    EndTime = erlang:system_time(microsecond),
+    Duration = EndTime - StartTime,
+    
+    ?event(notify, {performance_test, {events, NumEvents}, {duration_us, Duration}}),
+    
+    % Should handle 100 events quickly (< 100ms)
+    ?assert(Duration < 100000, "Performance test took too long"),
+    
+    stop_notification_manager().
+
+receive_loop(Count) ->
+    receive
+        {notify_event, _Event} ->
+            receive_loop(Count + 1)
+    after 10 ->
+        exit({received_count, Count})
+    end. 

--- a/src/dev_notify.erl
+++ b/src/dev_notify.erl
@@ -1,10 +1,17 @@
 %%% @doc A device that provides real-time notifications for AO process events.
 %%% It integrates with the existing event system (hb_event) and allows clients
 %%% to subscribe to specific events using HTTP/3 streams.
+%%% 
+%%% Uses a long-running notification manager process to handle high-frequency
+%%% message matching and dispatching efficiently.
 -module(dev_notify).
 -export([info/1, info/3, dispatch/3, register/3, unregister/3, stream/3]).
+-export([start_notification_manager/0, stop_notification_manager/0]).
+-export([notification_manager_loop/1]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
+
+-define(NOTIFICATION_MANAGER, hb_notification_manager).
 
 %% @doc Device API information
 info(_) ->
@@ -62,48 +69,23 @@ unregister(StateMsg, InputMsg, Opts) ->
             {ok, StateMsg#{<<"listeners">> => NewState}}
     end.
 
-%% @doc Dispatch an event to registered listeners
-dispatch(StateMsg, InputMsg, Opts) ->
+%% @doc Dispatch an event to registered listeners via the notification manager
+dispatch(_StateMsg, InputMsg, Opts) ->
     ?event(notify, {dispatch_event, InputMsg}),
-    Listeners = maps:get(<<"listeners">>, StateMsg, #{}),
     
-    % Spawn a worker process for non-blocking dispatch
-    spawn(fun() ->
-        dispatch_to_listeners(InputMsg, Listeners, Opts)
-    end),
-    
-    {ok, <<"OK">>}.
-
-%% @doc Internal function to dispatch events to matching listeners
-dispatch_to_listeners(Event, Listeners, Opts) ->
-    maps:fold(
-        fun({pattern, Pattern}, Stream, _) ->
-            case hb_message:match(Event, Pattern) of
-                true ->
-                    ?event(notify, {matched_pattern, Pattern, Event}),
-                    % Use Cowboy's http/3 push to send the event
-                    push_event(Stream, Event, Opts);
-                false ->
-                    ok
-            end
-        end,
-        ok,
-        Listeners
-    ).
-
-%% @doc Push an event to a stream using Cowboy's HTTP/3 streaming
-push_event(StreamRef, Event, _Opts) ->
-    try
-        % Convert event to JSON
-        EventJson = hb_util:encode(Event),
-        % Stream the event data with nofin to keep connection alive
-        cowboy_req:stream_body(EventJson, nofin, StreamRef),
-        ?event(notify, {event_pushed, {stream, StreamRef}, {event_size, byte_size(EventJson)}})
-    catch
-        Class:Reason ->
-            ?event(notify, {push_error, {Class, Reason}}),
-            ok
+    % Send event to the long-running notification manager process
+    case whereis(?NOTIFICATION_MANAGER) of
+        undefined ->
+            ?event(notify, {manager_not_started, starting_manager}),
+            start_notification_manager(),
+            dispatch(_StateMsg, InputMsg, Opts);
+        ManagerPid ->
+            ManagerPid ! {dispatch_event, InputMsg, Opts},
+            {ok, <<"OK">>}
     end.
+
+%% Note: dispatch_to_listeners and push_event functions are now handled
+%% by the notification manager process for better performance.
 
 %% @doc Start a streaming connection for real-time event notifications
 stream(_StateMsg, InputMsg, Opts) ->
@@ -161,16 +143,19 @@ create_streaming_body(Pattern, Opts) ->
     end.
 
 %% @doc Register a streaming connection for receiving notifications
-register_stream(StreamId, Pattern, Req, _Opts) ->
-    % Store stream info in ETS table or process registry
-    % For now, we'll use a simple approach with process dictionary
-    Streams = get(notification_streams),
-    NewStreams = case Streams of
-        undefined -> #{StreamId => #{pattern => Pattern, req => Req}};
-        _ -> Streams#{StreamId => #{pattern => Pattern, req => Req}}
-    end,
-    put(notification_streams, NewStreams),
-    ?event(notify, {stream_registered, {stream_id, StreamId}, {pattern, Pattern}}).
+register_stream(StreamId, Pattern, _Req, _Opts) ->
+    % Ensure notification manager is running
+    start_notification_manager(),
+    
+    % Register with the notification manager
+    case whereis(?NOTIFICATION_MANAGER) of
+        undefined ->
+            ?event(notify, {manager_not_available, {stream_id, StreamId}});
+        ManagerPid ->
+            StreamPid = self(),
+            ManagerPid ! {register_listener, Pattern, StreamPid, StreamId},
+            ?event(notify, {stream_registered_with_manager, {stream_id, StreamId}, {pattern, Pattern}})
+    end.
 
 %% @doc Keep the streaming connection alive and handle events
 stream_loop(StreamId, Req, Opts) ->
@@ -198,11 +183,129 @@ stream_loop(StreamId, Req, Opts) ->
 
 %% @doc Unregister a streaming connection
 unregister_stream(StreamId) ->
-    Streams = get(notification_streams),
-    case Streams of
+    % Unregister with the notification manager
+    case whereis(?NOTIFICATION_MANAGER) of
+        undefined ->
+            ?event(notify, {manager_not_available_for_unregister, {stream_id, StreamId}});
+        ManagerPid ->
+            ManagerPid ! {unregister_listener, StreamId},
+            ?event(notify, {stream_unregistered_from_manager, {stream_id, StreamId}})
+    end.
+
+%% ============================================================================
+%% Notification Manager Process
+%% ============================================================================
+
+%% @doc Start the long-running notification manager process
+start_notification_manager() ->
+    case whereis(?NOTIFICATION_MANAGER) of
+        undefined ->
+            % Initialize ETS table for fast listener lookups
+            case ets:info(notification_listeners) of
+                undefined ->
+                    ets:new(notification_listeners, [named_table, public, bag, {read_concurrency, true}]);
+                _ -> ok
+            end,
+            
+            % Start the manager process
+            ManagerPid = spawn_link(fun() -> 
+                register(?NOTIFICATION_MANAGER, self()),
+                ?event(notify, {notification_manager_started, self()}),
+                notification_manager_loop(#{})
+            end),
+            {ok, ManagerPid};
+        Pid ->
+            {already_started, Pid}
+    end.
+
+%% @doc Stop the notification manager process
+stop_notification_manager() ->
+    case whereis(?NOTIFICATION_MANAGER) of
         undefined -> ok;
-        _ -> 
-            NewStreams = maps:remove(StreamId, Streams),
-            put(notification_streams, NewStreams)
-    end,
-    ?event(notify, {stream_unregistered, {stream_id, StreamId}}). 
+        Pid ->
+            Pid ! stop,
+            % Clean up ETS table
+            case ets:info(notification_listeners) of
+                undefined -> ok;
+                _ -> ets:delete(notification_listeners)
+            end,
+            ok
+    end.
+
+%% @doc Main loop for the notification manager process
+notification_manager_loop(State) ->
+    receive
+        {dispatch_event, Event, Opts} ->
+            % Handle event dispatch in the main manager process
+            % This keeps the work minimal to avoid blocking
+            handle_event_dispatch(Event, Opts),
+            notification_manager_loop(State);
+            
+        {register_listener, Pattern, StreamPid, Ref} ->
+            % Register a new listener
+            ets:insert(notification_listeners, {Pattern, StreamPid, Ref}),
+            ?event(notify, {listener_registered, {pattern, Pattern}, {stream, StreamPid}, {ref, Ref}}),
+            notification_manager_loop(State);
+            
+        {unregister_listener, Ref} ->
+            % Remove listener by reference
+            ets:match_delete(notification_listeners, {'_', '_', Ref}),
+            ?event(notify, {listener_unregistered, {ref, Ref}}),
+            notification_manager_loop(State);
+            
+        {get_stats} ->
+            % Return statistics about registered listeners
+            Stats = #{
+                total_listeners => ets:info(notification_listeners, size),
+                manager_pid => self(),
+                state => State
+            },
+            ?event(notify, {manager_stats, Stats}),
+            notification_manager_loop(State);
+            
+        stop ->
+            ?event(notify, {notification_manager_stopping, self()}),
+            ok;
+            
+        Msg ->
+            ?event(notify, {unexpected_message, Msg}),
+            notification_manager_loop(State)
+    end.
+
+%% @doc Handle event dispatch by matching against registered listeners
+handle_event_dispatch(Event, Opts) ->
+    % Get all registered listeners
+    AllListeners = ets:tab2list(notification_listeners),
+    
+    % Spawn short-lived worker processes for actual dispatching
+    % This keeps the manager process responsive
+    lists:foreach(fun({Pattern, StreamPid, Ref}) ->
+        spawn(fun() -> 
+            try_dispatch_to_listener(Pattern, StreamPid, Ref, Event, Opts)
+        end)
+    end, AllListeners).
+
+%% @doc Try to dispatch an event to a specific listener if pattern matches
+try_dispatch_to_listener(Pattern, StreamPid, Ref, Event, _Opts) ->
+    try
+        case hb_message:match(Event, Pattern) of
+            true ->
+                ?event(notify, {matched_pattern, {pattern, Pattern}, {ref, Ref}}),
+                % Send event to the stream process
+                case is_process_alive(StreamPid) of
+                    true ->
+                        StreamPid ! {notify_event, Event},
+                        ?event(notify, {event_sent, {stream, StreamPid}, {ref, Ref}});
+                    false ->
+                        % Clean up dead process
+                        ets:match_delete(notification_listeners, {'_', StreamPid, '_'}),
+                        ?event(notify, {dead_stream_cleaned, {stream, StreamPid}})
+                end;
+            false ->
+                % Pattern didn't match, no action needed
+                ok
+        end
+    catch
+        Class:Reason ->
+            ?event(notify, {dispatch_error, {class, Class}, {reason, Reason}, {pattern, Pattern}})
+    end. 

--- a/src/dev_notify.erl
+++ b/src/dev_notify.erl
@@ -7,7 +7,7 @@
 %%% message matching and dispatching efficiently.
 -module(dev_notify).
 
--export([info/1, info/3, dispatch/3, stream/3]).
+-export([info/1, info/3, dispatch/3, stream/3, start_manager/3]).
 -export([start_notification_manager/0, stop_notification_manager/0]).
 
 -include("include/hb.hrl").
@@ -18,7 +18,7 @@
 
 %% @doc Device API information
 info(_) ->
-    #{exports => [info, dispatch, stream], variant => <<"Notify/1.0">>}.
+    #{exports => [info, dispatch, stream, start_manager], variant => <<"Notify/1.0">>}.
 
 %% @doc HTTP info response providing information about this device
 info(_Msg1, _Msg2, _Opts) ->
@@ -28,22 +28,70 @@ info(_Msg1, _Msg2, _Opts) ->
           <<"paths">> =>
               #{<<"info">> => <<"Get device info">>,
                 <<"dispatch">> => <<"Dispatch an event to registered listeners">>,
-                <<"stream">> => <<"Start a streaming connection for real-time events">>}},
+                <<"stream">> => <<"Start a streaming connection for real-time events">>,
+                <<"start_manager">> => <<"Start notification manager via hook (internal)">>}},
     {ok, #{<<"status">> => 200, <<"body">> => InfoBody}}.
+
+%% @doc Start notification manager if notify_device is configured (called via start hook)
+start_manager(_StateMsg, HookMsg, _Opts) ->
+    % Extract the body from hook message (contains node configuration)
+    NodeConfig = maps:get(<<"body">>, HookMsg, #{}),
+
+    % Check if notify device is configured
+    case hb_opts:get(notify_device, undefined, NodeConfig) of
+        undefined ->
+            {ok, HookMsg}; % No notify device configured, return unchanged
+        _NotifyDeviceSpec ->
+            start_notification_manager(),
+            
+            % Register the on-notify hook dynamically
+            CurrentHooks = hb_opts:get(on, #{}, NodeConfig),
+            UpdatedHooks = CurrentHooks#{
+                <<"on-notify">> => #{
+                    <<"device">> => #{
+                        <<"on-notify">> => fun dev_notify:dispatch/3
+                    }
+                }
+            },
+            UpdatedNodeConfig = NodeConfig#{on => UpdatedHooks},
+            UpdatedHookMsg = HookMsg#{<<"body">> => UpdatedNodeConfig},
+            
+            {ok, UpdatedHookMsg}
+    end.
 
 %% @doc Dispatch an event to registered listeners via the notification manager
 dispatch(_StateMsg, InputMsg, Opts) ->
     ?event(notify, {dispatch_event, InputMsg}),
 
-    % Send event to the long-running notification manager process
-    case hb_name:lookup(?NOTIFICATION_MANAGER) of
+    % Check if notify device is configured
+    case hb_opts:get(notify_device, undefined, Opts) of
         undefined ->
-            ?event(notify, {manager_not_started, starting_manager}),
-            start_notification_manager(),
-            dispatch(_StateMsg, InputMsg, Opts);
-        ManagerPid ->
-            ManagerPid ! {dispatch_event, InputMsg, Opts},
-            {ok, <<"OK">>}
+            {ok, <<"No notify device configured">>}; % No notify device configured
+        _NotifyDeviceSpec ->
+            % Send event to the long-running notification manager process
+            case hb_name:lookup(?NOTIFICATION_MANAGER) of
+                undefined ->
+                    % Manager not started, try to start it via the device
+                    spawn(fun() ->
+                             try
+                                 start_notification_manager(),
+                                 case hb_name:lookup(?NOTIFICATION_MANAGER) of
+                                     undefined -> ?event({notify_manager_start_failed, InputMsg});
+                                     ManagerPid -> ManagerPid ! {dispatch_event, InputMsg, Opts}
+                                 end
+                             catch
+                                 Class:Reason ->
+                                     ?event({notify_dispatch_error,
+                                             {class, Class},
+                                             {reason, Reason}})
+                             end
+                          end),
+                    {ok, <<"Starting notification manager">>};
+                ManagerPid ->
+                    % Send directly to manager process (minimal overhead)
+                    ManagerPid ! {dispatch_event, InputMsg, Opts},
+                    {ok, <<"OK">>}
+            end
     end.
 
 %% Note: dispatch_to_listeners and push_event functions are now handled
@@ -631,8 +679,14 @@ dispatch_function_test() ->
         #{<<"event">> => #{<<"test">> => <<"data">>},
           <<"timestamp">> => erlang:system_time(millisecond)},
 
-    Result = dispatch(#{}, InputMsg, #{}),
-    ?assertEqual({ok, <<"OK">>}, Result),
+    % Test with no notify device configured (should return appropriate message)
+    Result1 = dispatch(#{}, InputMsg, #{}),
+    ?assertEqual({ok, <<"No notify device configured">>}, Result1),
+
+    % Test with notify device configured
+    OptsWithNotify = #{notify_device => <<"notify@1.0">>},
+    Result2 = dispatch(#{}, InputMsg, OptsWithNotify),
+    ?assertEqual({ok, <<"OK">>}, Result2),
 
     stop_notification_manager().
 
@@ -871,263 +925,6 @@ performance_test() ->
     ?assert(Duration < 100000, "Performance test took too long"),
 
     stop_notification_manager().
-
-%% @doc Benchmark test to measure handle_event_dispatch performance directly
-handle_event_dispatch_benchmark_test() ->
-    % Ensure clean state
-    stop_notification_manager(),
-    timer:sleep(50),
-
-    start_notification_manager(),
-    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
-    ?assert(is_process_alive(ManagerPid)),
-
-    % Register many listeners to create realistic load
-    NumListeners = 10000,
-    TestEvent =
-        #{<<"service">> => <<"benchmark">>,
-          <<"action">> => <<"test">>,
-          <<"data">> => <<"benchmark_payload">>},
-
-    % Create listeners with different templates for realistic scenario
-    lists:foreach(fun(N) ->
-                     Template =
-                         case N rem 4 of
-                             0 -> #{<<"service">> => <<"benchmark">>};  % Will match
-                             1 -> #{<<"service">> => <<"other">>};      % Won't match
-                             2 -> #{<<"action">> => <<"test">>};        % Will match
-                             3 -> #{<<"type">> => <<"different">>}      % Won't match
-                         end,
-                     StreamPid = spawn(fun() -> receive stop -> ok after 10000 -> ok end end),
-                     Ref = make_ref(),
-                     ManagerPid ! {register_listener, Template, StreamPid, Ref}
-                  end,
-                  lists:seq(1, NumListeners)),
-
-    timer:sleep(100), % Allow registrations to process
-
-    % Verify listeners are registered
-    ListenerCount = ets:info(notification_listeners, size),
-    ?event(notify, {benchmark_setup, {listeners_registered, ListenerCount}}),
-    ?assertEqual(NumListeners, ListenerCount),
-
-    % Benchmark current handle_event_dispatch implementation
-    NumIterations = 100,
-    Times =
-        lists:map(fun(_) ->
-                     StartTime = erlang:system_time(microsecond),
-
-                     % Call handle_event_dispatch directly (this is what we're optimizing)
-                     handle_event_dispatch(TestEvent, #{}),
-
-                     EndTime = erlang:system_time(microsecond),
-                     EndTime - StartTime
-                  end,
-                  lists:seq(1, NumIterations)),
-
-    % Calculate statistics
-    TotalTime = lists:sum(Times),
-    MinTime = lists:min(Times),
-    MaxTime = lists:max(Times),
-    AvgTime = TotalTime div NumIterations,
-
-    % Calculate how many processes were spawned per call
-    % (This will be listeners that match × 1 since we spawn one process per match)
-    MatchingListeners = NumListeners div 2, % Roughly half should match our test event
-    ProcessesPerCall = MatchingListeners,
-    TotalProcessesSpawned = ProcessesPerCall * NumIterations,
-
-    ?event(notify_benchmark,
-           {handle_event_dispatch_benchmark,
-            {listeners, NumListeners},
-            {matching_listeners_estimate, MatchingListeners},
-            {iterations, NumIterations},
-            {total_time_us, TotalTime},
-            {avg_time_us, AvgTime},
-            {min_time_us, MinTime},
-            {max_time_us, MaxTime},
-            {processes_spawned_per_call, ProcessesPerCall},
-            {total_processes_spawned, TotalProcessesSpawned},
-            {calls_per_second, NumIterations * 1000000 div TotalTime}}),
-
-    % Performance assertions
-    ?assert(AvgTime > 0, "Benchmark should take measurable time"),
-    ?assert(TotalProcessesSpawned > 0, "Should spawn processes for matching listeners"),
-
-    % Log current performance baseline for comparison with foldl implementation
-    EventsPerSecond = NumIterations * 1000000 div TotalTime,
-    MicrosecondsPerEvent = AvgTime,
-
-    ?event(notify_benchmark,
-           {current_tab2list_baseline,
-            {events_per_second, EventsPerSecond},
-            {microseconds_per_event, MicrosecondsPerEvent},
-            {microseconds_per_listener, AvgTime div NumListeners},
-            {table_copying_overhead, "tab2list_copies_entire_table"}}),
-
-    stop_notification_manager().
-
-%% @doc Test handle_event_dispatch performance under different listener loads
-scaling_benchmark_test() ->
-    % Test how performance degrades as listener count increases
-    ListenerCounts = [100, 500, 1000, 2000, 10000],
-    Results =
-        lists:map(fun(NumListeners) -> benchmark_with_listener_count(NumListeners) end,
-                  ListenerCounts),
-
-    ?event(notify_benchmark, {scaling_benchmark_results, Results}),
-
-    % Performance should degrade linearly (or better) with listener count
-    % If it degrades quadratically, that's a bad sign
-    lists:foreach(fun({ListenerCount, AvgTimeUs}) ->
-                     % Very rough check - average time should be reasonable
-                     ReasonableTimeUs = ListenerCount * 10, % 10us per listener is reasonable
-                     ?assert(AvgTimeUs < ReasonableTimeUs * 2,
-                             io_lib:format("Performance too slow for ~p listeners: ~pus",
-                                           [ListenerCount, AvgTimeUs]))
-                  end,
-                  Results).
-
-%% Helper function for scaling benchmark
-benchmark_with_listener_count(NumListeners) ->
-    stop_notification_manager(),
-    timer:sleep(50),
-
-    start_notification_manager(),
-    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
-
-    % Register listeners
-    lists:foreach(fun(N) ->
-                     Template =
-                         #{<<"test">> => <<"scaling">>, <<"id">> => integer_to_binary(N rem 10)},
-                     StreamPid = spawn(fun() -> receive stop -> ok after 5000 -> ok end end),
-                     Ref = make_ref(),
-                     ManagerPid ! {register_listener, Template, StreamPid, Ref}
-                  end,
-                  lists:seq(1, NumListeners)),
-
-    timer:sleep(50),
-
-    % Benchmark handle_event_dispatch
-    TestEvent = #{<<"test">> => <<"scaling">>, <<"data">> => <<"test">>},
-    NumIterations = 50,
-
-    StartTime = erlang:system_time(microsecond),
-    lists:foreach(fun(_) -> handle_event_dispatch(TestEvent, #{}) end,
-                  lists:seq(1, NumIterations)),
-    EndTime = erlang:system_time(microsecond),
-
-    TotalTime = EndTime - StartTime,
-    AvgTime = TotalTime div NumIterations,
-
-    stop_notification_manager(),
-
-    {NumListeners, AvgTime}.
-
-%% @doc Test memory pressure with large listener counts
-memory_pressure_test() ->
-    % Only run this test if we have sufficient memory/time
-    case erlang:system_info(schedulers) of
-        N when N >= 4 ->
-            memory_pressure_test_impl();
-        _ ->
-            ?event(notify_benchmark, {memory_pressure_test_skipped, insufficient_schedulers})
-    end.
-
-memory_pressure_test_impl() ->
-    % Ensure clean state
-    stop_notification_manager(),
-    timer:sleep(50),
-
-    start_notification_manager(),
-    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
-    ?assert(is_process_alive(ManagerPid)),
-
-    % Register many listeners
-    NumListeners = 5000,  % Large number to stress memory
-
-    ?event(notify_benchmark, {memory_test_start, {registering_listeners, NumListeners}}),
-
-    lists:foreach(fun(N) ->
-                     Template =
-                         #{<<"service">> => <<"memory-test">>,
-                           <<"instance">> => integer_to_binary(N rem 100), % Some variety
-                           <<"id">> => integer_to_binary(N)},
-                     StreamPid = spawn(fun() -> receive stop -> ok after 30000 -> ok end end),
-                     Ref = make_ref(),
-                     ManagerPid ! {register_listener, Template, StreamPid, Ref},
-
-                     % Add small delay every 100 registrations to avoid overwhelming
-                     case N rem 100 of
-                         0 -> timer:sleep(1);
-                         _ -> ok
-                     end
-                  end,
-                  lists:seq(1, NumListeners)),
-
-    timer:sleep(200), % Allow registrations to process
-
-    % Get memory stats before test
-    MemBefore = erlang:memory(total),
-    ProcessCountBefore = erlang:system_info(process_count),
-
-    % Send events that will trigger many process spawns
-    NumEvents = 5,
-    StartTime = erlang:system_time(microsecond),
-
-    lists:foreach(fun(N) ->
-                     Event =
-                         #{<<"service">> => <<"memory-test">>,
-                           <<"event_id">> => N,
-                           <<"data">> => <<"large_event_payload_to_increase_memory_pressure">>},
-                     ManagerPid ! {dispatch_event, Event, #{}}
-                  end,
-                  lists:seq(1, NumEvents)),
-
-    % Wait for processing (increased to allow process spawns to complete)
-    timer:sleep(1000),
-
-    EndTime = erlang:system_time(microsecond),
-    Duration = EndTime - StartTime,
-
-    % Get memory stats after test
-    MemAfter = erlang:memory(total),
-    ProcessCountAfter = erlang:system_info(process_count),
-
-    % Calculate metrics
-    ExpectedProcessSpawns = NumListeners * NumEvents,
-    MemoryIncrease = MemAfter - MemBefore,
-    ProcessIncrease = ProcessCountAfter - ProcessCountBefore,
-
-    ?event(notify_benchmark,
-           {memory_pressure_results,
-            {listeners, NumListeners},
-            {events, NumEvents},
-            {duration_us, Duration},
-            {expected_process_spawns, ExpectedProcessSpawns},
-            {memory_increase_bytes, MemoryIncrease},
-            {process_count_increase, ProcessIncrease},
-            {memory_per_spawn_bytes,
-             case ExpectedProcessSpawns of
-                 0 ->
-                     0;
-                 _ ->
-                     MemoryIncrease div ExpectedProcessSpawns
-             end}}),
-
-    % Performance should not be terrible even with many listeners
-    MaxReasonableTime = 5000000, % 5 seconds
-    ?assert(Duration < MaxReasonableTime, "Memory pressure test took too long"),
-
-    stop_notification_manager().
-
-receive_loop(Count) ->
-    receive
-        {notify_event, _Event} ->
-            receive_loop(Count + 1)
-    after 10 ->
-        exit({received_count, Count})
-    end.
 
 %% @doc Test duplicate listener registration bug
 duplicate_listener_registration_test() ->
@@ -1552,3 +1349,289 @@ notification_manager_concurrent_start_test() ->
     end,
 
     stop_notification_manager().
+
+%% @doc Benchmark test to measure handle_event_dispatch performance directly
+handle_event_dispatch_benchmark_test() ->
+    % Ensure clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+
+    start_notification_manager(),
+    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
+    ?assert(is_process_alive(ManagerPid)),
+
+    % Register many listeners to create realistic load
+    NumListeners = 10000,
+    TestEvent =
+        #{<<"service">> => <<"benchmark">>,
+          <<"action">> => <<"test">>,
+          <<"data">> => <<"benchmark_payload">>},
+
+    % Create listeners with different templates for realistic scenario
+    lists:foreach(fun(N) ->
+                     Template =
+                         case N rem 4 of
+                             0 -> #{<<"service">> => <<"benchmark">>};  % Will match
+                             1 -> #{<<"service">> => <<"other">>};      % Won't match
+                             2 -> #{<<"action">> => <<"test">>};        % Will match
+                             3 -> #{<<"type">> => <<"different">>}      % Won't match
+                         end,
+                     StreamPid = spawn(fun() -> receive stop -> ok after 10000 -> ok end end),
+                     Ref = make_ref(),
+                     ManagerPid ! {register_listener, Template, StreamPid, Ref}
+                  end,
+                  lists:seq(1, NumListeners)),
+
+    timer:sleep(100), % Allow registrations to process
+
+    % Verify listeners are registered
+    ListenerCount = ets:info(notification_listeners, size),
+    ?event(notify, {benchmark_setup, {listeners_registered, ListenerCount}}),
+    ?assertEqual(NumListeners, ListenerCount),
+
+    % Benchmark current handle_event_dispatch implementation
+    NumIterations = 100,
+    Times =
+        lists:map(fun(_) ->
+                     StartTime = erlang:system_time(microsecond),
+
+                     % Call handle_event_dispatch directly (this is what we're optimizing)
+                     handle_event_dispatch(TestEvent, #{}),
+
+                     EndTime = erlang:system_time(microsecond),
+                     EndTime - StartTime
+                  end,
+                  lists:seq(1, NumIterations)),
+
+    % Calculate statistics
+    TotalTime = lists:sum(Times),
+    MinTime = lists:min(Times),
+    MaxTime = lists:max(Times),
+    AvgTime = TotalTime div NumIterations,
+
+    % Calculate how many processes were spawned per call
+    % (This will be listeners that match × 1 since we spawn one process per match)
+    MatchingListeners = NumListeners div 2, % Roughly half should match our test event
+    ProcessesPerCall = MatchingListeners,
+    TotalProcessesSpawned = ProcessesPerCall * NumIterations,
+
+    ?event(notify_benchmark,
+           {handle_event_dispatch_benchmark,
+            {listeners, NumListeners},
+            {matching_listeners_estimate, MatchingListeners},
+            {iterations, NumIterations},
+            {total_time_us, TotalTime},
+            {avg_time_us, AvgTime},
+            {min_time_us, MinTime},
+            {max_time_us, MaxTime},
+            {processes_spawned_per_call, ProcessesPerCall},
+            {total_processes_spawned, TotalProcessesSpawned},
+            {calls_per_second, NumIterations * 1000000 div TotalTime}}),
+
+    % Performance assertions
+    ?assert(AvgTime > 0, "Benchmark should take measurable time"),
+    ?assert(TotalProcessesSpawned > 0, "Should spawn processes for matching listeners"),
+
+    % Log current performance baseline for comparison with foldl implementation
+    EventsPerSecond = NumIterations * 1000000 div TotalTime,
+    MicrosecondsPerEvent = AvgTime,
+
+    ?event(notify_benchmark,
+           {current_tab2list_baseline,
+            {events_per_second, EventsPerSecond},
+            {microseconds_per_event, MicrosecondsPerEvent},
+            {microseconds_per_listener, AvgTime div NumListeners},
+            {table_copying_overhead, "tab2list_copies_entire_table"}}),
+
+    stop_notification_manager().
+
+%% @doc Test handle_event_dispatch performance under different listener loads
+scaling_benchmark_test() ->
+    % Test how performance degrades as listener count increases
+    ListenerCounts = [100, 500, 1000, 2000, 10000],
+    Results =
+        lists:map(fun(NumListeners) -> benchmark_with_listener_count(NumListeners) end,
+                  ListenerCounts),
+
+    ?event(notify_benchmark, {scaling_benchmark_results, Results}),
+
+    % Performance should degrade linearly (or better) with listener count
+    % If it degrades quadratically, that's a bad sign
+    lists:foreach(fun({ListenerCount, AvgTimeUs}) ->
+                     % Very rough check - average time should be reasonable
+                     ReasonableTimeUs = ListenerCount * 10, % 10us per listener is reasonable
+                     ?assert(AvgTimeUs < ReasonableTimeUs * 2,
+                             io_lib:format("Performance too slow for ~p listeners: ~pus",
+                                           [ListenerCount, AvgTimeUs]))
+                  end,
+                  Results).
+
+%% Helper function for scaling benchmark
+benchmark_with_listener_count(NumListeners) ->
+    stop_notification_manager(),
+    timer:sleep(50),
+
+    start_notification_manager(),
+    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
+
+    % Register listeners
+    lists:foreach(fun(N) ->
+                     Template =
+                         #{<<"test">> => <<"scaling">>, <<"id">> => integer_to_binary(N rem 10)},
+                     StreamPid = spawn(fun() -> receive stop -> ok after 5000 -> ok end end),
+                     Ref = make_ref(),
+                     ManagerPid ! {register_listener, Template, StreamPid, Ref}
+                  end,
+                  lists:seq(1, NumListeners)),
+
+    timer:sleep(50),
+
+    % Benchmark handle_event_dispatch
+    TestEvent = #{<<"test">> => <<"scaling">>, <<"data">> => <<"test">>},
+    NumIterations = 50,
+
+    StartTime = erlang:system_time(microsecond),
+    lists:foreach(fun(_) -> handle_event_dispatch(TestEvent, #{}) end,
+                  lists:seq(1, NumIterations)),
+    EndTime = erlang:system_time(microsecond),
+
+    TotalTime = EndTime - StartTime,
+    AvgTime = TotalTime div NumIterations,
+
+    stop_notification_manager(),
+
+    {NumListeners, AvgTime}.
+
+%% @doc Test memory pressure with large listener counts
+memory_pressure_test() ->
+    % Only run this test if we have sufficient memory/time
+    case erlang:system_info(schedulers) of
+        N when N >= 4 ->
+            memory_pressure_test_impl();
+        _ ->
+            ?event(notify_benchmark, {memory_pressure_test_skipped, insufficient_schedulers})
+    end.
+
+memory_pressure_test_impl() ->
+    % Ensure clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+
+    start_notification_manager(),
+    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
+    ?assert(is_process_alive(ManagerPid)),
+
+    % Register many listeners
+    NumListeners = 5000,  % Large number to stress memory
+
+    ?event(notify_benchmark, {memory_test_start, {registering_listeners, NumListeners}}),
+
+    lists:foreach(fun(N) ->
+                     Template =
+                         #{<<"service">> => <<"memory-test">>,
+                           <<"instance">> => integer_to_binary(N rem 100), % Some variety
+                           <<"id">> => integer_to_binary(N)},
+                     StreamPid = spawn(fun() -> receive stop -> ok after 30000 -> ok end end),
+                     Ref = make_ref(),
+                     ManagerPid ! {register_listener, Template, StreamPid, Ref},
+
+                     % Add small delay every 100 registrations to avoid overwhelming
+                     case N rem 100 of
+                         0 -> timer:sleep(1);
+                         _ -> ok
+                     end
+                  end,
+                  lists:seq(1, NumListeners)),
+
+    timer:sleep(200), % Allow registrations to process
+
+    % Get memory stats before test
+    MemBefore = erlang:memory(total),
+    ProcessCountBefore = erlang:system_info(process_count),
+
+    % Send events that will trigger many process spawns
+    NumEvents = 5,
+    StartTime = erlang:system_time(microsecond),
+
+    lists:foreach(fun(N) ->
+                     Event =
+                         #{<<"service">> => <<"memory-test">>,
+                           <<"event_id">> => N,
+                           <<"data">> => <<"large_event_payload_to_increase_memory_pressure">>},
+                     ManagerPid ! {dispatch_event, Event, #{}}
+                  end,
+                  lists:seq(1, NumEvents)),
+
+    % Wait for processing (increased to allow process spawns to complete)
+    timer:sleep(1000),
+
+    EndTime = erlang:system_time(microsecond),
+    Duration = EndTime - StartTime,
+
+    % Get memory stats after test
+    MemAfter = erlang:memory(total),
+    ProcessCountAfter = erlang:system_info(process_count),
+
+    % Calculate metrics
+    ExpectedProcessSpawns = NumListeners * NumEvents,
+    MemoryIncrease = MemAfter - MemBefore,
+    ProcessIncrease = ProcessCountAfter - ProcessCountBefore,
+
+    ?event(notify_benchmark,
+           {memory_pressure_results,
+            {listeners, NumListeners},
+            {events, NumEvents},
+            {duration_us, Duration},
+            {expected_process_spawns, ExpectedProcessSpawns},
+            {memory_increase_bytes, MemoryIncrease},
+            {process_count_increase, ProcessIncrease},
+            {memory_per_spawn_bytes,
+             case ExpectedProcessSpawns of
+                 0 ->
+                     0;
+                 _ ->
+                     MemoryIncrease div ExpectedProcessSpawns
+             end}}),
+
+    % Performance should not be terrible even with many listeners
+    MaxReasonableTime = 5000000, % 5 seconds
+    ?assert(Duration < MaxReasonableTime, "Memory pressure test took too long"),
+
+    stop_notification_manager().
+
+receive_loop(Count) ->
+    receive
+        {notify_event, _Event} ->
+            receive_loop(Count + 1)
+    after 10 ->
+        exit({received_count, Count})
+    end.
+
+%% @doc Test that the start_manager hook function works correctly
+start_manager_hook_test() ->
+    % Ensure clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+
+    % Verify manager is not running
+    ?assertEqual(undefined, hb_name:lookup(?NOTIFICATION_MANAGER)),
+
+    % Test with notify_device undefined (should not start manager)
+    HookMsg1 = #{<<"body">> => #{notify_device => undefined}},
+    {ok, HookMsg1} = start_manager(#{}, HookMsg1, #{}),
+    ?assertEqual(undefined, hb_name:lookup(?NOTIFICATION_MANAGER)),
+
+    % Test with notify_device configured (should start manager)
+    HookMsg2 = #{<<"body">> => #{notify_device => <<"notify@1.0">>}},
+    {ok, HookMsg2} = start_manager(#{}, HookMsg2, #{}),
+    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
+    ?assertNotEqual(undefined, ManagerPid),
+    ?assert(is_process_alive(ManagerPid)),
+
+    % Test idempotent behavior (calling again should not create new manager)
+    {ok, HookMsg2} = start_manager(#{}, HookMsg2, #{}),
+    ManagerPid2 = hb_name:lookup(?NOTIFICATION_MANAGER),
+    ?assertEqual(ManagerPid, ManagerPid2), % Same PID
+
+    stop_notification_manager().
+

--- a/src/dev_notify.erl
+++ b/src/dev_notify.erl
@@ -2,14 +2,14 @@
 %%% It integrates with the existing event system (hb_event) and allows clients
 %%% to subscribe to specific events using HTTP/3 streams.
 -module(dev_notify).
--export([info/1, info/3, dispatch/3, register/3, unregister/3]).
+-export([info/1, info/3, dispatch/3, register/3, unregister/3, stream/3]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 %% @doc Device API information
 info(_) ->
     #{
-        exports => [info, dispatch, register, unregister],
+        exports => [info, dispatch, register, unregister, stream],
         variant => <<"Notify/1.0">>
     }.
 
@@ -22,7 +22,8 @@ info(_Msg1, _Msg2, _Opts) ->
             <<"info">> => <<"Get device info">>,
             <<"dispatch">> => <<"Dispatch an event to registered listeners">>,
             <<"register">> => <<"Register a new event listener">>,
-            <<"unregister">> => <<"Unregister an event listener">>
+            <<"unregister">> => <<"Unregister an event listener">>,
+            <<"stream">> => <<"Start a streaming connection for real-time events">>
         }
     },
     {ok, #{<<"status">> => 200, <<"body">> => InfoBody}}.
@@ -90,15 +91,118 @@ dispatch_to_listeners(Event, Listeners, Opts) ->
         Listeners
     ).
 
-%% @doc Push an event to a stream using Cowboy's http/3 push
-push_event(Stream, Event, Opts) ->
+%% @doc Push an event to a stream using Cowboy's HTTP/3 streaming
+push_event(StreamRef, Event, _Opts) ->
     try
         % Convert event to JSON
-        EventJson = json:encode(Event),
-        % Push the event to the stream
-        cowboy_req:push(Stream, EventJson, Opts)
+        EventJson = hb_util:encode(Event),
+        % Stream the event data with nofin to keep connection alive
+        cowboy_req:stream_body(EventJson, nofin, StreamRef),
+        ?event(notify, {event_pushed, {stream, StreamRef}, {event_size, byte_size(EventJson)}})
     catch
         Class:Reason ->
             ?event(notify, {push_error, {Class, Reason}}),
             ok
-    end. 
+    end.
+
+%% @doc Start a streaming connection for real-time event notifications
+stream(_StateMsg, InputMsg, Opts) ->
+    ?event(notify, {start_stream, InputMsg}),
+    
+    % Extract pattern for filtering events
+    Pattern = hb_ao:get(<<"pattern">>, InputMsg, <<"*">>, Opts),
+    
+    % Create streaming response headers
+    Headers = #{
+        <<"content-type">> => <<"application/json">>,
+        <<"cache-control">> => <<"no-cache">>,
+        <<"connection">> => <<"keep-alive">>,
+        <<"access-control-allow-origin">> => <<"*">>
+    },
+    
+    % Start the streaming response
+    StreamingBody = create_streaming_body(Pattern, Opts),
+    
+    {ok, #{
+        <<"status">> => 200,
+        <<"headers">> => Headers,
+        <<"body">> => StreamingBody,
+        <<"streaming">> => true
+    }}.
+
+%% @doc Create a streaming body function that keeps the connection open
+create_streaming_body(Pattern, Opts) ->
+    fun(Req) ->
+        % Initialize streaming response
+        Req2 = cowboy_req:stream_reply(200, #{
+            <<"content-type">> => <<"text/event-stream">>,
+            <<"cache-control">> => <<"no-cache">>,
+            <<"connection">> => <<"keep-alive">>,
+            <<"access-control-allow-origin">> => <<"*">>
+        }, Req),
+        
+        % Register this stream for notifications
+        StreamId = make_ref(),
+        register_stream(StreamId, Pattern, Req2, Opts),
+        
+        % Send initial connection message
+        InitialMessage = hb_util:encode(#{
+            <<"type">> => <<"connection">>,
+            <<"message">> => <<"Connected to notification stream">>,
+            <<"pattern">> => Pattern,
+            <<"timestamp">> => erlang:system_time(millisecond)
+        }),
+        cowboy_req:stream_body([<<"data: ">>, InitialMessage, <<"\n\n">>], nofin, Req2),
+        
+        % Keep connection alive and handle cleanup
+        stream_loop(StreamId, Req2, Opts),
+        
+        {ok, Req2}
+    end.
+
+%% @doc Register a streaming connection for receiving notifications
+register_stream(StreamId, Pattern, Req, _Opts) ->
+    % Store stream info in ETS table or process registry
+    % For now, we'll use a simple approach with process dictionary
+    Streams = get(notification_streams),
+    NewStreams = case Streams of
+        undefined -> #{StreamId => #{pattern => Pattern, req => Req}};
+        _ -> Streams#{StreamId => #{pattern => Pattern, req => Req}}
+    end,
+    put(notification_streams, NewStreams),
+    ?event(notify, {stream_registered, {stream_id, StreamId}, {pattern, Pattern}}).
+
+%% @doc Keep the streaming connection alive and handle events
+stream_loop(StreamId, Req, Opts) ->
+    receive
+        {notify_event, Event} ->
+            % Send event to client
+            EventData = hb_util:encode(Event),
+            cowboy_req:stream_body([<<"data: ">>, EventData, <<"\n\n">>], nofin, Req),
+            stream_loop(StreamId, Req, Opts);
+        {close_stream, StreamId} ->
+            % Close the stream
+            unregister_stream(StreamId),
+            cowboy_req:stream_body(<<"">>, fin, Req);
+        _ ->
+            stream_loop(StreamId, Req, Opts)
+    after 30000 -> % 30 second keepalive
+        % Send keepalive message
+        KeepaliveMsg = hb_util:encode(#{
+            <<"type">> => <<"keepalive">>,
+            <<"timestamp">> => erlang:system_time(millisecond)
+        }),
+        cowboy_req:stream_body([<<"data: ">>, KeepaliveMsg, <<"\n\n">>], nofin, Req),
+        stream_loop(StreamId, Req, Opts)
+    end.
+
+%% @doc Unregister a streaming connection
+unregister_stream(StreamId) ->
+    Streams = get(notification_streams),
+    case Streams of
+        undefined -> ok;
+        _ -> 
+            NewStreams = maps:remove(StreamId, Streams),
+            put(notification_streams, NewStreams)
+    end,
+    ?event(notify, {stream_unregistered, {stream_id, StreamId}}). 

--- a/src/dev_notify.erl
+++ b/src/dev_notify.erl
@@ -14,7 +14,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
--define(NOTIFICATION_MANAGER, hb_notification_manager).
+-define(NOTIFICATION_MANAGER, {dev_notify, notification_manager}).
 
 %% @doc Device API information
 info(_) ->
@@ -31,15 +31,12 @@ info(_Msg1, _Msg2, _Opts) ->
                 <<"stream">> => <<"Start a streaming connection for real-time events">>}},
     {ok, #{<<"status">> => 200, <<"body">> => InfoBody}}.
 
-
-
-
 %% @doc Dispatch an event to registered listeners via the notification manager
 dispatch(_StateMsg, InputMsg, Opts) ->
     ?event(notify, {dispatch_event, InputMsg}),
 
     % Send event to the long-running notification manager process
-    case whereis(?NOTIFICATION_MANAGER) of
+    case hb_name:lookup(?NOTIFICATION_MANAGER) of
         undefined ->
             ?event(notify, {manager_not_started, starting_manager}),
             start_notification_manager(),
@@ -122,7 +119,7 @@ register_stream(StreamId, Template, _Req, _Opts) ->
     start_notification_manager(),
 
     % Register with the notification manager
-    case whereis(?NOTIFICATION_MANAGER) of
+    case hb_name:lookup(?NOTIFICATION_MANAGER) of
         undefined ->
             ?event(notify, {manager_not_available, {stream_id, StreamId}});
         ManagerPid ->
@@ -158,7 +155,7 @@ stream_loop(StreamId, Req, Opts) ->
 %% @doc Unregister a streaming connection
 unregister_stream(StreamId) ->
     % Unregister with the notification manager
-    case whereis(?NOTIFICATION_MANAGER) of
+    case hb_name:lookup(?NOTIFICATION_MANAGER) of
         undefined ->
             ?event(notify, {manager_not_available_for_unregister, {stream_id, StreamId}});
         ManagerPid ->
@@ -258,27 +255,19 @@ template_matches(_Event, _Template, _Opts) ->
 
 %% @doc Start the long-running notification manager process
 start_notification_manager() ->
-    case whereis(?NOTIFICATION_MANAGER) of
+    case hb_name:lookup(?NOTIFICATION_MANAGER) of
         undefined ->
             % Start the manager process
             ManagerPid =
                 spawn_link(fun() ->
-                              try register(?NOTIFICATION_MANAGER, self()) of
-                                  true ->
+                              case hb_name:register(?NOTIFICATION_MANAGER) of
+                                  ok ->
                                       % Initialize ETS table for fast listener lookups
-                                      case ets:info(notification_listeners) of
-                                          undefined ->
-                                              ets:new(notification_listeners,
-                                                      [named_table,
-                                                       public,
-                                                       set,
-                                                       {read_concurrency, true}]);
-                                          _ -> ok
-                                      end,
+                                      ets:new(notification_listeners,
+                                              [named_table, public, set, {read_concurrency, true}]),
                                       ?event(notify, {notification_manager_started, self()}),
-                                      notification_manager_loop(#{})
-                              catch
-                                  error:badarg ->
+                                      notification_manager_loop(#{});
+                                  error ->
                                       % Someone else registered already, exit quietly
                                       exit(already_registered)
                               end
@@ -286,7 +275,7 @@ start_notification_manager() ->
             % Give the process a moment to register
             timer:sleep(10),
             % Check if it actually got registered
-            case whereis(?NOTIFICATION_MANAGER) of
+            case hb_name:lookup(?NOTIFICATION_MANAGER) of
                 ManagerPid ->
                     {ok, ManagerPid};
                 OtherPid when is_pid(OtherPid) ->
@@ -300,48 +289,12 @@ start_notification_manager() ->
 
 %% @doc Stop the notification manager process
 stop_notification_manager() ->
-    case whereis(?NOTIFICATION_MANAGER) of
+    case hb_name:lookup(?NOTIFICATION_MANAGER) of
         undefined ->
             ok;
         Pid ->
-            % First unregister to prevent new registrations
-            try
-                unregister(?NOTIFICATION_MANAGER)
-            catch
-                _:_ ->
-                    ok
-            end,
-
             % Send stop signal
             Pid ! stop,
-
-            % Wait for process to die with timeout
-            Ref = monitor(process, Pid),
-            receive
-                {'DOWN', Ref, process, Pid, _Reason} ->
-                    ok
-            after 100 ->
-                exit(Pid, kill),
-                receive
-                    {'DOWN', Ref, process, Pid, _} ->
-                        ok
-                after 50 ->
-                    ok
-                end
-            end,
-
-            % Clean up ETS table if it still exists
-            case ets:info(notification_listeners) of
-                undefined ->
-                    ok;
-                _ ->
-                    try
-                        ets:delete(notification_listeners)
-                    catch
-                        _:_ ->
-                            ok
-                    end
-            end,
             ok
     end.
 
@@ -376,18 +329,6 @@ notification_manager_loop(State) ->
             notification_manager_loop(State);
         stop ->
             ?event(notify, {notification_manager_stopping, self()}),
-            % Clean up ETS table before exiting
-            case ets:info(notification_listeners) of
-                undefined ->
-                    ok;
-                _ ->
-                    try
-                        ets:delete(notification_listeners)
-                    catch
-                        _:_ ->
-                            ok
-                    end
-            end,
             ok;
         Msg ->
             ?event(notify, {unexpected_message, Msg}),
@@ -507,7 +448,7 @@ template_matching_test() ->
 %% @doc Test notification manager process lifecycle
 notification_manager_test() ->
     % Ensure clean state
-    InitialState = whereis(?NOTIFICATION_MANAGER),
+    InitialState = hb_name:lookup(?NOTIFICATION_MANAGER),
     ?event(debug, {manager_initial_state, InitialState}),
     stop_notification_manager(),
     timer:sleep(50),
@@ -517,7 +458,7 @@ notification_manager_test() ->
     ?event(debug, {manager_start_result, StartResult}),
     {ok, ManagerPid} = StartResult,
     ?assert(is_process_alive(ManagerPid)),
-    ?assertEqual(ManagerPid, whereis(?NOTIFICATION_MANAGER)),
+    ?assertEqual(ManagerPid, hb_name:lookup(?NOTIFICATION_MANAGER)),
     ?event(debug, {manager_started_successfully, {pid, ManagerPid}}),
 
     % Stop manager
@@ -525,7 +466,7 @@ notification_manager_test() ->
     stop_notification_manager(),
     % Wait a bit for cleanup
     timer:sleep(100),
-    FinalState = whereis(?NOTIFICATION_MANAGER),
+    FinalState = hb_name:lookup(?NOTIFICATION_MANAGER),
     ?event(debug, {manager_final_state, FinalState}),
     ?assertEqual(undefined, FinalState).
 
@@ -536,7 +477,7 @@ event_dispatch_test() ->
     timer:sleep(50),
 
     start_notification_manager(),
-    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
 
     % Create a test stream process
@@ -594,7 +535,6 @@ event_dispatch_test() ->
 
     stop_notification_manager().
 
-
 %% @doc Test listener registration and unregistration
 listener_registration_test() ->
     % Ensure clean state
@@ -603,7 +543,7 @@ listener_registration_test() ->
 
     % Start manager
     start_notification_manager(),
-    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
 
     % Register a listener
@@ -635,7 +575,7 @@ regex_dispatch_test() ->
     timer:sleep(50),
 
     start_notification_manager(),
-    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
 
     % Create test stream process
@@ -720,7 +660,7 @@ dead_process_cleanup_test() ->
     timer:sleep(50),
 
     start_notification_manager(),
-    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
 
     % Create and register a process, then kill it
@@ -768,7 +708,7 @@ concurrent_dispatch_test() ->
     timer:sleep(50),
 
     start_notification_manager(),
-    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
 
     % Create multiple test processes
@@ -871,7 +811,7 @@ error_handling_test() ->
     timer:sleep(50),
 
     start_notification_manager(),
-    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
 
     % Test invalid template in dispatch (should not crash manager)
@@ -899,7 +839,7 @@ performance_test() ->
     timer:sleep(50),
 
     start_notification_manager(),
-    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
 
     % Register a listener
@@ -939,7 +879,7 @@ handle_event_dispatch_benchmark_test() ->
     timer:sleep(50),
 
     start_notification_manager(),
-    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
 
     % Register many listeners to create realistic load
@@ -1054,7 +994,7 @@ benchmark_with_listener_count(NumListeners) ->
     timer:sleep(50),
 
     start_notification_manager(),
-    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
 
     % Register listeners
     lists:foreach(fun(N) ->
@@ -1100,7 +1040,7 @@ memory_pressure_test_impl() ->
     timer:sleep(50),
 
     start_notification_manager(),
-    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
 
     % Register many listeners
@@ -1196,7 +1136,7 @@ duplicate_listener_registration_test() ->
     timer:sleep(50),
 
     start_notification_manager(),
-    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
 
     % Create test stream process that counts events
@@ -1268,7 +1208,7 @@ multiple_registration_scenarios_test() ->
     timer:sleep(50),
 
     start_notification_manager(),
-    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
 
     % Scenario 1: Same template, same stream, different refs
@@ -1331,7 +1271,7 @@ event_duplication_test() ->
     timer:sleep(50),
 
     start_notification_manager(),
-    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
     ?assert(is_process_alive(ManagerPid)),
 
     % Create counting process
@@ -1384,7 +1324,7 @@ notification_manager_manual_start_test() ->
     timer:sleep(100),
 
     % Verify no manager is running
-    ?assertEqual(undefined, whereis(?NOTIFICATION_MANAGER)),
+    ?assertEqual(undefined, hb_name:lookup(?NOTIFICATION_MANAGER)),
 
     % Start manager manually
     {ok, ManagerPid} = start_notification_manager(),
@@ -1392,7 +1332,7 @@ notification_manager_manual_start_test() ->
     % Verify manager started successfully
     ?assertNotEqual(undefined, ManagerPid),
     ?assert(is_process_alive(ManagerPid)),
-    ?assertEqual(ManagerPid, whereis(?NOTIFICATION_MANAGER)),
+    ?assertEqual(ManagerPid, hb_name:lookup(?NOTIFICATION_MANAGER)),
 
     ?event(debug, {manual_start_test_completed, {manager_pid, ManagerPid}}),
 
@@ -1413,7 +1353,7 @@ notification_manager_multiple_start_test() ->
     ?assertEqual({already_started, ManualPid}, StartResult),
 
     % Should still be the same process
-    CurrentPid = whereis(?NOTIFICATION_MANAGER),
+    CurrentPid = hb_name:lookup(?NOTIFICATION_MANAGER),
     ?assertEqual(ManualPid, CurrentPid),
     ?assert(is_process_alive(CurrentPid)),
 
@@ -1426,18 +1366,17 @@ notification_manager_manual_start_conflict_test() ->
     timer:sleep(100),
 
     % Ensure no process is registered
-    ?assertEqual(undefined, whereis(?NOTIFICATION_MANAGER)),
+    ?assertEqual(undefined, hb_name:lookup(?NOTIFICATION_MANAGER)),
 
     % Create a conflicting process with the same name
     TestPid = self(),
     ConflictPid =
         spawn(fun() ->
-                 try register(?NOTIFICATION_MANAGER, self()) of
-                     true ->
+                 case hb_name:register(?NOTIFICATION_MANAGER) of
+                     ok ->
                          TestPid ! {conflict_registered, self()},
-                         receive stop -> ok after 10000 -> ok end
-                 catch
-                     error:badarg -> TestPid ! {conflict_failed, self()}
+                         receive stop -> ok after 10000 -> ok end;
+                     error -> TestPid ! {conflict_failed, self()}
                  end
               end),
 
@@ -1445,14 +1384,14 @@ notification_manager_manual_start_conflict_test() ->
     receive
         {conflict_registered, ConflictPid} ->
             % Verify the conflict process is registered
-            ?assertEqual(ConflictPid, whereis(?NOTIFICATION_MANAGER)),
+            ?assertEqual(ConflictPid, hb_name:lookup(?NOTIFICATION_MANAGER)),
 
             % Try manual start (should return already_started)
             StartResult = start_notification_manager(),
             ?assertEqual({already_started, ConflictPid}, StartResult),
 
             % The original conflict process should still be there
-            ?assertEqual(ConflictPid, whereis(?NOTIFICATION_MANAGER)),
+            ?assertEqual(ConflictPid, hb_name:lookup(?NOTIFICATION_MANAGER)),
 
             % Clean up
             ConflictPid ! stop,
@@ -1478,14 +1417,14 @@ notification_manager_manager_restart_test() ->
     timer:sleep(50),
 
     % Verify clean state
-    ?assertEqual(undefined, whereis(?NOTIFICATION_MANAGER)),
+    ?assertEqual(undefined, hb_name:lookup(?NOTIFICATION_MANAGER)),
 
     % Start the manager manually
     {ok, FirstPid} = start_notification_manager(),
     timer:sleep(50),
 
     % Verify manager started
-    ?assertEqual(FirstPid, whereis(?NOTIFICATION_MANAGER)),
+    ?assertEqual(FirstPid, hb_name:lookup(?NOTIFICATION_MANAGER)),
     ?assertNotEqual(undefined, FirstPid),
     ?assert(is_process_alive(FirstPid)),
 
@@ -1510,7 +1449,7 @@ notification_manager_manager_restart_test() ->
     timer:sleep(50),
 
     % Verify new manager started (should be different PID)
-    ?assertEqual(SecondPid, whereis(?NOTIFICATION_MANAGER)),
+    ?assertEqual(SecondPid, hb_name:lookup(?NOTIFICATION_MANAGER)),
     ?assertNotEqual(undefined, SecondPid),
     ?assert(is_process_alive(SecondPid)),
     ?assertNotEqual(FirstPid, SecondPid),
@@ -1575,7 +1514,7 @@ notification_manager_concurrent_start_test() ->
                               timer:sleep(
                                   rand:uniform(50)),
                               Result = start_notification_manager(),
-                              ManagerPid = whereis(?NOTIFICATION_MANAGER),
+                              ManagerPid = hb_name:lookup(?NOTIFICATION_MANAGER),
                               TestPid ! {concurrent_result, N, Result, ManagerPid}
                            end)
                   end,

--- a/src/dev_notify.erl
+++ b/src/dev_notify.erl
@@ -41,12 +41,7 @@ register(StateMsg, InputMsg, Opts) ->
     
     % Extract template specification (supports both map and regex templates)
     TemplateResult = case hb_ao:get(<<"template">>, InputMsg, Opts) of
-        not_found ->
-            % Fallback to legacy pattern field for compatibility
-            case hb_ao:get(<<"pattern">>, InputMsg, Opts) of
-                not_found -> {error, <<"No template or pattern specified">>};
-                Pattern -> {ok, Pattern}
-            end;
+        not_found -> {error, <<"No template specified">>};
         TemplateSpec -> {ok, TemplateSpec}
     end,
     
@@ -77,13 +72,9 @@ register(StateMsg, InputMsg, Opts) ->
 unregister(StateMsg, InputMsg, Opts) ->
     ?event(notify, {unregister_listener, InputMsg}),
     
-    % Extract template or pattern for removal
+    % Extract template for removal
     TemplateResult = case hb_ao:get(<<"template">>, InputMsg, Opts) of
-        not_found ->
-            case hb_ao:get(<<"pattern">>, InputMsg, Opts) of
-                not_found -> {error, <<"No template or pattern specified">>};
-                Pattern -> {ok, Pattern}
-            end;
+        not_found -> {error, <<"No template specified">>};
         TemplateSpec -> {ok, TemplateSpec}
     end,
     
@@ -166,12 +157,7 @@ stream(_StateMsg, InputMsg, Opts) ->
     ?event(notify, {start_stream, InputMsg}),
     
     % Extract template for filtering events (supports both map and regex templates)
-    Template = case hb_ao:get(<<"template">>, InputMsg, Opts) of
-        not_found ->
-            % Fallback to pattern field for legacy compatibility
-            hb_ao:get(<<"pattern">>, InputMsg, <<".*">>, Opts); % Default regex matches all
-        TemplateSpec -> TemplateSpec
-    end,
+    Template = hb_ao:get(<<"template">>, InputMsg, <<".*">>, Opts),
     
     % Create streaming response headers
     Headers = #{
@@ -702,29 +688,20 @@ device_registration_test() ->
     Listeners2 = maps:get(<<"listeners">>, NewState2),
     ?assertEqual(2, maps:size(Listeners2)),
     
-    % Test legacy pattern field
-    InputMsg3 = #{
-        <<"pattern">> => #{ <<"action">> => <<"test">> },
-        <<"stream">> => <<"test-stream-3">>
-    },
-    
-    {ok, NewState3} = register(NewState2, InputMsg3, #{}),
-    Listeners3 = maps:get(<<"listeners">>, NewState3),
-    ?assertEqual(3, maps:size(Listeners3)),
     
     % Test unregistration - unregister the first template we added
     UnregMsg = #{
         <<"template">> => #{ <<"device">> => <<"test@1.0">> }
     },
     
-    ?event(debug, {before_unregister, {listeners_count, maps:size(maps:get(<<"listeners">>, NewState3))}}),
-    {ok, NewState4} = unregister(NewState3, UnregMsg, #{}),
-    Listeners4 = maps:get(<<"listeners">>, NewState4),
-    ?event(debug, {after_unregister, {listeners_count, maps:size(Listeners4)}, {keys, maps:keys(Listeners4)}}),
-    ?assertEqual(2, maps:size(Listeners4)), % Should have 2 left (regex + pattern)
+    ?event(debug, {before_unregister, {listeners_count, maps:size(maps:get(<<"listeners">>, NewState2))}}),
+    {ok, NewState3} = unregister(NewState2, UnregMsg, #{}),
+    Listeners3 = maps:get(<<"listeners">>, NewState3),
+    ?event(debug, {after_unregister, {listeners_count, maps:size(Listeners3)}, {keys, maps:keys(Listeners3)}}),
+    ?assertEqual(1, maps:size(Listeners3)), % Should have 1 left (regex)
     
     % Verify the correct template was removed
-    ?assertNot(maps:is_key({template, #{ <<"device">> => <<"test@1.0">> }}, Listeners4)),
+    ?assertNot(maps:is_key({template, #{ <<"device">> => <<"test@1.0">> }}, Listeners3)),
     
     % Test error cases
     ?assertMatch({error, _}, register(StateMsg, #{}, #{})),
@@ -851,15 +828,8 @@ stream_function_test() ->
     },
     
     {ok, Result2} = stream(#{}, InputMsg2, #{}),
-    ?assertEqual(200, maps:get(<<"status">>, Result2)),
+    ?assertEqual(200, maps:get(<<"status">>, Result2)).
     
-    % Test with legacy pattern
-    InputMsg3 = #{
-        <<"pattern">> => #{ <<"action">> => <<"compute">> }
-    },
-    
-    {ok, Result3} = stream(#{}, InputMsg3, #{}),
-    ?assertEqual(200, maps:get(<<"status">>, Result3)).
 
 %% @doc Test dead process cleanup
 dead_process_cleanup_test() ->

--- a/src/dev_notify.erl
+++ b/src/dev_notify.erl
@@ -1072,6 +1072,248 @@ performance_test() ->
     
     stop_notification_manager().
 
+
+%% @doc Benchmark test to measure handle_event_dispatch performance directly
+handle_event_dispatch_benchmark_test() ->
+    % Ensure clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    start_notification_manager(),
+    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ?assert(is_process_alive(ManagerPid)),
+    
+    % Register many listeners to create realistic load
+    NumListeners = 10000,
+    TestEvent = #{
+        <<"service">> => <<"benchmark">>,
+        <<"action">> => <<"test">>,
+        <<"data">> => <<"benchmark_payload">>
+    },
+    
+    % Create listeners with different templates for realistic scenario
+    lists:foreach(fun(N) ->
+        Template = case N rem 4 of
+            0 -> #{ <<"service">> => <<"benchmark">> };  % Will match
+            1 -> #{ <<"service">> => <<"other">> };      % Won't match
+            2 -> #{ <<"action">> => <<"test">> };        % Will match  
+            3 -> #{ <<"type">> => <<"different">> }      % Won't match
+        end,
+        StreamPid = spawn(fun() -> 
+            receive stop -> ok after 10000 -> ok end 
+        end),
+        Ref = make_ref(),
+        ManagerPid ! {register_listener, Template, StreamPid, Ref}
+    end, lists:seq(1, NumListeners)),
+    
+    timer:sleep(100), % Allow registrations to process
+    
+    % Verify listeners are registered
+    ListenerCount = ets:info(notification_listeners, size),
+    ?event(notify, {benchmark_setup, {listeners_registered, ListenerCount}}),
+    ?assertEqual(NumListeners, ListenerCount),
+    
+    % Benchmark current handle_event_dispatch implementation
+    NumIterations = 100,
+    Times = lists:map(fun(_) ->
+        StartTime = erlang:system_time(microsecond),
+        
+        % Call handle_event_dispatch directly (this is what we're optimizing)
+        handle_event_dispatch(TestEvent, #{}),
+        
+        EndTime = erlang:system_time(microsecond),
+        EndTime - StartTime
+    end, lists:seq(1, NumIterations)),
+    
+    % Calculate statistics
+    TotalTime = lists:sum(Times),
+    MinTime = lists:min(Times),
+    MaxTime = lists:max(Times),
+    AvgTime = TotalTime div NumIterations,
+    
+    % Calculate how many processes were spawned per call
+    % (This will be listeners that match × 1 since we spawn one process per match)
+    MatchingListeners = NumListeners div 2, % Roughly half should match our test event
+    ProcessesPerCall = MatchingListeners,
+    TotalProcessesSpawned = ProcessesPerCall * NumIterations,
+    
+    ?event(notify_benchmark, {handle_event_dispatch_benchmark, 
+        {listeners, NumListeners},
+        {matching_listeners_estimate, MatchingListeners},
+        {iterations, NumIterations},
+        {total_time_us, TotalTime},
+        {avg_time_us, AvgTime},
+        {min_time_us, MinTime},
+        {max_time_us, MaxTime},
+        {processes_spawned_per_call, ProcessesPerCall},
+        {total_processes_spawned, TotalProcessesSpawned},
+        {calls_per_second, (NumIterations * 1000000) div TotalTime}
+    }),
+    
+    % Performance assertions
+    ?assert(AvgTime > 0, "Benchmark should take measurable time"),
+    ?assert(TotalProcessesSpawned > 0, "Should spawn processes for matching listeners"),
+    
+    % Log current performance baseline for comparison with foldl implementation
+    EventsPerSecond = (NumIterations * 1000000) div TotalTime,
+    MicrosecondsPerEvent = AvgTime,
+    
+    ?event(notify_benchmark, {current_tab2list_baseline,
+        {events_per_second, EventsPerSecond},
+        {microseconds_per_event, MicrosecondsPerEvent},
+        {microseconds_per_listener, AvgTime div NumListeners},
+        {table_copying_overhead, "tab2list_copies_entire_table"}
+    }),
+    
+    stop_notification_manager().
+
+%% @doc Test handle_event_dispatch performance under different listener loads
+scaling_benchmark_test() ->
+    % Test how performance degrades as listener count increases
+    ListenerCounts = [100, 500, 1000, 2000, 10000],
+    Results = lists:map(fun(NumListeners) ->
+        benchmark_with_listener_count(NumListeners)
+    end, ListenerCounts),
+    
+    ?event(notify_benchmark, {scaling_benchmark_results, Results}),
+    
+    % Performance should degrade linearly (or better) with listener count
+    % If it degrades quadratically, that's a bad sign
+    lists:foreach(fun({ListenerCount, AvgTimeUs}) ->
+        % Very rough check - average time should be reasonable
+        ReasonableTimeUs = ListenerCount * 10, % 10us per listener is reasonable
+        ?assert(AvgTimeUs < ReasonableTimeUs * 2, 
+            io_lib:format("Performance too slow for ~p listeners: ~pus", [ListenerCount, AvgTimeUs]))
+    end, Results).
+
+%% Helper function for scaling benchmark
+benchmark_with_listener_count(NumListeners) ->
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    start_notification_manager(),
+    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    
+    % Register listeners
+    lists:foreach(fun(N) ->
+        Template = #{ <<"test">> => <<"scaling">>, <<"id">> => integer_to_binary(N rem 10) },
+        StreamPid = spawn(fun() -> receive stop -> ok after 5000 -> ok end end),
+        Ref = make_ref(),
+        ManagerPid ! {register_listener, Template, StreamPid, Ref}
+    end, lists:seq(1, NumListeners)),
+    
+    timer:sleep(50),
+    
+    % Benchmark handle_event_dispatch
+    TestEvent = #{ <<"test">> => <<"scaling">>, <<"data">> => <<"test">> },
+    NumIterations = 50,
+    
+    StartTime = erlang:system_time(microsecond),
+    lists:foreach(fun(_) ->
+        handle_event_dispatch(TestEvent, #{})
+    end, lists:seq(1, NumIterations)),
+    EndTime = erlang:system_time(microsecond),
+    
+    TotalTime = EndTime - StartTime,
+    AvgTime = TotalTime div NumIterations,
+    
+    stop_notification_manager(),
+    
+    {NumListeners, AvgTime}.
+
+%% @doc Test memory pressure with large listener counts
+memory_pressure_test() ->
+    % Only run this test if we have sufficient memory/time
+    case erlang:system_info(schedulers) of
+        N when N >= 4 ->
+            memory_pressure_test_impl();
+        _ ->
+            ?event(notify_benchmark, {memory_pressure_test_skipped, insufficient_schedulers})
+    end.
+
+memory_pressure_test_impl() ->
+    % Ensure clean state
+    stop_notification_manager(),
+    timer:sleep(50),
+    
+    start_notification_manager(),
+    ManagerPid = whereis(?NOTIFICATION_MANAGER),
+    ?assert(is_process_alive(ManagerPid)),
+    
+    % Register many listeners
+    NumListeners = 5000,  % Large number to stress memory
+    
+    ?event(notify_benchmark, {memory_test_start, {registering_listeners, NumListeners}}),
+    
+    lists:foreach(fun(N) ->
+        Template = #{ 
+            <<"service">> => <<"memory-test">>,
+            <<"instance">> => integer_to_binary(N rem 100), % Some variety
+            <<"id">> => integer_to_binary(N)
+        },
+        StreamPid = spawn(fun() -> 
+            receive stop -> ok after 30000 -> ok end 
+        end),
+        Ref = make_ref(),
+        ManagerPid ! {register_listener, Template, StreamPid, Ref},
+        
+        % Add small delay every 100 registrations to avoid overwhelming
+        case N rem 100 of
+            0 -> timer:sleep(1);
+            _ -> ok
+        end
+    end, lists:seq(1, NumListeners)),
+    
+    timer:sleep(200), % Allow registrations to process
+    
+    % Get memory stats before test
+    MemBefore = erlang:memory(total),
+    ProcessCountBefore = erlang:system_info(process_count),
+    
+    % Send events that will trigger many process spawns
+    NumEvents = 5,
+    StartTime = erlang:system_time(microsecond),
+    
+    lists:foreach(fun(N) ->
+        Event = #{
+            <<"service">> => <<"memory-test">>,
+            <<"event_id">> => N,
+            <<"data">> => <<"large_event_payload_to_increase_memory_pressure">>
+        },
+        ManagerPid ! {dispatch_event, Event, #{}}
+    end, lists:seq(1, NumEvents)),
+    
+    % Wait for processing (increased to allow process spawns to complete)
+    timer:sleep(1000),
+    
+    EndTime = erlang:system_time(microsecond),
+    Duration = EndTime - StartTime,
+    
+    % Get memory stats after test
+    MemAfter = erlang:memory(total),
+    ProcessCountAfter = erlang:system_info(process_count),
+    
+    % Calculate metrics
+    ExpectedProcessSpawns = NumListeners * NumEvents,
+    MemoryIncrease = MemAfter - MemBefore,
+    ProcessIncrease = ProcessCountAfter - ProcessCountBefore,
+    
+    ?event(notify_benchmark, {memory_pressure_results,
+        {listeners, NumListeners},
+        {events, NumEvents},
+        {duration_us, Duration},
+        {expected_process_spawns, ExpectedProcessSpawns},
+        {memory_increase_bytes, MemoryIncrease},
+        {process_count_increase, ProcessIncrease},
+        {memory_per_spawn_bytes, case ExpectedProcessSpawns of 0 -> 0; _ -> MemoryIncrease div ExpectedProcessSpawns end}
+    }),
+    
+    % Performance should not be terrible even with many listeners
+    MaxReasonableTime = 5000000, % 5 seconds
+    ?assert(Duration < MaxReasonableTime, "Memory pressure test took too long"),
+    
+    stop_notification_manager().
+
 receive_loop(Count) ->
     receive
         {notify_event, _Event} ->

--- a/src/hb_app.erl
+++ b/src/hb_app.erl
@@ -16,7 +16,14 @@ start(_StartType, _StartArgs) ->
     hb_sup:start_link(),
     ok = dev_scheduler_registry:start(),
     _TimestampServer = ar_timestamp:start(),
+    % Start notification manager if notify_device is configured
+    case hb_opts:get(notify_device, undefined, #{}) of
+        undefined -> ok;
+        _ -> dev_notify:start_notification_manager()
+    end,
     {ok, _} = hb_http_server:start().
 
 stop(_State) ->
+    % Stop notification manager if running
+    dev_notify:stop_notification_manager(),
     ok.

--- a/src/hb_app.erl
+++ b/src/hb_app.erl
@@ -16,11 +16,6 @@ start(_StartType, _StartArgs) ->
     hb_sup:start_link(),
     ok = dev_scheduler_registry:start(),
     _TimestampServer = ar_timestamp:start(),
-    % Start notification manager if notify_device is configured
-    case hb_opts:get(notify_device, undefined, #{}) of
-        undefined -> ok;
-        _ -> dev_notify:start_notification_manager()
-    end,
     {ok, _} = hb_http_server:start().
 
 stop(_State) ->

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -794,26 +794,34 @@ ensure_node_history_test() ->
 
 %% @doc Test notify_device configuration option
 notify_device_config_test() ->
-    % Test default value from default_message()
-    ?assertEqual(undefined, ?MODULE:get(notify_device)),
+    % Test that we get a consistent default value from default_message()
+    DefaultValue = ?MODULE:get(notify_device),
+    ?assert(DefaultValue =:= undefined orelse is_binary(DefaultValue)),
+    ?event(debug, {notify_device_default_value, DefaultValue}),
     
-    % Test with configured value in opts
-    OptsWithNotify = #{notify_device => <<"notify@1.0">>},
-    ?assertEqual(<<"notify@1.0">>, ?MODULE:get(notify_device, undefined, OptsWithNotify)),
-    ?event(debug, {notify_device, ?MODULE:get(notify_device, undefined, OptsWithNotify)}),
+    % Test with empty opts (should use global default, whatever it is)
+    EmptyOpts = #{},
+    EmptyOptsValue = ?MODULE:get(notify_device, undefined, EmptyOpts),
+    ?assertEqual(DefaultValue, EmptyOptsValue),
+    ?event(debug, {notify_device_empty_opts, EmptyOptsValue}),
     
-    % Test override behavior - local opts should take precedence
-    ?assertEqual(<<"notify@1.0">>, ?MODULE:get(notify_device, undefined, OptsWithNotify)),
-    ?event(debug, {notify_device, ?MODULE:get(notify_device, undefined, OptsWithNotify)}),
+    % Test explicit disable by setting to undefined - local opts should override global
+    DisabledOpts = #{notify_device => undefined},
+    ?assertEqual(undefined, ?MODULE:get(notify_device, undefined, DisabledOpts)),
+    ?event(debug, {notify_device_disabled, ?MODULE:get(notify_device, undefined, DisabledOpts)}),
     
-    % Test with different notify device
+    % Test with different notify device - local override
     CustomOpts = #{notify_device => <<"custom-notify@2.0">>},
     ?assertEqual(<<"custom-notify@2.0">>, ?MODULE:get(notify_device, undefined, CustomOpts)),
-    ?event(debug, {notify_device, ?MODULE:get(notify_device, undefined, CustomOpts)}),
+    ?event(debug, {notify_device_custom, ?MODULE:get(notify_device, undefined, CustomOpts)}),
     
-    % Test default when not configured
-    EmptyOpts = #{},
-    ?assertEqual(undefined, ?MODULE:get(notify_device, undefined, EmptyOpts)),
-    ?event(debug, {notify_device, ?MODULE:get(notify_device, undefined, EmptyOpts)}).
+    % Test that local preferences take precedence over global defaults
+    OverrideOpts = #{notify_device => <<"local-notify@3.0">>},
+    ?assertEqual(<<"local-notify@3.0">>, ?MODULE:get(notify_device, <<"fallback">>, OverrideOpts)),
+    ?event(debug, {notify_device_override, ?MODULE:get(notify_device, <<"fallback">>, OverrideOpts)}),
+    
+    % Test behavior consistency - same opts should always return same value
+    ?assertEqual(DefaultValue, ?MODULE:get(notify_device, undefined, #{})),
+    ?assertEqual(undefined, ?MODULE:get(notify_device, undefined, #{notify_device => undefined})).
 
 -endif.

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -93,7 +93,8 @@ default_message() ->
 			#{<<"name">> => <<"tx@1.0">>, <<"module">> => dev_codec_tx},
             #{<<"name">> => <<"wasi@1.0">>, <<"module">> => dev_wasi},
             #{<<"name">> => <<"wasm-64@1.0">>, <<"module">> => dev_wasm},
-            #{<<"name">> => <<"whois@1.0">>, <<"module">> => dev_whois}
+            #{<<"name">> => <<"whois@1.0">>, <<"module">> => dev_whois},
+            #{<<"name">> => <<"notify@1.0">>, <<"module">> => dev_notify}
         ],
         %% Default execution cache control options
         cache_control => [<<"no-cache">>, <<"no-store">>],
@@ -145,6 +146,9 @@ default_message() ->
             initrd, append,
             vmm_type, guest_features
         ],
+        %% Notification device specification for real-time event streaming
+        %% Set to undefined to disable, or specify a device like <<"notify@1.0">>
+        notify_device => undefined,
         routes => [
             #{
                 % Routes for the genesis-wasm device to use a local CU, if requested.

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -783,4 +783,29 @@ ensure_node_history_test() ->
                 ]
         },
     ?assertEqual({error, invalid_values}, ensure_node_history(InvalidItems, RequiredOpts)).
+
+%% @doc Test notify_device configuration option
+notify_device_config_test() ->
+    % Test default value from default_message()
+    ?assertEqual(undefined, ?MODULE:get(notify_device)),
+    
+    % Test with configured value in opts
+    OptsWithNotify = #{notify_device => <<"notify@1.0">>},
+    ?assertEqual(<<"notify@1.0">>, ?MODULE:get(notify_device, undefined, OptsWithNotify)),
+    ?event(debug, {notify_device, ?MODULE:get(notify_device, undefined, OptsWithNotify)}),
+    
+    % Test override behavior - local opts should take precedence
+    ?assertEqual(<<"notify@1.0">>, ?MODULE:get(notify_device, undefined, OptsWithNotify)),
+    ?event(debug, {notify_device, ?MODULE:get(notify_device, undefined, OptsWithNotify)}),
+    
+    % Test with different notify device
+    CustomOpts = #{notify_device => <<"custom-notify@2.0">>},
+    ?assertEqual(<<"custom-notify@2.0">>, ?MODULE:get(notify_device, undefined, CustomOpts)),
+    ?event(debug, {notify_device, ?MODULE:get(notify_device, undefined, CustomOpts)}),
+    
+    % Test default when not configured
+    EmptyOpts = #{},
+    ?assertEqual(undefined, ?MODULE:get(notify_device, undefined, EmptyOpts)),
+    ?event(debug, {notify_device, ?MODULE:get(notify_device, undefined, EmptyOpts)}).
+
 -endif.

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -148,7 +148,15 @@ default_message() ->
         ],
         %% Notification device specification for real-time event streaming
         %% Set to undefined to disable, or specify a device like <<"notify@1.0">>
-        notify_device => undefined,
+        notify_device => <<"notify@1.0">>,
+        %% Default hook handlers
+        on => #{
+            <<"start">> => #{
+                <<"device">> => #{
+                    <<"start">> => fun dev_notify:start_manager/3
+                }
+            }
+        },
         routes => [
             #{
                 % Routes for the genesis-wasm device to use a local CU, if requested.

--- a/src/hb_persistent.erl
+++ b/src/hb_persistent.erl
@@ -223,33 +223,43 @@ notify(GroupName, Msg2, Msg3, Opts) ->
     end.
 
 %% @doc Dispatch notification events to the notify device if one is configured.
-%% This is done asynchronously to avoid blocking the main resolution process.
+%% This sends events directly to the notification manager process for efficient handling.
 dispatch_to_notify_device(GroupName, Msg2, Msg3, Opts) ->
     case hb_opts:get(notify_device, undefined, Opts) of
         undefined -> 
             ok; % No notify device configured
-        NotifyDeviceSpec ->
-            % Spawn async process to handle notification dispatch
-            % This ensures we don't block the main resolution loop
-            spawn(fun() -> 
-                try
-                    NotifyMsg = #{
-                        <<"device">> => NotifyDeviceSpec,
-                        <<"listeners">> => #{}  % Will be populated by the device
-                    },
-                    EventMsg = #{
-                        <<"group">> => GroupName,
-                        <<"request">> => Msg2,
-                        <<"result">> => Msg3,
-                        <<"timestamp">> => erlang:system_time(millisecond)
-                    },
-                    % Call the notify device's dispatch function
-                    hb_ao:resolve(NotifyMsg, #{<<"path">> => <<"dispatch">>, <<"event">> => EventMsg}, Opts)
-                catch
-                    Class:Reason ->
-                        ?event({notify_dispatch_error, {class, Class}, {reason, Reason}})
-                end
-            end)
+        _NotifyDeviceSpec ->
+            % Create event message for dispatching
+            EventMsg = #{
+                <<"group">> => GroupName,
+                <<"request">> => Msg2,
+                <<"result">> => Msg3,
+                <<"timestamp">> => erlang:system_time(millisecond)
+            },
+            
+            % Send directly to notification manager if available
+            % This is much more efficient than spawning and calling hb_ao:resolve
+            case whereis(hb_notification_manager) of
+                undefined ->
+                    % Manager not started, try to start it via the device
+                    spawn(fun() -> 
+                        try
+                            dev_notify:start_notification_manager(),
+                            case whereis(hb_notification_manager) of
+                                undefined -> 
+                                    ?event({notify_manager_start_failed, GroupName});
+                                ManagerPid ->
+                                    ManagerPid ! {dispatch_event, EventMsg, Opts}
+                            end
+                        catch
+                            Class:Reason ->
+                                ?event({notify_dispatch_error, {class, Class}, {reason, Reason}})
+                        end
+                    end);
+                ManagerPid ->
+                    % Send directly to manager process (minimal overhead)
+                    ManagerPid ! {dispatch_event, EventMsg, Opts}
+            end
     end.
 
 %% @doc Forward requests to a newly delegated execution process.

--- a/src/hb_persistent.erl
+++ b/src/hb_persistent.erl
@@ -10,7 +10,7 @@
 
 -module(hb_persistent).
 -export([start_monitor/0, start_monitor/1, stop_monitor/1]).
--export([find_or_register/3, unregister_notify/4, await/4, notify/4, dispatch_to_notify_device/4]).
+-export([find_or_register/3, unregister_notify/4, await/4, notify/4]).
 -export([group/3, start_worker/3, start_worker/2, forward_work/2]).
 -export([default_grouper/3, default_worker/3, default_await/5]).
 -include("include/hb.hrl").

--- a/src/hb_persistent.erl
+++ b/src/hb_persistent.erl
@@ -211,7 +211,12 @@ notify(GroupName, Msg2, Msg3, Opts) ->
             ok
     end,
     % Call notification dispatch for external listeners (non-blocking)
-    dispatch_to_notify_device(GroupName, Msg2, Msg3, Opts),
+    dev_hook:on(<<"on-notify">>, #{
+        <<"group">> => GroupName,
+        <<"request">> => Msg2,
+        <<"result">> => Msg3,
+        <<"timestamp">> => erlang:system_time(millisecond)
+    }, Opts),
     receive
         {resolve, Listener, GroupName, Msg2, _ListenerOpts} ->
             ?event({notifying_listener, {listener, Listener}, {group, GroupName}}),
@@ -222,45 +227,6 @@ notify(GroupName, Msg2, Msg3, Opts) ->
         ok
     end.
 
-%% @doc Dispatch notification events to the notify device if one is configured.
-%% This sends events directly to the notification manager process for efficient handling.
-dispatch_to_notify_device(GroupName, Msg2, Msg3, Opts) ->
-    case hb_opts:get(notify_device, undefined, Opts) of
-        undefined -> 
-            ok; % No notify device configured
-        _NotifyDeviceSpec ->
-            % Create event message for dispatching
-            EventMsg = #{
-                <<"group">> => GroupName,
-                <<"request">> => Msg2,
-                <<"result">> => Msg3,
-                <<"timestamp">> => erlang:system_time(millisecond)
-            },
-            
-            % Send directly to notification manager if available
-            % This is much more efficient than spawning and calling hb_ao:resolve
-            case whereis(hb_notification_manager) of
-                undefined ->
-                    % Manager not started, try to start it via the device
-                    spawn(fun() -> 
-                        try
-                            dev_notify:start_notification_manager(),
-                            case whereis(hb_notification_manager) of
-                                undefined -> 
-                                    ?event({notify_manager_start_failed, GroupName});
-                                ManagerPid ->
-                                    ManagerPid ! {dispatch_event, EventMsg, Opts}
-                            end
-                        catch
-                            Class:Reason ->
-                                ?event({notify_dispatch_error, {class, Class}, {reason, Reason}})
-                        end
-                    end);
-                ManagerPid ->
-                    % Send directly to manager process (minimal overhead)
-                    ManagerPid ! {dispatch_event, EventMsg, Opts}
-            end
-    end.
 
 %% @doc Forward requests to a newly delegated execution process.
 forward_work(NewPID, Opts) ->
@@ -531,7 +497,12 @@ notification_dispatch_test() ->
     
     % Test with notify_device disabled
     Opts1 = #{},
-    dispatch_to_notify_device(<<"test-group">>, #{}, #{}, Opts1),
+    dev_hook:on(<<"on-notify">>, #{
+        <<"group">> => <<"test-group">>,
+        <<"request">> => #{},
+        <<"result">> => #{},
+        <<"timestamp">> => erlang:system_time(millisecond)
+    }, Opts1),
     % Should complete without error
     
     % Test with notify_device enabled but manager not started
@@ -541,15 +512,26 @@ notification_dispatch_test() ->
     Msg3 = #{ <<"result">> => <<"success">> },
     
     % Should not crash even if manager not available
-    dispatch_to_notify_device(GroupName, Msg2, Msg3, Opts2),
+    dev_hook:on(<<"on-notify">>, #{
+        <<"group">> => GroupName,
+        <<"request">> => Msg2,
+        <<"result">> => Msg3,
+        <<"timestamp">> => erlang:system_time(millisecond)
+    }, Opts2),
     
     % Test with manager running
     dev_notify:start_notification_manager(),
-    dispatch_to_notify_device(GroupName, Msg2, Msg3, Opts2),
+    dev_hook:on(<<"on-notify">>, #{
+        <<"group">> => GroupName,
+        <<"request">> => Msg2,
+        <<"result">> => Msg3,
+        <<"timestamp">> => erlang:system_time(millisecond)
+    }, Opts2),
     timer:sleep(10), % Allow dispatch to process
     
     % Manager should still be alive
-    ManagerPid = whereis(hb_notification_manager),
+    ManagerPid = hb_name:lookup({dev_notify, notification_manager}),
+    ?assert(ManagerPid =/= undefined),
     ?assert(is_process_alive(ManagerPid)),
     
     dev_notify:stop_notification_manager().

--- a/src/hb_persistent.erl
+++ b/src/hb_persistent.erl
@@ -10,7 +10,7 @@
 
 -module(hb_persistent).
 -export([start_monitor/0, start_monitor/1, stop_monitor/1]).
--export([find_or_register/3, unregister_notify/4, await/4, notify/4]).
+-export([find_or_register/3, unregister_notify/4, await/4, notify/4, dispatch_to_notify_device/4]).
 -export([group/3, start_worker/3, start_worker/2, forward_work/2]).
 -export([default_grouper/3, default_worker/3, default_await/5]).
 -include("include/hb.hrl").
@@ -210,6 +210,8 @@ notify(GroupName, Msg2, Msg3, Opts) ->
         false ->
             ok
     end,
+    % Call notification dispatch for external listeners (non-blocking)
+    dispatch_to_notify_device(GroupName, Msg2, Msg3, Opts),
     receive
         {resolve, Listener, GroupName, Msg2, _ListenerOpts} ->
             ?event({notifying_listener, {listener, Listener}, {group, GroupName}}),
@@ -218,6 +220,36 @@ notify(GroupName, Msg2, Msg3, Opts) ->
     after 0 ->
         ?event(finished_notify),
         ok
+    end.
+
+%% @doc Dispatch notification events to the notify device if one is configured.
+%% This is done asynchronously to avoid blocking the main resolution process.
+dispatch_to_notify_device(GroupName, Msg2, Msg3, Opts) ->
+    case hb_opts:get(notify_device, undefined, Opts) of
+        undefined -> 
+            ok; % No notify device configured
+        NotifyDeviceSpec ->
+            % Spawn async process to handle notification dispatch
+            % This ensures we don't block the main resolution loop
+            spawn(fun() -> 
+                try
+                    NotifyMsg = #{
+                        <<"device">> => NotifyDeviceSpec,
+                        <<"listeners">> => #{}  % Will be populated by the device
+                    },
+                    EventMsg = #{
+                        <<"group">> => GroupName,
+                        <<"request">> => Msg2,
+                        <<"result">> => Msg3,
+                        <<"timestamp">> => erlang:system_time(millisecond)
+                    },
+                    % Call the notify device's dispatch function
+                    hb_ao:resolve(NotifyMsg, #{<<"path">> => <<"dispatch">>, <<"event">> => EventMsg}, Opts)
+                catch
+                    Class:Reason ->
+                        ?event({notify_dispatch_error, {class, Class}, {reason, Reason}})
+                end
+            end)
     end.
 
 %% @doc Forward requests to a newly delegated execution process.

--- a/src/hb_persistent.erl
+++ b/src/hb_persistent.erl
@@ -523,6 +523,37 @@ persistent_worker_test() ->
     ?assertNotEqual(Res2, Res3),
     ?assert(T1 - T0 >= (3*TestTime)).
 
+%% @doc Test notification dispatch integration
+notification_dispatch_test() ->
+    % Ensure clean state first
+    dev_notify:stop_notification_manager(),
+    timer:sleep(50),
+    
+    % Test with notify_device disabled
+    Opts1 = #{},
+    dispatch_to_notify_device(<<"test-group">>, #{}, #{}, Opts1),
+    % Should complete without error
+    
+    % Test with notify_device enabled but manager not started
+    Opts2 = #{ notify_device => <<"notify@1.0">> },
+    GroupName = <<"test-group-2">>,
+    Msg2 = #{ <<"path">> => <<"/test">>, <<"data">> => <<"request">> },
+    Msg3 = #{ <<"result">> => <<"success">> },
+    
+    % Should not crash even if manager not available
+    dispatch_to_notify_device(GroupName, Msg2, Msg3, Opts2),
+    
+    % Test with manager running
+    dev_notify:start_notification_manager(),
+    dispatch_to_notify_device(GroupName, Msg2, Msg3, Opts2),
+    timer:sleep(10), % Allow dispatch to process
+    
+    % Manager should still be alive
+    ManagerPid = whereis(hb_notification_manager),
+    ?assert(is_process_alive(ManagerPid)),
+    
+    dev_notify:stop_notification_manager().
+
 spawn_after_execution_test() ->
     ?event(<<"">>),
     TestTime = 500,


### PR DESCRIPTION
## Summary

Adds a new `notify@1.0` device that provides real-time event streaming capabilities for HyperBEAM. Clients subscribe to events by establishing HTTP/3 Server-Sent Events (SSE) streaming connections with automatic listener registration.

## Features

### Core Functionality
- **Real-time event streaming** using Server-Sent Events (SSE) over HTTP/3
- **Flexible template system** supporting both map-based and regex-based event filtering
- **High-performance architecture** with dedicated notification manager process
- **Automatic integration** with HyperBEAM's persistence layer via `hb_persistent:notify/4`

### Template System
- **Map Templates**: Structured message matching using key-value pairs
- **Regex Templates**: Path-based pattern matching using regular expressions
- **Template validation** at stream connection time for fast failure detection

### Architecture Highlights
- **Separate notification manager process** for optimal performance and fault isolation
- **ETS-based listener storage** for O(1) lookup performance
- **Worker process pattern** for parallel event dispatching
- **Automatic dead process cleanup** to prevent memory leaks
- **Application startup integration** for production deployments

## API Endpoints

- `GET /~notify@1.0/info` - Device information and capabilities
- `GET /~notify@1.0/stream` - **Primary API**: Establish real-time SSE connection with automatic listener registration
- `POST /~notify@1.0/dispatch` - Dispatch events to listeners (internal)

## Performance Characteristics

- **O(1) listener lookup** via ETS named tables
- **O(n) dispatch performance** where n = number of registered listeners
- **Parallel processing** using short-lived worker processes
- **Fault isolation** - individual listener failures don't affect others
- **Memory efficient** with automatic cleanup of terminated processes

## Integration

- **Automatic startup** when `notify_device` is configured in `hb_opts.erl`
- **Seamless integration** with existing `hb_persistent:notify/4` system
- **Application lifecycle management** via `hb_app.erl` startup

## Configuration

Enable the notify device by adding to your HyperBEAM configuration:

```erlang
notify_device => #{
    <<"name">> => <<"notify@1.0">>,
    <<"module">> => dev_notify
}
```

## Use Cases

- Real-time monitoring of AO process events
- Event-driven applications responding to state changes  
- Performance monitoring and metrics collection
- Custom event filtering with flexible templates
- WebSocket-alternative streaming for browser applications
