### PR TITLE
Misc fixes to cron PR

### DIFF
--- a/scripts/cron.lua
+++ b/scripts/cron.lua
@@ -1,4 +1,35 @@
 -- Command handlers
+local function extract_task_id(msg_body)
+    if not msg_body then return nil end
+
+    -- Case 1: Direct access when task_id sits under .body (format from handle_put_command)
+    if msg_body.body and msg_body.body.task_id then
+        return msg_body.body.task_id
+    end
+
+    -- Case 2: Nested access for stored format (body.body.task_id)  
+    if msg_body.body and msg_body.body.body and msg_body.body.body.task_id then
+        return msg_body.body.body.task_id
+    end
+
+    if msg_body.task_id then
+        return msg_body.task_id
+    end
+
+    return nil
+end
+
+-- Helper function to find job index by task_id
+local function find_job_index(process, task_id)
+    for i, job in ipairs(process.crons) do
+        local existing_id = extract_task_id(job)
+        if existing_id == task_id then
+            return i
+        end
+    end
+    return nil
+end
+
 local handle_put_command = function(process, message)
     -- Validate the task_id for put
     if not message.body.body.task_id or type(message.body.body.task_id) ~= "string" then
@@ -12,7 +43,20 @@ local handle_put_command = function(process, message)
     end
 
     ao.event("debug_cron", { "adding task", message.body.body.task_id })
-    table.insert(process.crons, message.body)
+    
+    local incoming_id = message.body.body.task_id
+    -- If a cron with the same task_id already exists we
+    -- simply replace it and return, avoiding duplicates when the node is
+    -- normalised after a reboot.
+    local idx_to_replace = find_job_index(process, incoming_id)
+    
+    -- If we found a replacement index, replace the job. 
+    -- Otherwise, insert as new.
+    if idx_to_replace then
+        process.crons[idx_to_replace] = message.body
+    else
+        table.insert(process.crons, message.body)
+    end
     return process
 end
 
@@ -27,15 +71,7 @@ local handle_remove_command = function(process, message)
     ao.event("debug_cron", { "removing task", task_id_to_remove, "crons_count_before", #process.crons })
 
     -- Find the index of the task to remove.
-    local idx_to_remove = nil
-    -- process.crons is a list of maps, each with a "body" key
-    -- the task_id is stored in the "body" map
-    for i, job in ipairs(process.crons) do
-        if job.body and job.body.task_id == task_id_to_remove then
-            idx_to_remove = i
-            break
-        end
-    end
+    local idx_to_remove = find_job_index(process, task_id_to_remove)
     
     -- If an index is found, remove the task. Otherwise, log a warning.
     if idx_to_remove then

--- a/src/dev_cron.erl
+++ b/src/dev_cron.erl
@@ -1,14 +1,14 @@
 %%% @doc A device that inserts new messages into the schedule to allow processes
 %%% to passively 'call' themselves without user interaction.
 -module(dev_cron).
--export([list/3, once/3, every/3, stop/3, info/1, info/3]).
+-export([list/3, once/3, every/3, stop/3, clear/3, info/1, info/3]).
 -export([normalize/3]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 %% @doc Exported function for getting device info.
 info(_) -> 
-	#{ exports => [info, once, every, stop, add, list, normalize] }.
+	#{ exports => [info, clear, once, every, stop, list, normalize] }.
 
 %% @doc Exported function for granting a description of the device.
 info(_Msg1, _Msg2, _Opts) ->
@@ -21,7 +21,8 @@ info(_Msg1, _Msg2, _Opts) ->
 			<<"every">> => <<"Schedule a recurring message">>,
 			<<"stop">> => <<"Stop a scheduled task {task}">>,
 			<<"list">> => <<"List all registered cron tasks">>,
-			<<"normalize">> => <<"Boostrap cron jobs from cache">>
+			<<"normalize">> => <<"Boostrap cron jobs from cache">>,
+			<<"clear">> => <<"Clear cache">>
 		}
 	},
 	{ok, #{<<"status">> => 200, <<"body">> => InfoBody}}.
@@ -104,33 +105,32 @@ extract_job_details(Job) ->
     AugmentedData = maps:get(<<"data">>, Body, #{}),
     Type = maps:get(<<"type">>, AugmentedData, undefined),
     Interval = maps:get(<<"interval">>, AugmentedData, undefined),
+    CronPath = maps:get(<<"cron_path">>, AugmentedData, undefined),
     WorkerMsg = maps:get(<<"worker_msg">>, AugmentedData, #{}),
-    if TaskId == undefined orelse Type == undefined orelse not is_map(WorkerMsg) orelse WorkerMsg == #{} ->
+    if TaskId == undefined orelse Type == undefined orelse CronPath == undefined orelse not is_map(WorkerMsg) orelse WorkerMsg == #{} ->
         ?event({normalize_skipping_invalid_job, {reason, invalid_structure}, {raw_job, Job}}),
         {error, {unknown_task_id, invalid_job_structure}};
        true ->
-            {ok, #{ task_id => TaskId, type => Type, interval => Interval, worker_msg => WorkerMsg }}
+            {ok, #{ task_id => TaskId, type => Type, interval => Interval, cron_path => CronPath, worker_msg => WorkerMsg }}
     end.
 
 %% Helper function to reconstruct the original message for once/every from cached details
 reconstruct_original_msg(DetailsMap) ->
-    #{ task_id := TaskId, type := Type, interval := Interval, worker_msg := WorkerMsg } = DetailsMap,
-    TargetPath = maps:get(<<"path">>, WorkerMsg, undefined),
-    if TargetPath == undefined ->
-        ?event({normalize_skipping_no_target_path, {task_id, TaskId}, {worker_msg, WorkerMsg}}),
-        {error, no_target_path};
-       true ->
-            OtherParams = maps:remove(<<"path">>, WorkerMsg),
-            OriginalMsg0 = maps:put(<<"cron-path">>, TargetPath, OtherParams),
-            OriginalMsg1 = case Type of
-                               <<"every">> when Interval =/= null andalso Interval =/= undefined -> 
-                                   maps:put(<<"interval">>, Interval, OriginalMsg0);
-                               _ -> OriginalMsg0
-                           end,
-            OriginalMsgPath = <<"/~cron@1.0/", Type/binary>>,
-            OriginalMsg = maps:put(<<"path">>, OriginalMsgPath, OriginalMsg1),
-            {ok, OriginalMsg}
-    end.
+    #{ task_id := TaskId, type := Type, interval := Interval, cron_path := CronPath, worker_msg := WorkerMsg } = DetailsMap,
+    OtherParams = maps:remove(<<"path">>, WorkerMsg),
+    OriginalMsg0 = maps:put(<<"cron-path">>, CronPath, OtherParams),
+    OriginalMsg1 =
+        (case Type of
+             <<"every">> when Interval =/= null andalso Interval =/= undefined ->
+                 maps:put(<<"interval">>, Interval, OriginalMsg0);
+             _ -> OriginalMsg0
+         end),
+    % Carry the original task_id so that every/3 can reuse it verbatim and
+    % avoid generating a new one during normalisation.
+    OriginalMsg2 = maps:put(<<"task_id">>, TaskId, OriginalMsg1),
+    OriginalMsgPath = <<"/~cron@1.0/", Type/binary>>,
+    OriginalMsg = maps:put(<<"path">>, OriginalMsgPath, OriginalMsg2),
+    {ok, OriginalMsg}.
 
 %% Helper function to attempt the restart of a single job
 attempt_job_restart(DetailsMap, OriginalMsg, Msg1, CronOpts) ->
@@ -180,11 +180,19 @@ list(_, _, Opts) ->
 
 %% @doc Exported function for scheduling a one-time message.
 once(_Msg1, Msg2, Opts) ->
+	% Allow callers (e.g. normalisation) to pin the TaskId explicitly so that
+	% we do not re-hash the message and end up with a *different* id after a
+	% reboot.  If the caller passes `task_id` we MUST reuse it verbatim.
+	PinnedId = hb_ao:get(<<"task_id">>, Msg2, undefined, Opts),
 	case hb_ao:get(<<"cron-path">>, Msg2, Opts) of
 		not_found ->
 			{error, <<"No cron path found in message.">>};
 		CronPath ->
-			ReqMsgID = hb_message:id(Msg2, all),
+			ReqMsgID =
+				case PinnedId of
+					undefined -> hb_message:id(Msg2, all);
+					Id when is_binary(Id) -> Id
+				end,
 			% make the path specific for the end device to be used
 			ModifiedMsg2 =
                 maps:remove(
@@ -204,14 +212,15 @@ once(_Msg1, Msg2, Opts) ->
 					% Define the data structure for the cache
 					MinimalAugmentedData = #{ 
 						<<"type">> => <<"once">>,
-						<<"interval">> => null, % No interval for 'once'
-						<<"worker_msg">> => ModifiedMsg2 
+                        % No interval for 'once'
+						<<"interval">> => null, 
+						<<"worker_msg">> => ModifiedMsg2,
+                        % Persist the real target path
+						<<"cron_path">> => CronPath               
 					},
 					% Cache the augmented task data
 					{ok, PutResult} = cache_put(ReqMsgID, MinimalAugmentedData, cron_opts(Opts)),
 					?event({once_cache_put_result, {result, PutResult}}),
-					% {ok, Crons} = cache_list(cron_opts(Opts)),
-					% ?event({once_cron_cache_load_test_crons, {crons, Crons}}),
 					{ok, ReqMsgID}
 			end
 	end.
@@ -240,6 +249,10 @@ once_worker(Path, Req, Opts) ->
 
 %% @doc Exported function for scheduling a recurring message.
 every(_Msg1, Msg2, Opts) ->
+	% Allow callers (e.g. normalisation) to pin the TaskId explicitly so that
+	% we do not re-hash the message and end up with a *different* id after a
+	% reboot.  If the caller passes `task_id` we MUST reuse it verbatim.
+	PinnedId = hb_ao:get(<<"task_id">>, Msg2, undefined, Opts),
 	case {
 		hb_ao:get(<<"cron-path">>, Msg2, Opts),
 		hb_ao:get(<<"interval">>, Msg2, Opts)
@@ -256,7 +269,11 @@ every(_Msg1, Msg2, Opts) ->
 				true ->
 					ok
 				end,
-				ReqMsgID = hb_message:id(Msg2, all),
+				ReqMsgID =
+					case PinnedId of
+						undefined -> hb_message:id(Msg2, all);
+						Id when is_binary(Id) -> Id
+					end,
 				ModifiedMsg2 =
                     maps:remove(
                         <<"cron-path">>,
@@ -287,8 +304,16 @@ every(_Msg1, Msg2, Opts) ->
 						MinimalAugmentedData = #{ 
 							<<"type">> => <<"every">>,
 							<<"interval">> => IntervalString,
-							<<"worker_msg">> => ModifiedMsg2 
+							<<"worker_msg">> => ModifiedMsg2,
+							<<"cron_path">> => CronPath               % Persist the real target path
 						},
+                        % First check if the task ID already exists in the cache
+                        % if it does, we need to remove it first
+                        case cache_get(ReqMsgID, cron_opts(Opts)) of
+                            {ok, _} ->
+                                cache_remove(ReqMsgID, cron_opts(Opts));
+                            _ -> ok
+                        end,
 						% Cache the augmented task data
 						{ok, PutResult} = cache_put(ReqMsgID, MinimalAugmentedData, cron_opts(Opts)),
 						?event({every_cache_put_result, {result, PutResult}}),
@@ -324,7 +349,7 @@ every_worker_loop(CronPath, Req, Opts, IntervalMillis) ->
                     {error, Class, Reason, Stacktrace}
                 }
             ),
-			every_worker_loop(CronPath, Req, Opts, IntervalMillis)
+            exit(Class, Reason)
 	end,
 	timer:sleep(IntervalMillis),
 	every_worker_loop(CronPath, Req, Opts, IntervalMillis).
@@ -440,15 +465,20 @@ cache_list(Opts) ->
 		<<"cron">>,
 		#{ 
 			<<"path">> => <<"now/crons">>, 
-			<<"method">> => <<"GET">> 
+			<<"method">> => <<"GET">>,
+            <<"spawn">> => true
 		}
 	],
 	{ok, Result} = hb_ao:resolve_many(SampleMsg, Opts),
 	CronData = hb_ao:get(<<"crons">>, Result, #{}),
 	?event({cache_list_cron_data, {cron_data, CronData}}),
-    case is_list(CronData) of
-        true -> {ok, CronData};
-        false -> {error, CronData}
+    case CronData of
+        % for when there are no jobs yet
+        not_found -> {ok, []};
+        % for when there are jobs
+        List when is_list(List) -> {ok, List};
+        % for when there is an error
+        Other -> {error, Other}
     end.
 
 %% @doc Clear all values from the cache
@@ -458,6 +488,10 @@ cache_clear(Opts) ->
     {ok, cleared}.
 
 %% @doc Helper function to find a job by task ID in a list of jobs
+%% Handle “no crons”
+find_job_by_task_id(not_found, _TaskId) ->
+    {error, not_found};
+
 find_job_by_task_id([], _) ->
     {error, not_found};
 
@@ -980,3 +1014,48 @@ start_hook_normalize_test() ->
 	% verify we can find the once job in the crons list after node start
 	?assertMatch({ok, _}, find_job_by_task_id(Crons, _OnceTaskId)),
 	?event({start_hook_normalize_test, test_end}).
+
+%% @doc Clear all cron tasks.
+clear(_Msg1, _Msg2, Opts) ->
+    CronOpts = cron_opts(Opts),
+    case cache_clear(CronOpts) of
+        {ok, cleared} ->
+            {ok, #{
+                <<"status">> => 200,
+                <<"body">> => #{ <<"message">> => <<"All cron tasks cleared">> }
+            }};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% @doc Test that normalize doesn't create duplicate cron jobs
+normalize_no_duplicates_test() ->
+    Opts = generate_test_opts(),
+    Node = hb_http_server:start_node(Opts),
+    % Setup test worker
+    PID = spawn(fun test_worker/0),
+    ID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    hb_name:register({<<"test">>, ID}, PID),
+    % Create cron jobs
+    OnceUrlPath = <<"/~cron@1.0/once?test-id=", ID/binary,
+                   "&cron-path=/~test-device@1.0/update_state">>,
+    {ok, _OnceTaskId} = hb_http:get(Node, OnceUrlPath, #{}),
+    EveryUrlPath = <<"/~cron@1.0/every?test-id=", ID/binary,
+                    "&interval=1000-milliseconds",
+                    "&cron-path=/~test-device@1.0/increment_counter">>,
+    {ok, _EveryTaskId} = hb_http:get(Node, EveryUrlPath, #{}),
+    timer:sleep(100),
+    % Get initial count
+    {ok, InitialCrons} = cache_list(Opts),
+    InitialCount = length(InitialCrons),
+    ?event({'normalize_no_duplicates_test_initial', {count, InitialCount}}),
+    % Call normalize (simulates restart)
+    NormalizeUrlPath = <<"/~cron@1.0/normalize">>,
+    {ok, _NormalizeResult} = hb_http:get(Node, NormalizeUrlPath, #{}),
+    timer:sleep(100),
+    % Verify count unchanged (no duplicates)
+    {ok, FinalCrons} = cache_list(Opts),
+    FinalCount = length(FinalCrons),
+    ?event({'normalize_no_duplicates_test_final', {count, FinalCount}}),
+    ?assertEqual(InitialCount, FinalCount, "Normalize should not create duplicates"),
+    ?event({'normalize_no_duplicates_test_done'}).

--- a/src/dev_cron.erl
+++ b/src/dev_cron.erl
@@ -229,9 +229,8 @@ once(_Msg1, Msg2, Opts) ->
 once_worker(Path, Req, Opts) ->
     % Directly call the meta device on the newly constructed 'singleton', just
     % as hb_http_server does.
-    TracePID = hb_tracer:start_trace(),
     try
-        dev_meta:handle(Opts#{ trace => TracePID }, Req#{ <<"path">> => Path})
+        dev_meta:handle(Opts, Req#{ <<"path">> => Path})
     catch
         %% Cowboy / Ranch listener is gone (node stopped) – exit quietly
         error:badarg ->
@@ -279,7 +278,6 @@ every(_Msg1, Msg2, Opts) ->
                         <<"cron-path">>,
                         maps:remove(<<"interval">>, Msg2)
                     ),
-				TracePID = hb_tracer:start_trace(),
 				Name = {<<"cron@1.0">>, ReqMsgID},
 				case hb_name:lookup(Name) of
 					Pid when is_pid(Pid) ->
@@ -294,7 +292,7 @@ every(_Msg1, Msg2, Opts) ->
 		                            every_worker_loop(
 		                                CronPath,
 		                                ModifiedMsg2,
-		                                Opts#{ trace => TracePID },
+		                                Opts,
 		                                IntervalMillis
 		                            )
 		                        end

--- a/src/dev_test.erl
+++ b/src/dev_test.erl
@@ -40,7 +40,8 @@ info(_Msg1, _Msg2, _Opts) ->
 			<<"mul">> => <<"Multiply function">>,
 			<<"snapshot">> => <<"Snapshot function">>,
 			<<"response">> => <<"Response function">>,
-			<<"update_state">> => <<"Update state function">>
+			<<"update_state">> => <<"Update state function">>,
+			<<"increment_counter">> => <<"Increment counter function">>
 		}
 	},
 	{ok, #{<<"status">> => 200, <<"body">> => InfoBody}}.

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -427,7 +427,12 @@ get_opts(NodeMsg = #{ http_server := no_server_ref }) ->
     NodeMsg;
 get_opts(NodeMsg) ->
     ServerRef = hb_opts:get(http_server, no_server_ref, NodeMsg),
-    cowboy:get_env(ServerRef, node_msg, no_node_msg).
+    try cowboy:get_env(ServerRef, node_msg, no_node_msg)
+    catch error:badarg ->
+      % If the server is not yet started, might happen with dev_hook
+      % So we just return the original NodeMsg.
+      NodeMsg
+    end.
 
 set_default_opts(Opts) ->
     % Create a temporary opts map that does not include the defaults.

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -212,7 +212,15 @@ default_message() ->
         % Should the node store all signed messages?
         store_all_signed => true,
         % Should the node use persistent processes?
-        process_workers => false
+        process_workers => false,
+        % Ensure that cron device normalizes by default on node restart.
+        on => #{
+            <<"start">> => #{
+                <<"device">> => <<"cron@1.0">>,
+                <<"path">> => <<"normalize">>,
+                <<"hook">> => #{ <<"result">> => <<"ignore">> }
+            }
+        }
         % Should the node track and expose prometheus metrics?
         % We do not set this explicitly, so that the hb_features:test() value
         % can be used to determine if we should expose metrics instead,


### PR DESCRIPTION
- fix cache recovery issue with cronpath
- handle if a taskId already exists to avoid duplicated cron jobs. if it does then update its process body with the new one
- refactor task ID lookup into a function
- add a not found guard for find job by task ID
- cherry pick commit from @samuelmanzanera to fix dev_hook / cowboy opts issue that was preventing restored cron jobs from running
- clean up test code
- refactor cron.lua find job by id into a different function
- Remove hb_trace from cron workers