### PR TITLE
Fix/push from ref

### DIFF
--- a/src/dev_lua_test_ledgers.erl
+++ b/src/dev_lua_test_ledgers.erl
@@ -604,7 +604,10 @@ single_subledger_to_subledger() ->
         ),
     SubLedger1 = subledger(RootLedger, Opts),
     SL1ID = hb_message:id(SubLedger1, signed, Opts),
-    SubLedger2 = hb_message:without_commitments(SL1ID, subledger(RootLedger, Opts), Opts),
+    ?event(debug, {sl1ID, SL1ID}),
+    SubLedger2 = subledger(RootLedger, Opts),
+    SL2ID = hb_message:id(SubLedger2, signed, Opts),
+    ?event(debug, {sl2ID, SL2ID}),
     Names = #{
         Alice => alice,
         Bob => bob,
@@ -612,11 +615,16 @@ single_subledger_to_subledger() ->
         SubLedger1 => subledger1,
         SubLedger2 => subledger2
     },
+    ?event(debug, {root_ledger, RootLedger}),
+    ?event(debug, {sl1, SubLedger1}),
+    ?event(debug, {sl2, SubLedger2}),
     ?assertEqual(100, balance(RootLedger, Alice, Opts)),
     % 2. Alice sends 90 tokens to herself on SubLedger1.
+    ?event(debug, {transfer_1}),
     transfer(RootLedger, Alice, Alice, 90, SubLedger1, Opts),
     ?assertEqual(10, balance(RootLedger, Alice, Opts)),
     ?assertEqual(90, balance(SubLedger1, Alice, Opts)),
+    ?event(debug, {transfer_2}),
     PushRes = transfer(SubLedger1, Alice, Alice, 80, SubLedger2, Opts),
     ?event(debug, {push_res, PushRes}),
     ?event(debug, {map, map([RootLedger, SubLedger1, SubLedger2], Opts)}),

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -432,7 +432,6 @@ ensure_loaded(Msg1, Msg2, Opts) ->
     % Get the nonce we are currently on and the inbound nonce.
     TargetSlot = hb_ao:get(<<"slot">>, Msg2, undefined, Opts),
     ProcID = process_id(Msg1, #{}, Opts),
-
     ?event({ensure_loaded, {msg1, Msg1}, {msg2, Msg2}, {opts, Opts}}),
     case hb_ao:get(<<"initialized">>, Msg1, Opts) of
         <<"true">> ->
@@ -485,7 +484,7 @@ ensure_loaded(Msg1, Msg2, Opts) ->
                                       Opts),
                     LoadedSnapshotMsg2 = LoadedSnapshotMsg#{ <<"process">> => UpdateProcess },
                     LoadedSlot = hb_cache:ensure_all_loaded(MaybeLoadedSlot, Opts),
-                    ?event(debug, {found_state_checkpoint, ProcID, LoadedSnapshotMsg2}),
+                    ?event(compute, {found_state_checkpoint, ProcID, LoadedSnapshotMsg2}),
                     {ok, Normalized} =
                         run_as(
                             <<"execution">>,

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -470,18 +470,17 @@ ensure_loaded(Msg1, Msg2, Opts) ->
                     Process = hb_maps:get(<<"process">>, LoadedSnapshotMsg, Opts),
                     #{ <<"commitments">> := HmacCommits} =
                         hb_message:with_commitments(
-                          #{ <<"type">> => <<"hmac-sha256">>},
-                          Process,
-                          Opts),
+                            #{ <<"type">> => <<"hmac-sha256">>},
+                            Process,
+                            Opts),
                     #{ <<"commitments">> := SignCommits } =
-                        hb_message:with_commitments(ProcID,
-                                                    Process,
-                                                    Opts),
+                        hb_message:with_commitments(ProcID, Process, Opts),
                     UpdateProcess = hb_maps:put(
-                                      <<"commitments">>,
-                                      hb_maps:merge(HmacCommits, SignCommits),
-                                      Process,
-                                      Opts),
+                        <<"commitments">>,
+                        hb_maps:merge(HmacCommits, SignCommits),
+                        Process,
+                        Opts
+                    ),
                     LoadedSnapshotMsg2 = LoadedSnapshotMsg#{ <<"process">> => UpdateProcess },
                     LoadedSlot = hb_cache:ensure_all_loaded(MaybeLoadedSlot, Opts),
                     ?event(compute, {found_state_checkpoint, ProcID, LoadedSnapshotMsg2}),

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -468,18 +468,18 @@ ensure_loaded(Msg1, Msg2, Opts) ->
                             Opts
                         ),
                     Process = hb_maps:get(<<"process">>, LoadedSnapshotMsg, Opts),
-                    #{ <<"commitments">> := HmacCommit} =
+                    #{ <<"commitments">> := HmacCommits} =
                         hb_message:with_commitments(
                           #{ <<"type">> => <<"hmac-sha256">>},
                           Process,
                           Opts),
-                    #{ <<"commitments">> := SignCommit } =
+                    #{ <<"commitments">> := SignCommits } =
                         hb_message:with_commitments(ProcID,
                                                     Process,
                                                     Opts),
                     UpdateProcess = hb_maps:put(
                                       <<"commitments">>,
-                                      hb_maps:merge(HmacCommit, SignCommit),
+                                      hb_maps:merge(HmacCommits, SignCommits),
                                       Process,
                                       Opts),
                     LoadedSnapshotMsg2 = LoadedSnapshotMsg#{ <<"process">> => UpdateProcess },

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -107,7 +107,8 @@ do_push(PrimaryProcess, Assignment, Opts) ->
     ?event(debug,
         {push_computed,
             {status, Status},
-            {request, maps:get(<<"body">>, Assignment, Assignment)},
+            {assignment, Assignment},
+            {request, hb_maps:get(<<"body">>, Assignment, Assignment)},
             {result,
                 if is_list(Result) ->
                     hb_ao:normalize_keys(Result);

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -95,15 +95,6 @@ do_push(PrimaryProcess, Assignment, Opts) ->
         #{ <<"path">> => <<"compute/results">>, <<"slot">> => Slot },
         Opts#{ hashpath => ignore }
     ),
-    % Handle the case where compute/results fails for uninitialized processes
-    case {Status, Result} of
-        {ok, ComputeResult} -> {ok, ComputeResult};
-        {error, _} ->
-            % If compute/results fails, provide empty result with empty outbox
-            % This allows message delivery to processes that haven't been executed yet
-            ?event(push, {process_not_executed_providing_empty_outbox, {process, ID}, {slot, Slot}}),
-            {ok, #{<<"outbox">> => #{}}}
-    end,
     % Determine if we should include the full compute result in our response.
     IncludeDepth = hb_ao:get(<<"result-depth">>, Assignment, 1, Opts),
     AdditionalRes =

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -74,19 +74,7 @@ is_async(Process, Req, Opts) ->
 %% @doc Push a message or slot number, including its downstream results.
 do_push(PrimaryProcess, Assignment, Opts) ->
     Slot = hb_ao:get(<<"slot">>, Assignment, Opts),
-    Process = hb_ao:get(<<"process">>, PrimaryProcess, Opts),
-    AuthorityLink = maps:get(<<"authority">>, Process),
-    ID = case AuthorityLink of
-        {link, Link, _} ->
-           Authority = hd(binary:split(Link, <<"/">>, [global, trim_all])),
-           ?event(x, {authority, Authority}),
-           P = hb_message:with_commitments(Authority, Process, Opts),
-           ?event(x, {process_with_comm, P}),
-           dev_process:process_id(P, #{}, Opts);
-        _ ->
-          ?event(x, {no_authority_link, PrimaryProcess}),
-          dev_process:process_id(PrimaryProcess, #{}, Opts)
-    end,
+    ID = dev_process:process_id(PrimaryProcess, #{}, Opts),
     ?event(x, {process_signed_id, ID}),
     UncommittedID =
         dev_process:process_id(

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -74,7 +74,20 @@ is_async(Process, Req, Opts) ->
 %% @doc Push a message or slot number, including its downstream results.
 do_push(PrimaryProcess, Assignment, Opts) ->
     Slot = hb_ao:get(<<"slot">>, Assignment, Opts),
-    ID = dev_process:process_id(PrimaryProcess, #{}, Opts),
+    Process = hb_ao:get(<<"process">>, PrimaryProcess, Opts),
+    AuthorityLink = maps:get(<<"authority">>, Process),
+    ID = case AuthorityLink of
+        {link, Link, _} ->
+           Authority = hd(binary:split(Link, <<"/">>, [global, trim_all])),
+           ?event(x, {authority, Authority}),
+           P = hb_message:with_commitments(Authority, Process, Opts),
+           ?event(x, {process_with_comm, P}),
+           dev_process:process_id(P, #{}, Opts);
+        _ ->
+          ?event(x, {no_authority_link, PrimaryProcess}),
+          dev_process:process_id(PrimaryProcess, #{}, Opts)
+    end,
+    ?event(x, {process_signed_id, ID}),
     UncommittedID =
         dev_process:process_id(
             PrimaryProcess,

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -645,6 +645,7 @@ do_post_schedule(ProcID, PID, Msg2, Opts) ->
             false -> true
         end,
     ?event({verified, Verified}),
+    ?event(debug, {scheduling_message, {msg2, Msg2}, {proc_id, ProcID}, {pid, PID}}),
     % Handle scheduling of the message if the message is valid.
     case {Verified, hb_ao:get(<<"type">>, Msg2, Opts)} of
         {false, _} ->

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -645,7 +645,6 @@ do_post_schedule(ProcID, PID, Msg2, Opts) ->
             false -> true
         end,
     ?event({verified, Verified}),
-    ?event(debug, {scheduling_message, {msg2, Msg2}, {proc_id, ProcID}, {pid, PID}}),
     % Handle scheduling of the message if the message is valid.
     case {Verified, hb_ao:get(<<"type">>, Msg2, Opts)} of
         {false, _} ->


### PR DESCRIPTION
This PR aims to resolve issue regarding process commitments which creating conflicts when two processes with the same data were scheduled, resulting into the same unsigned ID. 
By filtering the right RSA commitment for the current process ID, this resolves the issue.
Running `rebar3 eunit -m dev_lua_test_ledgers`  is now working.