### PR TITLE
feat: `/profile` key in `~hyperbuddy@1.0`, exposing flame graphs of execution time

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,10 +5,10 @@
     {no_events, [{erl_opts, [{d, 'NO_EVENTS', true}]}]},
     {store_events, [{erl_opts, [{d, 'STORE_EVENTS', true}]}]},
     {ao_profiling, [{erl_opts, [{d, 'AO_PROFILING', true}]}]},
-    {erl_profiling,
+    {eflame,
         [
             {deps, [{eflame, "1.0.1"}]},
-            {erl_opts, [{d, 'ERL_PROFILING', true}]}
+            {erl_opts, [{d, 'EFLAME', true}]}
         ]
     },
     {genesis_wasm, [

--- a/src/hb.erl
+++ b/src/hb.erl
@@ -283,32 +283,47 @@ build() ->
 %% @doc Utility function to start a profiling session and run a function,
 %% then analyze the results. Obviously -- do not use in production. Uses `eflame`
 %% if available, otherwise uses `eprof'.
--ifdef(ERL_PROFILING).
 profile(Fun) ->
-    File = <<"stacks.out">>,
-    Res = eflame:apply(Fun, []),
+    File =
+        <<
+            "profile-",
+            (integer_to_binary(os:system_time(microsecond)))/binary,
+            ".out"
+        >>,
+    profile(Fun, File).
+
+-ifdef(EFLAME).
+profile(Fun, File) ->
+    Res = eflame:apply(normal, File, Fun, []),
     EflameDir = code:lib_dir(eflame),
     StackToFlameScript = filename:join(EflameDir, "stack_to_flame.sh"),
-    os:cmd(
-        StackToFlameScript ++
-            " < "
-            ++ hb_util:list(File)
-            ++ " > flame.svg"),
-    os:cmd("open flame.svg"),
-    {File, Res}.
+    Flame = hb_util:bin(os:cmd(StackToFlameScript ++ " < " ++ hb_util:list(File))),
+    file:delete(File),
+    {
+        #{
+            <<"content-type">> => <<"image/svg+xml">>,
+            <<"body">> => Flame
+        },
+        Res
+    }.
 -else.
-profile(Fun) ->
-    eprof_profile(Fun).
+profile(Fun, File) ->
+    eprof_profile(Fun, File).
 -endif.
 
-eprof_profile(Fun) ->
+eprof_profile(Fun, File) ->
     eprof:start_profiling([self()]),
-    try
-        Fun()
-    after
-        eprof:stop_profiling()
-    end,
-    eprof:analyze(total).
+    Res = try Fun() after eprof:stop_profiling() end,
+    eprof:log(File),
+    eprof:analyze(total),
+    {ok, Log} = file:read_file(File),
+    {
+        #{
+            <<"content-type">> => <<"text/plain">>,
+            <<"body">> => Log
+        },
+        Res
+    }.
 
 %% @doc Utility function to wait for a given amount of time, printing a debug
 %% message to the console first.


### PR DESCRIPTION
In order to generate a flame graph that shows a performance profile of your execution, browse to `/~hyperbuddy@1.0/profile?profile-path=...`. The `profile-path` will be set as the normal path upon your request and will be parsed in the typical way. As with all paths-containing-paths, make sure not to place your parameters in `&x=y` clauses in the middle of your path, as these will be interpreted as part of the outer message. Instead, include them at the start or end of the query parameters.

An example execution with the hyperbuddy profiler looks as follows:

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/19ff7797-2d56-4093-b94b-b51f5317de70" />

Currently the underlying profiler (`eflame`) comes with a heavy burden on performance. There are likely tweaks that can be made to it to improve this, but for now always try to limit the amount of computation performed under profiling so that you avoid timeouts.