### PR TITLE
PR 287 merge with edge

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -31,6 +31,11 @@
             {add, cowboy, [{erl_opts, [{d, 'COWBOY_QUICER', 1}]}]},
             {add, gun, [{erl_opts, [{d, 'GUN_QUICER', 1}]}]}
         ]}
+    ]},
+    {lua_cache, [
+        {erl_opts, [
+            {d, 'ENABLE_LUA_CACHE', true}
+        ]}
     ]}
 ]}.
 

--- a/scripts/cron.lua
+++ b/scripts/cron.lua
@@ -1,0 +1,146 @@
+-- Command handlers
+local function extract_task_id(msg_body)
+    if not msg_body then return nil end
+
+    -- Case 1: Direct access when task_id sits under .body (format from handle_put_command)
+    if msg_body.body and msg_body.body.task_id then
+        return msg_body.body.task_id
+    end
+
+    -- Case 2: Nested access for stored format (body.body.task_id)  
+    if msg_body.body and msg_body.body.body and msg_body.body.body.task_id then
+        return msg_body.body.body.task_id
+    end
+
+    if msg_body.task_id then
+        return msg_body.task_id
+    end
+
+    return nil
+end
+
+-- Helper function to find job index by task_id
+local function find_job_index(process, task_id)
+    for i, job in ipairs(process.crons) do
+        local existing_id = extract_task_id(job)
+        if existing_id == task_id then
+            return i
+        end
+    end
+    return nil
+end
+
+local handle_put_command = function(process, message)
+    -- Validate the task_id for put
+    if not message.body.body.task_id or type(message.body.body.task_id) ~= "string" then
+        ao.event("debug_cron", { "error", "Invalid put: missing/invalid task_id", command_body = message.body.body })
+        return process
+    end
+
+    if not message.body.body.data or type(message.body.body.data) ~= "table" then
+        ao.event("debug_cron", { "error", "Invalid put: missing/invalid data", command_body = message.body.body })
+        return process
+    end
+
+    ao.event("debug_cron", { "adding task", message.body.body.task_id })
+    
+    local incoming_id = message.body.body.task_id
+    -- If a cron with the same task_id already exists we
+    -- simply replace it and return, avoiding duplicates when the node is
+    -- normalised after a reboot.
+    local idx_to_replace = find_job_index(process, incoming_id)
+    
+    -- If we found a replacement index, replace the job. 
+    -- Otherwise, insert as new.
+    if idx_to_replace then
+        process.crons[idx_to_replace] = message.body
+    else
+        table.insert(process.crons, message.body)
+    end
+    return process
+end
+
+local handle_remove_command = function(process, message)
+    -- Validate the task_id for remove
+    if not message.body.body.task_id or type(message.body.body.task_id) ~= "string" then
+        ao.event("debug_cron", { "error", "Invalid remove: missing/invalid task_id", command_body = message.body.body })
+        return process
+    end
+
+    local task_id_to_remove = message.body.body.task_id
+    ao.event("debug_cron", { "removing task", task_id_to_remove, "crons_count_before", #process.crons })
+
+    -- Find the index of the task to remove.
+    local idx_to_remove = find_job_index(process, task_id_to_remove)
+    
+    -- If an index is found, remove the task. Otherwise, log a warning.
+    if idx_to_remove then
+        table.remove(process.crons, idx_to_remove)
+        ao.event("debug_cron", { "removed task", task_id_to_remove, "crons_count_after", #process.crons })
+    else
+        ao.event("debug_cron", { "warn", "Task not found for removal", task_id = task_id_to_remove })
+    end
+
+    return process
+end
+
+local handle_clear_command = function(process)
+    ao.event("debug_cron", { "clearing all tasks" })
+    process.crons = {}
+    collectgarbage()
+    ao.event("debug_cron", { "cleared all tasks" })
+    return process
+end
+
+function compute(process, message, opts)
+    -- Early return when no body is provided
+    -- This handles the initial invocation during process setup
+    if not message or not message.body or not message.body.body then
+        return process
+    end
+    
+    -- Validate that the path exists
+    if not message.body.body.path or type(message.body.body.path) ~= "string" then
+        ao.event("debug_cron", { "error", "Invalid path", command_body = message.body.body })
+        return process
+    end
+
+    ao.event("debug_cron", { "compute incoming", message })
+    
+    -- Supported commands: "put" | "remove" | "clear"
+    local command = message.body.body.path
+    ao.event("debug_cron", { "compute command", command })
+    
+    -- Initialize the crons table if it doesn't exist
+    process.crons = process.crons or {}
+    
+    -- Command dispatch
+    if command == "put" then
+        local ok, new_process_or_err = pcall(handle_put_command, process, message)
+        if not ok then
+            ao.event("debug_cron",
+                     { "error", "Error handling put command", error = new_process_or_err })
+            return process
+        end
+        return new_process_or_err
+    elseif command == "remove" then
+        local ok, new_process_or_err = pcall(handle_remove_command, process, message)
+        if not ok then
+            ao.event("debug_cron",
+                     { "error", "Error handling remove command", error = new_process_or_err })
+            return process
+        end
+        return new_process_or_err
+    elseif command == "clear" then
+        local ok, new_process_or_err = pcall(handle_clear_command, process)
+        if not ok then
+            ao.event("debug_cron",
+                     { "error", "Error handling clear command", error = new_process_or_err })
+            return process
+        end
+        return new_process_or_err
+    else
+        ao.event("debug_cron", { "error", "Unknown command received", command = command, command_body = message.body.body })
+        return process
+    end
+end

--- a/scripts/lua-cache-test.lua
+++ b/scripts/lua-cache-test.lua
@@ -1,0 +1,63 @@
+--- Test functions for ao.cache.* bindings
+--- 
+-- Writes a map using ao.cache_write
+-- @param map_to_write The Lua table/map to write
+-- @return The result table from ao.cache_write (e.g., { status = "ok", value = "id_string" })
+function write_test(map_to_write)
+    if map_to_write == nil then
+        return { status = "error", reason = "map_to_write is nil" }
+    end
+	ao.event("cache_test_lua", {"test_write called", {map=map_to_write}})
+	-- ao.cache_write now returns multiple values in Lua (status, value_or_reason)
+	-- based on the Erlang list [Status, ValueOrReason]
+	local status, value_or_reason = ao.cache_write(map_to_write)
+	ao.event("cache_test_lua", {"test_write raw result", {status=status, value_or_reason=value_or_reason}})
+  
+	if status == "ok" then
+	  -- On success, value_or_reason is the ID
+	  return { status = status, value = value_or_reason }
+	else
+	  -- On error, value_or_reason is the ReasonMap
+	  return { status = status, reason = value_or_reason }
+	end
+end
+  
+-- Reads data using ao.cache_read
+-- @param id_or_path The ID or path string
+-- @return The result table from ao.cache_read (e.g., { status = "ok", value = map } or {status="not_found"})
+function read_test(id_or_path)
+    if id_or_path == nil then
+        return { status = "error", reason = "id_or_path is nil" }
+    end
+	ao.event("cache_test_lua", {"test_read called", {id=id_or_path}})
+	-- ao.cache_read returns multiple values (status, value_or_reason)
+	-- OR just one value ('not_found')
+	local status, value_or_reason = ao.cache_read(id_or_path)
+	ao.event("cache_test_lua", {"test_read raw result", {status=status, value_or_reason=value_or_reason}})
+  
+	if status == "ok" then
+	   -- Success case: value_or_reason holds the actual data
+	  return { status = status, value = value_or_reason }
+	elseif status == "not_found" then
+	  -- Not found case: Erlang returned [not_found], so Lua receives status="not_found", value_or_reason=nil
+	  return { status = status }
+	else
+	  -- Error case: status="error", value_or_reason=ReasonMap
+	  return { status = status, reason = value_or_reason }
+	end
+end
+
+-- Test the cache functions
+function test_cache()
+    -- Test writing a map
+    local map_to_write = {
+        test_key = "test_value"
+    }
+    local result = write_test(map_to_write)
+    ao.event("cache_test_lua", {"test_write result", {result=result}})
+
+    -- Test reading the map
+    local id_or_path = result.value
+    local read_result = read_test(id_or_path)
+    ao.event("cache_test_lua", {"test_read result", {result=read_result}})
+end

--- a/src/dev_cron.erl
+++ b/src/dev_cron.erl
@@ -1,14 +1,16 @@
 %%% @doc A device that inserts new messages into the schedule to allow processes
 %%% to passively 'call' themselves without user interaction.
 -module(dev_cron).
--export([once/3, every/3, stop/3, info/1, info/3]).
+-export([list/3, once/3, every/3, stop/3, clear/3, info/1, info/3]).
+-export([normalize/3]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 %% @doc Exported function for getting device info.
 info(_) -> 
-	#{ exports => [info, once, every, stop] }.
+	#{ exports => [info, clear, once, every, stop, list, normalize] }.
 
+%% @doc Exported function for granting a description of the device.
 info(_Msg1, _Msg2, _Opts) ->
 	InfoBody = #{
 		<<"description">> => <<"Cron device for scheduling messages">>,
@@ -17,18 +19,180 @@ info(_Msg1, _Msg2, _Opts) ->
 			<<"info">> => <<"Get device info">>,
 			<<"once">> => <<"Schedule a one-time message">>,
 			<<"every">> => <<"Schedule a recurring message">>,
-			<<"stop">> => <<"Stop a scheduled task {task}">>
+			<<"stop">> => <<"Stop a scheduled task {task}">>,
+			<<"list">> => <<"List all registered cron tasks">>,
+			<<"normalize">> => <<"Boostrap cron jobs from cache">>,
+			<<"clear">> => <<"Clear cache">>
 		}
 	},
 	{ok, #{<<"status">> => 200, <<"body">> => InfoBody}}.
 
+
+%% @doc Modify a given node message to include the cron process.
+cron_opts(Opts) ->
+    {ok, Script} = file:read_file("scripts/cron.lua"),
+    CronProcDef = #{
+        <<"device">> => <<"process@1.0">>,
+        <<"execution-device">> => <<"lua@5.3a">>,
+        <<"function">> => <<"compute">>,
+        <<"module">> => #{
+            <<"content-type">> => <<"application/lua">>,
+            <<"body">> => Script
+        }
+    },
+    ?event({debug_cron_opts, {cron_process_def, CronProcDef}}),
+    Opts#{
+        node_processes =>
+            (hb_opts:get(node_processes, #{}, Opts))#{
+                <<"cron">> => CronProcDef
+            }
+    }.
+
+%% @doc Normalize the cron jobs from cache by attempting to restart them.
+normalize(Msg1, _Msg2, Opts) ->
+	?event({normalize_cron_jobs_start}),
+    CronOpts = cron_opts(Opts),
+    case cache_list(CronOpts) of
+		{ok, Crons} -> 
+			?event({normalize_cron_jobs_loaded, {count, length(Crons)}}),
+            {Successes, Errors} = process_cached_jobs(Crons, Msg1, CronOpts),
+            NumSuccess = length(Successes),
+            ErrorDetails = Errors,
+            ?event({normalize_cron_jobs_finished, 
+				{success_or_existing, NumSuccess}, 
+				{errors, length(ErrorDetails)}, 
+				{error_details, ErrorDetails}}),
+			{ok, #{
+				<<"restarted_or_existing">> => NumSuccess, 
+				<<"errors">> => ErrorDetails
+			}};
+		{error, Reason} ->
+			 ?event({normalize_cron_jobs_load_error, {error, Reason}}),
+             {error, Reason}
+	end.
+
+%% Helper function to process the list of cached cron jobs
+process_cached_jobs(Crons, Msg1, CronOpts) ->
+    Results = lists:map(
+        fun(Job) -> 
+            process_single_job(Job, Msg1, CronOpts)
+        end, Crons
+    ),
+    lists:partition(
+		fun({ok, _}) -> true; 
+		(_) -> false end, 
+		Results).
+
+%% Helper function to process a single cached job entry
+process_single_job(Job, Msg1, CronOpts) ->
+    case extract_job_details(Job) of
+        {ok, DetailsMap} ->
+            case reconstruct_original_msg(DetailsMap) of
+                {ok, OriginalMsg} ->
+                    attempt_job_restart(DetailsMap, OriginalMsg, Msg1, CronOpts);
+                {error, Reason} ->
+                    TaskId = maps:get(task_id, DetailsMap, unknown),
+                    {error, {TaskId, Reason}}
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% Helper function to extract and validate details from a raw cache job entry
+extract_job_details(Job) ->
+    Body = maps:get(<<"body">>, Job, #{}),
+    TaskId = maps:get(<<"task_id">>, Body, undefined),
+    AugmentedData = maps:get(<<"data">>, Body, #{}),
+    Type = maps:get(<<"type">>, AugmentedData, undefined),
+    Interval = maps:get(<<"interval">>, AugmentedData, undefined),
+    CronPath = maps:get(<<"cron_path">>, AugmentedData, undefined),
+    WorkerMsg = maps:get(<<"worker_msg">>, AugmentedData, #{}),
+    if TaskId == undefined orelse Type == undefined orelse CronPath == undefined orelse not is_map(WorkerMsg) orelse WorkerMsg == #{} ->
+        ?event({normalize_skipping_invalid_job, {reason, invalid_structure}, {raw_job, Job}}),
+        {error, {unknown_task_id, invalid_job_structure}};
+       true ->
+            {ok, #{ task_id => TaskId, type => Type, interval => Interval, cron_path => CronPath, worker_msg => WorkerMsg }}
+    end.
+
+%% Helper function to reconstruct the original message for once/every from cached details
+reconstruct_original_msg(DetailsMap) ->
+    #{ task_id := TaskId, type := Type, interval := Interval, cron_path := CronPath, worker_msg := WorkerMsg } = DetailsMap,
+    OtherParams = maps:remove(<<"path">>, WorkerMsg),
+    OriginalMsg0 = maps:put(<<"cron-path">>, CronPath, OtherParams),
+    OriginalMsg1 =
+        (case Type of
+             <<"every">> when Interval =/= null andalso Interval =/= undefined ->
+                 maps:put(<<"interval">>, Interval, OriginalMsg0);
+             _ -> OriginalMsg0
+         end),
+    % Carry the original task_id so that every/3 can reuse it verbatim and
+    % avoid generating a new one during normalisation.
+    OriginalMsg2 = maps:put(<<"task_id">>, TaskId, OriginalMsg1),
+    OriginalMsgPath = <<"/~cron@1.0/", Type/binary>>,
+    OriginalMsg = maps:put(<<"path">>, OriginalMsgPath, OriginalMsg2),
+    {ok, OriginalMsg}.
+
+%% Helper function to attempt the restart of a single job
+attempt_job_restart(DetailsMap, OriginalMsg, Msg1, CronOpts) ->
+    #{ task_id := TaskId, type := Type } = DetailsMap,
+    %?event({normalize_attempting_restart, {task_id, TaskId}, {type, Type}, {original_msg_preview, OriginalMsg#{ 
+    %     commitments => commitments
+    % }}}),
+    case Type of
+        <<"once">> -> 
+            case once(Msg1, OriginalMsg, CronOpts) of
+                {ok, ReturnedId} -> 
+                     % Success if original ID matches OR a new ID was returned (idempotency handled)
+                    ?event({normalize_once_success, {task_id, TaskId}, {returned_id, ReturnedId}}),
+                    {ok, TaskId};
+                Error -> 
+                    ?event({normalize_once_error, {task_id, TaskId}, {error, Error}}),
+                    {error, {TaskId, Error}}
+            end;
+        <<"every">> -> 
+            case every(Msg1, OriginalMsg, CronOpts) of
+                 {ok, ReturnedId} -> 
+                     % Success if original ID matches OR a new ID was returned (idempotency handled)
+                    ?event({normalize_every_success, {task_id, TaskId}, {returned_id, ReturnedId}}),
+                    {ok, TaskId};
+                Error -> 
+                    ?event({normalize_every_error, {task_id, TaskId}, {error, Error}}),
+                    {error, {TaskId, Error}}
+            end;
+        _ ->
+            ?event({normalize_unknown_type, {task_id, TaskId}, {type, Type}}),
+            {error, {TaskId, unknown_type}}
+    end.
+
+%% @doc List all registered cron tasks.
+list(_, _, Opts) ->
+    CronOpts = cron_opts(Opts),
+    ?event({list_cron_jobs_start, {cron_opts, CronOpts}}),
+    case cache_list(CronOpts) of
+        {ok, Crons} ->
+            ?event({list_cron_jobs_success, {crons, Crons}}),
+            {ok, #{<<"crons">> => Crons}};
+        {error, Reason} ->
+            ?event({list_cron_jobs_error, {error, Reason}}),
+            {error, Reason}
+    end.
+
+
 %% @doc Exported function for scheduling a one-time message.
 once(_Msg1, Msg2, Opts) ->
+	% Allow callers (e.g. normalisation) to pin the TaskId explicitly so that
+	% we do not re-hash the message and end up with a *different* id after a
+	% reboot.  If the caller passes `task_id` we MUST reuse it verbatim.
+	PinnedId = hb_ao:get(<<"task_id">>, Msg2, undefined, Opts),
 	case hb_ao:get(<<"cron-path">>, Msg2, Opts) of
 		not_found ->
 			{error, <<"No cron path found in message.">>};
 		CronPath ->
-			ReqMsgID = hb_message:id(Msg2, all, Opts),
+			ReqMsgID =
+				case PinnedId of
+					undefined -> hb_message:id(Msg2, all);
+					Id when is_binary(Id) -> Id
+				end,
 			% make the path specific for the end device to be used
 			ModifiedMsg2 =
                 maps:remove(
@@ -36,32 +200,58 @@ once(_Msg1, Msg2, Opts) ->
                     maps:put(<<"path">>, CronPath, Msg2)
                 ),
 			Name = {<<"cron@1.0">>, ReqMsgID},
-			Pid = spawn(fun() -> once_worker(CronPath, ModifiedMsg2, Opts) end),
-			hb_name:register(Name, Pid),
-			{ok, ReqMsgID}
+			case hb_name:lookup(Name) of
+				Pid when is_pid(Pid) ->
+					% Process already registered, return existing TaskID
+					?event({once_already_registered, {task_id, ReqMsgID}, {pid, Pid}}),
+					{ok, ReqMsgID};
+				undefined ->
+					% Process not found, spawn and register
+                    Pid = spawn(fun() -> once_worker(CronPath, ModifiedMsg2, Opts) end),
+					hb_name:register(Name, Pid),
+					% Define the data structure for the cache
+					MinimalAugmentedData = #{ 
+						<<"type">> => <<"once">>,
+                        % No interval for 'once'
+						<<"interval">> => null, 
+						<<"worker_msg">> => ModifiedMsg2,
+                        % Persist the real target path
+						<<"cron_path">> => CronPath               
+					},
+					% Cache the augmented task data
+					{ok, PutResult} = cache_put(ReqMsgID, MinimalAugmentedData, cron_opts(Opts)),
+					?event({once_cache_put_result, {result, PutResult}}),
+					{ok, ReqMsgID}
+			end
 	end.
 
 %% @doc Internal function for scheduling a one-time message.
 once_worker(Path, Req, Opts) ->
-	% Directly call the meta device on the newly constructed 'singleton', just
+    % Directly call the meta device on the newly constructed 'singleton', just
     % as hb_http_server does.
-    TracePID = hb_tracer:start_trace(),
-	try
-		dev_meta:handle(Opts#{ trace => TracePID }, Req#{ <<"path">> => Path})
-	catch
-		Class:Reason:Stacktrace ->
-			?event(
-                {cron_every_worker_error,
+    try
+        dev_meta:handle(Opts, Req#{ <<"path">> => Path})
+    catch
+        %% Cowboy / Ranch listener is gone (node stopped) – exit quietly
+        error:badarg ->
+            exit(normal);
+        Class:Reason:Stacktrace ->
+            ?event(
+                {cron_once_worker_error,
                     {path, Path},
                     {error, Class, Reason, Stacktrace}
                 }
             ),
-			throw({error, Class, Reason, Stacktrace})
-	end.
+            exit({Class, Reason, Stacktrace})
+    end.
 
 
 %% @doc Exported function for scheduling a recurring message.
 every(_Msg1, Msg2, Opts) ->
+	% Allow callers (e.g. normalisation) to pin the TaskId explicitly so that
+	% we do not re-hash the message and end up with a *different* id after a
+	% reboot.  If the caller passes `task_id` we MUST reuse it verbatim.
+	PinnedId = hb_ao:get(<<"task_id">>, Msg2, undefined, Opts),
 	case {
 		hb_ao:get(<<"cron-path">>, Msg2, Opts),
 		hb_ao:get(<<"interval">>, Msg2, Opts)
@@ -78,27 +268,55 @@ every(_Msg1, Msg2, Opts) ->
 				true ->
 					ok
 				end,
-				ReqMsgID = hb_message:id(Msg2, all, Opts),
+				ReqMsgID =
+					case PinnedId of
+						undefined -> hb_message:id(Msg2, all);
+						Id when is_binary(Id) -> Id
+					end,
 				ModifiedMsg2 =
                     maps:remove(
                         <<"cron-path">>,
                         maps:remove(<<"interval">>, Msg2)
                     ),
-				TracePID = hb_tracer:start_trace(),
-				Pid =
-                    spawn(
-                        fun() ->
-                            every_worker_loop(
-                                CronPath,
-                                ModifiedMsg2,
-                                Opts#{ trace => TracePID },
-                                IntervalMillis
-                            )
-                        end
-                    ),
 				Name = {<<"cron@1.0">>, ReqMsgID},
-				hb_name:register(Name, Pid),
-				{ok, ReqMsgID}
+				case hb_name:lookup(Name) of
+					Pid when is_pid(Pid) ->
+						% Process already registered, return existing TaskID
+						?event({every_already_registered, {task_id, ReqMsgID}, {pid, Pid}}),
+						{ok, ReqMsgID};
+					undefined ->
+						% Process not found, spawn and register
+						Pid =
+		                    spawn(
+		                        fun() ->
+		                            every_worker_loop(
+		                                CronPath,
+		                                ModifiedMsg2,
+		                                Opts,
+		                                IntervalMillis
+		                            )
+		                        end
+		                    ),
+						hb_name:register(Name, Pid),
+						% Define the data structure for the cache
+						MinimalAugmentedData = #{ 
+							<<"type">> => <<"every">>,
+							<<"interval">> => IntervalString,
+							<<"worker_msg">> => ModifiedMsg2,
+							<<"cron_path">> => CronPath               % Persist the real target path
+						},
+                        % First check if the task ID already exists in the cache
+                        % if it does, we need to remove it first
+                        case cache_get(ReqMsgID, cron_opts(Opts)) of
+                            {ok, _} ->
+                                cache_remove(ReqMsgID, cron_opts(Opts));
+                            _ -> ok
+                        end,
+						% Cache the augmented task data
+						{ok, PutResult} = cache_put(ReqMsgID, MinimalAugmentedData, cron_opts(Opts)),
+						?event({every_cache_put_result, {result, PutResult}}),
+						{ok, ReqMsgID}
+				end
 			catch
 				error:{invalid_time_unit, Unit} ->
                     {error, <<"Invalid time unit: ", Unit/binary>>};
@@ -108,6 +326,31 @@ every(_Msg1, Msg2, Opts) ->
 					{error, {<<"Error parsing interval">>, Reason}}
 			end
 	end.
+every_worker_loop(CronPath, Req, Opts, IntervalMillis) ->
+    Req1 = Req#{<<"path">> => CronPath},
+    ?event(
+        {cron_every_worker_executing,
+            {path, CronPath},
+            {req_id, hb_message:id(Req, all, Opts)}
+        }
+    ),
+	try
+		Result = dev_meta:handle(Opts, Req1),
+		?event({cron_every_worker_executed, {path, CronPath}, {result, Result}})
+	catch
+        error:badarg ->
+            exit(normal);
+		Class:Reason:Stacktrace ->
+			?event(
+                {cron_every_worker_error,
+                    {path, CronPath},
+                    {error, Class, Reason, Stacktrace}
+                }
+            ),
+            exit(Class, Reason)
+	end,
+	timer:sleep(IntervalMillis),
+	every_worker_loop(CronPath, Req, Opts, IntervalMillis).
 
 %% @doc Exported function for stopping a scheduled task.
 stop(_Msg1, Msg2, Opts) ->
@@ -121,6 +364,8 @@ stop(_Msg1, Msg2, Opts) ->
 					?event({cron_stopping_task, {task_id, TaskID}, {pid, Pid}}),
 					exit(Pid, kill),
 					hb_name:unregister(Name),
+					{ok, RemoveResult} = cache_remove(TaskID, cron_opts(Opts)),
+					?event({stop_cache_remove_result, {result, RemoveResult}}),
 					{ok, #{<<"status">> => 200, <<"body">> => #{
 						<<"message">> => <<"Task stopped successfully">>,
 						<<"task_id">> => TaskID
@@ -137,26 +382,6 @@ stop(_Msg1, Msg2, Opts) ->
 			end
 	end.
 
-every_worker_loop(CronPath, Req, Opts, IntervalMillis) ->
-    Req1 = Req#{<<"path">> => CronPath},
-    ?event(
-        {cron_every_worker_executing,
-            {path, CronPath},
-            {req_id, hb_message:id(Req, all, Opts)}
-        }
-    ),
-    try
-        dev_meta:handle(Opts, Req1),
-        ?event({cron_every_worker_executed, {path, CronPath}})
-    catch
-        Class:Reason:Stack ->
-            ?event(cron_error, {cron_every_worker_error,
-                    {path, CronPath},
-                    {error, Class, Reason, Stack}})
-    end,
-    timer:sleep(IntervalMillis),
-    every_worker_loop(CronPath, Req, Opts, IntervalMillis).
-
 %% @doc Parse a time string into milliseconds.
 parse_time(BinString) ->
 	[AmountStr, UnitStr] = binary:split(BinString, <<"-">>),
@@ -171,11 +396,153 @@ parse_time(BinString) ->
 		_ -> throw({error, invalid_time_unit, UnitStr})
 	end.
 
-%%% Tests
 
+%% Cache functions and helpers
+%% @doc Helper function to send commands to the cron process
+send_cron_command(Command, Body, Opts) ->
+    SampleMsg = [
+        #{ <<"device">> => <<"node-process@1.0">> },
+        <<"cron">>,
+        #{
+            <<"path">> => <<"schedule">>,
+            <<"method">> => <<"POST">>,
+            <<"body">> =>
+                hb_message:commit(
+                    #{
+                        <<"path">> => <<"compute">>,
+                        <<"body">> => Body#{<<"path">> => Command}
+                    },
+                    Opts
+                )
+        }
+    ],
+    Result = hb_ao:resolve_many(SampleMsg, Opts),
+    ?event({cron_command_result, {command, Command}, {result, Result}}),
+    Result.
+
+%% @doc Put a value in the cache with the specified task ID
+%% Returns {ok, TaskId} on success
+cache_put(TaskId, AugmentedData, Opts) ->
+	?event({cache_put_start, {task_id, TaskId}, {augmented_data, AugmentedData}}),
+    send_cron_command(
+		<<"put">>,
+		#{ 
+			<<"task_id">> => TaskId,
+        	<<"data">> => AugmentedData % Pass the augmented data map
+    	},
+		Opts
+	),
+	{ok, TaskId}.
+
+%% @doc Get a value from the cache by task ID
+%% Returns {ok, Value} if found, {error, not_found} otherwise
+cache_get(TaskId, Opts) ->
+    AllJobs = hb_ao:get(
+        << "cron/now/crons" >>,
+        #{ <<"device">> => <<"node-process@1.0">> },
+        Opts
+    ),
+    find_job_by_task_id(AllJobs, TaskId).
+
+%% @doc Remove a value from the cache by task ID
+%% Returns {ok, removed} if successful
+cache_remove(TaskId, Opts) ->
+    send_cron_command(
+		<<"remove">>, 
+		#{
+        	<<"task_id">> => TaskId
+    	}, 
+	Opts),
+{ok, removed}.
+
+cache_list(Opts) ->
+	?event({cache_list_start}),
+	SampleMsg = [
+		#{ <<"device">> => <<"node-process@1.0">> },
+		<<"cron">>,
+		#{ 
+			<<"path">> => <<"now/crons">>, 
+			<<"method">> => <<"GET">>,
+            <<"spawn">> => true
+		}
+	],
+	{ok, Result} = hb_ao:resolve_many(SampleMsg, Opts),
+	CronData = hb_ao:get(<<"crons">>, Result, #{}),
+	?event({cache_list_cron_data, {cron_data, CronData}}),
+    case CronData of
+        % for when there are no jobs yet
+        not_found -> {ok, []};
+        % for when there are jobs
+        List when is_list(List) -> {ok, List};
+        % for when there is an error
+        Other -> {error, Other}
+    end.
+
+%% @doc Clear all values from the cache
+%% Returns {ok, cleared} on success
+cache_clear(Opts) ->
+    send_cron_command(<<"clear">>, #{}, Opts),
+    {ok, cleared}.
+
+%% @doc Helper function to find a job by task ID in a list of jobs
+%% Handle “no crons”
+find_job_by_task_id(not_found, _TaskId) ->
+    {error, not_found};
+
+find_job_by_task_id([], _) ->
+    {error, not_found};
+
+find_job_by_task_id([Job|Rest], TaskId) ->
+	?event({find_job_by_task_id, {job, Job}, {task_id, TaskId}}),
+    case hb_ao:get(<<"body/task_id">>, Job, #{}) of
+        TaskId -> 
+            JobData = hb_ao:get(<<"body/data">>, Job, #{}),
+            ?event({found_job_by_task_id_job_data, {job_data, JobData}}),
+            {ok, JobData};
+        _ -> find_job_by_task_id(Rest, TaskId)
+    end.
+
+
+%%%
+%%% Cron device tests
+%%%
+% Helper functions to generate test opts
+generate_test_opts() ->
+	{ok, Script} = file:read_file("scripts/cron.lua"),
+	generate_test_opts(#{
+		<<"cron">> => #{
+			<<"device">> => <<"process@1.0">>,
+			<<"execution-device">> => <<"lua@5.3a">>,
+			<<"scheduler-device">> => <<"scheduler@1.0">>,
+			<<"module">> => #{
+				<<"content-type">> => <<"application/lua">>,
+				<<"body">> => Script
+			}
+		}
+	}).
+generate_test_opts(Defs) ->
+#{
+	store =>
+		[
+			#{
+				<<"store-module">> => hb_store_fs,
+				<<"prefix">> =>
+					<<
+						"cache-TEST-",
+						(integer_to_binary(os:system_time(millisecond)))/binary
+					>>
+			}
+		],
+	node_processes => Defs,
+	priv_wallet => ar_wallet:new()
+}.
+
+%% @doc This test verifies that a one-time task can be stopped by
+%% calling the stop function with the task ID.
 stop_once_test() ->
+	Opts = generate_test_opts(),
 	% Start a new node
-	Node = hb_http_server:start_node(),
+	Node = hb_http_server:start_node(Opts),
 	% Set up a standard test worker (even though delay doesn't use its state)
 	TestWorkerPid = spawn(fun test_worker/0),
 	TestWorkerNameId = hb_util:human_id(crypto:strong_rand_bytes(32)),
@@ -204,7 +571,6 @@ stop_once_test() ->
 	timer:sleep(100),
 	% Verify process termination
 	?assertNot(erlang:is_process_alive(OncePid), "Process not killed by stop"),
-	
 	% Call stop again to verify 404 response
 	{error, <<"Task not found.">>} = hb_http:get(Node, OnceStopPath, #{}).
 
@@ -212,8 +578,9 @@ stop_once_test() ->
 %% @doc This test verifies that a recurring task can be stopped by
 %% calling the stop function with the task ID.
 stop_every_test() ->
+	Opts = generate_test_opts(),
 	% Start a new node
-	Node = hb_http_server:start_node(),
+	Node = hb_http_server:start_node(Opts),
 	% Set up a test worker process to hold state (counter)
 	TestWorkerPid = spawn(fun test_worker/0),
 	TestWorkerNameId = hb_util:human_id(crypto:strong_rand_bytes(32)),
@@ -257,8 +624,9 @@ stop_every_test() ->
 
 %% @doc This test verifies that a one-time task can be scheduled and executed.
 once_executed_test() ->
+	Opts = generate_test_opts(),
 	% start a new node 
-	Node = hb_http_server:start_node(),
+	Node = hb_http_server:start_node(Opts),
 	% spawn a worker on the new node that calls test_worker/0 which inits
     % test_worker/1 with a state of undefined
 	PID = spawn(fun test_worker/0),
@@ -271,7 +639,10 @@ once_executed_test() ->
 			"&cron-path=/~test-device@1.0/update_state">>,
 	% this should call the worker via the test device
 	% the test device should look up the worker via the id given 
-	{ok, _ReqMsgId} = hb_http:get(Node, UrlPath, #{}),
+	{ok, ReqMsgId1} = hb_http:get(Node, UrlPath, #{}),
+	% Call again to test idempotency
+	{ok, ReqMsgId2} = hb_http:get(Node, UrlPath, #{}),
+	?assertEqual(ReqMsgId1, ReqMsgId2, "Second call should return the same Task ID"),
 	% wait for the request to be processed
 	timer:sleep(1000),
 	% send a message to the worker to get the state
@@ -289,7 +660,8 @@ once_executed_test() ->
 
 %% @doc This test verifies that a recurring task can be scheduled and executed.
 every_worker_loop_test() ->
-	Node = hb_http_server:start_node(),
+	Opts = generate_test_opts(),
+	Node = hb_http_server:start_node(Opts),
 	PID = spawn(fun test_worker/0),
 	ID = hb_util:human_id(crypto:strong_rand_bytes(32)),
 	hb_name:register({<<"test">>, ID}, PID),
@@ -297,8 +669,12 @@ every_worker_loop_test() ->
 		"&interval=500-milliseconds",
 		"&cron-path=/~test-device@1.0/increment_counter">>,
 	?event({'cron:every:test:sendUrl', {url_path, UrlPath}}),
-	{ok, ReqMsgId} = hb_http:get(Node, UrlPath, #{}),
-	?event({'cron:every:test:get_done', {req_id, ReqMsgId}}),
+	{ok, ReqMsgId1} = hb_http:get(Node, UrlPath, #{}),
+	?event({'cron:every:test:get_done', {req_id, ReqMsgId1}}),
+	% Call again to test idempotency
+	{ok, ReqMsgId2} = hb_http:get(Node, UrlPath, #{}),
+	?assertEqual(ReqMsgId1, ReqMsgId2, "Second call should return the same Task ID"),
+	?event({'cron:every:test:idempotency_check_done', {req_id, ReqMsgId2}}),
 	timer:sleep(1500),
 	PID ! {get, self()},
 	% receive the state from the worker
@@ -311,20 +687,372 @@ every_worker_loop_test() ->
 		?event({'cron:every:test:timeout', {pid, PID}, {lookup_result, FinalLookup}}),
 		throw({test_timeout_waiting_for_state, {id, ID}})
 	end.
-	
+
+%% @doc Test that verifies a one-time job is added to 
+%% the cron cache and can be loaded via the load endpoint
+once_cron_cache_list_test() ->
+    Opts = generate_test_opts(),
+    % Start a new node with test options
+    Node = hb_http_server:start_node(Opts),
+    % Create a test worker
+    PID = spawn(fun test_worker/0),
+    ID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    hb_name:register({<<"test">>, ID}, PID),
+    % Create a "once" task
+    UrlPath = <<"/~cron@1.0/once?test-id=", ID/binary,
+              "&cron-path=/~test-device@1.0/update_state">>,
+    {ok, ReqMsgId} = hb_http:get(Node, UrlPath, #{}),
+    ?event({once_load_test_created, {task_id, ReqMsgId}}),
+    % Wait for the task to be processed
+    timer:sleep(1000),
+	% Use the cache list function to retrieve cron jobs
+	{ok, Crons} = cache_list(Opts),
+	?event({once_cron_cache_load_test_crons, {crons, Crons}}),
+    % % Use the load function to retrieve cron jobs
+	{ok, LoadedCrons} = hb_ao:resolve_many(
+        hb_singleton:from(#{
+            <<"path">> => <<"/~cron@1.0/list">>
+        }),
+        Opts
+    ),
+    ?event({once_load_test_loaded, {loaded_crons, LoadedCrons}}),
+    % Extract the list of cron jobs from the result map
+    CronsList = hb_ao:get(<<"crons">>, LoadedCrons, #{}),
+    ?event({once_load_test_extracted, {crons_list, CronsList}}),
+    % Verify the task is in the loaded list
+    Res = find_job_by_task_id(CronsList, ReqMsgId),
+    ?event({once_load_test_job, {res, Res}}),
+    ?assertMatch({ok, _}, Res),
+    ?event({'once_load_test_done'}).
+
+%% @doc Test that verifies a recurring job is added to
+%% the cron cache and can be loaded via cache_list.
+every_cron_cache_list_test() ->
+    Opts = generate_test_opts(),
+    % Start a new node with test options
+    Node = hb_http_server:start_node(Opts),
+    % Create a test worker
+    PID = spawn(fun test_worker/0),
+    ID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    hb_name:register({<<"test">>, ID}, PID),
+    % Create an "every" task
+    UrlPath = <<"/~cron@1.0/every?test-id=", ID/binary,
+              "&interval=500-milliseconds", % Specify interval
+              "&cron-path=/~test-device@1.0/increment_counter">>, % Specify target path
+    {ok, ReqMsgId} = hb_http:get(Node, UrlPath, #{}),
+    ?event({every_load_test_created, {task_id, ReqMsgId}}),
+    % Wait for the task to be processed and added to the cache
+    timer:sleep(100), % Short sleep just to ensure cache_put completes
+    % Use the cache list function to retrieve cron jobs
+    {ok, Crons} = cache_list(Opts),
+    ?event({every_cron_cache_list_test_crons, {crons, Crons}}),
+    % Verify the task is in the loaded list
+    ?assertMatch({ok, _}, find_job_by_task_id(Crons, ReqMsgId)),
+    ?event({'every_load_test_done'}).
+
+cron_device_load_test() ->
+	% This test checks whether the cron load function returns 
+	% the correct data
+	Opts = generate_test_opts(),
+	Node = hb_http_server:start_node(Opts),
+	TaskId = <<"load-test-task-id">>,
+	TestData = #{<<"key">> => <<"value">>, <<"timestamp">> => os:system_time(millisecond)},
+	{ok, _PutResult} = cache_put(TaskId, TestData, Opts),
+	TaskId2 = <<"load-test-task-id-2">>,
+	TestData2 = #{<<"key">> => <<"value-2">>, <<"timestamp">> => os:system_time(millisecond)},
+	{ok, _PutResult2} = cache_put(TaskId2, TestData2, Opts),
+	UrlPath = <<"/~cron@1.0/list">>,
+	{ok, LoadedCrons} = hb_http:get(Node, UrlPath, #{}),
+	CronsList = hb_ao:get(<<"crons">>, LoadedCrons, #{}),
+	{ok, RetrievedData} = find_job_by_task_id(CronsList, TaskId),
+	{ok, RetrievedData2} = find_job_by_task_id(CronsList, TaskId2),
+	CleanedData = maps:remove(<<"priv">>, RetrievedData),
+	CleanedData2 = maps:remove(<<"priv">>, RetrievedData2),
+	?assertEqual(TestData, CleanedData),
+	?assertEqual(TestData2, CleanedData2),
+	?event({'cache_load_test_done'}).
+
 %% @doc This is a helper function that is used to test the cron device.
 %% It is used to increment a counter and update the state of the worker.
 test_worker() -> test_worker(#{count => 0}).
 test_worker(State) ->
 	receive
 		{increment} ->
-			NewCount = maps:get(count, State, 0) + 1,
+            % ensure that count is defined in the case that a full message
+            % is already in the state.
+			Current = case State of
+                #{count := N} -> N;
+                _             -> 0
+            end,
+            NewCount = Current + 1,
 			?event({'test_worker:incremented', {new_count, NewCount}}),
-			test_worker(State#{count := NewCount});
+			NewState = maps:put(count, NewCount, State),
+			test_worker(NewState);
 		{update, NewState} ->
 			 ?event({'test_worker:updated', {new_state, NewState}}),
 			 test_worker(NewState);
 		{get, Pid} ->
 			Pid ! {state, State},
-			test_worker(State)
+			test_worker(State);
+        _Other ->
+            test_worker(State)
 	end.
+
+
+% Cache test framework for cron.lua via the node-process devices
+cache_put_test() ->
+	Opts = generate_test_opts(),
+	TaskId = <<"test-task-id">>,
+	TestData = #{<<"key">> => <<"value">>, <<"timestamp">> => os:system_time(millisecond)},
+	% Put the data in the cache
+	{ok, PutResult} = cache_put(TaskId, TestData, Opts),
+	?event({cache_put_test_result, {task_id, TaskId}, {result, PutResult}}),
+	?assertEqual(TaskId, PutResult),
+	timer:sleep(100),
+	% Verify the data was stored by retrieving the crons list
+	StoredData = hb_ao:get(
+		<<"cron/now/crons">>,
+		#{ <<"device">> => <<"node-process@1.0">> },
+		Opts
+	),
+	?event({cache_put_test_stored_data, {stored_data, StoredData}}),
+	% % Verify we can find our task in the stored data
+	{ok, RetrievedData} = find_job_by_task_id(StoredData, TaskId),
+	CleanedData = maps:remove(<<"priv">>, RetrievedData),
+	?event({cache_put_test_retrieved, {retrieved_data, CleanedData}}),
+	?assertEqual(TestData, CleanedData),
+	?event({'cache_put_test_done'}).
+
+%% @doc Test the cache_remove function
+cache_remove_test() ->
+    Opts = generate_test_opts(),
+    TaskId = <<"test-remove-task-id">>,
+    TestData = #{<<"key">> => <<"value-to-remove">>, <<"timestamp">> => os:system_time(millisecond)},
+    % First put the data in the cache
+    {ok, PutResult} = cache_put(TaskId, TestData, Opts),
+    ?event({cache_remove_test_put, {task_id, TaskId}, {result, PutResult}}),
+    ?assertEqual(TaskId, PutResult),
+    timer:sleep(100),
+    % Verify the data was stored
+    StoredData = hb_ao:get(
+        <<"cron/now/crons">>,
+        #{ <<"device">> => <<"node-process@1.0">> },
+        Opts
+    ),
+    ?event({cache_remove_test_stored, {stored_data, StoredData}}),
+    % Verify we can find our task
+    {ok, RetrievedData} = find_job_by_task_id(StoredData, TaskId),
+    ?event({cache_remove_test_retrieved, {retrieved_data, RetrievedData}}),
+    CleanedData = maps:remove(<<"priv">>, RetrievedData),
+    ?assertEqual(TestData, CleanedData),
+    % Now remove the data
+    {ok, RemoveResult} = cache_remove(TaskId, Opts),
+    ?event({cache_remove_test_remove, {result, RemoveResult}}),
+    ?assertEqual(removed, RemoveResult),
+    timer:sleep(100),
+    % Verify the data was removed
+    UpdatedData = hb_ao:get(
+        <<"cron/now/crons">>,
+        #{ <<"device">> => <<"node-process@1.0">> },
+        Opts
+    ),
+    ?event({cache_remove_test_after, {updated_data, UpdatedData}}),
+    % Verify the task is no longer found
+    NotFoundResult = find_job_by_task_id(UpdatedData, TaskId),
+    ?assertEqual({error, not_found}, NotFoundResult),
+    ?event({'cache_remove_test_done'}).
+
+%% @doc Test the cache_list function
+cache_list_test() ->
+    Opts = generate_test_opts(),
+    % Create a few task IDs and test data
+    TaskId1 = <<"test-list-task-1">>,
+    TaskId2 = <<"test-list-task-2">>,
+    TestData1 = #{<<"key">> => <<"value-1">>, <<"timestamp">> => os:system_time(millisecond)},
+    TestData2 = #{<<"key">> => <<"value-2">>, <<"timestamp">> => os:system_time(millisecond)},
+    % Clear any existing data first (for test isolation)
+    {ok, _} = cache_clear(Opts),
+    timer:sleep(100),
+    % Put the test data in the cache
+    {ok, PutResult1} = cache_put(TaskId1, TestData1, Opts),
+    {ok, PutResult2} = cache_put(TaskId2, TestData2, Opts),
+    ?event({cache_list_test_put, {task_id1, TaskId1}, {task_id2, TaskId2}}),
+    ?assertEqual(TaskId1, PutResult1),
+    ?assertEqual(TaskId2, PutResult2),
+    timer:sleep(100),
+    % List all values in the cache
+    {ok, AllJobs} = cache_list(Opts),
+    ?event({cache_list_test_all_jobs, {all_jobs, AllJobs}}),
+    % Verify we can find both tasks in the list
+    {ok, RetrievedData1} = find_job_by_task_id(AllJobs, TaskId1),
+    {ok, RetrievedData2} = find_job_by_task_id(AllJobs, TaskId2),
+    % Clean the data for comparison
+    CleanedData1 = maps:remove(<<"priv">>, RetrievedData1),
+    CleanedData2 = maps:remove(<<"priv">>, RetrievedData2),
+    % Verify the data matches
+    ?assertEqual(TestData1, CleanedData1),
+    ?assertEqual(TestData2, CleanedData2),
+    % Verify the list length
+    ?assertEqual(2, length(AllJobs)),
+    ?event({'cache_list_test_done'}).
+
+%% @doc Test the cache_clear function
+cache_clear_test() ->
+    Opts = generate_test_opts(),
+    % Create test data
+    TaskId1 = <<"test-clear-task-1">>,
+    TaskId2 = <<"test-clear-task-2">>,
+    TestData1 = #{<<"key">> => <<"value-to-clear-1">>, <<"timestamp">> => os:system_time(millisecond)},
+    TestData2 = #{<<"key">> => <<"value-to-clear-2">>, <<"timestamp">> => os:system_time(millisecond)},
+    % Add data to the cache
+    {ok, PutResult1} = cache_put(TaskId1, TestData1, Opts),
+    {ok, PutResult2} = cache_put(TaskId2, TestData2, Opts),
+    ?event({cache_clear_test_put, {task_id1, TaskId1}, {task_id2, TaskId2}}),
+    ?assertEqual(TaskId1, PutResult1),
+    ?assertEqual(TaskId2, PutResult2),
+    timer:sleep(100),
+    % Verify the data was stored
+    {ok, AllJobsBefore} = cache_list(Opts),
+    ?event({cache_clear_test_before, {all_jobs, AllJobsBefore}}),
+    ?assert(length(AllJobsBefore) >= 2),
+    % Clear the cache
+    {ok, ClearResult} = cache_clear(Opts),
+    ?event({cache_clear_test_clear, {result, ClearResult}}),
+    ?assertEqual(cleared, ClearResult),
+    timer:sleep(100),
+    % Verify the cache is empty
+    {ok, AllJobsAfter} = cache_list(Opts),
+    ?event({cache_clear_test_after, {all_jobs, AllJobsAfter}}),
+    ?assertEqual(0, length(AllJobsAfter)),
+    ?event({'cache_clear_test_done'}).
+
+%% @doc Test the cache_get function
+cache_get_test() ->
+    Opts = generate_test_opts(),
+    TaskId = <<"test-get-task-id">>,
+    TestData = #{<<"key">> => <<"value-to-get">>, <<"timestamp">> => os:system_time(millisecond)},
+    % First put the data in the cache
+    {ok, PutResult} = cache_put(TaskId, TestData, Opts),
+    ?event({cache_get_test_put, {task_id, TaskId}, {result, PutResult}}),
+    ?assertEqual(TaskId, PutResult),
+    timer:sleep(100),
+    % Get the data from the cache
+    {ok, RetrievedData} = cache_get(TaskId, Opts),
+    ?event({cache_get_test_retrieved, {retrieved_data, RetrievedData}}),
+    % Clean the data for comparison
+    CleanedData = maps:remove(<<"priv">>, RetrievedData),
+    % Verify the data matches
+    ?assertEqual(TestData, CleanedData),
+    % Test getting a non-existent task
+    NonExistentResult = cache_get(<<"non-existent-task">>, Opts),
+    ?assertEqual({error, not_found}, NonExistentResult),
+    ?event({'cache_get_test_done'}).
+
+normalize_test() ->
+    Opts = generate_test_opts(),
+    Node = hb_http_server:start_node(Opts),
+    % Setup test worker
+    PID = spawn(fun test_worker/0),
+    ID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    hb_name:register({<<"test">>, ID}, PID),
+    % Create a once job
+    OnceUrlPath = <<"/~cron@1.0/once?test-id=", ID/binary,
+                   "&cron-path=/~test-device@1.0/update_state">>,
+    {ok, _OnceTaskId} = hb_http:get(Node, OnceUrlPath, #{}),
+    ?event({'normalize_test_once_created'}),
+    % Create an every job
+    EveryUrlPath = <<"/~cron@1.0/every?test-id=", ID/binary,
+                    "&interval=1000-milliseconds", % Use a reasonable interval
+                    "&cron-path=/~test-device@1.0/increment_counter">>,
+    {ok, _EveryTaskId} = hb_http:get(Node, EveryUrlPath, #{}),
+    ?event({'normalize_test_every_created'}),
+    timer:sleep(100), 
+    NormalizeUrlPath = <<"/~cron@1.0/normalize">>,
+    ?event({'normalize_test_calling_normalize', {url, NormalizeUrlPath}}),
+    {ok, NormalizeResult} = hb_http:get(Node, NormalizeUrlPath, #{}),
+    ?event({'normalize_test_normalize_result', {result, NormalizeResult}}),
+    ?assertMatch(#{ 
+        <<"status">> := 200,
+        <<"restarted_or_existing">> := _,
+        <<"errors">> := _
+    }, NormalizeResult),
+    ?event({'normalize_test_done'}).
+
+start_hook_normalize_test() ->
+	Opts = generate_test_opts(),
+	Node = hb_http_server:start_node(Opts),
+	?event({start_hook_normalize_test}),
+	% schedule a once job
+	PID = spawn(fun test_worker/0),
+    ID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    hb_name:register({<<"test">>, ID}, PID),
+	OnceUrlPath = <<"/~cron@1.0/once?test-id=", ID/binary,
+                   "&cron-path=/~test-device@1.0/update_state">>,
+    {ok, _OnceTaskId} = hb_http:get(Node, OnceUrlPath, #{}),
+	?event({start_hook_normalize_test, once_created}),
+	% stop the node.
+	Res = hb_http_server:stop_node(Opts),
+	?event({start_hook_normalize_test, node_stopped, Res}),
+	HookNodeOpts = maps:merge(Opts, #{
+		on => #{
+			<<"start">> => #{
+				<<"device">> => <<"cron@1.0">>,
+				<<"path">> => <<"normalize">>,
+				<<"hook">> => #{ <<"result">> => <<"ignore">> }
+			}
+		}
+	}),
+	% ?event({start_hook_normalize_test, hook_node_opts, HookNodeOpts}),
+	HookNode = hb_http_server:start_node(HookNodeOpts),
+	% ?event({start_hook_normalize_test, hook_node_started, HookNode}),
+	timer:sleep(200),
+	% check the cron cache list
+	{ok, Crons} = cache_list(HookNodeOpts),
+	% verify we can find the once job in the crons list after node start
+	?assertMatch({ok, _}, find_job_by_task_id(Crons, _OnceTaskId)),
+	?event({start_hook_normalize_test, test_end}).
+
+%% @doc Clear all cron tasks.
+clear(_Msg1, _Msg2, Opts) ->
+    CronOpts = cron_opts(Opts),
+    case cache_clear(CronOpts) of
+        {ok, cleared} ->
+            {ok, #{
+                <<"status">> => 200,
+                <<"body">> => #{ <<"message">> => <<"All cron tasks cleared">> }
+            }};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% @doc Test that normalize doesn't create duplicate cron jobs
+normalize_no_duplicates_test() ->
+    Opts = generate_test_opts(),
+    Node = hb_http_server:start_node(Opts),
+    % Setup test worker
+    PID = spawn(fun test_worker/0),
+    ID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    hb_name:register({<<"test">>, ID}, PID),
+    % Create cron jobs
+    OnceUrlPath = <<"/~cron@1.0/once?test-id=", ID/binary,
+                   "&cron-path=/~test-device@1.0/update_state">>,
+    {ok, _OnceTaskId} = hb_http:get(Node, OnceUrlPath, #{}),
+    EveryUrlPath = <<"/~cron@1.0/every?test-id=", ID/binary,
+                    "&interval=1000-milliseconds",
+                    "&cron-path=/~test-device@1.0/increment_counter">>,
+    {ok, _EveryTaskId} = hb_http:get(Node, EveryUrlPath, #{}),
+    timer:sleep(100),
+    % Get initial count
+    {ok, InitialCrons} = cache_list(Opts),
+    InitialCount = length(InitialCrons),
+    ?event({'normalize_no_duplicates_test_initial', {count, InitialCount}}),
+    % Call normalize (simulates restart)
+    NormalizeUrlPath = <<"/~cron@1.0/normalize">>,
+    {ok, _NormalizeResult} = hb_http:get(Node, NormalizeUrlPath, #{}),
+    timer:sleep(100),
+    % Verify count unchanged (no duplicates)
+    {ok, FinalCrons} = cache_list(Opts),
+    FinalCount = length(FinalCrons),
+    ?event({'normalize_no_duplicates_test_final', {count, FinalCount}}),
+    ?assertEqual(InitialCount, FinalCount, "Normalize should not create duplicates"),
+    ?event({'normalize_no_duplicates_test_done'}).

--- a/src/dev_lua_lib.erl
+++ b/src/dev_lua_lib.erl
@@ -15,8 +15,12 @@
 %%% Library functions. Each exported function is _automatically_ added to the
 %%% Lua environment, except for the `install/3' function, which is used to
 %%% install the library in the first place.
--export([get/3, resolve/3, set/3, event/3, install/3]).
+-export([resolve/3, set/3, event/3, install/3]).
+-ifdef(ENABLE_LUA_CACHE).
+-export([cache_write/3, cache_read/3]).
+-endif.
 -include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
 
 %%% The set of devices that must be included in the device sandbox for an
 %%% execution that is able to perform AO-Core resolutions. Without the following
@@ -197,3 +201,105 @@ event([Group, Event], ExecState, Opts) ->
     ),
     ?event(Group, Event),
     {[<<"ok">>], ExecState}.
+
+
+-ifdef(ENABLE_LUA_CACHE). 
+
+%% Lua Cache Functions Wrappers
+
+%% @doc Wrapper for hb_cache:write/2 (structured message version).
+%% Expects Lua call: ao.cache_write(message_map, opts?)
+%% Returns [ok, UncommittedID] | [error, #{reason => Reason}]
+cache_write(Args, ExecState, ExecOpts) ->
+    [MsgMapLua | RestArgs] = Args,
+    MsgMapErlang = dev_lua:decode(MsgMapLua),
+    LuaOpts = maybe_decode_opts(RestArgs),
+    FinalOpts = maps:merge(ExecOpts, LuaOpts),
+    ?event(debug_lua_lib_cache, {cache_write_call, {msg, MsgMapErlang}, {final_opts, FinalOpts}}),
+    Result = hb_cache:write(MsgMapErlang, FinalOpts),
+    ReturnList = case Result of
+        {ok, ID} -> [ok, ID]; % Return [ok, ID]
+        {error, Reason} -> [error, #{ <<"reason">> => Reason }] % Return [error, ReasonMap]
+    end,
+    ?event(debug_lua_lib_cache, {cache_write_return_list, {list, ReturnList}}),
+    {ReturnList, ExecState}.
+
+%% @doc Wrapper for hb_cache:read/2.
+%% Expects Lua call: ao.cache_read(id_or_path_string, opts?)
+%% Returns [ok, Value] | [not_found] | [error, #{reason => Reason}]
+cache_read(Args, ExecState, ExecOpts) ->
+    [IDOrPathBin | RestArgs] = Args,
+    LuaOpts = maybe_decode_opts(RestArgs),
+    FinalOpts = maps:merge(ExecOpts, LuaOpts),
+    ?event(dev_lua_lib, {cache_read_call, {id_or_path, IDOrPathBin}, {final_opts, FinalOpts}}),
+    Result = hb_cache:read(IDOrPathBin, FinalOpts),
+    ReturnList = case Result of
+        {ok, Value} -> [ok, Value]; % Return [ok, Value]
+        not_found -> [not_found]; % Return [not_found]
+        {error, Reason} -> [error, #{ <<"reason">> => Reason }] % Return [error, ReasonMap]
+    end,
+    ?event(dev_lua_lib, {cache_read_return_list, {list, ReturnList}}),
+    {ReturnList, ExecState}.
+
+%% @doc Helper to decode optional Opts map from Lua args list.
+%% Expects Opts map to be the last argument if present.
+maybe_decode_opts([]) -> #{};
+maybe_decode_opts(ArgsList) ->
+    LastArg = lists:last(ArgsList),
+    case dev_lua:decode(LastArg) of
+        OptsMap when is_map(OptsMap) -> OptsMap;
+        _ -> #{} % Ignore if not a map
+    end.
+
+
+%% Test calling ao.cache_read from Lua via dev_lua
+lua_ao_cache_write_read_test() ->
+    ?event(lua_cache_test, {starting}),
+    Opts = #{ store => [#{ 
+		<<"store-module">> => hb_store_fs, 
+		<<"prefix">> => <<"cache-TEST-writeread">> 
+	}]},
+    TestMap = #{ 
+		<<"type">> => <<"test_data">>, 
+		<<"value">> => rand:uniform(1000), 
+		<<"nested">> => [1, <<"two">>] },
+    {ok, Script} = file:read_file("scripts/lua-cache-test.lua"),
+    Base = #{
+        <<"device">> => <<"lua@5.3a">>,
+        <<"module">> => #{
+            <<"content-type">> => <<"application/lua">>,
+            <<"body">> => Script
+        }
+    },
+    WriteRequest = #{
+        <<"path">> => <<"write_test">>,  % Lua function name
+        <<"parameters">> => [TestMap]     % Arguments for Lua function
+    },
+    ?event(lua_cache_test, {resolving_lua_write, WriteRequest}),
+    {ok, WriteResolveResult} = hb_ao:resolve(Base, WriteRequest, Opts),
+    ?event(lua_cache_test, {resolve_write_result, WriteResolveResult}),
+	Status = hb_ao:get(<<"status">>, WriteResolveResult, Opts),
+	?event(lua_cache_test, {status, Status}),
+	Value = hb_ao:get(<<"value">>, WriteResolveResult, Opts),
+	?event(lua_cache_test, {value, Value}),
+	% Assert the extracted values
+	?assertEqual(<<"ok">>, Status),
+	?assert(is_binary(Value)), % Assert that the value (ID) is a binary
+    % Create and Resolve Read Request (Found case)
+    ReadRequestFound = #{
+        <<"path">> => <<"read_test">>,
+        <<"parameters">> => [Value] % Argument: the ID from write step
+    },
+    ?event(lua_cache_test, {resolving_lua_read_found, ReadRequestFound}),
+    {ok, ReadResolveResultFound} = hb_ao:resolve(Base, ReadRequestFound, Opts),
+    ?event(lua_cache_test, {resolve_read_result_found, ReadResolveResultFound}),
+	Status2 = hb_ao:get(<<"status">>, ReadResolveResultFound, Opts),
+	?event(lua_cache_test, {read_resolve_status, Status2}),
+	RetrievedValueMap = maps:get(<<"value">>, ReadResolveResultFound),
+	?event(lua_cache_test, {read_resolve_value, RetrievedValueMap}),
+	% Assert the extracted values
+	?assertEqual(<<"ok">>, Status),
+	?assertEqual(TestMap, maps:remove(<<"priv">>, RetrievedValueMap)),
+    ok.
+
+-endif.

--- a/src/dev_node_process.erl
+++ b/src/dev_node_process.erl
@@ -198,11 +198,15 @@ lookup_execute_test() ->
         {ok, #{ <<"slot">> := 1 }},
         Res1
     ),
+	?event({lookup_execute_test_result, {res1, Res1}}),
+	Res2 = hb_ao:get(
+		<< ?TEST_NAME/binary, "/now/results/output/body" >>,
+		#{ <<"device">> => <<"node-process@1.0">> },
+		Opts
+	),
+	?event({lookup_execute_test_result2, {res2, Res2}}),
     ?assertMatch(
         42,
-        hb_ao:get(
-            << ?TEST_NAME/binary, "/now/results/output/body" >>,
-            #{ <<"device">> => <<"node-process@1.0">> },
-            Opts
-        )
-    ).
+        Res2
+    ),
+	?event({lookup_execute_test_done}).

--- a/src/dev_test.erl
+++ b/src/dev_test.erl
@@ -41,7 +41,8 @@ info(_Msg1, _Msg2, _Opts) ->
 			<<"mul">> => <<"Multiply function">>,
 			<<"snapshot">> => <<"Snapshot function">>,
 			<<"response">> => <<"Response function">>,
-			<<"update_state">> => <<"Update state function">>
+			<<"update_state">> => <<"Update state function">>,
+			<<"increment_counter">> => <<"Increment counter function">>
 		}
 	},
 	{ok, #{<<"status">> => 200, <<"body">> => InfoBody}}.

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -11,9 +11,9 @@
 %%% the execution parameters of all downstream requests to be controlled.
 -module(hb_http_server).
 -export([start/0, start/1, allowed_methods/2, init/2]).
--export([set_opts/1, set_opts/2, get_opts/0, get_opts/1]).
+-export([set_opts/1, set_opts/2, get_opts/1]).
 -export([set_default_opts/1, set_proc_server_id/1]).
--export([start_node/0, start_node/1]).
+-export([start_node/0, start_node/1, stop_node/1]).
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
 
@@ -97,6 +97,7 @@ start() ->
         }
     ).
 start(Opts) ->
+	
     application:ensure_all_started([
         kernel,
         stdlib,
@@ -110,7 +111,10 @@ start(Opts) ->
     hb:init(),
     BaseOpts = set_default_opts(Opts),
     {ok, Listener, _Port} = new_server(BaseOpts),
+	
     {ok, Listener}.
+
+
 
 %% @doc Trigger the creation of a new HTTP server node. Accepts a `NodeMsg'
 %% message, which is used to configure the server. This function executed the
@@ -460,12 +464,22 @@ set_opts(Request, Opts) ->
     },
     {set_opts(FinalOpts), FinalOpts}.
 
-%% @doc Get the node message for the current process.
-get_opts() ->
-    get_opts(#{ http_server => get(server_id) }).
+%% hb_http_server/start_node/1 executes a start hook before cowboy is 
+%% listening. This means there is no valid http_server ref in node_opts.
+%% When we run dev_cron/normalize as part of a start hook, it spawns
+%% workers using the original NodeMsg, which does not contain a valid
+%% http_server ref. This can crash the cowboy:get_env. To solve for this,
+%% we return the original NodeMsg when no Cowboy listener is attached.
+get_opts(NodeMsg = #{ http_server := no_server_ref }) ->
+    NodeMsg;
 get_opts(NodeMsg) ->
     ServerRef = hb_opts:get(http_server, no_server_ref, NodeMsg),
-    cowboy:get_env(ServerRef, node_msg, no_node_msg).
+    try cowboy:get_env(ServerRef, node_msg, no_node_msg)
+    catch error:badarg ->
+      % If the server is not yet started, might happen with dev_hook
+      % So we just return the original NodeMsg.
+      NodeMsg
+    end.
 
 %% @doc Initialize the server ID for the current process.
 set_proc_server_id(ServerID) ->
@@ -531,6 +545,15 @@ start_node(Opts) ->
     {ok, _Listener, Port} = new_server(ServerOpts),
     <<"http://localhost:", (integer_to_binary(Port))/binary, "/">>.
 
+stop_node(Opts) ->
+	?event(http, {node_stopping, Opts}),
+	application:stop(ranch),
+	application:stop(cowboy),
+	% application:stop(gun),
+	% application:stop(inets),
+	?event(http, {node_stopped, Opts}),
+	<<"node stopped">>.
+	
 %%% Tests
 %%% The following only covering the HTTP server initialization process. For tests
 %%% of HTTP server requests/responses, see `hb_http.erl'.

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -238,6 +238,14 @@ default_message() ->
         % Options for the router device
         <<"router@1.0">> => #{
             routes => []
+        },
+        % Ensure that cron device normalizes by default on node restart.
+        on => #{
+            <<"start">> => #{
+                <<"device">> => <<"cron@1.0">>,
+                <<"path">> => <<"normalize">>,
+                <<"hook">> => #{ <<"result">> => <<"ignore">> }
+            }
         }
         % Should the node track and expose prometheus metrics?
         % We do not set this explicitly, so that the hb_features:test() value


### PR DESCRIPTION
PR https://github.com/permaweb/HyperBEAM/pull/287 merged with the `edge` branch.

Commit list
```
cherry picked fixes: defensive http_server get_opts + test_worker state fix + load->list rename
add comment for defensive guard for http_server get_opts
add defensive schema checks to cron.lua
refactor to move command handlers to individual functions
move task removal to 2 phase
fix small bugs in rewrite
update the test workers with better logic to update state
add pcall to handlers for cron commands
gate cache/read write functions and add error handling to lua wrappers
fix cache recovery issue with cronpath
handle if a taskId already exists to avoid duplicated cron jobs. if it does then update its process body with the new one refactor task ID lookup into a function
add a not found guard for find job by task ID
cherry pick commit from @samuelmanzanera to fix dev_hook / cowboy opts issue that was preventing restored cron jobs from running clean up test code
refactor cron.lua find job by id into a different function more cleanup of comments
remove hb_trace from cron workers
```