### PR TITLE
Enforce tag limits

### DIFF
--- a/src/ar_bundles.erl
+++ b/src/ar_bundles.erl
@@ -254,6 +254,10 @@ enforce_valid_tx(TX) ->
         hb_util:check_size(TX#tx.signature, [0, 65, byte_size(?DEFAULT_SIG)]),
         {invalid_field, signature, TX#tx.signature}
     ),
+    hb_util:ok_or_throw(TX,
+        length(TX#tx.tags) =< ?MAX_TAG_COUNT,
+        {invalid_field, tag_count, TX#tx.tags}
+    ),
     lists:foreach(
         fun({Name, Value}) ->
             hb_util:ok_or_throw(TX,

--- a/src/ar_bundles.erl
+++ b/src/ar_bundles.erl
@@ -255,35 +255,28 @@ enforce_valid_tx(TX) ->
         {invalid_field, signature, TX#tx.signature}
     ),
     hb_util:ok_or_throw(TX,
-        length(TX#tx.tags) =< ?MAX_TAG_COUNT,
-        {invalid_field, tag_count, TX#tx.tags}
-    ),
-    lists:foreach(
-        fun({Name, Value}) ->
-            hb_util:ok_or_throw(TX,
-                hb_util:check_type(Name, binary),
-                {invalid_field, tag_name, Name}
-            ),
-            hb_util:ok_or_throw(TX,
-                hb_util:check_size(Name, {range, 0, ?MAX_TAG_NAME_SIZE}),
-                {invalid_field, tag_name, Name}
-            ),
-            hb_util:ok_or_throw(TX,
-                hb_util:check_type(Value, binary),
-                {invalid_field, tag_value, Value}
-            ),
-            hb_util:ok_or_throw(TX,
-                hb_util:check_size(Value, {range, 0, ?MAX_TAG_VALUE_SIZE}),
-                {invalid_field, tag_value, Value}
-            ),
-            hb_util:ok_or_throw(TX,
-                hb_util:check_size(<<Name/binary, Value/binary>>, {range, 0, ?MAX_TAG_COMBINED_SIZE}),
-                {invalid_field, tag_size, {Name, Value}}
-            );
-            (InvalidTagForm) ->
-                throw({invalid_field, tag, InvalidTagForm})
-        end,
-        TX#tx.tags
+        lists:foldl(
+            fun({Name, Value}, Acc) ->
+                hb_util:ok_or_throw(TX,
+                    hb_util:check_type(Name, binary),
+                    {invalid_field, tag_name, Name}
+                ),
+                hb_util:ok_or_throw(TX,
+                    hb_util:check_type(Value, binary),
+                    {invalid_field, tag_value, Value}
+                ),
+                hb_util:ok_or_throw(TX,
+                    hb_util:check_size(<<Name/binary, Value/binary>>, {range, 0, ?MAX_TAG_COMBINED_SIZE}),
+                    {invalid_field, tag_size, {Name, Value}}
+                ),
+                Acc + byte_size(Name) + byte_size(Value);
+                (InvalidTagForm, _Acc) ->
+                    throw({invalid_field, tag, InvalidTagForm})
+            end,
+            0,
+            TX#tx.tags
+        ) =< ?MAX_TAG_SECTION_SIZE,
+      {invalid_field, tag_section_size, TX#tx.tags}
     ),
     hb_util:ok_or_throw(
         TX,

--- a/src/ar_bundles.erl
+++ b/src/ar_bundles.erl
@@ -275,6 +275,10 @@ enforce_valid_tx(TX) ->
             hb_util:ok_or_throw(TX,
                 hb_util:check_size(Value, {range, 0, ?MAX_TAG_VALUE_SIZE}),
                 {invalid_field, tag_value, Value}
+            ),
+            hb_util:ok_or_throw(TX,
+                hb_util:check_size(<<Name/binary, Value/binary>>, {range, 0, ?MAX_TAG_COMBINED_SIZE}),
+                {invalid_field, tag_size, {Name, Value}}
             );
             (InvalidTagForm) ->
                 throw({invalid_field, tag, InvalidTagForm})

--- a/src/ar_tx.erl
+++ b/src/ar_tx.erl
@@ -478,6 +478,10 @@ enforce_valid_tx(TX) ->
             hb_util:ok_or_throw(TX,
                 hb_util:check_size(Value, {range, 0, ?MAX_TAG_VALUE_SIZE}),
                 {invalid_field, tag_value, Value}
+            ),
+            hb_util:ok_or_throw(TX,
+                hb_util:check_size(<<Name/binary, Value/binary>>, {range, 0, ?MAX_TAG_COMBINED_SIZE}),
+                {invalid_field, tag_size, {Name, Value}}
             );
             (InvalidTagForm) ->
                 throw({invalid_field, tag, InvalidTagForm})
@@ -985,6 +989,7 @@ test_enforce_valid_tx_happy() ->
         {empty_tag_name_value, BaseTX#tx{tags = [{<<>>, <<>>}]}},
         {max_len_tag_name, BaseTX#tx{tags = [{crypto:strong_rand_bytes(?MAX_TAG_NAME_SIZE), <<"val">>}]}},
         {max_len_tag_value, BaseTX#tx{tags = [{<<"key">>, crypto:strong_rand_bytes(?MAX_TAG_VALUE_SIZE)}]}},
+        {max_len_combined, BaseTX#tx{tags = [{crypto:strong_rand_bytes(?MAX_TAG_COMBINED_SIZE div 2), crypto:strong_rand_bytes(?MAX_TAG_COMBINED_SIZE div 2)}]}},
         {max_len_tags, BaseTX#tx{tags = [{crypto:strong_rand_bytes(42), <<"val">>} || _ <- lists:seq(1,?MAX_TAG_COUNT)]}}
     ],
 
@@ -1005,6 +1010,8 @@ test_enforce_valid_tx_failure() ->
     TooLongTagName = crypto:strong_rand_bytes(?MAX_TAG_NAME_SIZE + 1),
     TooLongTagValue = crypto:strong_rand_bytes(?MAX_TAG_VALUE_SIZE + 1),
     TooManyTags = [{crypto:strong_rand_bytes(42), <<"val">>} || _ <- lists:seq(1,?MAX_TAG_COUNT + 1)],
+    LargeTag = crypto:strong_rand_bytes((?MAX_TAG_COMBINED_SIZE div 2) + 1),
+    TooLongCombinedTag = {LargeTag, LargeTag},
 
     SigInvalidSize1 = crypto:strong_rand_bytes(1),
     SigInvalidSize64 = crypto:strong_rand_bytes(64),
@@ -1048,6 +1055,7 @@ test_enforce_valid_tx_failure() ->
         {tag_name_too_long, BaseTX#tx{tags = [{TooLongTagName, <<"val">>}]}, {invalid_field, tag_name, TooLongTagName}},
         {tag_value_not_binary, BaseTX#tx{tags = [{<<"key">>, not_binary}]}, {invalid_field, tag_value, not_binary}},
         {tag_value_too_long, BaseTX#tx{tags = [{<<"key">>, TooLongTagValue}]}, {invalid_field, tag_value, TooLongTagValue}},
+        {tag_combined_size_too_long, BaseTX#tx{tags = [TooLongCombinedTag]}, {invalid_field, tag_size, TooLongCombinedTag}},
         {tag_list_length_too_high, BaseTX#tx{tags = TooManyTags}, {invalid_field, tag_count, TooManyTags}},
         {invalid_tag_form_atom, BaseTX#tx{tags = [not_a_tuple]}, {invalid_field, tag, not_a_tuple}},
         {invalid_tag_form_list, BaseTX#tx{tags = [[<<"name">>, <<"value">>]]}, {invalid_field, tag, [<<"name">>, <<"value">>]} }

--- a/src/ar_tx.erl
+++ b/src/ar_tx.erl
@@ -458,35 +458,28 @@ enforce_valid_tx(TX) ->
         {invalid_field, tags, TX#tx.tags}
     ),
     hb_util:ok_or_throw(TX,
-        length(TX#tx.tags) =< ?MAX_TAG_COUNT,
-        {invalid_field, tag_count, TX#tx.tags}
-    ),
-    lists:foreach(
-        fun({Name, Value}) ->
-            hb_util:ok_or_throw(TX,
-                hb_util:check_type(Name, binary),
-                {invalid_field, tag_name, Name}
-            ),
-            hb_util:ok_or_throw(TX,
-                hb_util:check_size(Name, {range, 0, ?MAX_TAG_NAME_SIZE}),
-                {invalid_field, tag_name, Name}
-            ),
-            hb_util:ok_or_throw(TX,
-                hb_util:check_type(Value, binary),
-                {invalid_field, tag_value, Value}
-            ),
-            hb_util:ok_or_throw(TX,
-                hb_util:check_size(Value, {range, 0, ?MAX_TAG_VALUE_SIZE}),
-                {invalid_field, tag_value, Value}
-            ),
-            hb_util:ok_or_throw(TX,
-                hb_util:check_size(<<Name/binary, Value/binary>>, {range, 0, ?MAX_TAG_COMBINED_SIZE}),
-                {invalid_field, tag_size, {Name, Value}}
-            );
-            (InvalidTagForm) ->
+        lists:foldl(
+            fun({Name, Value}, Acc) ->
+                hb_util:ok_or_throw(TX,
+                    hb_util:check_type(Name, binary),
+                    {invalid_field, tag_name, Name}
+                ),
+                hb_util:ok_or_throw(TX,
+                    hb_util:check_type(Value, binary),
+                    {invalid_field, tag_value, Value}
+                ),
+                hb_util:ok_or_throw(TX,
+                    hb_util:check_size(<<Name/binary, Value/binary>>, {range, 0, ?MAX_TAG_COMBINED_SIZE}),
+                    {invalid_field, tag_size, {Name, Value}}
+                ),
+                Acc + byte_size(Name) + byte_size(Value);
+            (InvalidTagForm, _Acc) ->
                 throw({invalid_field, tag, InvalidTagForm})
-        end,
-        TX#tx.tags
+            end,
+            0,
+            TX#tx.tags
+        ) =< ?MAX_TAG_SECTION_SIZE,
+      {invalid_field, tag_section_size, TX#tx.tags}
     ),
     true.
 
@@ -987,10 +980,10 @@ test_enforce_valid_tx_happy() ->
         {data_root_32_bytes, BaseTX#tx{data_root = crypto:strong_rand_bytes(32)}},
         {simple_tag, BaseTX#tx{tags = [{<<"name">>, <<"value">>}]}},
         {empty_tag_name_value, BaseTX#tx{tags = [{<<>>, <<>>}]}},
-        {max_len_tag_name, BaseTX#tx{tags = [{crypto:strong_rand_bytes(?MAX_TAG_NAME_SIZE), <<"val">>}]}},
-        {max_len_tag_value, BaseTX#tx{tags = [{<<"key">>, crypto:strong_rand_bytes(?MAX_TAG_VALUE_SIZE)}]}},
+        {max_len_tag_name, BaseTX#tx{tags = [{crypto:strong_rand_bytes(?MAX_TAG_COMBINED_SIZE), <<"">>}]}},
+        {max_len_tag_value, BaseTX#tx{tags = [{<<"">>, crypto:strong_rand_bytes(?MAX_TAG_COMBINED_SIZE)}]}},
         {max_len_combined, BaseTX#tx{tags = [{crypto:strong_rand_bytes(?MAX_TAG_COMBINED_SIZE div 2), crypto:strong_rand_bytes(?MAX_TAG_COMBINED_SIZE div 2)}]}},
-        {max_len_tags, BaseTX#tx{tags = [{crypto:strong_rand_bytes(42), <<"val">>} || _ <- lists:seq(1,?MAX_TAG_COUNT)]}}
+        {max_len_tags, BaseTX#tx{tags = [{crypto:strong_rand_bytes(42), <<"">>} || _ <- lists:seq(1,?MAX_TAG_SECTION_SIZE div 42)]}}
     ],
 
     lists:foreach(
@@ -1007,9 +1000,9 @@ test_enforce_valid_tx_failure() ->
     BadID31 = crypto:strong_rand_bytes(31),
     BadID33 = crypto:strong_rand_bytes(33),
     BadOwnerSize = crypto:strong_rand_bytes(byte_size(?DEFAULT_OWNER) - 1),
-    TooLongTagName = crypto:strong_rand_bytes(?MAX_TAG_NAME_SIZE + 1),
-    TooLongTagValue = crypto:strong_rand_bytes(?MAX_TAG_VALUE_SIZE + 1),
-    TooManyTags = [{crypto:strong_rand_bytes(42), <<"val">>} || _ <- lists:seq(1,?MAX_TAG_COUNT + 1)],
+    TooLongTagName = {crypto:strong_rand_bytes(?MAX_TAG_COMBINED_SIZE + 1), <<"val">>},
+    TooLongTagValue = {<<"key">>, crypto:strong_rand_bytes(?MAX_TAG_COMBINED_SIZE + 1)},
+    TooManyTags = [{crypto:strong_rand_bytes(?MAX_TAG_COMBINED_SIZE), <<"">>} || _ <- lists:seq(1,1 + ?MAX_TAG_SECTION_SIZE div ?MAX_TAG_COMBINED_SIZE)],
     LargeTag = crypto:strong_rand_bytes((?MAX_TAG_COMBINED_SIZE div 2) + 1),
     TooLongCombinedTag = {LargeTag, LargeTag},
 
@@ -1052,11 +1045,11 @@ test_enforce_valid_tx_failure() ->
         {signature_type_not_rsa, BaseTX#tx{signature_type = ?ECDSA_KEY_TYPE}, {invalid_field, signature_type, ?ECDSA_KEY_TYPE}},
         {tags_not_list, BaseTX#tx{tags = #{}}, {invalid_field, tags, #{}}},
         {tag_name_not_binary, BaseTX#tx{tags = [{not_binary, <<"val">>}]}, {invalid_field, tag_name, not_binary}},
-        {tag_name_too_long, BaseTX#tx{tags = [{TooLongTagName, <<"val">>}]}, {invalid_field, tag_name, TooLongTagName}},
+        {tag_name_too_long, BaseTX#tx{tags = [TooLongTagName]}, {invalid_field, tag_size, TooLongTagName}},
         {tag_value_not_binary, BaseTX#tx{tags = [{<<"key">>, not_binary}]}, {invalid_field, tag_value, not_binary}},
-        {tag_value_too_long, BaseTX#tx{tags = [{<<"key">>, TooLongTagValue}]}, {invalid_field, tag_value, TooLongTagValue}},
+        {tag_value_too_long, BaseTX#tx{tags = [TooLongTagValue]}, {invalid_field, tag_size, TooLongTagValue}},
         {tag_combined_size_too_long, BaseTX#tx{tags = [TooLongCombinedTag]}, {invalid_field, tag_size, TooLongCombinedTag}},
-        {tag_list_length_too_high, BaseTX#tx{tags = TooManyTags}, {invalid_field, tag_count, TooManyTags}},
+        {tag_section_too_big, BaseTX#tx{tags = TooManyTags}, {invalid_field, tag_section_size, TooManyTags}},
         {invalid_tag_form_atom, BaseTX#tx{tags = [not_a_tuple]}, {invalid_field, tag, not_a_tuple}},
         {invalid_tag_form_list, BaseTX#tx{tags = [[<<"name">>, <<"value">>]]}, {invalid_field, tag, [<<"name">>, <<"value">>]} }
     ],

--- a/src/ar_tx.erl
+++ b/src/ar_tx.erl
@@ -457,6 +457,10 @@ enforce_valid_tx(TX) ->
         hb_util:check_type(TX#tx.tags, list),
         {invalid_field, tags, TX#tx.tags}
     ),
+    hb_util:ok_or_throw(TX,
+        length(TX#tx.tags) =< ?MAX_TAG_COUNT,
+        {invalid_field, tag_count, TX#tx.tags}
+    ),
     lists:foreach(
         fun({Name, Value}) ->
             hb_util:ok_or_throw(TX,
@@ -980,7 +984,8 @@ test_enforce_valid_tx_happy() ->
         {simple_tag, BaseTX#tx{tags = [{<<"name">>, <<"value">>}]}},
         {empty_tag_name_value, BaseTX#tx{tags = [{<<>>, <<>>}]}},
         {max_len_tag_name, BaseTX#tx{tags = [{crypto:strong_rand_bytes(?MAX_TAG_NAME_SIZE), <<"val">>}]}},
-        {max_len_tag_value, BaseTX#tx{tags = [{<<"key">>, crypto:strong_rand_bytes(?MAX_TAG_VALUE_SIZE)}]}}
+        {max_len_tag_value, BaseTX#tx{tags = [{<<"key">>, crypto:strong_rand_bytes(?MAX_TAG_VALUE_SIZE)}]}},
+        {max_len_tags, BaseTX#tx{tags = [{crypto:strong_rand_bytes(42), <<"val">>} || _ <- lists:seq(1,?MAX_TAG_COUNT)]}}
     ],
 
     lists:foreach(
@@ -999,6 +1004,7 @@ test_enforce_valid_tx_failure() ->
     BadOwnerSize = crypto:strong_rand_bytes(byte_size(?DEFAULT_OWNER) - 1),
     TooLongTagName = crypto:strong_rand_bytes(?MAX_TAG_NAME_SIZE + 1),
     TooLongTagValue = crypto:strong_rand_bytes(?MAX_TAG_VALUE_SIZE + 1),
+    TooManyTags = [{crypto:strong_rand_bytes(42), <<"val">>} || _ <- lists:seq(1,?MAX_TAG_COUNT + 1)],
 
     SigInvalidSize1 = crypto:strong_rand_bytes(1),
     SigInvalidSize64 = crypto:strong_rand_bytes(64),
@@ -1042,6 +1048,7 @@ test_enforce_valid_tx_failure() ->
         {tag_name_too_long, BaseTX#tx{tags = [{TooLongTagName, <<"val">>}]}, {invalid_field, tag_name, TooLongTagName}},
         {tag_value_not_binary, BaseTX#tx{tags = [{<<"key">>, not_binary}]}, {invalid_field, tag_value, not_binary}},
         {tag_value_too_long, BaseTX#tx{tags = [{<<"key">>, TooLongTagValue}]}, {invalid_field, tag_value, TooLongTagValue}},
+        {tag_list_length_too_high, BaseTX#tx{tags = TooManyTags}, {invalid_field, tag_count, TooManyTags}},
         {invalid_tag_form_atom, BaseTX#tx{tags = [not_a_tuple]}, {invalid_field, tag, not_a_tuple}},
         {invalid_tag_form_list, BaseTX#tx{tags = [[<<"name">>, <<"value">>]]}, {invalid_field, tag, [<<"name">>, <<"value">>]} }
     ],

--- a/src/include/ar.hrl
+++ b/src/include/ar.hrl
@@ -11,10 +11,8 @@
 -define(DEFAULT_OWNER, << 0:4096 >>).
 -define(DEFAULT_DATA, <<>>).
 
--define(MAX_TAG_NAME_SIZE, 3072).
--define(MAX_TAG_VALUE_SIZE, 3072).
 -define(MAX_TAG_COMBINED_SIZE, 4096).
--define(MAX_TAG_COUNT, 128).
+-define(MAX_TAG_SECTION_SIZE, 128 * 4096).
 
 %% The hashing algorithm used to calculate wallet addresses.
 -define(HASH_ALG, sha256).

--- a/src/include/ar.hrl
+++ b/src/include/ar.hrl
@@ -13,6 +13,7 @@
 
 -define(MAX_TAG_NAME_SIZE, 3072).
 -define(MAX_TAG_VALUE_SIZE, 3072).
+-define(MAX_TAG_COMBINED_SIZE, 4096).
 -define(MAX_TAG_COUNT, 128).
 
 %% The hashing algorithm used to calculate wallet addresses.

--- a/src/include/ar.hrl
+++ b/src/include/ar.hrl
@@ -13,6 +13,7 @@
 
 -define(MAX_TAG_NAME_SIZE, 3072).
 -define(MAX_TAG_VALUE_SIZE, 3072).
+-define(MAX_TAG_COUNT, 128).
 
 %% The hashing algorithm used to calculate wallet addresses.
 -define(HASH_ALG, sha256).


### PR DESCRIPTION
Following the reasoning in https://github.com/DHA-Team/arbundles/pull/6, this pull request does the same on HyperBEAM: Enforce that the tags section is at most 128*4096 bytes in size and that a combination of tag name and value does not exceed 4096 bytes. That still allows for tags that aren't strictly [ans-104](https://github.com/ArweaveTeam/arweave-standards/blob/master/ans/ANS-104.md) but at least adds an upper bound on tag amount and combined size.

The changes aim at making hyperbeam backwards compatible with what's currently stored on chain and accepted by gateways and projects using arbundles.

(short change summary generated by AI)
### Tag validation logic changes

* Updated tag validation in `enforce_valid_tx/1` to check the combined size of tag name and value against a new `MAX_TAG_COMBINED_SIZE` constant, replacing separate checks for name and value lengths. Also added a check for the total tag section size. (`src/ar_tx.erl`, `src/ar_bundles.erl`) [[1]](diffhunk://#diff-8538c54e746029a85065f6edfc0c70b9d2fd49725f6739a9fa605921679997c9L460-R482) [[2]](diffhunk://#diff-a19418fb387f5ae1a5a01973d5e31dff60fc8474c60c7f45c25604a28205b7c7L257-R279)
* Changed error reporting to use `{invalid_field, tag_size, {Name, Value}}` when the combined size exceeds the limit, and `{invalid_field, tag_section_size, Tags}` when the total section size is too large. (`src/ar_tx.erl`, `src/ar_bundles.erl`) [[1]](diffhunk://#diff-8538c54e746029a85065f6edfc0c70b9d2fd49725f6739a9fa605921679997c9L460-R482) [[2]](diffhunk://#diff-a19418fb387f5ae1a5a01973d5e31dff60fc8474c60c7f45c25604a28205b7c7L257-R279)

### Constant definitions

* Replaced `MAX_TAG_NAME_SIZE` and `MAX_TAG_VALUE_SIZE` with a single `MAX_TAG_COMBINED_SIZE` and updated `MAX_TAG_SECTION_SIZE` to be based on the new combined size in `ar.hrl`. (`src/include/ar.hrl`)

### Test updates

* Updated happy path tests to use the new combined tag size and section size logic, including new cases for maximum combined tag size and maximum section size. (`src/ar_tx.erl`)
* Updated failure tests to reflect the new validation logic, including cases for too-long combined tags and oversized tag sections. (`src/ar_tx.erl`) [[1]](diffhunk://#diff-8538c54e746029a85065f6edfc0c70b9d2fd49725f6739a9fa605921679997c9L1000-R1007) [[2]](diffhunk://#diff-8538c54e746029a85065f6edfc0c70b9d2fd49725f6739a9fa605921679997c9L1042-R1052)