### PR TITLE
impr: remove spawning of hb_tracer in dev_cron

### DIFF
--- a/src/dev_cron.erl
+++ b/src/dev_cron.erl
@@ -45,9 +45,8 @@ once(_Msg1, Msg2, Opts) ->
 once_worker(Path, Req, Opts) ->
 	% Directly call the meta device on the newly constructed 'singleton', just
     % as hb_http_server does.
-    TracePID = hb_tracer:start_trace(),
 	try
-		dev_meta:handle(Opts#{ trace => TracePID }, Req#{ <<"path">> => Path})
+        dev_meta:handle(Opts, Req#{ <<"path">> => Path})
 	catch
 		Class:Reason:Stacktrace ->
 			?event(
@@ -84,14 +83,13 @@ every(_Msg1, Msg2, Opts) ->
                         <<"cron-path">>,
                         maps:remove(<<"interval">>, Msg2)
                     ),
-				TracePID = hb_tracer:start_trace(),
 				Pid =
                     spawn(
                         fun() ->
                             every_worker_loop(
                                 CronPath,
                                 ModifiedMsg2,
-                                Opts#{ trace => TracePID },
+                                Opts,
                                 IntervalMillis
                             )
                         end

--- a/src/hb_ao.erl
+++ b/src/hb_ao.erl
@@ -510,7 +510,7 @@ resolve_stage(6, Func, Msg1, Msg2, ExecName, Opts) ->
 	% Execution.
 	% First, determine the arguments to pass to the function.
 	% While calculating the arguments we unset the add_key option.
-	UserOpts1 = hb_maps:remove(trace, hb_maps:without(?TEMP_OPTS, Opts, Opts), Opts),
+	UserOpts1 = hb_maps:without(?TEMP_OPTS, Opts, Opts),
     % Unless the user has explicitly requested recursive spawning, we
     % unset the spawn_worker option so that we do not spawn a new worker
     % for every resulting execution.


### PR DESCRIPTION
This PR leverages the `hb_tracer` from `http_server` instead to spawn a new one for each `dev_cron` processes