### PR TITLE
refactor(dev_push, hb_http): use hb_opts:get for store config and hb_maps:get for ao-peer-port lookup

### DIFF
--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -970,19 +970,7 @@ nested_push_prompts_encoding_change() ->
     Opts = #{
         priv_wallet => hb:wallet(),
         cache_control => <<"always">>,
-        store => [
-            #{
-                <<"store-module">> => hb_store_fs,
-                <<"name">> => <<"cache-mainnet">>
-            },
-            #{
-                <<"store-module">> => hb_store_gateway,
-                <<"store">> => #{
-                    <<"store-module">> => hb_store_fs,
-                    <<"name">> => <<"cache-mainnet">>
-                }
-            }
-        ]
+        store => hb_opts:get(store)
     },
     ?event(push_debug, {opts, Opts}),
     Msg1 = dev_process:test_aos_process(Opts),

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -910,7 +910,7 @@ normalize_unsigned(Req = #{ headers := RawHeaders }, Msg, Opts) ->
                     maps:get(<<"accept-bundle">>, RawHeaders, false)
                 )
         },
-    case hb_ao:get(<<"ao-peer-port">>, WithoutPeer, undefined, Opts) of
+    case hb_maps:get(<<"ao-peer-port">>, WithoutPeer, undefined, Opts) of
         undefined -> WithoutPeer;
         P2PPort ->
             % Calculate the peer address from the request. We honor the 


### PR DESCRIPTION
**Description**
This PR simplifies and unifies our option-retrieval logic across two modules:

* **src/dev\_push.erl**

  * Remove the hard-coded `store` list definition
  * Replace with a single call to `hb_opts:get(store)` so that the store configuration is pulled from our centralized options

* **src/hb\_http.erl**

  * Swap out `hb_ao:get("ao-peer-port", …)`
  * Use `hb_maps:get("ao-peer-port", …)` instead for direct map-based lookup

These changes eliminate duplication, make the configuration flow more declarative, and ensure consistent use of our `hb_opts`/`hb_maps` APIs without altering any external behavior.
