### PR TITLE
feat: Support for snapshot coordination in `~genesis-wasm@1.0`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ compile:
 WAMR_VERSION = 2.2.0
 WAMR_DIR = _build/wamr
 
-GENESIS_WASM_BRANCH = tillathehun0/cu-experimental
+GENESIS_WASM_BRANCH = feat/http-checkpoint
 GENESIS_WASM_REPO = https://github.com/permaweb/ao.git
 GENESIS_WASM_SERVER_DIR = _build/genesis_wasm/genesis-wasm-server
 

--- a/rebar.config
+++ b/rebar.config
@@ -27,7 +27,10 @@
         ]},
         {relx, [
             {overlay, [
-                {copy, "_build/genesis_wasm/genesis-wasm-server", "genesis-wasm-server"}
+                {copy,
+                    "_build/genesis_wasm/genesis-wasm-server",
+                    "genesis-wasm-server"
+                }
             ]}
         ]}
     ]},

--- a/src/dev_delegated_compute.erl
+++ b/src/dev_delegated_compute.erl
@@ -11,9 +11,16 @@
 %% need to do anything special here.
 init(Msg1, _Msg2, _Opts) ->
     {ok, Msg1}.
-normalize(Msg1, _Msg2, _Opts) -> {ok, Msg1}.
-snapshot(Msg1, _Msg2, _Opts) -> {ok, Msg1}.
 
+%% @doc We assume that the compute engine stores its own internal state,
+%% with snapshots triggered only when HyperBEAM requests them. Subsequently,
+%% to load a snapshot, we just need to return the original message.
+normalize(Msg1, _Msg2, Opts) ->
+    hb_ao:set(Msg1, #{ <<"snapshot">> => unset }, Opts).
+
+%% @doc Call the delegated server to compute the result. The endpoint is
+%% `POST /compute' and the body is the JSON-encoded message that we want to
+%% evaluate.
 compute(Msg1, Msg2, Opts) ->
     RawProcessID = dev_process:process_id(Msg1, #{}, Opts),
     OutputPrefix = dev_stack:prefix(Msg1, Msg2, Opts),
@@ -101,3 +108,28 @@ do_compute(ProcID, Msg2, Opts) ->
         {Err, Error} when Err == error; Err == failure ->
             {error, Error}
     end.
+
+%% @doc Generate a snapshot of a running computation by calling the 
+%% `GET /snapshot' endpoint.
+snapshot(Msg, Msg2, Opts) ->
+    ?event({snapshotting, {req, Msg2}}),
+    {ok, ProcID} = dev_process:process_id(Msg, #{}, Opts),
+    Res = 
+        hb_ao:resolve(
+            #{
+                <<"device">> => <<"relay@1.0">>,
+                <<"content-type">> => <<"application/json">>
+            },
+            #{
+                <<"path">> => <<"call">>,
+                <<"relay-method">> => <<"POST">>,
+                <<"relay-path">> => <<"/snapshot/", ProcID/binary>>,
+                <<"content-type">> => <<"application/json">>
+            },
+            Opts#{
+                hashpath => ignore,
+                cache_control => [<<"no-store">>, <<"no-cache">>]
+            }
+        ),
+    ?event({snapshotting_result, Res}),
+    Res.

--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -84,7 +84,15 @@ ensure_started(Opts) ->
                 filename:join([Cwd, "genesis-wasm-server"]);
             _ ->
                 % We're in development mode - look in the build directory
-                DevPath = filename:join([Cwd, "_build", "genesis_wasm", "genesis-wasm-server"]),
+                DevPath =
+                    filename:join(
+                        [
+                            Cwd,
+                            "_build",
+                            "genesis_wasm",
+                            "genesis-wasm-server"
+                        ]
+                    ),
                 case filelib:is_dir(DevPath) of
                     true -> DevPath;
                     false -> filename:join([Cwd, "genesis-wasm-server"]) % Fallback
@@ -135,11 +143,16 @@ ensure_started(Opts) ->
                         Port =
                             open_port(
                                 {spawn_executable,
-                                    filename:join([GenesisWasmServerDir, "launch-monitored.sh"])
+                                    filename:join(
+                                        [
+                                            GenesisWasmServerDir,
+                                            "launch-monitored.sh"
+                                        ]
+                                    )
                                 },
                                 [
                                     binary, use_stdio, stderr_to_stdout,
-                                    {args, [
+                                    {args, Args = [
                                         "npm",
                                         "--prefix",
                                         GenesisWasmServerDir,
@@ -147,7 +160,7 @@ ensure_started(Opts) ->
                                         "start"
                                     ]},
                                     {env,
-                                        [
+                                        Env = [
                                             {"UNIT_MODE", "hbu"},
                                             {"HB_URL", NodeURL},
                                             {"PORT",
@@ -188,6 +201,13 @@ ensure_started(Opts) ->
                                 ]
                             ),
                         ?event({genesis_wasm_port_opened, {port, Port}}),
+                        ?event(
+                            debug_genesis,
+                            {started_genesis_wasm,
+                                {args, Args},
+                                {env, maps:from_list(Env)}
+                            }
+                        ),
                         collect_events(Port)
                     end
                 ),

--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -13,7 +13,8 @@
 init(Msg, _Msg2, _Opts) -> {ok, Msg}.
 
 %% @doc Normalize the device.
-normalize(Msg, _Msg2, _Opts) -> {ok, Msg}.
+normalize(Msg, Msg2, Opts) ->
+    dev_delegated_compute:normalize(Msg, Msg2, Opts).
 
 %% @doc All the `delegated-compute@1.0' device to execute the request. We then apply
 %% the `patch@1.0' device, applying any state patches that the AO process may have

--- a/src/dev_process_cache.erl
+++ b/src/dev_process_cache.erl
@@ -67,7 +67,13 @@ latest(ProcID, Opts) -> latest(ProcID, [], Opts).
 latest(ProcID, RequiredPath, Opts) ->
     latest(ProcID, RequiredPath, undefined, Opts).
 latest(ProcID, RawRequiredPath, Limit, Opts) ->
-    ?event({latest_called, {proc_id, ProcID}, {required_path, RawRequiredPath}, {limit, Limit}, {opts, Opts}}),
+    ?event(
+        {latest_called,
+            {proc_id, ProcID},
+            {required_path, RawRequiredPath},
+            {limit, Limit}
+        }
+    ),
     % Convert the required path to a list of _binary_ keys.
     RequiredPath =
         case RawRequiredPath of

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -23,7 +23,9 @@
 -ifdef(TEST).
 -define(DEFAULT_PRINT_OPTS, [error, http_error]).
 -else.
--define(DEFAULT_PRINT_OPTS, [error, http_error, http_short, compute_short, push_short]).
+-define(DEFAULT_PRINT_OPTS,
+    [error, http_error, http_short, compute_short, push_short]
+).
 -endif.
 
 -define(ENV_KEYS,
@@ -221,6 +223,11 @@ default_message() ->
             #{
                 % Routes for the genesis-wasm device to use a local CU, if requested.
                 <<"template">> => <<"/result/.*">>,
+                <<"node">> => #{ <<"prefix">> => <<"http://localhost:6363">> }
+            },
+            #{
+                % Routes for the genesis-wasm device to use a local CU, if requested.
+                <<"template">> => <<"/snapshot/.*">>,
                 <<"node">> => #{ <<"prefix">> => <<"http://localhost:6363">> }
             },
             #{


### PR DESCRIPTION
This PR introduces:
- Support for calling the embedded CU's `snapshot` functionality through the `~genesis-wasm@1.0` and `~delegated-compute@1.0` device interfaces. These calls store only the response to the delegated snapshot request, rather than transferring the full memory snapshot.
- Support for controlling snapshot frequency via the `process_snapshot_secs` node message parameter. Defaults to 60 seconds when the node is not in `?TEST == true` mode.