### PR TITLE
feat: `~whois@1.0` device

### DIFF
--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -390,7 +390,8 @@ get_location(_Msg1, Req, Opts) ->
 
 %% @doc Generate a new scheduler location record and register it. We both send 
 %% the new scheduler-location to the given registry, and return it to the caller.
-post_location(Msg1, RawReq, Opts) ->
+post_location(Msg1, RawReq, RawOpts) ->
+    Opts = dev_whois:ensure_host(RawOpts),
     % Ensure that the request is signed by the operator.
     Req =
         case hb_ao:get_first(

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -391,7 +391,11 @@ get_location(_Msg1, Req, Opts) ->
 %% @doc Generate a new scheduler location record and register it. We both send 
 %% the new scheduler-location to the given registry, and return it to the caller.
 post_location(Msg1, RawReq, RawOpts) ->
-    Opts = dev_whois:ensure_host(RawOpts),
+    Opts =
+        case dev_whois:ensure_host(RawOpts) of
+            {ok, NewOpts} -> NewOpts;
+            _ -> RawOpts
+        end,
     % Ensure that the request is signed by the operator.
     Req =
         case hb_ao:get_first(

--- a/src/dev_whois.erl
+++ b/src/dev_whois.erl
@@ -7,7 +7,7 @@
 
 %% @doc Return the calculated host information for the requester.
 echo(_, Req, Opts) ->
-    {ok, hb_maps:get(<<"host">>, Req, <<"unknown">>, Opts)}.
+    {ok, hb_maps:get(<<"peer">>, Req, <<"unknown">>, Opts)}.
 
 %% @doc Return the host information for the node. Sets the `host' key in the
 %% node message if it is not already set.
@@ -50,12 +50,11 @@ bootstrap_node_echo(Opts) ->
 find_self_test() ->
     BoostrapNode =
         hb_http_server:start_node(#{
-            priv_wallet => ar_wallet:new(),
-            port => 13337
+            priv_wallet => ar_wallet:new()
         }),
     PeerNode =
         hb_http_server:start_node(#{
-            port => 1111,
+            port => Port = rand:uniform(40000) + 10000,
             priv_wallet => ar_wallet:new(),
             host_bootstrap_node => BoostrapNode,
             http_client => httpc
@@ -63,4 +62,4 @@ find_self_test() ->
     ?event({nodes, {peer, PeerNode}, {bootstrap, BoostrapNode}}),
     {ok, ReceivedPeerHost} = hb_http:get(PeerNode, <<"/~whois@1.0/node">>, #{}),
     ?event({find_self_test, ReceivedPeerHost}),
-    ?assertEqual(PeerNode, ReceivedPeerHost).
+    ?assertEqual(<<"127.0.0.1:", (hb_util:bin(Port))/binary>>, ReceivedPeerHost).

--- a/src/dev_whois.erl
+++ b/src/dev_whois.erl
@@ -7,7 +7,7 @@
 
 %% @doc Return the calculated host information for the requester.
 echo(_, Req, Opts) ->
-    {ok, hb_maps:get(<<"peer">>, Req, <<"unknown">>, Opts)}.
+    {ok, hb_maps:get(<<"ao-peer">>, Req, <<"unknown">>, Opts)}.
 
 %% @doc Return the host information for the node. Sets the `host' key in the
 %% node message if it is not already set.

--- a/src/dev_whois.erl
+++ b/src/dev_whois.erl
@@ -1,0 +1,66 @@
+%%% @doc A device for returning the IP/host information of a requester or
+%%% itself.
+-module(dev_whois).
+-export([node/3, echo/3]).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%% @doc Return the calculated host information for the requester.
+echo(_, Req, Opts) ->
+    {ok, hb_maps:get(<<"host">>, Req, <<"unknown">>, Opts)}.
+
+%% @doc Return the host information for the node. Sets the `host' key in the
+%% node message if it is not already set.
+node(_, _, Opts) ->
+    case ensure_host(Opts) of
+        {ok, NewOpts} ->
+            {ok, hb_opts:get(host, <<"unknown">>, NewOpts)};
+        Error ->
+            Error
+    end.
+
+%% @doc Return the node message ensuring that the host is set. If it is not, we
+%% attempt to find the host information from the specified bootstrap node.
+ensure_host(Opts) ->
+    case hb_opts:get(host, <<"unknown">>, Opts) of
+        <<"unknown">> ->
+            case bootstrap_node_echo(Opts) of
+                {ok, Host} ->
+                    % Set the host information in the persisted node message.
+                    hb_http_server:set_opts(NewOpts = Opts#{ host => Host }),
+                    {ok, NewOpts};
+                Error ->
+                    Error
+            end;
+        _ ->
+            {ok, Opts}
+    end.
+
+%% @doc Find the local host information from the specified bootstrap node.
+bootstrap_node_echo(Opts) ->
+    case hb_opts:get(host_bootstrap_node, false, Opts) of
+        false ->
+            {error, <<"No bootstrap node configured.">>};
+        BootstrapNode ->
+            hb_http:get(BootstrapNode, <<"/~whois@1.0/echo">>, Opts)
+    end.
+
+%%% Tests
+
+find_self_test() ->
+    BoostrapNode =
+        hb_http_server:start_node(#{
+            priv_wallet => ar_wallet:new(),
+            port => 13337
+        }),
+    PeerNode =
+        hb_http_server:start_node(#{
+            port => 1111,
+            priv_wallet => ar_wallet:new(),
+            host_bootstrap_node => BoostrapNode,
+            http_client => httpc
+        }),
+    ?event({nodes, {peer, PeerNode}, {bootstrap, BoostrapNode}}),
+    {ok, ReceivedPeerHost} = hb_http:get(PeerNode, <<"/~whois@1.0/node">>, #{}),
+    ?event({find_self_test, ReceivedPeerHost}),
+    ?assertEqual(PeerNode, ReceivedPeerHost).

--- a/src/dev_whois.erl
+++ b/src/dev_whois.erl
@@ -1,7 +1,10 @@
 %%% @doc A device for returning the IP/host information of a requester or
 %%% itself.
 -module(dev_whois).
+%%% Device API
 -export([node/3, echo/3]).
+%%% Public utilities
+-export([ensure_host/1]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -918,7 +918,7 @@ normalize_unsigned(Req = #{ headers := RawHeaders }, Msg, Opts) ->
                 end,
             Peer = <<RealIP/binary, ":", (hb_util:bin(P2PPort))/binary>>,
             (remove_unless_signed([<<"ao-peer-port">>], WithoutPeer, Opts))#{
-                <<"peer">> => Peer
+                <<"ao-peer">> => Peer
             }
     end.
 

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -262,13 +262,21 @@ prepare_request(Format, Method, Peer, Path, RawMessage, Opts) ->
             not_found -> Message#{ <<"accept-bundle">> => true };
             _ -> Message
         end,
+    % Determine the `ao-peer-port' from the message to send or the node message.
+    % `port_external' can be set in the node message to override the port that
+    % the peer node should receive. This allows users to proxy requests to their
+    % HB node from another port.
     WithSelfPort =
         WithAcceptBundle#{
             <<"ao-peer-port">> =>
                 hb_ao:get(
                     <<"ao-peer-port">>,
                     WithAcceptBundle,
-                    hb_opts:get(port, undefined, Opts),
+                    hb_opts:get(
+                        port_external,
+                        hb_opts:get(port, undefined, Opts),
+                        Opts
+                    ),
                     Opts
                 )
         },

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -218,7 +218,7 @@ route_to_request(M, {ok, #{ <<"uri">> := XPath, <<"opts">> := ReqOpts}}, Opts) -
     % the host should already be known to the caller.
     MsgWithoutMeta = hb_maps:without([<<"path">>, <<"host">>], M, Opts),
     Port =
-        case hb_maps:get(port, URI, undefined, Opts) of
+        case maps:get(port, URI, undefined) of
             undefined ->
                 % If no port is specified, use 80 for HTTP and 443
                 % for HTTPS.
@@ -228,11 +228,11 @@ route_to_request(M, {ok, #{ <<"uri">> := XPath, <<"opts">> := ReqOpts}}, Opts) -
                 end;
             X -> integer_to_binary(X)
         end,
-    Protocol = hb_maps:get(scheme, URI, <<"https">>, Opts),
-    Host = hb_maps:get(host, URI, <<"localhost">>, Opts),
+    Protocol = maps:get(scheme, URI, <<"https">>),
+    Host = maps:get(host, URI, <<"localhost">>),
     Node = << Protocol/binary, "://", Host/binary, ":", Port/binary  >>,
-    PathParts = [hb_maps:get(path, URI, <<"/">>, Opts)] ++
-        case hb_maps:get(query, URI, <<>>, Opts) of
+    PathParts = [maps:get(path, URI, <<"/">>)] ++
+        case maps:get(query, URI, <<>>) of
             <<>> -> [];
             Query -> [<<"?", Query/binary>>]
         end,

--- a/src/hb_http_client.erl
+++ b/src/hb_http_client.erl
@@ -462,8 +462,6 @@ inc_prometheus_counter(Name, Labels, Value) ->
 open_connection(#{ peer := Peer }, Opts) ->
     {Host, Port} = parse_peer(Peer, Opts),
     ?event(http_outbound, {parsed_peer, {peer, Peer}, {host, Host}, {port, Port}}),
-	ConnectTimeout =
-		hb_opts:get(http_connect_timeout, no_connect_timeout, Opts),
     BaseGunOpts =
         #{
             http_opts =>
@@ -476,7 +474,12 @@ open_connection(#{ peer := Peer }, Opts) ->
                         )
                 },
             retry => 0,
-            connect_timeout => ConnectTimeout
+            connect_timeout =>
+                hb_opts:get(
+                    http_connect_timeout,
+                    no_connect_timeout,
+                    Opts
+                )
         },
     Transport =
         case Port of

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -38,7 +38,6 @@ default_message() ->
         %% Options: aggressive, lazy
         compute_mode => lazy,
         %% Choice of remote nodes for tasks that are not local to hyperbeam.
-        host => <<"localhost">>,
         gateway => <<"https://arweave.net">>,
         bundler_ans104 => <<"https://up.arweave.net:443">>,
         %% Location of the wallet keyfile on disk that this node will use.
@@ -91,7 +90,8 @@ default_message() ->
             #{<<"name">> => <<"test-device@1.0">>, <<"module">> => dev_test},
             #{<<"name">> => <<"volume@1.0">>, <<"module">> => dev_volume},
             #{<<"name">> => <<"wasi@1.0">>, <<"module">> => dev_wasi},
-            #{<<"name">> => <<"wasm-64@1.0">>, <<"module">> => dev_wasm}
+            #{<<"name">> => <<"wasm-64@1.0">>, <<"module">> => dev_wasm},
+            #{<<"name">> => <<"whois@1.0">>, <<"module">> => dev_whois}
         ],
         %% Default execution cache control options
         cache_control => [<<"no-cache">>, <<"no-store">>],


### PR DESCRIPTION
This PR adds a device that allows callers to determine their own IP address from another node in the network. Additionally, it exposes the local node's host information from its node message.