### PR TITLE
fix: lua ledger test 

### DIFF
--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -440,7 +440,7 @@ ensure_loaded(Msg1, Msg2, Opts) ->
             LoadRes =
                 dev_process_cache:latest(
                     ProcID,
-                    [<<"snapshot+link">>],
+                    [<<"snapshot">>],
                     TargetSlot,
                     Opts
                 ),


### PR DESCRIPTION
@parthks and me found out the when reading `cache` we were using the older version for the nested cases of `process msgs` i.e. reading with the `+link`

- However in hyperstate we removed `+link` while reading from the cache when we added `linkify => true`

But it was missed here,
hence the tests were breaking.
