### PR TITLE
fix: use hb_opts names for store opts

### DIFF
--- a/src/hb_store.erl
+++ b/src/hb_store.erl
@@ -125,8 +125,9 @@ do_find(StoreOpts = #{ <<"store-module">> := Mod }) ->
 
 %% @doc Create a new instance of a store and return its term.
 spawn_instance(StoreOpts = #{ <<"store-module">> := Mod }) ->
+    NodeStoreOpts = maybe_use_config_name(StoreOpts, Mod),
     Name = maps:get(<<"name">>, StoreOpts, Mod),
-    try Mod:start(StoreOpts) of
+    try Mod:start(NodeStoreOpts) of
         ok -> ok;
         {ok, InstanceMessage} ->
             set(Mod, Name, InstanceMessage),
@@ -356,6 +357,22 @@ call_all([Store = #{<<"store-module">> := Mod} | Rest], Function, Args) ->
             ok
     end,
     call_all(Rest, Function, Args).
+
+maybe_use_config_name(StoreOpts, Mod) ->
+    case maps:find(<<"name">>, StoreOpts) of
+        {ok, _Name} ->
+            StoreOpts;
+        error ->
+            NodeOptsStores = hb_opts:get(store, #{}),
+            MatchingStores = [maps:get(<<"name">>, S, Mod) || S <- NodeOptsStores,
+                is_map(S) andalso maps:find(<<"store-module">>, S) =:= {ok, Mod}],
+            case lists:uniq(MatchingStores) of
+                [Name] ->
+                    StoreOpts#{<<"name">> => Name};
+                [] ->
+                    StoreOpts % No name found, return as is.
+            end
+    end.
 
 %%% Test helpers
 

--- a/src/hb_store.erl
+++ b/src/hb_store.erl
@@ -365,12 +365,12 @@ maybe_use_config_name(StoreOpts, Mod) ->
         error ->
             NodeOptsStores = hb_opts:get(store, #{}),
             MatchingStores = [maps:get(<<"name">>, S, Mod) || S <- NodeOptsStores,
-                is_map(S) andalso maps:find(<<"store-module">>, S) =:= {ok, Mod}],
+                maps:find(<<"store-module">>, S) =:= {ok, Mod}],
             case lists:uniq(MatchingStores) of
                 [Name] ->
                     StoreOpts#{<<"name">> => Name};
                 [] ->
-                    StoreOpts % No name found, return as is.
+                    StoreOpts
             end
     end.
 

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -67,7 +67,7 @@ start(Opts = #{ <<"name">> := DataDir }) ->
     persistent_term:put(StoreKey, {Env, DataDir}),
     {ok, #{ <<"env">> => Env, <<"db">> => DBInstance }};
 start(_) ->
-    {error, {badarg, <<"StoreOpts must be a map">>}}.
+    {error, {badarg, <<"StoreOpts must be a map with a name">>}}.
 
 %% @doc Determine whether a key represents a simple value or composite group.
 %%


### PR DESCRIPTION
## Problem

When writing to a store passing the `store-module` without a specific `name` it throws an error saying the StoreOpts should be a map: 
```
1> StoreOpts = #{~"store-module" => hb_store_lmdb}.
#{<<"store-module">> => hb_store_lmdb}
2> hb_store:write(StoreOpts, ~"test-key", ~"test-value").
=== HB DEBUG ===[0ms in <0.4918.0> @ hb_store:301 / hb_store:319 / hb_store_lmdb:126 / hb_store:135]==>
store_start_failed: hb_store_lmdb, hb_store_lmdb, badarg: StoreOpts must be a map
```

## Proposal

This PR suggests to use the HyperBEAM Node config set by `hb_opts` which defines a mapping as such:
```
store =>
            [
                % #{
                %     <<"name">> => <<"cache-mainnet/lru">>,
                %     <<"capacity">> => 512 * 1024 * 1024,
                %     <<"store-module">> => hb_store_lru,
                %     <<"persistent-store">> => #{
                %         <<"store-module">> => hb_store_fs,
                %         <<"name">> => <<"cache-mainnet/lru">>
                %     }
                % },
                #{
                    <<"name">> => <<"cache-mainnet/lmdb">>,
                    <<"store-module">> => hb_store_lmdb
                },
                #{
                    <<"store-module">> => hb_store_fs,
                    <<"name">> => <<"cache-mainnet">>
                },
                ...
```

Once the Node knows how to locate the store, it simplifies the `hb_store` calls using the names defined by `hb_opts` as the default names. When a name is not found as for `hb_store_gateway`, it preserves the `edge` behaviour to use the `Mod` (calling `Name = maps:get(<<"name">>, StoreOpts, Mod)`)