### PR TITLE
impr: process throughput

### DIFF
--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -452,18 +452,24 @@ ensure_loaded(Msg1, Msg2, Opts) ->
                     % the public component of a message) into memory.
                     % Do not update the hashpath while we do this, and remove
                     % the snapshot key after we have normalized the message.
-                    ?event(compute, {loaded_state_checkpoint, ProcID, MaybeLoadedSlot}),
+                    LoadedSnapshotMsg =
+                        hb_cache:ensure_all_loaded(
+                            MaybeLoadedSnapshotMsg,
+                            Opts
+                        ),
+                    LoadedSlot = hb_cache:ensure_all_loaded(MaybeLoadedSlot, Opts),
+                    ?event(compute, {loaded_state_checkpoint, ProcID, LoadedSlot}),
                     {ok, Normalized} =
                         run_as(
                             <<"execution">>,
-                            MaybeLoadedSnapshotMsg,
+                            LoadedSnapshotMsg,
                             normalize,
                             Opts#{ hashpath => ignore }
                         ),
                     NormalizedWithoutSnapshot = hb_maps:remove(<<"snapshot">>, Normalized, Opts),
                     ?event({loaded_state_checkpoint_result,
                         {proc_id, ProcID},
-                        {slot, MaybeLoadedSlot},
+                        {slot, LoadedSlot},
                         {after_normalization, NormalizedWithoutSnapshot}
                     }),
                     {ok, NormalizedWithoutSnapshot};

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -267,7 +267,8 @@ spawn_lookahead_worker(ProcID, Slot, Opts) ->
             ),
             case dev_scheduler_cache:read(ProcID, Slot, Opts) of
                 {ok, Assignment} ->
-                    Caller ! {assignment, ProcID, Slot, Assignment};
+                    LoadedAssignment = hb_cache:ensure_all_loaded(Assignment, Opts),
+                    Caller ! {assignment, ProcID, Slot, LoadedAssignment};
                 not_found ->
                     fail
             end
@@ -309,14 +310,14 @@ check_lookahead_and_local_cache(Worker, ProcID, TargetSlot, Opts) when is_pid(Wo
             ),
             {ok, NewWorker, Assignment}
     after ?LOOKAHEAD_TIMEOUT ->
-        ?event(next_lookahead, {lookahead_worker_timed_out, {slot, TargetSlot}}),
+        ?event(next_lookahead, {lookahead_read_timeout, {slot, TargetSlot}}),
         erlang:exit(Worker, timeout),
         check_lookahead_and_local_cache(undefined, ProcID, TargetSlot, Opts)
     end;
 check_lookahead_and_local_cache(undefined, ProcID, TargetSlot, Opts) ->
     % The lookahead worker has not found an assignment for the target
     % slot yet, so we check our local cache.
-    ?event(next_lookahead, {no_lookahead_worker, {slot, TargetSlot}}),
+    ?event(next_lookahead, {reading_local_cache, {slot, TargetSlot}}),
     case dev_scheduler_cache:read(ProcID, TargetSlot, Opts) of
         not_found -> not_found;
         {ok, Assignment} ->
@@ -334,7 +335,7 @@ check_lookahead_and_local_cache(undefined, ProcID, TargetSlot, Opts) ->
                         % ahead of time.
                         spawn_lookahead_worker(ProcID, TargetSlot + 1, Opts)
                 end,
-            {ok, Worker, Assignment}
+            {ok, Worker, hb_cache:ensure_all_loaded(Assignment, Opts)}
     end.
 
 %% @doc Returns information about the entire scheduler.

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -31,7 +31,7 @@
 %%% The maximum number of assignments that we will query/return at a time.
 -define(MAX_ASSIGNMENT_QUERY_LEN, 1000).
 %%% The timeout for a lookahead worker.
--define(LOOKAHEAD_TIMEOUT, 200).
+-define(LOOKAHEAD_TIMEOUT, 1500).
 
 %% @doc Helper to ensure that the environment is started.
 start() ->

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -327,7 +327,7 @@ check_lookahead_and_local_cache(undefined, ProcID, TargetSlot, Opts) ->
             % if we have them locally, ahead of time.
             Worker =
                 case hb_opts:get(scheduler_lookahead, true, Opts) of
-                    false -> unset;
+                    false -> undefined;
                     true ->
                         % We found the assignment in our local cache, so
                         % optionally spawn a new Erlang process to fetch


### PR DESCRIPTION
This PR improves process execution time when compute is triggered after the initial schedule assignments have been loaded.

For optimal performance, execute with `list-mode => <<"moderate">>` in the options for your `hb_store_lmdb`. The easiest way to configure this is by modifying `hb_opts:default_message`'s `store` field.