### PR TITLE
impr: ANS-104 scheduler decoding performance

### DIFF
--- a/src/hb_store.erl
+++ b/src/hb_store.erl
@@ -284,7 +284,18 @@ do_call_function([Store = #{<<"store-module">> := Mod} | Rest], Function, Args) 
             Result
     catch
         Class:Reason:Stacktrace ->
-            ?event(warning, {store_call_failed, {Class, Reason, Stacktrace}}),
+            ?event(store_error,
+                {store_call_failed,
+                    #{
+                        store => Store,
+                        function => Function,
+                        args => Args,
+                        class => Class,
+                        reason => Reason,
+                        stacktrace => Stacktrace
+                    }
+                }
+            ),
             do_call_function(Rest, Function, Args)
     end.
 


### PR DESCRIPTION
Using #354 we were able to locate a series of calls in the codepath for legacynet schedule decoding that could be optimized. The net effect of these changes is an approximate improvement in LN process execution of ~5%.