### PR TITLE
fix: defer lua_tests parsing to prevent boot crash

### DIFF
--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -49,7 +49,12 @@
                 {preparsed, ?DEFAULT_PRINT_OPTS}
             },
         lua_scripts => {"LUA_SCRIPTS", "scripts"},
-        lua_tests => {"LUA_TESTS", fun dev_lua_test:parse_spec/1, tests},
+        lua_tests => 
+            {
+                "LUA_TESTS", 
+                fun(Str) -> {lazy, dev_lua_test, parse_spec, [Str]} end,
+                "tests"
+            },
         default_index =>
             {
                 "INDEX",


### PR DESCRIPTION
Use lazy evaluation for LUA_TESTS env var to avoid circular dependency during application startup that was causing release boot failures.