### PR TITLE
Fix startup crash in release mode due to missing scripts directory

### DIFF
--- a/src/dev_lua_test.erl
+++ b/src/dev_lua_test.erl
@@ -44,7 +44,11 @@ parse_spec(Str) when is_list(Str) ->
 parse_spec(tests) ->
     % The user has not given a test spec, so we default to running all tests in
     % the `LUA_SCRIPTS' directory (defaulting to `scripts/').
-    {ok, Files} = file:list_dir(ScriptDir = hb_opts:get(lua_scripts)),
+    Files = 
+        case file:list_dir(ScriptDir = hb_opts:get(lua_scripts)) of
+            {ok, FileList} -> FileList;
+            {error, enoent} -> []
+        end,
     RelevantFiles = 
         lists:filter(
             fun(File) ->


### PR DESCRIPTION
# Fix startup crash in release mode due to missing scripts directory

## Issue
HyperBEAM crashes on startup when running in release mode with `foreground` command due to `dev_lua_test.erl` attempting to read the `scripts/` directory which doesn't exist in the release environment.

**Error:**
```
{badmatch,{error,enoent}}, [{dev_lua_test,parse_spec,1, [{file,"/home/ubuntu/HyperBEAM/src/dev_lua_test.erl"},{line,47}]}
```

## Root Cause
- In development mode (`rebar3 shell`), the working directory is the project root where `scripts/` exists
- In release mode, the working directory is `_build/genesis_wasm/rel/hb/` where `scripts/` doesn't exist
- The `dev_lua_test:parse_spec/1` function uses `file:list_dir/1` with pattern matching that crashes on `{error, enoent}`

## Fix
Modified `dev_lua_test.erl` to gracefully handle missing scripts directory by:
- Replacing pattern match `{ok, Files} = file:list_dir(...)` with case expression
- Returning empty list `[]` when directory doesn't exist (`{error, enoent}`)
- Preserving existing functionality when directory is present

## Notes
This fix assumes that Lua tests are not needed for production releases. Alternative approaches would be to:
- Copy the `scripts/` directory to the release
- Set `LUA_SCRIPTS` environment variable to point to the correct path
- Use absolute paths in configuration

## Testing
- Development mode (`rebar3 shell`) continues to work normally
- Release mode no longer crashes on startup
- Lua test functionality remains intact when scripts directory is available
