### PR TITLE
impr: increase LMDB message read speed from cache by ~534x.

### DIFF
--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -801,13 +801,3 @@ test_device_map_cannot_be_written_test() ->
     catch
         _:_:_ -> ?assert(true)
     end.
-
-run_test() ->
-    Store =
-        [
-            #{
-                <<"store-module">> => hb_store_lmdb,
-                <<"name">> => <<"cache-TEST/lmdb">>
-            }
-        ],
-    test_store_simple_signed_message(Store).

--- a/src/hb_store.erl
+++ b/src/hb_store.erl
@@ -57,6 +57,9 @@
 %% @doc The number of write and read operations to perform in the benchmark.
 -define(STORE_BENCH_WRITE_OPS, 100_000).
 -define(STORE_BENCH_READ_OPS, 100_000).
+-define(STORE_BENCH_LIST_KEYS, 500_000).
+-define(STORE_BENCH_LIST_GROUP_SIZE, 10).
+-define(STORE_BENCH_LIST_OPS, 100).
 -define(BENCH_MSG_WRITE_OPS, 250).
 -define(BENCH_MSG_READ_OPS, 250).
 -define(BENCH_MSG_DATA_SIZE, 1024).
@@ -500,6 +503,142 @@ benchmark_key_read_write(Store, WriteOps, ReadOps) ->
         ]
     ),
     ?assertEqual(0, NotFoundCount, "Written keys not found in store.").
+
+benchmark_list(Store) ->
+    benchmark_list(
+        Store,
+        ?STORE_BENCH_LIST_KEYS,
+        ?STORE_BENCH_LIST_OPS,
+        ?STORE_BENCH_LIST_GROUP_SIZE
+    ).
+benchmark_list(Store, WriteOps, ListOps, GroupSize) ->
+    start(Store),
+    timer:sleep(100),
+    ?event(
+        {benchmarking,
+            {store, Store},
+            {keys, hb_util:human_int(WriteOps)},
+            {groups, hb_util:human_int(WriteOps div GroupSize)},
+            {lists, hb_util:human_int(ListOps)}
+        }
+    ),
+    % Generate a random message to write and the keys to read ahead of time.
+    Groups =
+        lists:map(
+            fun(_) ->
+                GroupID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+                {
+                    GroupID,
+                    lists:map(
+                        fun(M) ->
+                            {
+                                <<"key-", (integer_to_binary(M))/binary >>,
+                                <<"value-", (integer_to_binary(M))/binary >>
+                            }
+                        end,
+                        lists:seq(1, GroupSize)
+                    )
+                }
+            end,
+            lists:seq(1, GroupCount = WriteOps div GroupSize)
+        ),
+    hb_util:eunit_print(
+        "Generated ~s groups of ~s keys",
+        [
+            hb_util:human_int(GroupCount),
+            hb_util:human_int(GroupSize)
+        ]
+    ),
+    {WriteTime, _} =
+        timer:tc(
+            fun() ->
+                lists:map(
+                    fun({GroupID, KeyPairs}) ->
+                        ok = make_group(Store, GroupID),
+                        lists:foreach(
+                            fun({Key, Value}) ->
+                                ok =
+                                    write(
+                                        Store,
+                                        <<GroupID/binary, "/", Key/binary >>,
+                                        Value
+                                    )
+                            end,
+                            KeyPairs
+                        )
+                    end,
+                    Groups
+                )
+            end
+        ),
+    % Print the results. Our write time is in microseconds, so we normalize it
+    % to seconds.
+    hb_test_utils:benchmark_print(
+        <<"Wrote">>,
+        <<"keys">>,
+        WriteOps,
+        WriteTime / 1_000_000
+    ),
+    % Generate groups to read ahead of time.
+    ReadGroups =
+        lists:map(
+            fun(_) ->
+                lists:nth(rand:uniform(GroupCount), Groups)
+            end,
+            lists:seq(1, ListOps)
+        ),
+    % Time random reads.
+    {ReadTime, NotFoundCount} =
+        timer:tc(
+            fun() ->
+                lists:foldl(
+                    fun({GroupID, GroupKeyValues}, Count) ->
+                        ExpectedKeys =
+                            [ KeyInGroup || {KeyInGroup, _} <- GroupKeyValues ],
+                        case list(Store, GroupID) of
+                            {ok, ListedKeys} ->
+                                Res =
+                                    lists:all(
+                                        fun({KeyInGroup, _ExpectedValue}) ->
+                                            lists:member(KeyInGroup, ListedKeys)
+                                        end,
+                                        GroupKeyValues
+                                    ),
+                                case Res of
+                                    true -> Count;
+                                    _ ->
+                                        ?event(
+                                            {list_group_not_found,
+                                                {group, GroupID},
+                                                {received_keys, ListedKeys},
+                                                {expected_keys, ExpectedKeys}
+                                            }
+                                        ),
+                                        Count + 1
+                                end;
+                            _ ->
+                                ?event(
+                                    {list_group_not_found,
+                                        {group, GroupID},
+                                        {expected_keys, ExpectedKeys}
+                                    }
+                                ),
+                                Count + 1
+                        end
+                    end,
+                    0,
+                    ReadGroups
+                )
+            end
+        ),
+    % Print the results.
+    hb_test_utils:benchmark_print(
+        <<"Listed">>,
+        <<"groups">>,
+        ListOps,
+        ReadTime / 1_000_000
+    ),
+    ?assertEqual(0, NotFoundCount, "Groups listed in correctly.").
 
 benchmark_message_read_write(Store) ->
     benchmark_message_read_write(Store, ?BENCH_MSG_WRITE_OPS, ?BENCH_MSG_READ_OPS).


### PR DESCRIPTION
This PR removes an issue which would cause the `hb_store:list` operation to perform an extremely long scan through the entire database. On a micro-benchmark benchmark level (only testing the `list` operation alone) the effect of this change is an approximately 5,800x increase in performance (~107,854 lists per second now, vs 20 per second prior to this PR).

Because the `list` operation is used multiple times during every message read in HyperBEAM, which is itself essentially a caching and memoization system, `list` is used in virtually every codepath (to greater or lesser extents). This improvement subsequently ripples through the rest of the system, to greater and lesser extents:

- A ~534x improvement in full message read speeds (from ~200 msgs/s to ~106,800 msgs/s).
- ~2x faster message writes, as these also `list` the known signatures on the message during write.
- An increase in `~lua@5.3a` execution speeds from approximately ~60-180 msg/s (settings depending) to ~250-330 msgs/s.
- ~60ms cached message return times.

A flame graph tells the story well. Below is an execution of a `~genesis-wasm@1.0` legacynet process before this PR:

<img width="1080" alt="image" src="https://github.com/user-attachments/assets/5f7eee79-0ecd-4a5c-8ad7-3c3b459e8e6a" />

Note how virtually all the time is consumed by store operations. Here is the same request performed after the PR:

<img width="1073" alt="image" src="https://github.com/user-attachments/assets/77d4e331-149b-4624-a031-3643041cf777" />

Almost all of the execution time is now spent on signature verification and computation of the WASM itself.

Huge thanks to @twilson63 @Lucifer0x17 @samuelmanzanera and the crew for all their help on the road to this one!