### PR TITLE
Fix/race condition

### DIFF
--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -1387,3 +1387,102 @@ list_with_link_test() ->
     ?assertEqual(ExpectedChildren, lists:sort(LinkChildren)),
     
     stop(StoreOpts).
+
+%% Add this test to verify transaction cleanup
+transaction_cleanup_test() ->
+    StoreOpts = #{
+        <<"store-module">> => ?MODULE,
+        <<"name">> => <<"/tmp/txn-cleanup-test">>,
+        <<"capacity">> => ?DEFAULT_SIZE
+    },
+    reset(StoreOpts),
+
+    % Write some data to create pending writes
+    write(StoreOpts, <<"key1">>, <<"value1">>),
+    write(StoreOpts, <<"key2">>, <<"value2">>),
+
+    % Force a flush to test transaction handling
+    sync(StoreOpts),
+
+    % Verify data was written correctly
+    ?assertEqual({ok, <<"value1">>}, read(StoreOpts, <<"key1">>)),
+    ?assertEqual({ok, <<"value2">>}, read(StoreOpts, <<"key2">>)),
+
+    stop(StoreOpts).
+
+%% Test cursor cleanup under error conditions
+cursor_cleanup_test() ->
+    StoreOpts = #{
+        <<"store-module">> => ?MODULE,
+        <<"name">> => <<"/tmp/cursor-cleanup-test">>,
+        <<"capacity">> => ?DEFAULT_SIZE
+    },
+    reset(StoreOpts),
+
+    % Create some test data
+    write(StoreOpts, <<"test/key1">>, <<"value1">>),
+    write(StoreOpts, <<"test/key2">>, <<"value2">>),
+    sync(StoreOpts),
+
+    % Test that fold operations work correctly
+    {ok, Results} = list(StoreOpts, <<"test">>),
+    ?assertEqual([<<"key1">>, <<"key2">>], lists:sort(Results)),
+
+    stop(StoreOpts).
+
+concurrent_reader_race_test() ->
+    StoreOpts = #{
+        <<"store-module">> => ?MODULE,
+        <<"name">> => <<"/tmp/concurrent-race-test">>,
+        <<"capacity">> => ?DEFAULT_SIZE
+    },
+    reset(StoreOpts),
+
+    Parent = self(),
+    Key = <<"missing/key">>,
+
+    % Spawn multiple readers simultaneously
+    Readers = [
+        spawn(fun() ->
+            Result = read(StoreOpts, Key),
+            Parent ! {read_result, self(), Result}
+        end)
+        || _ <- lists:seq(1, 10)
+    ],
+
+    % Collect results
+    Results = [
+        receive {read_result, Pid, Result} -> Result
+        after 5000 -> timeout end
+        || Pid <- Readers
+    ],
+
+    % All should return not_found, none should timeout
+    ExpectedResults = lists:duplicate(10, not_found),
+    ?assertEqual(ExpectedResults, Results),
+
+    stop(StoreOpts).
+
+read_after_write_race_test() ->
+    StoreOpts = #{
+        <<"store-module">> => ?MODULE,
+        <<"name">> => <<"/tmp/race-test">>,
+        <<"capacity">> => ?DEFAULT_SIZE
+    },
+    reset(StoreOpts),
+
+    % Write and immediately read in same process
+    Key = <<"race/test/key">>,
+    Value = <<"test-value">>,
+
+    ok = write(StoreOpts, Key, Value),
+
+    % This should always succeed with read-your-writes consistency
+    case read(StoreOpts, Key) of
+        {ok, Value} ->
+            ?assert(true);  % Success
+        not_found ->
+            ?assert(false)  % This indicates the race condition
+    end,
+
+    stop(StoreOpts).

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -741,47 +741,68 @@ server_flush(RawState) ->
     PendingWrites = maps:get(<<"pending-writes">>, RawState, #{}),
     case maps:size(PendingWrites) of
         0 ->
-            % No pending writes, nothing to flush
             RawState;
         _ ->
-            % We have pending writes, create transaction and commit them
-            case {maps:get(<<"env">>, RawState, undefined), 
-                  maps:get(<<"db">>, RawState, undefined)} of
+            case {maps:get(<<"env">>, RawState, undefined),
+                maps:get(<<"db">>, RawState, undefined)} of
                 {undefined, _} ->
-                    % Environment missing, clear pending writes and return
                     ?event(error, {flush_failed_no_env}),
                     RawState#{<<"pending-writes">> => #{}};
                 {_, undefined} ->
-                    % Database instance missing, clear pending writes and return
                     ?event(error, {flush_failed_no_db_instance}),
                     RawState#{<<"pending-writes">> => #{}};
                 {Env, Dbi} ->
-                    % Create a fresh transaction for this batch of writes
-                    try
-                        {ok, Txn} = elmdb:txn_begin(Env),
-                        % Write all pending writes to the transaction in a single batch
-                        maps:map(
-                            fun(Key, Value) ->
-                                elmdb:txn_put(Txn, Dbi, Key, Value)
-                            end,
-                            PendingWrites
-                        ),
-                        % Commit the transaction with all writes
-                        elmdb:txn_commit(Txn),
-                        notify_flush(RawState),
-                        % Clear pending writes after successful commit
-                        RawState#{
-                            <<"pending-writes">> => #{}
-                        }
-                    catch
-                        Class:Reason:Stacktrace ->
-                            ?event(error, {txn_commit_failed, Class, Reason, Stacktrace}),
-                            % Even if commit fails, clean up state and notify
-                            notify_flush(RawState),
-                            RawState#{
-                                <<"pending-writes">> => #{}
-                            }
-                    end
+                    % Create transaction with proper cleanup
+                    TxnResult =
+                        case elmdb:txn_begin(Env) of
+                            {ok, Txn} ->
+                                try
+                                    % Write all pending writes to the transaction
+                                    maps:map(
+                                        fun(Key, Value) ->
+                                            elmdb:txn_put(Txn, Dbi, Key, Value)
+                                        end,
+                                        PendingWrites
+                                    ),
+                                    % Commit the transaction
+                                    case elmdb:txn_commit(Txn) of
+                                        ok ->
+                                            ?event(debug, {txn_committed_successfully, maps:size(PendingWrites)}),
+                                            ok;
+                                        {error, CommitError} ->
+                                            ?event(error, {txn_commit_error, CommitError}),
+                                            {error, CommitError}
+                                    end
+                                catch
+                                    Class:Reason:Stacktrace ->
+                                        % CRITICAL FIX: Always abort transaction on any error
+                                        ?event(error, {txn_operation_failed, Class, Reason}),
+                                        try
+                                            elmdb:txn_abort(Txn)
+                                        catch
+                                            _:AbortError ->
+                                                ?event(error, {txn_abort_failed, AbortError})
+                                        end,
+                                        {error, {Class, Reason, Stacktrace}}
+                                end;
+                            {error, TxnBeginError} ->
+                                ?event(error, {txn_begin_failed, TxnBeginError}),
+                                {error, TxnBeginError}
+                        end,
+
+                    % Always notify flush and clear pending writes, regardless of outcome
+                    notify_flush(RawState),
+                    NewState = RawState#{<<"pending-writes">> => #{}},
+
+                    % Log the result for monitoring
+                    case TxnResult of
+                        ok ->
+                            ?event(info, {flush_completed, {writes_count, maps:size(PendingWrites)}});
+                        {error, Error} ->
+                            ?event(error, {flush_failed, Error, {lost_writes, maps:size(PendingWrites)}})
+                    end,
+
+                    NewState
             end
     end.
 


### PR DESCRIPTION
Added tests for race conditions.

Findings:
- running `rebar3 eunit -t hb_store_lmdb:concurrent_reader_race_test` fails sometimes and works perfectly other times.

Maybe this is one of the potential issues.