### PR TITLE
feat: add `event` profiler, showing event count during execution

### DIFF
--- a/src/dev_profile.erl
+++ b/src/dev_profile.erl
@@ -188,7 +188,7 @@ eflame_profile(Fun, Req, Opts) ->
     StackToFlameScript = hb_util:bin(filename:join(EflameDir, "flamegraph.pl")),
     FlameArg =
         case MergeStacks of
-            <<"merge">> -> <<"--merge">>;
+            <<"merge">> -> <<"">>;
             <<"time">> -> <<"--flamechart">>
         end,
     PreparedCommand = 


### PR DESCRIPTION
Additionally, this patch adds a `mode` flag to the eflame profile. The supported modes are `time` (chronologically ordering the flame graph), and `merge` (showing stacked charts of cumulative time spent in functions). The default for now remains `merge`, as `flamegraph.pl` uses.
