### PR TITLE
Fix HTTP3 Server Configuration

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -46,6 +46,9 @@
         {overrides, [
             {add, cowboy, [{erl_opts, [{d, 'COWBOY_QUICER', 1}]}]},
             {add, gun, [{erl_opts, [{d, 'GUN_QUICER', 1}]}]}
+        ]},
+        {relx, [
+            {release, {'hb', "0.0.1"}, [hb, b64fast, cowboy, gun, luerl, prometheus, prometheus_cowboy, elmdb, quicer]}
         ]}
     ]}
 ]}.
@@ -135,7 +138,10 @@
 	{overlay, [
 		{mkdir, "bin/priv"},
 		{copy, "priv", "bin/priv"},
-		{copy, "config.flat", "config.flat"}
+		{copy, "config.flat", "config.flat"},
+		{mkdir, "certs"},
+		{copy, "certificates/server.pem", "certs/server.pem"},
+		{copy, "certificates/server.key", "certs/server.key"}
 	]}
 ]}.
 

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -216,18 +216,20 @@ new_server(RawNodeMsg) ->
     ),
     {ok, Listener, Port}.
 
-start_http3(ServerID, ProtoOpts, _NodeMsg) ->
+start_http3(ServerID, ProtoOpts, NodeMsg) ->
     ?event(http, {start_http3, ServerID}),
     Parent = self(),
     ServerPID =
         spawn(fun() ->
             application:ensure_all_started(quicer),
+            Port = hb_opts:get(port, 8734, NodeMsg),
             {ok, Listener} = cowboy:start_quic(
                 ServerID, 
                 TransOpts = #{
                     socket_opts => [
-                        {certfile, "test/test-tls.pem"},
-                        {keyfile, "test/test-tls.key"}
+                        {port, Port},
+                        {certfile, "certs/server.pem"},
+                        {keyfile, "certs/server.key"}
                     ]
                 },
                 ProtoOpts

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -218,46 +218,54 @@ new_server(RawNodeMsg) ->
 
 start_http3(ServerID, ProtoOpts, NodeMsg) ->
     ?event(http, {start_http3, ServerID}),
-    Parent = self(),
-    ServerPID =
-        spawn(fun() ->
-            application:ensure_all_started(quicer),
-            Port = hb_opts:get(port, 8734, NodeMsg),
-            {ok, Listener} = cowboy:start_quic(
-                ServerID, 
-                TransOpts = #{
-                    socket_opts => [
-                        {port, Port},
-                        {certfile, "certs/server.pem"},
-                        {keyfile, "certs/server.key"}
-                    ]
-                },
-                ProtoOpts
-            ),
-            {ok, {_, GivenPort}} = quicer:sockname(Listener),
-            ranch_server:set_new_listener_opts(
-                ServerID,
-                1024,
-                ranch:normalize_opts(
-                    hb_maps:to_list(TransOpts#{ port => GivenPort })
-                ),
-                ProtoOpts,
-                []
-            ),
-            ranch_server:set_addr(ServerID, {<<"localhost">>, GivenPort}),
-            % Bypass ranch's requirement to have a connection supervisor define
-            % to support updating protocol opts.
-            % Quicer doesn't use a connection supervisor, so we just spawn one
-            % that does nothing.
-            ConnSup = spawn(fun() -> http3_conn_sup_loop() end),
-            ranch_server:set_connections_sup(ServerID, ConnSup),
-            Parent ! {ok, GivenPort},
-            receive stop -> stopped end
-        end),
-    receive {ok, GivenPort} -> {ok, GivenPort, ServerPID}
-    after 2000 ->
-        {error, {timeout, staring_http3_server, ServerID}}
+    CertFile = "certs/server.pem",
+    KeyFile = "certs/server.key",
+    case {filelib:is_regular(CertFile), filelib:is_regular(KeyFile)} of
+        {true, true} ->
+            Parent = self(),
+            ServerPID = spawn(fun() -> start_http3_listener(Parent, ServerID, ProtoOpts, NodeMsg, CertFile, KeyFile) end),
+            receive
+                {ok, GivenPort} -> {ok, GivenPort, ServerPID}
+            after 2000 ->
+                {error, {timeout, ServerID}}
+            end;
+        {false, _} -> {error, {missing_certificate, CertFile}};
+        {_, false} -> {error, {missing_key, KeyFile}}
     end.
+
+start_http3_listener(Parent, ServerID, ProtoOpts, NodeMsg, CertFile, KeyFile) ->
+    application:ensure_all_started(quicer),
+    Port = hb_opts:get(port, 8734, NodeMsg),
+    {ok, Listener} = cowboy:start_quic(
+        ServerID, 
+        TransOpts = #{
+            socket_opts => [
+                {port, Port},
+                {certfile, CertFile},
+                {keyfile, KeyFile}
+            ]
+        },
+        ProtoOpts
+    ),
+    {ok, {_, GivenPort}} = quicer:sockname(Listener),
+    ranch_server:set_new_listener_opts(
+        ServerID,
+        1024,
+        ranch:normalize_opts(
+            hb_maps:to_list(TransOpts#{ port => GivenPort })
+        ),
+        ProtoOpts,
+        []
+    ),
+    ranch_server:set_addr(ServerID, {<<"localhost">>, GivenPort}),
+    % Bypass ranch's requirement to have a connection supervisor define
+    % to support updating protocol opts.
+    % Quicer doesn't use a connection supervisor, so we just spawn one
+    % that does nothing.
+    ConnSup = spawn(fun() -> http3_conn_sup_loop() end),
+    ranch_server:set_connections_sup(ServerID, ConnSup),
+    Parent ! {ok, GivenPort},
+    receive stop -> stopped end.
 
 http3_conn_sup_loop() ->
     receive
@@ -617,3 +625,35 @@ restart_server_test() ->
         {ok, <<"server-2">>},
         hb_http:get(N2, <<"/~meta@1.0/info/test-key">>, #{})
     ).
+
+http3_certificate_validation_test() ->
+    ServerID = test_server,
+    ProtoOpts = #{},
+    NodeMsg = #{},
+    
+    % Test missing certificate file
+    {error, {missing_certificate, "certs/server.pem"}} = start_http3(ServerID, ProtoOpts, NodeMsg),
+    
+    % Create temporary certificate files for testing
+    ok = filelib:ensure_dir("certs/"),
+    ok = file:write_file("certs/server.pem", <<"dummy cert content">>),
+    
+    % Test missing key file
+    {error, {missing_key, "certs/server.key"}} = start_http3(ServerID, ProtoOpts, NodeMsg),
+    
+    % Create key file
+    ok = file:write_file("certs/server.key", <<"dummy key content">>),
+    
+    % Test with both files present - should attempt to start but fail due to invalid certs
+    % We expect either a timeout or cowboy/quicer error, not missing file errors
+    Result = start_http3(ServerID, ProtoOpts, NodeMsg),
+    case Result of
+        {error, {missing_certificate, _}} -> ?assert(false);
+        {error, {missing_key, _}} -> ?assert(false);
+        _ -> ?assert(true) % Any other error (timeout, invalid cert, etc.) is expected
+    end,
+    
+    % Clean up
+    file:delete("certs/server.pem"),
+    file:delete("certs/server.key"),
+    file:del_dir("certs/").


### PR DESCRIPTION
# Fix HTTP3 Server Configuration

## Issues Fixed
- HTTP3 server binding to random ports instead of configured port
- TLS certificate files not found during server startup  
- Missing `quicer` dependency in HTTP3 profile releases

## Changes
- **Port Configuration**: Add port specification to `socket_opts` list in `start_http3/3`
- **Certificate Management**: Update certificate paths to use `certs/server.pem` and `certs/server.key`
- **Release Configuration**: Add automatic certificate copying to release overlay
- **Profile Dependencies**: Add `quicer` dependency to HTTP3 profile releases

## Usage
Place your TLS certificates in the `certificates/` directory:
- `certificates/server.pem` - TLS certificate file
- `certificates/server.key` - TLS private key file

The build system will automatically copy these to `certs/` in the release.

## Testing
- [x] HTTP3 server now binds to configured port (10001) from `config.flat`
- [x] HTTP/3 requests return `HTTP/3 200` responses successfully
- [x] Server uses proper certificate files from `certs/` directory
- [x] Default release builds without `quicer` dependency work correctly

## Changes
- `src/hb_http_server.erl`: Fix configuration in `start_http3/3`
- `rebar.config`: Add profile-specific `quicer` dependency and certificate overlay
