### PR TITLE
impr: reduce ID generation 

### DIFF
--- a/src/dev_codec_ans104.erl
+++ b/src/dev_codec_ans104.erl
@@ -181,7 +181,11 @@ to(InputTABM, Req, Opts) when is_map(InputTABM) ->
     % 5. Set the data items on the #tx record.
     TXWithData = set_tx_data_or_throw(TXWithoutData, DataItems, Req, Opts),
 
-    TXResult = ar_bundles:reset_ids(ar_bundles:normalize(TXWithData)),
+    % 6. Set the unsigned ID on the #tx record.
+    ID = hb_message:id(InputTABM),
+    TXResult = ar_bundles:normalize(TXWithData#tx {
+        unsigned_id = ID
+    }),
     ?event({to, {result, TXResult}}),
     {ok, TXResult};
 to(_Other, _Req, _Opts) ->

--- a/src/dev_codec_ans104.erl
+++ b/src/dev_codec_ans104.erl
@@ -587,7 +587,11 @@ set_tx_value_or_throw(Field, TX, DefaultValue, NewValue) ->
 
 flatten_commitments(TABM, Opts) ->
     Commitments = hb_maps:get(<<"commitments">>, TABM, #{}, Opts),
-    case hb_maps:keys(Commitments, Opts) of
+    FilteredCommitments = hb_maps:filter(
+        fun(_, #{ <<"type">> := Type }) -> Type /= <<"hmac-sha256">> end,
+        Commitments,
+        Opts),
+    case hb_maps:keys(FilteredCommitments, Opts) of
         [] ->
             {#{}, []};
         [ID] ->

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -201,24 +201,30 @@ id(RawMsg, RawCommitters, Opts) ->
 %% unsigned ID present. By forcing this work to occur in strategically positioned
 %% places, we avoid the need to recalculate the IDs for every `hb_message:id`
 %% call.
-normalize_commitments(Msg, Opts) when is_map(Msg) ->
+normalize_commitments(Msg, Opts) when is_map(Msg), map_size(Msg) > 0 ->
     NormMsg = 
         maps:map(
             fun(Key, Val) when Key == <<"commitments">> orelse Key == <<"priv">> ->
                 Val;
-               (_Key, Val) -> normalize_commitments(Val, Opts)
+               (Key, Val) -> 
+                    ?event(x, {key, Key, Val}),
+                    normalize_commitments(Val, Opts)
             end,
             Msg
         ),
     case hb_maps:get(<<"commitments">>, NormMsg, not_found, Opts) of
         not_found ->
-            {ok, #{ <<"commitments">> := Commitments }} =
-                dev_message:commit(
-                    NormMsg,
-                    #{ <<"type">> => <<"unsigned">> },
-                    Opts
-                ),
-            NormMsg#{ <<"commitments">> => Commitments };
+            case maps:get(<<"ao-types">>, NormMsg, not_found) of
+                not_found ->
+                    {ok, #{ <<"commitments">> := Commitments }} =
+                        dev_message:commit(
+                            NormMsg,
+                            #{ <<"type">> => <<"unsigned">> },
+                            Opts
+                        ),
+                        NormMsg#{ <<"commitments">> => Commitments };
+                _ -> NormMsg
+            end;
         _ -> NormMsg
     end;
 normalize_commitments(Msg, Opts) when is_list(Msg) ->

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -206,9 +206,7 @@ normalize_commitments(Msg, Opts) when is_map(Msg), map_size(Msg) > 0 ->
         maps:map(
             fun(Key, Val) when Key == <<"commitments">> orelse Key == <<"priv">> ->
                 Val;
-               (Key, Val) -> 
-                    ?event(x, {key, Key, Val}),
-                    normalize_commitments(Val, Opts)
+            (_Key, Val) -> normalize_commitments(Val, Opts)
             end,
             Msg
         ),

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -177,7 +177,8 @@ conversion_spec_to_req(Spec, Opts) ->
 id(Msg) -> id(Msg, uncommitted).
 id(Msg, Opts) when is_map(Opts) -> id(Msg, uncommitted, Opts);
 id(Msg, Committers) -> id(Msg, Committers, #{}).
-id(Msg, RawCommitters, Opts) ->
+id(RawMsg, RawCommitters, Opts) ->
+    Msg = normalize_commitments(RawMsg, Opts),
     CommSpec =
         case RawCommitters of
             none -> #{ <<"committers">> => <<"none">> };


### PR DESCRIPTION
This PR aims to reduce ID generation using `hb_message:normalize_commitments` to pre-calculate ID generation (HMAC Signature commitment).