### PR TITLE
impr: LMDB store performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 <img src="https://arweave.net/dOpRkKrNNQ4HHebxZlPCo0BWfrjwJ-CEBQs2EPgrwbg" />
 
-Soon.
+The original HyperBEAM (and `SuperSU`) implementation, preserved for historical purposes.
+
+Unless you are curious about how the design of AO-Core evolved from a simple implementation of AO testnet's original SU specification, you want to be [here](https://github.com/permaweb/HyperBEAM).

--- a/src/hb_cache_control.erl
+++ b/src/hb_cache_control.erl
@@ -163,6 +163,8 @@ necessary_messages_not_found_error(Msg1, Msg2, Opts) ->
 
 %% @doc Determine whether we are likely to be faster looking up the result in
 %% our cache (hoping we have it), or executing it directly.
+exec_likely_faster_heuristic(M1, M2, _) when (not ?IS_ID(M1)) and (not is_map(M2)) ->
+    true;
 exec_likely_faster_heuristic({as, _, Msg1}, Msg2, Opts) ->
     exec_likely_faster_heuristic(Msg1, Msg2, Opts);
 exec_likely_faster_heuristic(Msg1, Msg2, Opts) ->

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -258,6 +258,8 @@ resolve_path_links(Opts, Path, Depth) ->
 resolve_path_links_acc(_Opts, [], AccPath, _Depth) ->
     % No more segments to process
     {ok, lists:reverse(AccPath)};
+resolve_path_links_acc(_, FullPath = [<<"data">>|_], [], _Depth) ->
+    {ok, FullPath};
 resolve_path_links_acc(Opts, [Head | Tail], AccPath, Depth) ->
     % Build the accumulated path so far
     CurrentPath = lists:reverse([Head | AccPath]),


### PR DESCRIPTION
This PR makes a series of improvements and refactors to the `hb_store_lmdb` store implementation. The effect is a significant reduction in the execution time of cache lookups for existing results when a node is under heavy strain, moving from ~30s to ~1-3s in our benchmarks.