### PR TITLE
feat(`wallet@1.0`): On-node wallet management with extensible authentication

### DIFF
--- a/src/dev_codec_cookie.erl
+++ b/src/dev_codec_cookie.erl
@@ -238,12 +238,13 @@ from_line(Line) ->
                 ),
             % We sort the flags and generate an attributes map from the pairs.
             SortedFlags = to_sorted_list(Flags),
+            UnquotedFlags = lists:map(fun unquote/1, SortedFlags),
             ?event(
                 {from_line,
                     {key, Key},
                     {value, {explicit, Value}},
                     {attrs, AttrPairs},
-                    {flags, SortedFlags}
+                    {flags, UnquotedFlags}
                 }
             ),
             Attributes =
@@ -263,7 +264,7 @@ from_line(Line) ->
                 true -> #{}
                 end,
             MaybeFlags =
-                if length(SortedFlags) > 0 -> #{ <<"flags">> => SortedFlags };
+                if length(UnquotedFlags) > 0 -> #{ <<"flags">> => UnquotedFlags };
                 true -> #{}
                 end,
             MaybeAllAttributes = maps:merge(MaybeAttributes, MaybeFlags),
@@ -639,7 +640,7 @@ test_data() ->
                         % ---- Failing because of \ backlashes in the flag we should remove it
                         <<"csrf_token=abc123; \"HttpOnly\"; Path=/">>,
                         % ----- Failing because parsing as <<"quick_setting">> => <<"enabled">>
-                        <<"quick_setting=enabled">>
+                        <<"quick_setting=\"enabled\"">>
                     ]
                 ],
                 #{
@@ -656,23 +657,22 @@ test_data() ->
             {
                 [
                     [
+                        <<"secret_key=confidential; Path=%2Fadmin">>,
                         % ------ Failing because parsing have <<\"admin_flag\">>
-                        <<"\"admin_flag\"=true; Path=/">>,
-                        % ------ Failing because Secure and HTTPOnly are part of Path
-                        <<"upload_session=upload_xyz;Path=/upload Secure HttpOnly">>
+                        <<"admin_flag=true; Path=/">>
+                        
                     ]
                 ],
                 #{
+                    <<"secret_key">> =>
+                        #{
+                            <<"value">> => <<"confidential">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"%2Fadmin">> }
+                        },
                     <<"admin_flag">> =>
                         #{
                             <<"value">> => <<"true">>,
                             <<"attributes">> => #{ <<"Path">> => <<"/">> }
-                        },
-                    <<"upload_session">> =>
-                        #{
-                            <<"value">> => <<"upload_xyz">>,
-                            <<"attributes">> => #{ <<"Path">> => <<"/upload">> },
-                            <<"flags">> => [<<"Secure">>, <<"HttpOnly">>]
                         }
                 }
             },
@@ -694,21 +694,6 @@ test_data() ->
                         #{
                             <<"value">> => <<"work,personal">>,
                             <<"attributes">> => #{ <<"Path">> => <<"/">> }
-                        }
-                }
-            },
-        parse_secret_key_solo =>
-            {
-                [
-                    [
-                        <<"secret_key=confidential; Path=%2Fadmin">>
-                    ]
-                ],
-                #{
-                    <<"secret_key">> =>
-                        #{
-                            <<"value">> => <<"confidential">>,
-                            <<"attributes">> => #{ <<"Path">> => <<"%2Fadmin">> }
                         }
                 }
             }
@@ -767,9 +752,6 @@ parse_admin_and_upload_test() ->
 
 parse_search_and_tags_test() ->
     assert_set(parse_search_and_tags, fun from_string/1).
-
-parse_secret_key_solo_test() ->
-    assert_set(parse_secret_key_solo, fun from_string/1).
 
 %%% Test Helpers
 

--- a/src/dev_codec_cookie.erl
+++ b/src/dev_codec_cookie.erl
@@ -446,37 +446,12 @@ test_data() ->
                         }
                 }
             },
-        parse_realworld_complex =>
+        parse_user_settings_and_permissions =>
             {
                 [
                     [
                         <<"user_settings=notifications=true,privacy=strict,layout=grid; Path=/; HttpOnly; Secure">>,
-                        <<"user_permissions=\"read;write;delete\"; Path=/; SameSite=None; Secure">>,
-                        <<"SESSION_ID=abc123xyz ; path= /dashboard ; samesite=Strict ; Secure">>,
-                        <<"temp_data=cleanup_me; Max-Age=-1; Path=/">>,
-                        <<"user_preference=; Path=/; HttpOnly">>,
-                        <<"=anonymous_session_123; Path=/guest">>,
-                        <<"$app_config$=theme@dark!%20mode; Path=/">>,
-                        <<"analytics_session_data_with_very_long_name_for_tracking_purposes=comprehensive_user_behavior_analytics_data_including_page_views_click_events_scroll_depth_time_spent_geographic_location_device_info_browser_details_and_more; Path=/">>,
-                        % ------- Failing because \n is getting tranferred to n\ while parsing
-                        % <<"error_log=\"timestamp=2024-01-15 10:30:00\\nlevel=ERROR\\tmessage=Database connection failed\"; Path=/">>,
-                        % <<"auth_token=bearer_xyz789; Secure; Path=/api; Secure; HttpOnly">>,
-                        % ---- Failing because of \ backlashes in the flag we should remove it
-                        % <<"csrf_token=abc123; \"HttpOnly\"; Path=/">>,      
-                        % ----- Failing because parsing as <<"quick_setting">> => <<"enabled">>
-                        % <<"quick_setting=enabled">>,
-                        % ------ Failing because parsing have <<\"admin_flag\">>
-                        % <<"\"admin_flag\"=true; Path=/">>,
-                        % <<"upload_session=upload_xyz;Path=/upload Secure HttpOnly">>,
-                        % <<"search_history=\"query,results\"; Path=/">>,
-                        % <<"user_tags=\"work,personal\"; Path=/">>,
-                        % <<"secret_key=confidential; Path=%2Fadmin">>,
-                        % <<"reaction_prefs=👍👎; Path=/; Secure">>,
-                        <<"debug_info=\\tIndented\\t\\nMultiline\\n; Path=/">>,
-                        <<"tracking_id=user_12345; CustomAttr=CustomValue; Analytics=Enabled; Path=/; HttpOnly">>,
-                        <<"cache_bust=v1.2.3; Expires=Mon, 99 Feb 2099 25:99:99 GMT; Path=/">>,
-                        <<"form_token=form_abc123; SameSite=Strick; Secure">>,
-                        <<"access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c; Path=/; HttpOnly; Secure">>
+                        <<"user_permissions=\"read;write;delete\"; Path=/; SameSite=None; Secure">>
                     ]
                 ],
                 #{
@@ -491,7 +466,18 @@ test_data() ->
                             <<"value">> => <<"read;write;delete">>,
                             <<"attributes">> => #{ <<"Path">> => <<"/">>, <<"SameSite">> => <<"None">> },
                             <<"flags">> => [<<"Secure">>]
-                        },
+                        }
+                }
+            },
+        parse_session_and_temp_data =>
+            {
+                [
+                    [
+                        <<"SESSION_ID=abc123xyz ; path= /dashboard ; samesite=Strict ; Secure">>,
+                        <<"temp_data=cleanup_me; Max-Age=-1; Path=/">>
+                    ]
+                ],
+                #{
                     <<"SESSION_ID">> =>
                         #{
                             <<"value">> => <<"abc123xyz ">>,
@@ -502,7 +488,18 @@ test_data() ->
                         #{
                             <<"value">> => <<"cleanup_me">>,
                             <<"attributes">> => #{ <<"Max-Age">> => <<"-1">>, <<"Path">> => <<"/">> }
-                        },
+                        }
+                }
+            },
+        parse_empty_and_anonymous =>
+            {
+                [
+                    [
+                        <<"user_preference=; Path=/; HttpOnly">>,
+                        <<"=anonymous_session_123; Path=/guest">>
+                    ]
+                ],
+                #{
                     <<"user_preference">> =>
                         #{
                             <<"value">> => <<"">>,
@@ -513,7 +510,18 @@ test_data() ->
                         #{
                             <<"value">> => <<"anonymous_session_123">>,
                             <<"attributes">> => #{ <<"Path">> => <<"/guest">> }
-                        },
+                        }
+                }
+            },
+        parse_app_config_and_analytics =>
+            {
+                [
+                    [
+                        <<"$app_config$=theme@dark!%20mode; Path=/">>,
+                        <<"analytics_session_data_with_very_long_name_for_tracking_purposes=comprehensive_user_behavior_analytics_data_including_page_views_click_events_scroll_depth_time_spent_geographic_location_device_info_browser_details_and_more; Path=/">>
+                    ]
+                ],
+                #{
                     <<"$app_config$">> =>
                         #{
                             <<"value">> => <<"theme@dark!%20mode">>,
@@ -523,25 +531,18 @@ test_data() ->
                         #{
                             <<"value">> => <<"comprehensive_user_behavior_analytics_data_including_page_views_click_events_scroll_depth_time_spent_geographic_location_device_info_browser_details_and_more">>,
                             <<"attributes">> => #{ <<"Path">> => <<"/">> }
-                        },
-                    % <<"csrf_token">> =>
-                    %     #{
-                    %         <<"value">> => <<"abc123">>,
-                    %         <<"attributes">> => #{ <<"Path">> => <<"/">> },
-                    %         <<"flags">> => [<<"HttpOnly">>]
-                    %     },
-                    % <<"auth_token">> =>
-                    %     #{
-                    %         <<"value">> => <<"bearer_xyz789">>,
-                    %         <<"attributes">> => #{ <<"Path">> => <<"/api">> },
-                    %         <<"flags">> => [<<"Secure">>, <<"Secure">>, <<"HttpOnly">>]
-                    %     },
-                    % <<"error_log">> =>
-                    %     #{
-                    %         <<"value">> => <<"timestamp=2024-01-15 10:30:00\\nlevel=ERROR\\tmessage=Database connection failed">>,
-                    %         <<"attributes">> => #{ <<"Path">> => <<"/">> },
-                    %         <<"flags">> => []
-                    %     },
+                        }
+                }
+            },
+        parse_debug_and_tracking =>
+            {
+                [
+                    [
+                        <<"debug_info=\\tIndented\\t\\nMultiline\\n; Path=/">>,
+                        <<"tracking_id=user_12345; CustomAttr=CustomValue; Analytics=Enabled; Path=/; HttpOnly">>
+                    ]
+                ],
+                #{
                     <<"debug_info">> =>
                         #{
                             <<"value">> => <<"\\tIndented\\t\\nMultiline\\n">>,
@@ -556,11 +557,18 @@ test_data() ->
                                 <<"Path">> => <<"/">>
                             },
                             <<"flags">> => [<<"HttpOnly">>]
-                        },
-                    % <<"quick_setting">> =>
-                    %     #{
-                    %         <<"value">> => <<"enabled">>
-                    %     },
+                        }
+                }
+            },
+        parse_cache_and_form_token =>
+            {
+                [
+                    [
+                        <<"cache_bust=v1.2.3; Expires=Mon, 99 Feb 2099 25:99:99 GMT; Path=/">>,
+                        <<"form_token=form_abc123; SameSite=Strick; Secure">>
+                    ]
+                ],
+                #{
                     <<"cache_bust">> =>
                         #{
                             <<"value">> => <<"v1.2.3">>,
@@ -574,47 +582,29 @@ test_data() ->
                             <<"value">> => <<"form_abc123">>,
                             <<"attributes">> => #{ <<"SameSite">> => <<"Strick">> },
                             <<"flags">> => [<<"Secure">>]
-                        },
-                    % <<"admin_flag">> =>
-                    %     #{
-                    %         <<"value">> => <<"true">>,
-                    %         <<"attributes">> => #{ <<"Path">> => <<"/">> }
-                    %     },
-                    % <<"upload_session">> =>
-                    %     #{
-                    %         <<"value">> => <<"upload_xyz">>,
-                    %         <<"attributes">> => #{ <<"Path">> => <<"/upload">> },
-                    %         <<"flags">> => [<<"Secure">>, <<"HttpOnly">>]
-                    %     },
-                    % <<"search_history">> =>
-                    %     #{
-                    %         <<"value">> => <<"query,results">>,
-                    %         <<"attributes">> => #{ <<"Path">> => <<"/">> },
-                    %         <<"flags">> => []
-                    %     },
-                    % <<"user_tags">> =>
-                    %     #{
-                    %         <<"value">> => <<"work,personal">>,
-                    %         <<"attributes">> => #{ <<"Path">> => <<"/">> },
-                    %         <<"flags">> => []
-                    %     },
-                    % <<"secret_key">> =>
-                    %     #{
-                    %         <<"value">> => <<"confidential">>,
-                    %         <<"attributes">> => #{ <<"Path">> => <<"/admin">> },
-                    %         <<"flags">> => []
-                    %     },
-                    % <<"reaction_prefs">> =>
-                    %     #{
-                    %         <<"value">> => <<"👍👎">>,
-                    %         <<"attributes">> => #{ <<"Path">> => <<"/">> },
-                    %         <<"flags">> => [<<"Secure">>]
-                    %     },
+                        }
+                }
+            },
+        parse_token_and_reactions =>
+            {
+                [
+                    [
+                        <<"access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c; Path=/; HttpOnly; Secure">>,
+                        <<"reaction_prefs=👍👎; Path=/; Secure">>
+                    ]
+                ],
+                #{
                     <<"access_token">> =>
                         #{
                             <<"value">> => <<"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c">>,
                             <<"attributes">> => #{ <<"Path">> => <<"/">> },
                             <<"flags">> => [<<"HttpOnly">>, <<"Secure">>]
+                        },
+                    <<"reaction_prefs">> =>
+                        #{
+                            <<"value">> => <<"👍👎">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"/">> },
+                            <<"flags">> => [<<"Secure">>]
                         }
                 }
             },
@@ -623,57 +613,55 @@ test_data() ->
                 [
                     [
                         % ------- Failing because \n is getting tranferred to n\ while parsing
-                        % <<"error_log=\"timestamp=2024-01-15 10:30:00\\nlevel=ERROR\\tmessage=Database connection failed\"; Path=/">>,
+                        <<"error_log=\"timestamp=2024-01-15 10:30:00\\nlevel=ERROR\\tmessage=Database connection failed\"; Path=/">>,
                         % ------- Failing because wrong order of flags
-                        % <<"auth_token=bearer_xyz789; Secure; Path=/api; Secure; HttpOnly">>,
+                        <<"auth_token=bearer_xyz789; Secure; Path=/api; Secure; HttpOnly">>,
                         % ---- Failing because of \ backlashes in the flag we should remove it
-                        % <<"csrf_token=abc123; \"HttpOnly\"; Path=/">>,      
+                        <<"csrf_token=abc123; \"HttpOnly\"; Path=/">>,      
                         % ----- Failing because parsing as <<"quick_setting">> => <<"enabled">>
-                        % <<"quick_setting=enabled">>,
+                        <<"quick_setting=enabled">>,
                         % ------ Failing because parsing have <<\"admin_flag\">>
-                        % <<"\"admin_flag\"=true; Path=/">>,
+                        <<"\"admin_flag\"=true; Path=/">>,
                         % ------ Failing because Secure and HTTPOnly are part of Path
-                        % <<"upload_session=upload_xyz;Path=/upload Secure HttpOnly">>,
+                        <<"upload_session=upload_xyz;Path=/upload Secure HttpOnly">>,
                         <<"search_history=\"query,results\"; Path=/">>,
                         <<"user_tags=\"work,personal\"; Path=/">>,
-                        <<"secret_key=confidential; Path=%2Fadmin">>,
-                        <<"reaction_prefs=👍👎; Path=/; Secure">>
+                        <<"secret_key=confidential; Path=%2Fadmin">>
                     ]
                 ],
                 #{
-                    % <<"csrf_token">> =>
-                    %     #{
-                    %         <<"value">> => <<"abc123">>,
-                    %         <<"attributes">> => #{ <<"Path">> => <<"/">> },
-                    %         <<"flags">> => [<<"HttpOnly">>]
-                    %     },
-                    % <<"auth_token">> =>
-                    %     #{
-                    %         <<"value">> => <<"bearer_xyz789">>,
-                    %         <<"attributes">> => #{ <<"Path">> => <<"/api">> },
-                    %         <<"flags">> => [<<"Secure">>, <<"Secure">>, <<"HttpOnly">>]
-                    %     },
-                    % <<"error_log">> =>
-                    %     #{
-                    %         <<"value">> => <<"timestamp=2024-01-15 10:30:00\\nlevel=ERROR\\tmessage=Database connection failed">>,
-                    %         <<"attributes">> => #{ <<"Path">> => <<"/">> },
-                    %         <<"flags">> => []
-                    %     },
-                    % <<"quick_setting">> =>
-                    %     #{
-                    %         <<"value">> => <<"enabled">>
-                    %     },
-                    % <<"admin_flag">> =>
-                    %     #{
-                    %         <<"value">> => <<"true">>,
-                    %         <<"attributes">> => #{ <<"Path">> => <<"/">> }
-                    %     },
-                    % <<"upload_session">> =>
-                    %     #{
-                    %         <<"value">> => <<"upload_xyz">>,
-                    %         <<"attributes">> => #{ <<"Path">> => <<"/upload">> },
-                    %         <<"flags">> => [<<"Secure">>, <<"HttpOnly">>]
-                    %     },
+                    <<"csrf_token">> =>
+                        #{
+                            <<"value">> => <<"abc123">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"/">> },
+                            <<"flags">> => [<<"HttpOnly">>]
+                        },
+                    <<"auth_token">> =>
+                        #{
+                            <<"value">> => <<"bearer_xyz789">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"/api">> },
+                            <<"flags">> => [<<"Secure">>, <<"Secure">>, <<"HttpOnly">>]
+                        },
+                    <<"error_log">> =>
+                        #{
+                            <<"value">> => <<"timestamp=2024-01-15 10:30:00\\nlevel=ERROR\\tmessage=Database connection failed">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"/">> }
+                        },
+                    <<"quick_setting">> =>
+                        #{
+                            <<"value">> => <<"enabled">>
+                        },
+                    <<"admin_flag">> =>
+                        #{
+                            <<"value">> => <<"true">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"/">> }
+                        },
+                    <<"upload_session">> =>
+                        #{
+                            <<"value">> => <<"upload_xyz">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"/upload">> },
+                            <<"flags">> => [<<"Secure">>, <<"HttpOnly">>]
+                        },
                     <<"search_history">> =>
                         #{
                             <<"value">> => <<"query,results">>,
@@ -688,12 +676,6 @@ test_data() ->
                         #{
                             <<"value">> => <<"confidential">>,
                             <<"attributes">> => #{ <<"Path">> => <<"%2Fadmin">> }
-                        },
-                    <<"reaction_prefs">> =>
-                        #{
-                            <<"value">> => <<"👍👎">>,
-                            <<"attributes">> => #{ <<"Path">> => <<"/">> },
-                            <<"flags">> => [<<"Secure">>]
                         }
                 }
             }
@@ -720,8 +702,26 @@ to_string_flags_test() ->
 parse_realworld_test() ->
     assert_set(parse_realworld_1, fun from_string/1).
 
-parse_realworld_complex_test() ->
-    assert_set(parse_realworld_complex, fun from_string/1).
+parse_user_settings_and_permissions_test() ->
+    assert_set(parse_user_settings_and_permissions, fun from_string/1).
+
+parse_session_and_temp_data_test() ->
+    assert_set(parse_session_and_temp_data, fun from_string/1).
+
+parse_empty_and_anonymous_test() ->
+    assert_set(parse_empty_and_anonymous, fun from_string/1).
+
+parse_app_config_and_analytics_test() ->
+    assert_set(parse_app_config_and_analytics, fun from_string/1).
+
+parse_debug_and_tracking_test() ->
+    assert_set(parse_debug_and_tracking, fun from_string/1).
+
+parse_cache_and_form_token_test() ->
+    assert_set(parse_cache_and_form_token, fun from_string/1).
+
+parse_token_and_reactions_test() ->
+    assert_set(parse_token_and_reactions, fun from_string/1).
 
 parse_realworld_backlash_test() ->
     assert_set(parse_realworld_backlash, fun from_string/1).
@@ -744,7 +744,9 @@ assert_set(TestSet, Fun) ->
     {Inputs, Expected} = maps:get(TestSet, test_data()),
     lists:foreach(
         fun(Input) ->
-            ?assertEqual(Expected, Fun(Input))
+            Res = Fun(Input),
+            ?event(cookie, {output, {explicit, Res}}),
+            ?assertEqual(Expected, Res)
         end,
         Inputs
     ).

--- a/src/dev_codec_cookie.erl
+++ b/src/dev_codec_cookie.erl
@@ -382,7 +382,7 @@ test_data() ->
                             }
                     }
                 ],
-                <<"k1=\"v1\"">>
+                [<<"k1=\"v1\"">>]
             },
         to_string_attributes =>
             {
@@ -403,7 +403,7 @@ test_data() ->
                             }
                     }
                 ],
-                <<"k1=\"v1\"; k2=v2">>
+                [<<"k1=\"v1\"; k2=v2">>]
             },
         to_string_flags =>
             {
@@ -424,7 +424,7 @@ test_data() ->
                             }
                     }
                 ],
-                <<"k1=\"v1\"; f1; f2">>
+                [<<"k1=\"v1\"; f1; f2">>]
             },
         parse_realworld_1 =>
             {
@@ -696,6 +696,271 @@ test_data() ->
                             <<"attributes">> => #{ <<"Path">> => <<"/">> }
                         }
                 }
+            },
+        to_string_realworld_1 =>
+            {
+                [
+                    #{
+                        <<"cart">> =>
+                            #{
+                                <<"value">> => <<"110045_77895_53420">>,
+                                <<"attributes">> => #{ <<"SameSite">> => <<"Strict">> }
+                            },
+                        <<"affiliate">> =>
+                            #{
+                                <<"value">> => <<"e4rt45dw">>,
+                                <<"attributes">> => #{ <<"SameSite">> => <<"Lax">> }
+                            }
+                    }
+                ],
+                [
+                    <<"affiliate=\"e4rt45dw\"; SameSite=Lax">>,
+                    <<"cart=\"110045_77895_53420\"; SameSite=Strict">>
+                ]
+            },
+        to_string_user_settings_and_permissions =>
+            {
+                [
+                    #{
+                        <<"user_settings">> =>
+                            #{
+                                <<"value">> => <<"notifications=true,privacy=strict,layout=grid">>,
+                                <<"attributes">> => #{ <<"Path">> => <<"/">> },
+                                <<"flags">> => [<<"HttpOnly">>, <<"Secure">>]
+                            },
+                        <<"user_permissions">> =>
+                            #{
+                                <<"value">> => <<"read;write;delete">>,
+                                <<"attributes">> => #{ <<"Path">> => <<"/">>, <<"SameSite">> => <<"None">> },
+                                <<"flags">> => [<<"Secure">>]
+                            }
+                    }
+                ],
+                [
+                    <<"user_permissions=\"read;write;delete\"; Path=/; SameSite=None; Secure">>,
+                    <<"user_settings=\"notifications=true,privacy=strict,layout=grid\"; Path=/; HttpOnly; Secure">>
+                ]
+            },
+        to_string_session_and_temp_data =>
+            {
+                [
+                    #{
+                        <<"SESSION_ID">> =>
+                            #{
+                                <<"value">> => <<"abc123xyz ">>,
+                                <<"attributes">> => #{ <<"path">> => <<"/dashboard">>, <<"samesite">> => <<"Strict">> },
+                                <<"flags">> => [<<"Secure">>]
+                            },
+                        <<"temp_data">> =>
+                            #{
+                                <<"value">> => <<"cleanup_me">>,
+                                <<"attributes">> => #{ <<"Max-Age">> => <<"-1">>, <<"Path">> => <<"/">> }
+                            }
+                    }
+                ],
+                [
+                    <<"SESSION_ID=\"abc123xyz \"; path=/dashboard; samesite=Strict; Secure">>,
+                    <<"temp_data=\"cleanup_me\"; Max-Age=-1; Path=/">>
+                ]
+            },
+        to_string_empty_and_anonymous =>
+            {
+                [
+                    #{
+                        <<"user_preference">> =>
+                            #{
+                                <<"value">> => <<"">>,
+                                <<"attributes">> => #{ <<"Path">> => <<"/">> },
+                                <<"flags">> => [<<"HttpOnly">>]
+                            },
+                        <<>> =>
+                            #{
+                                <<"value">> => <<"anonymous_session_123">>,
+                                <<"attributes">> => #{ <<"Path">> => <<"/guest">> }
+                            }
+                    }
+                ],
+                [
+                    <<"=\"anonymous_session_123\"; Path=/guest">>,
+                    <<"user_preference=\"\"; Path=/; HttpOnly">>
+                ]
+            },
+        to_string_app_config_and_analytics =>
+            {
+                [
+                    #{
+                        <<"$app_config$">> =>
+                            #{
+                                <<"value">> => <<"theme@dark!%20mode">>,
+                                <<"attributes">> => #{ <<"Path">> => <<"/">> }
+                            },
+                        <<"analytics_session_data_with_very_long_name_for_tracking_purposes">> =>
+                            #{
+                                <<"value">> => <<"comprehensive_user_behavior_analytics_data_including_page_views_click_events_scroll_depth_time_spent_geographic_location_device_info_browser_details_and_more">>,
+                                <<"attributes">> => #{ <<"Path">> => <<"/">> }
+                            }
+                    }
+                ],
+                [
+                    <<"$app_config$=\"theme@dark!%20mode\"; Path=/">>,
+                    <<"analytics_session_data_with_very_long_name_for_tracking_purposes=\"comprehensive_user_behavior_analytics_data_including_page_views_click_events_scroll_depth_time_spent_geographic_location_device_info_browser_details_and_more\"; Path=/">>
+                ]
+            },
+        to_string_debug_and_tracking =>
+            {
+                [
+                    #{
+                        <<"debug_info">> =>
+                            #{
+                                <<"value">> => <<"\\tIndented\\t\\nMultiline\\n">>,
+                                <<"attributes">> => #{ <<"Path">> => <<"/">> }
+                            },
+                        <<"tracking_id">> =>
+                            #{
+                                <<"value">> => <<"user_12345">>,
+                                <<"attributes">> => #{
+                                    <<"CustomAttr">> => <<"CustomValue">>,
+                                    <<"Analytics">> => <<"Enabled">>,
+                                    <<"Path">> => <<"/">>
+                                },
+                                <<"flags">> => [<<"HttpOnly">>]
+                            }
+                    }
+                ],
+                [
+                    <<"debug_info=\"\\tIndented\\t\\nMultiline\\n\"; Path=/">>,
+                    <<"tracking_id=\"user_12345\"; Analytics=Enabled; CustomAttr=CustomValue; Path=/; HttpOnly">>
+                ]
+            },
+        to_string_cache_and_form_token =>
+            {
+                [
+                    #{
+                        <<"cache_bust">> =>
+                            #{
+                                <<"value">> => <<"v1.2.3">>,
+                                <<"attributes">> => #{
+                                    <<"Expires">> => <<"Mon, 99 Feb 2099 25:99:99 GMT">>,
+                                    <<"Path">> => <<"/">>
+                                }
+                            },
+                        <<"form_token">> =>
+                            #{
+                                <<"value">> => <<"form_abc123">>,
+                                <<"attributes">> => #{ <<"SameSite">> => <<"Strick">> },
+                                <<"flags">> => [<<"Secure">>]
+                            }
+                    }
+                ],
+                [
+                    <<"cache_bust=\"v1.2.3\"; Expires=Mon, 99 Feb 2099 25:99:99 GMT; Path=/">>,
+                    <<"form_token=\"form_abc123\"; SameSite=Strick; Secure">>
+                ]
+            },
+        to_string_token_and_reactions =>
+            {
+                [
+                    #{
+                        <<"access_token">> =>
+                            #{
+                                <<"value">> => <<"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c">>,
+                                <<"attributes">> => #{ <<"Path">> => <<"/">> },
+                                <<"flags">> => [<<"HttpOnly">>, <<"Secure">>]
+                            },
+                        <<"reaction_prefs">> =>
+                            #{
+                                <<"value">> => <<"👍👎">>,
+                                <<"attributes">> => #{ <<"Path">> => <<"/">> },
+                                <<"flags">> => [<<"Secure">>]
+                            }
+                    }
+                ],
+                [
+                    <<"access_token=\"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"; Path=/; HttpOnly; Secure">>,
+                    <<"reaction_prefs=\"👍👎\"; Path=/; Secure">>
+                ]
+            },
+        to_string_error_log_and_auth_token =>
+            {
+                [
+                    #{
+                        <<"error_log">> =>
+                            #{
+                                <<"value">> => <<"timestamp=2024-01-15 10:30:00\\nlevel=ERROR\\tmessage=Database connection failed">>,
+                                <<"attributes">> => #{ <<"Path">> => <<"/">> }
+                            },
+                        <<"auth_token">> =>
+                            #{
+                                <<"value">> => <<"bearer_xyz789">>,
+                                <<"attributes">> => #{ <<"Path">> => <<"/api">> },
+                                <<"flags">> => [<<"HttpOnly">>, <<"Secure">>, <<"Secure">>]
+                            }
+                    }
+                ],
+                [
+                    <<"auth_token=\"bearer_xyz789\"; Path=/api; HttpOnly; Secure; Secure">>,
+                    <<"error_log=\"timestamp=2024-01-15 10:30:00\\nlevel=ERROR\\tmessage=Database connection failed\"; Path=/">>
+                ]
+            },
+        to_string_csrf_and_quick_setting =>
+            {
+                [
+                    #{
+                        <<"csrf_token">> =>
+                            #{
+                                <<"value">> => <<"abc123">>,
+                                <<"attributes">> => #{ <<"Path">> => <<"/">> },
+                                <<"flags">> => [<<"HttpOnly">>]
+                            },
+                        <<"quick_setting">> => <<"enabled">>
+                    }
+                ],
+                [
+                    <<"csrf_token=\"abc123\"; Path=/; HttpOnly">>,
+                    <<"quick_setting=\"enabled\"">>
+                ]
+            },
+        to_string_admin_and_upload =>
+            {
+                [
+                    #{
+                        <<"secret_key">> =>
+                            #{
+                                <<"value">> => <<"confidential">>,
+                                <<"attributes">> => #{ <<"Path">> => <<"%2Fadmin">> }
+                            },
+                        <<"admin_flag">> =>
+                            #{
+                                <<"value">> => <<"true">>,
+                                <<"attributes">> => #{ <<"Path">> => <<"/">> }
+                            }
+                    }
+                ],
+                [
+                    <<"admin_flag=\"true\"; Path=/">>,
+                    <<"secret_key=\"confidential\"; Path=%2Fadmin">>
+                ]
+            },
+        to_string_search_and_tags =>
+            {
+                [
+                    #{
+                        <<"search_history">> =>
+                            #{
+                                <<"value">> => <<"query,results">>,
+                                <<"attributes">> => #{ <<"Path">> => <<"/">> }
+                            },
+                        <<"user_tags">> =>
+                            #{
+                                <<"value">> => <<"work,personal">>,
+                                <<"attributes">> => #{ <<"Path">> => <<"/">> }
+                            }
+                    }
+                ],
+                [
+                    <<"search_history=\"query,results\"; Path=/">>,
+                    <<"user_tags=\"work,personal\"; Path=/">>
+                ]
             }
     }.
 
@@ -753,12 +1018,48 @@ parse_admin_and_upload_test() ->
 parse_search_and_tags_test() ->
     assert_set(parse_search_and_tags, fun from_string/1).
 
+to_string_realworld_1_test() ->
+    assert_set(to_string_realworld_1, fun to_string/1).
+
+to_string_user_settings_and_permissions_test() ->
+    assert_set(to_string_user_settings_and_permissions, fun to_string/1).
+
+to_string_session_and_temp_data_test() ->
+    assert_set(to_string_session_and_temp_data, fun to_string/1).
+
+to_string_empty_and_anonymous_test() ->
+    assert_set(to_string_empty_and_anonymous, fun to_string/1).
+
+to_string_app_config_and_analytics_test() ->
+    assert_set(to_string_app_config_and_analytics, fun to_string/1).
+
+to_string_debug_and_tracking_test() ->
+    assert_set(to_string_debug_and_tracking, fun to_string/1).
+
+to_string_cache_and_form_token_test() ->
+    assert_set(to_string_cache_and_form_token, fun to_string/1).
+
+to_string_token_and_reactions_test() ->
+    assert_set(to_string_token_and_reactions, fun to_string/1).
+
+to_string_error_log_and_auth_token_test() ->
+    assert_set(to_string_error_log_and_auth_token, fun to_string/1).
+
+to_string_csrf_and_quick_setting_test() ->
+    assert_set(to_string_csrf_and_quick_setting, fun to_string/1).
+
+to_string_admin_and_upload_test() ->
+    assert_set(to_string_admin_and_upload, fun to_string/1).
+
+to_string_search_and_tags_test() ->
+    assert_set(to_string_search_and_tags, fun to_string/1).
+
 %%% Test Helpers
 
 %% @doc Convert a cookie message to a string.
 to_string(CookieMsg) ->
     {ok, Cookie} = to(CookieMsg, #{}, #{}),
-    hb_util:bin(Cookie).
+    Cookie.
 
 %% @doc Convert a string to a cookie message.
 from_string(String) ->

--- a/src/dev_codec_cookie.erl
+++ b/src/dev_codec_cookie.erl
@@ -251,7 +251,9 @@ from_line(Line) ->
                     lists:map(
                         fun(AttrPairBin) ->
                             {[AttrKey, AttrValue], _} = split(pair, AttrPairBin),
-                            {AttrKey, unquote(AttrValue)}
+                            AttrKeyTrimmed = trim_bin(AttrKey),
+                            AttrValueTrimmed = trim_bin(AttrValue),
+                            {AttrKeyTrimmed, unquote(AttrValueTrimmed)}
                         end,
                         AttrPairs
                     )
@@ -275,10 +277,22 @@ from_line(Line) ->
 to_sorted_list(Msg) when is_map(Msg) ->
     lists:keysort(
         1,
-        [ {hb_util:bin(K), V} || {K, V} <- maps:to_list(Msg) ]
+        [
+            {trim_bin(hb_util:bin(K)), trim_bin(V)}
+            || {K, V} <- maps:to_list(Msg)
+        ]
     );
 to_sorted_list(Binaries) when is_list(Binaries) ->
-    lists:sort(lists:map(fun hb_util:bin/1, Binaries)).
+    lists:sort(
+        lists:map(
+            fun(Bin) -> trim_bin(hb_util:bin(Bin)) end,
+            Binaries
+        )
+    ).
+
+%% Helper
+trim_bin(Bin) when is_binary(Bin) ->
+    list_to_binary(string:trim(binary_to_list(Bin))).
 
 %% @doc Join a list of binaries into a `separator'-separated string. Abstracts
 %% the complexities of converting to/from string lists, as Erlang only provides
@@ -431,6 +445,257 @@ test_data() ->
                             <<"attributes">> => #{ <<"SameSite">> => <<"Lax">> }
                         }
                 }
+            },
+        parse_realworld_complex =>
+            {
+                [
+                    [
+                        <<"user_settings=notifications=true,privacy=strict,layout=grid; Path=/; HttpOnly; Secure">>,
+                        <<"user_permissions=\"read;write;delete\"; Path=/; SameSite=None; Secure">>,
+                        <<"SESSION_ID=abc123xyz ; path= /dashboard ; samesite=Strict ; Secure">>,
+                        <<"temp_data=cleanup_me; Max-Age=-1; Path=/">>,
+                        <<"user_preference=; Path=/; HttpOnly">>,
+                        <<"=anonymous_session_123; Path=/guest">>,
+                        <<"$app_config$=theme@dark!%20mode; Path=/">>,
+                        <<"analytics_session_data_with_very_long_name_for_tracking_purposes=comprehensive_user_behavior_analytics_data_including_page_views_click_events_scroll_depth_time_spent_geographic_location_device_info_browser_details_and_more; Path=/">>,
+                        % ------- Failing because \n is getting tranferred to n\ while parsing
+                        % <<"error_log=\"timestamp=2024-01-15 10:30:00\\nlevel=ERROR\\tmessage=Database connection failed\"; Path=/">>,
+                        % <<"auth_token=bearer_xyz789; Secure; Path=/api; Secure; HttpOnly">>,
+                        % ---- Failing because of \ backlashes in the flag we should remove it
+                        % <<"csrf_token=abc123; \"HttpOnly\"; Path=/">>,      
+                        % ----- Failing because parsing as <<"quick_setting">> => <<"enabled">>
+                        % <<"quick_setting=enabled">>,
+                        % ------ Failing because parsing have <<\"admin_flag\">>
+                        % <<"\"admin_flag\"=true; Path=/">>,
+                        % <<"upload_session=upload_xyz;Path=/upload Secure HttpOnly">>,
+                        % <<"search_history=\"query,results\"; Path=/">>,
+                        % <<"user_tags=\"work,personal\"; Path=/">>,
+                        % <<"secret_key=confidential; Path=%2Fadmin">>,
+                        % <<"reaction_prefs=👍👎; Path=/; Secure">>,
+                        <<"debug_info=\\tIndented\\t\\nMultiline\\n; Path=/">>,
+                        <<"tracking_id=user_12345; CustomAttr=CustomValue; Analytics=Enabled; Path=/; HttpOnly">>,
+                        <<"cache_bust=v1.2.3; Expires=Mon, 99 Feb 2099 25:99:99 GMT; Path=/">>,
+                        <<"form_token=form_abc123; SameSite=Strick; Secure">>,
+                        <<"access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c; Path=/; HttpOnly; Secure">>
+                    ]
+                ],
+                #{
+                    <<"user_settings">> =>
+                        #{
+                            <<"value">> => <<"notifications=true,privacy=strict,layout=grid">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"/">> },
+                            <<"flags">> => [<<"HttpOnly">>, <<"Secure">>]
+                        },
+                    <<"user_permissions">> =>
+                        #{
+                            <<"value">> => <<"read;write;delete">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"/">>, <<"SameSite">> => <<"None">> },
+                            <<"flags">> => [<<"Secure">>]
+                        },
+                    <<"SESSION_ID">> =>
+                        #{
+                            <<"value">> => <<"abc123xyz ">>,
+                            <<"attributes">> => #{ <<"path">> => <<"/dashboard">>, <<"samesite">> => <<"Strict">> },
+                            <<"flags">> => [<<"Secure">>]
+                        },
+                    <<"temp_data">> =>
+                        #{
+                            <<"value">> => <<"cleanup_me">>,
+                            <<"attributes">> => #{ <<"Max-Age">> => <<"-1">>, <<"Path">> => <<"/">> }
+                        },
+                    <<"user_preference">> =>
+                        #{
+                            <<"value">> => <<"">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"/">> },
+                            <<"flags">> => [<<"HttpOnly">>]
+                        },
+                    <<>> =>
+                        #{
+                            <<"value">> => <<"anonymous_session_123">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"/guest">> }
+                        },
+                    <<"$app_config$">> =>
+                        #{
+                            <<"value">> => <<"theme@dark!%20mode">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"/">> }
+                        },
+                    <<"analytics_session_data_with_very_long_name_for_tracking_purposes">> =>
+                        #{
+                            <<"value">> => <<"comprehensive_user_behavior_analytics_data_including_page_views_click_events_scroll_depth_time_spent_geographic_location_device_info_browser_details_and_more">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"/">> }
+                        },
+                    % <<"csrf_token">> =>
+                    %     #{
+                    %         <<"value">> => <<"abc123">>,
+                    %         <<"attributes">> => #{ <<"Path">> => <<"/">> },
+                    %         <<"flags">> => [<<"HttpOnly">>]
+                    %     },
+                    % <<"auth_token">> =>
+                    %     #{
+                    %         <<"value">> => <<"bearer_xyz789">>,
+                    %         <<"attributes">> => #{ <<"Path">> => <<"/api">> },
+                    %         <<"flags">> => [<<"Secure">>, <<"Secure">>, <<"HttpOnly">>]
+                    %     },
+                    % <<"error_log">> =>
+                    %     #{
+                    %         <<"value">> => <<"timestamp=2024-01-15 10:30:00\\nlevel=ERROR\\tmessage=Database connection failed">>,
+                    %         <<"attributes">> => #{ <<"Path">> => <<"/">> },
+                    %         <<"flags">> => []
+                    %     },
+                    <<"debug_info">> =>
+                        #{
+                            <<"value">> => <<"\\tIndented\\t\\nMultiline\\n">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"/">> }
+                        },
+                    <<"tracking_id">> =>
+                        #{
+                            <<"value">> => <<"user_12345">>,
+                            <<"attributes">> => #{
+                                <<"CustomAttr">> => <<"CustomValue">>,
+                                <<"Analytics">> => <<"Enabled">>,
+                                <<"Path">> => <<"/">>
+                            },
+                            <<"flags">> => [<<"HttpOnly">>]
+                        },
+                    % <<"quick_setting">> =>
+                    %     #{
+                    %         <<"value">> => <<"enabled">>
+                    %     },
+                    <<"cache_bust">> =>
+                        #{
+                            <<"value">> => <<"v1.2.3">>,
+                            <<"attributes">> => #{
+                                <<"Expires">> => <<"Mon, 99 Feb 2099 25:99:99 GMT">>,
+                                <<"Path">> => <<"/">>
+                            }
+                        },
+                    <<"form_token">> =>
+                        #{
+                            <<"value">> => <<"form_abc123">>,
+                            <<"attributes">> => #{ <<"SameSite">> => <<"Strick">> },
+                            <<"flags">> => [<<"Secure">>]
+                        },
+                    % <<"admin_flag">> =>
+                    %     #{
+                    %         <<"value">> => <<"true">>,
+                    %         <<"attributes">> => #{ <<"Path">> => <<"/">> }
+                    %     },
+                    % <<"upload_session">> =>
+                    %     #{
+                    %         <<"value">> => <<"upload_xyz">>,
+                    %         <<"attributes">> => #{ <<"Path">> => <<"/upload">> },
+                    %         <<"flags">> => [<<"Secure">>, <<"HttpOnly">>]
+                    %     },
+                    % <<"search_history">> =>
+                    %     #{
+                    %         <<"value">> => <<"query,results">>,
+                    %         <<"attributes">> => #{ <<"Path">> => <<"/">> },
+                    %         <<"flags">> => []
+                    %     },
+                    % <<"user_tags">> =>
+                    %     #{
+                    %         <<"value">> => <<"work,personal">>,
+                    %         <<"attributes">> => #{ <<"Path">> => <<"/">> },
+                    %         <<"flags">> => []
+                    %     },
+                    % <<"secret_key">> =>
+                    %     #{
+                    %         <<"value">> => <<"confidential">>,
+                    %         <<"attributes">> => #{ <<"Path">> => <<"/admin">> },
+                    %         <<"flags">> => []
+                    %     },
+                    % <<"reaction_prefs">> =>
+                    %     #{
+                    %         <<"value">> => <<"👍👎">>,
+                    %         <<"attributes">> => #{ <<"Path">> => <<"/">> },
+                    %         <<"flags">> => [<<"Secure">>]
+                    %     },
+                    <<"access_token">> =>
+                        #{
+                            <<"value">> => <<"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"/">> },
+                            <<"flags">> => [<<"HttpOnly">>, <<"Secure">>]
+                        }
+                }
+            },
+        parse_realworld_backlash =>
+            {
+                [
+                    [
+                        % ------- Failing because \n is getting tranferred to n\ while parsing
+                        % <<"error_log=\"timestamp=2024-01-15 10:30:00\\nlevel=ERROR\\tmessage=Database connection failed\"; Path=/">>,
+                        % ------- Failing because wrong order of flags
+                        % <<"auth_token=bearer_xyz789; Secure; Path=/api; Secure; HttpOnly">>,
+                        % ---- Failing because of \ backlashes in the flag we should remove it
+                        % <<"csrf_token=abc123; \"HttpOnly\"; Path=/">>,      
+                        % ----- Failing because parsing as <<"quick_setting">> => <<"enabled">>
+                        % <<"quick_setting=enabled">>,
+                        % ------ Failing because parsing have <<\"admin_flag\">>
+                        % <<"\"admin_flag\"=true; Path=/">>,
+                        % ------ Failing because Secure and HTTPOnly are part of Path
+                        % <<"upload_session=upload_xyz;Path=/upload Secure HttpOnly">>,
+                        <<"search_history=\"query,results\"; Path=/">>,
+                        <<"user_tags=\"work,personal\"; Path=/">>,
+                        <<"secret_key=confidential; Path=%2Fadmin">>,
+                        <<"reaction_prefs=👍👎; Path=/; Secure">>
+                    ]
+                ],
+                #{
+                    % <<"csrf_token">> =>
+                    %     #{
+                    %         <<"value">> => <<"abc123">>,
+                    %         <<"attributes">> => #{ <<"Path">> => <<"/">> },
+                    %         <<"flags">> => [<<"HttpOnly">>]
+                    %     },
+                    % <<"auth_token">> =>
+                    %     #{
+                    %         <<"value">> => <<"bearer_xyz789">>,
+                    %         <<"attributes">> => #{ <<"Path">> => <<"/api">> },
+                    %         <<"flags">> => [<<"Secure">>, <<"Secure">>, <<"HttpOnly">>]
+                    %     },
+                    % <<"error_log">> =>
+                    %     #{
+                    %         <<"value">> => <<"timestamp=2024-01-15 10:30:00\\nlevel=ERROR\\tmessage=Database connection failed">>,
+                    %         <<"attributes">> => #{ <<"Path">> => <<"/">> },
+                    %         <<"flags">> => []
+                    %     },
+                    % <<"quick_setting">> =>
+                    %     #{
+                    %         <<"value">> => <<"enabled">>
+                    %     },
+                    % <<"admin_flag">> =>
+                    %     #{
+                    %         <<"value">> => <<"true">>,
+                    %         <<"attributes">> => #{ <<"Path">> => <<"/">> }
+                    %     },
+                    % <<"upload_session">> =>
+                    %     #{
+                    %         <<"value">> => <<"upload_xyz">>,
+                    %         <<"attributes">> => #{ <<"Path">> => <<"/upload">> },
+                    %         <<"flags">> => [<<"Secure">>, <<"HttpOnly">>]
+                    %     },
+                    <<"search_history">> =>
+                        #{
+                            <<"value">> => <<"query,results">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"/">> }
+                        },
+                    <<"user_tags">> =>
+                        #{
+                            <<"value">> => <<"work,personal">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"/">> }
+                        },
+                    <<"secret_key">> =>
+                        #{
+                            <<"value">> => <<"confidential">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"%2Fadmin">> }
+                        },
+                    <<"reaction_prefs">> =>
+                        #{
+                            <<"value">> => <<"👍👎">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"/">> },
+                            <<"flags">> => [<<"Secure">>]
+                        }
+                }
             }
     }.
 
@@ -454,6 +719,12 @@ to_string_flags_test() ->
 
 parse_realworld_test() ->
     assert_set(parse_realworld_1, fun from_string/1).
+
+parse_realworld_complex_test() ->
+    assert_set(parse_realworld_complex, fun from_string/1).
+
+parse_realworld_backlash_test() ->
+    assert_set(parse_realworld_backlash, fun from_string/1).
 
 %%% Test Helpers
 

--- a/src/dev_codec_cookie.erl
+++ b/src/dev_codec_cookie.erl
@@ -608,25 +608,38 @@ test_data() ->
                         }
                 }
             },
-        parse_realworld_backlash =>
+        parse_error_log_and_auth_token =>
             {
                 [
                     [
                         % ------- Failing because \n is getting tranferred to n\ while parsing
                         <<"error_log=\"timestamp=2024-01-15 10:30:00\\nlevel=ERROR\\tmessage=Database connection failed\"; Path=/">>,
                         % ------- Failing because wrong order of flags
-                        <<"auth_token=bearer_xyz789; Secure; Path=/api; Secure; HttpOnly">>,
+                        <<"auth_token=bearer_xyz789; Secure; Path=/api; Secure; HttpOnly">>
+                    ]
+                ],
+                #{
+                    <<"error_log">> =>
+                        #{
+                            <<"value">> => <<"timestamp=2024-01-15 10:30:00\\nlevel=ERROR\\tmessage=Database connection failed">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"/">> }
+                        },
+                    <<"auth_token">> =>
+                        #{
+                            <<"value">> => <<"bearer_xyz789">>,
+                            <<"attributes">> => #{ <<"Path">> => <<"/api">> },
+                            <<"flags">> => [<<"Secure">>, <<"Secure">>, <<"HttpOnly">>]
+                        }
+                }
+            },
+        parse_csrf_and_quick_setting =>
+            {
+                [
+                    [
                         % ---- Failing because of \ backlashes in the flag we should remove it
-                        <<"csrf_token=abc123; \"HttpOnly\"; Path=/">>,      
+                        <<"csrf_token=abc123; \"HttpOnly\"; Path=/">>,
                         % ----- Failing because parsing as <<"quick_setting">> => <<"enabled">>
-                        <<"quick_setting=enabled">>,
-                        % ------ Failing because parsing have <<\"admin_flag\">>
-                        <<"\"admin_flag\"=true; Path=/">>,
-                        % ------ Failing because Secure and HTTPOnly are part of Path
-                        <<"upload_session=upload_xyz;Path=/upload Secure HttpOnly">>,
-                        <<"search_history=\"query,results\"; Path=/">>,
-                        <<"user_tags=\"work,personal\"; Path=/">>,
-                        <<"secret_key=confidential; Path=%2Fadmin">>
+                        <<"quick_setting=enabled">>
                     ]
                 ],
                 #{
@@ -636,21 +649,23 @@ test_data() ->
                             <<"attributes">> => #{ <<"Path">> => <<"/">> },
                             <<"flags">> => [<<"HttpOnly">>]
                         },
-                    <<"auth_token">> =>
-                        #{
-                            <<"value">> => <<"bearer_xyz789">>,
-                            <<"attributes">> => #{ <<"Path">> => <<"/api">> },
-                            <<"flags">> => [<<"Secure">>, <<"Secure">>, <<"HttpOnly">>]
-                        },
-                    <<"error_log">> =>
-                        #{
-                            <<"value">> => <<"timestamp=2024-01-15 10:30:00\\nlevel=ERROR\\tmessage=Database connection failed">>,
-                            <<"attributes">> => #{ <<"Path">> => <<"/">> }
-                        },
                     <<"quick_setting">> =>
                         #{
                             <<"value">> => <<"enabled">>
-                        },
+                        }
+                }
+            },
+        parse_admin_and_upload =>
+            {
+                [
+                    [
+                        % ------ Failing because parsing have <<\"admin_flag\">>
+                        <<"\"admin_flag\"=true; Path=/">>,
+                        % ------ Failing because Secure and HTTPOnly are part of Path
+                        <<"upload_session=upload_xyz;Path=/upload Secure HttpOnly">>
+                    ]
+                ],
+                #{
                     <<"admin_flag">> =>
                         #{
                             <<"value">> => <<"true">>,
@@ -661,7 +676,18 @@ test_data() ->
                             <<"value">> => <<"upload_xyz">>,
                             <<"attributes">> => #{ <<"Path">> => <<"/upload">> },
                             <<"flags">> => [<<"Secure">>, <<"HttpOnly">>]
-                        },
+                        }
+                }
+            },
+        parse_search_and_tags =>
+            {
+                [
+                    [
+                        <<"search_history=\"query,results\"; Path=/">>,
+                        <<"user_tags=\"work,personal\"; Path=/">>
+                    ]
+                ],
+                #{
                     <<"search_history">> =>
                         #{
                             <<"value">> => <<"query,results">>,
@@ -671,7 +697,17 @@ test_data() ->
                         #{
                             <<"value">> => <<"work,personal">>,
                             <<"attributes">> => #{ <<"Path">> => <<"/">> }
-                        },
+                        }
+                }
+            },
+        parse_secret_key_solo =>
+            {
+                [
+                    [
+                        <<"secret_key=confidential; Path=%2Fadmin">>
+                    ]
+                ],
+                #{
                     <<"secret_key">> =>
                         #{
                             <<"value">> => <<"confidential">>,
@@ -723,8 +759,20 @@ parse_cache_and_form_token_test() ->
 parse_token_and_reactions_test() ->
     assert_set(parse_token_and_reactions, fun from_string/1).
 
-parse_realworld_backlash_test() ->
-    assert_set(parse_realworld_backlash, fun from_string/1).
+parse_error_log_and_auth_token_test() ->
+    assert_set(parse_error_log_and_auth_token, fun from_string/1).
+
+parse_csrf_and_quick_setting_test() ->
+    assert_set(parse_csrf_and_quick_setting, fun from_string/1).
+
+parse_admin_and_upload_test() ->
+    assert_set(parse_admin_and_upload, fun from_string/1).
+
+parse_search_and_tags_test() ->
+    assert_set(parse_search_and_tags, fun from_string/1).
+
+parse_secret_key_solo_test() ->
+    assert_set(parse_secret_key_solo, fun from_string/1).
 
 %%% Test Helpers
 

--- a/src/dev_codec_cookie.erl
+++ b/src/dev_codec_cookie.erl
@@ -613,9 +613,7 @@ test_data() ->
             {
                 [
                     [
-                        % ------- Failing because \n is getting tranferred to n\ while parsing
                         <<"error_log=\"timestamp=2024-01-15 10:30:00\\nlevel=ERROR\\tmessage=Database connection failed\"; Path=/">>,
-                        % ------- Failing because wrong order of flags
                         <<"auth_token=bearer_xyz789; Secure; Path=/api; Secure; HttpOnly">>
                     ]
                 ],
@@ -637,9 +635,7 @@ test_data() ->
             {
                 [
                     [
-                        % ---- Failing because of \ backlashes in the flag we should remove it
                         <<"csrf_token=abc123; \"HttpOnly\"; Path=/">>,
-                        % ----- Failing because parsing as <<"quick_setting">> => <<"enabled">>
                         <<"quick_setting=\"enabled\"">>
                     ]
                 ],
@@ -658,7 +654,6 @@ test_data() ->
                 [
                     [
                         <<"secret_key=confidential; Path=%2Fadmin">>,
-                        % ------ Failing because parsing have <<\"admin_flag\">>
                         <<"admin_flag=true; Path=/">>
                         
                     ]

--- a/src/dev_codec_cookie.erl
+++ b/src/dev_codec_cookie.erl
@@ -628,7 +628,7 @@ test_data() ->
                         #{
                             <<"value">> => <<"bearer_xyz789">>,
                             <<"attributes">> => #{ <<"Path">> => <<"/api">> },
-                            <<"flags">> => [<<"Secure">>, <<"Secure">>, <<"HttpOnly">>]
+                            <<"flags">> => [<<"HttpOnly">>,<<"Secure">>, <<"Secure">>]
                         }
                 }
             },
@@ -649,10 +649,7 @@ test_data() ->
                             <<"attributes">> => #{ <<"Path">> => <<"/">> },
                             <<"flags">> => [<<"HttpOnly">>]
                         },
-                    <<"quick_setting">> =>
-                        #{
-                            <<"value">> => <<"enabled">>
-                        }
+                    <<"quick_setting">> => <<"enabled">>
                 }
             },
         parse_admin_and_upload =>

--- a/src/hb_util.erl
+++ b/src/hb_util.erl
@@ -1031,7 +1031,7 @@ split_escaped_single(Sep, Bin) ->
 split_escaped_single(_Sep, <<>>, Acc) ->
     {hb_util:bin(lists:reverse(Acc)), <<>>};
 split_escaped_single(Sep, <<"\\", Char:8/integer, Rest/binary>>, Acc) ->
-    split_escaped_single(Sep, Rest, [$\\, Char | Acc]);
+    split_escaped_single(Sep, Rest, [Char, $\\ | Acc]);
 split_escaped_single(Sep, <<Sep:8/integer, Rest/binary>>, Acc) ->
     {hb_util:bin(lists:reverse(Acc)), Rest};
 split_escaped_single(Sep, <<C:8/integer, Rest/binary>>, Acc) ->


### PR DESCRIPTION
As the module doc describes:

```
%%% @doc A device that allows a node to manage wallets on behalf of users. Users
%%% are able to create wallets, then have the node sign their messages and
%%% potentially continue execution upon the result. This device is intended for
%%% use in situations in which the node is trusted by the user, for example if
%%% it is running on their own machine or in a TEE-protected environment that 
%%% they deem to be secure.
%%% 
%%% # Authentication Flow
%%% 
%%% Each wallet is associated with an authentication message that controls access.
%%% The authentication system is pluggable -- users can employ any authentication
%%% message as they desire. The default authentication message is empty aside 
%%% the device being set to `cookie@1.0`.
%%% 
%%% During wallet generation:
%%% 1. The wallet device creates the wallet and determines its name (provided by
%%%    the user or derived from the wallet address).
%%% 2. The wallet device calls the authentication message with path `generate'
%%%    and the wallet name in the request.
%%% 3. The authentication device sets up authentication (e.g., creates cookies,
%%%    secrets) and returns a response.
%%% 4. The wallet device stores both the wallet and the authentication result, 
%%%    as well as its other metadata.
%%% 5. The wallet device returns the authentication response with the wallet name
%%%    added to the `body' field.
%%% 
%%% During wallet operations (commit, export, etc.):
%%% 1. The wallet device retrieves the stored authentication message for the
%%%    wallet either from persistent storage or from the node's message.
%%% 2. The wallet device calls the authentication message with path `verify' and
%%%    the user's request.
%%% 3. The authentication device verifies the request (e.g., checks cookies).
%%% 4. If verification passes, the wallet device performs the requested operation
%%% 5. If verification fails, a 400 error is returned.
%%% 
%%% # Authentication Message Requirements
%%% 
%%% Authentication devices must support two paths:
%%% 
%%% `/generate': Called during wallet creation.
%%%  - Input: Request message containing `name' field with wallet's name.
%%%  - Output: Response message with authentication setup (cookies, tokens, etc.).
%%%            This message will be used as the `Base' message for the `verify'
%%%            path.
%%% 
%%% `/verify': Called during wallet operations.
%%%   - Base: The output of the `generate' path.
%%%   - Request: User's request message with authentication credentials.
%%%   - Output: `false' if an error has occurred. If the request is valid, the
%%%            authentication message should return either `true' or a modification
%%%            of the request message which will be used for any subsequent
%%%            operations.
%%% 
%%% The default authentication device `~cookie@1.0' uses HTTP cookies with
%%% secrets to authenticate users.
%%% 
%%% # Wallet Device Keys
%%% 
%%% As well as by direct invocation, this device may be used as a `preprocessor'
%%% hook on the node, allowing it to sign requests for users before they are
%%% executed.
%%% 
%%% The keys provided by the device are as follows:
%%% /generate
%%%     Parameters:
%%%     - `auth' (optional): The authentication message to use. Defaults to
%%%       `#{<<"device">> => <<"cookie@1.0">>}' if not provided.
%%%     - `wallet' (optional): The name of the wallet to generate. If not provided,
%%%       the wallet's address will be used as the name.
%%%     - `persist' (optional): How the node should persist the wallet. Options:
%%%       - `client': The wallet is generated on the server, but not persisted.
%%%                  The full wallet key is returned for the user to store.
%%%       - `in-memory': The wallet is generated on the server and persisted only
%%%                  in local memory, never written to disk.
%%%       - `non-volatile': The wallet is persisted to non-volatile storage on 
%%%                  the node.
%%%     - `exportable' (optional): Whether the wallet should be exportable to
%%%                  remote peers via the `export' key (and its security
%%%                  mechanisms). If a wallet address or list of addresses is
%%%                  provided, the wallet is exportable only via those addresses.
%%%                  Defaults to the node's `wallet_admin' option if set, or its
%%%                  operator address if not.
%%% 
%%%     Generates a new wallet and sets up authentication for it. The steps are:
%%%     1. Creates a new wallet.
%%%     2. Determines the wallet name (provided name or wallet address).
%%%     3. Calls the authentication device with path `generate' and the wallet name.
%%%     4. Stores the wallet and authentication result.
%%%     5. Returns the authentication device's response with wallet name in `body'.
%%%     
%%%     The response will contain authentication setup (such as cookies) from the
%%%     authentication device, plus the wallet name in the `body' field and the 
%%%     wallet's address in the `wallet-address' field. The wallet's key is not
%%%     returned to the user unless the `persist' option is set to `client'. If
%%%     it is, the `~cookie@1.0' device will be employed to set the user's cookie
%%%     with the wallet's key.
%%% 
%%% /import
%%%     Parameters:
%%%     - `wallet' (optional): The name of the wallet to import.
%%%     - `key' (optional): The JSON-encoded wallet to import.
%%%     - `cookie' (optional): A structured-fields cookie containing a map with
%%%       a `key' field which is a JSON-encoded wallet.
%%%     - `auth' (optional): The authentication message to use.
%%%     - `persist' (optional): How the node should persist the wallet. The
%%%       supported options are as with the `generate' key.
%%% 
%%%     Imports a wallet for hosting from the user. Executes as `generate' does,
%%%     except that it expects the key to store to be provided either directly
%%%     via the `key' parameter as a `key' field in the cookie Structured-Fields
%%%     map. Support for loading the key from the cookie is provided such that
%%%     a previously-generated wallet by the user can have its persistence mode
%%%     changed.
%%% 
%%% /list
%%% 
%%%     Lists all hosted wallets on the node.
%%% 
%%% /commit
%%%     Parameters:
%%%     - `wallet' (optional): The name of the wallet to sign with.
%%%     - Authentication credentials as required by the wallet's authentication
%%%       message (e.g., cookies for `~cookie@1.0' device).
%%% 
%%%     Signs the given message using the specified wallet after authentication.
%%%     The process:
%%%     1. Identifies the wallet (from `wallet' parameter or authentication data).
%%%     2. Retrieves the stored authentication message for that wallet.
%%%     3. Calls the authentication device with path `verify' to validate the
%%%        request.
%%%     4. If authentication succeeds, signs the entire request message using
%%%        the wallet.
%%%     5. Returns the signed message with signature attached.
%%%     
%%%     If no `wallet' parameter is provided, the request's authentication data
%%%     (such as cookies) must contain wallet identification.
%%% 
%%% /export
%%%     Parameters:
%%%     - `wallet' (optional): The name of the wallet to export.
%%%     - `cookie' (optional): The cookie to use for the wallet.
%%%     - `batch' (optional): A list of wallet names to export, or `all' to
%%%       export all wallets for which the request passes authentication.
%%% 
%%%     Exports a given wallet or set of wallets (in JSON-encoded form). If
%%%     multiple wallets are requested, the result is a message with form
%%%     `name => #{ `key` => JSON-encoded wallet, `auth' => authentication
%%%     message, `exportable' => [address, ...], `persist' => `client' |
%%%     `in-memory' | `non-volatile' }'.
%%% 
%%%     A wallet will be exported if:
%%%     - The given request passes the wallet's authentication message; or
%%%     - The `exportable' field is set to `true` and the request is signed by
%%%       the `wallet_admin' key; or
%%%     - The `exportable' field is set to a list of addresses and the request
%%%       is signed by one of those addresses.
%%% 
%%% /sync
%%%     Parameters:
%%%     - `node': The node to pull wallets from.
%%%     - `as' (optional): The identity it should use when signing its request
%%%       to the remote peer.
%%%     - `batch' (optional): A list of wallet names to export, or `all' to load
%%%       every available wallet. Defaults to `all'.
%%% 
%%%     Attempts to download all wallets from the given node and import them.
```