### PR TITLE
feat: Isolated scheduler stores

### DIFF
--- a/src/dev_lua.erl
+++ b/src/dev_lua.erl
@@ -652,7 +652,7 @@ pure_lua_process_benchmark_test_() ->
         30,
         fun() ->
             pure_lua_process_benchmark(#{
-                process_cache_frequency => 50
+                process_snapshot_slots => 50
             })
     end}.
 pure_lua_process_benchmark(Opts) ->
@@ -725,7 +725,7 @@ aos_process_benchmark_test_() ->
         Opts = #{
             process_async_cache => true,
             hashpath => ignore,
-            process_cache_frequency => 50
+            process_snapshot_slots => 50
         },
         Process = generate_lua_process("test/hyper-aos.lua", Opts),
         Message = generate_test_message(Process, Opts),

--- a/src/dev_scheduler_cache.erl
+++ b/src/dev_scheduler_cache.erl
@@ -197,3 +197,307 @@ volatile_schedule_test() ->
     hb_store:start(VolStore),
     ?assertMatch(not_found, latest(ProcID, Opts)),
     ?assertMatch(not_found, read(ProcID, 1, Opts)).
+
+%% @doc Test concurrent writes to scheduler store from multiple processes.
+concurrent_scheduler_write_test() ->
+    VolStore = hb_test_utils:test_store(hb_store_fs, <<"concurrent-vol">>),
+    NonVolStore = hb_test_utils:test_store(hb_store_fs, <<"concurrent-nonvol">>),
+    Opts = #{
+        store => [NonVolStore],
+        scheduler_store => [VolStore]
+    },
+    hb_store:start(VolStore),
+    hb_store:start(NonVolStore),
+    Workers = 50,
+    ProcID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    Parent = self(),
+    lists:foreach(fun(Slot) ->
+        spawn_link(fun() ->
+            Assignment = #{
+                <<"process">> => ProcID,
+                <<"slot">> => Slot,
+                <<"hash-chain">> => <<"concurrent-test-", (integer_to_binary(Slot))/binary>>
+            },
+            Result = write(Assignment, Opts),
+            Parent ! {write_result, Slot, Result}
+        end)
+    end, lists:seq(1, Workers)),
+    Results = lists:map(fun(Slot) ->
+        receive
+            {write_result, Slot, Result} -> 
+                ?event(testing, {write_result, Slot, Result}),
+                Result
+        after 5000 ->
+            timeout
+        end
+    end, lists:seq(1, Workers)),
+    ?event(testing, {concurrent_write_results, Results,Workers}),
+    ?assertEqual(lists:duplicate(Workers, ok), Results),
+    AllSlots = list(ProcID, Opts),
+    ?event(testing, {all_slots, AllSlots}),
+    ?assertEqual(Workers, length(AllSlots)),
+    ?assertEqual(lists:seq(1, Workers), lists:sort(AllSlots)).
+
+%% @doc Test concurrent reads during writes to detect race conditions.
+concurrent_read_write_test() ->
+    VolStore = hb_test_utils:test_store(hb_store_fs, <<"race-vol">>),
+    NonVolStore = hb_test_utils:test_store(hb_store_fs, <<"race-nonvol">>),
+    Opts = #{
+        store => [NonVolStore],
+        scheduler_store => [VolStore]
+    },
+    hb_store:start(VolStore),
+    hb_store:start(NonVolStore),
+    ProcID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    Parent = self(),
+    ?event(testing, {concurrent_test_proc_id, ProcID}),
+    spawn_link(fun() ->
+        lists:foreach(fun(Slot) ->
+            Assignment = #{
+                <<"process">> => ProcID,
+                <<"slot">> => Slot,
+                <<"hash-chain">> => <<"race-test-", (integer_to_binary(Slot))/binary>>
+            },
+            write(Assignment, Opts),
+            timer:sleep(1)
+        end, lists:seq(1, 100)),
+        ?event(testing, {writer_completed}),
+        Parent ! writer_done
+    end),
+    lists:foreach(fun(ReaderNum) ->
+        spawn_link(fun() ->
+            ReadResults = lists:map(fun(Slot) ->
+                timer:sleep(rand:uniform(5)),
+                case read(ProcID, Slot, Opts) of
+                    {ok, _} -> success;
+                    not_found -> not_found
+                end
+            end, lists:seq(1, 100)),
+            SuccessCount = length([R || R <- ReadResults, R == success]),
+            ?event(testing, {reader_done, ReaderNum, SuccessCount}),
+            Parent ! {reader_done, ReaderNum, ReadResults}
+        end)
+    end, lists:seq(1, 10)),
+    receive 
+        writer_done -> ok
+    after 15000 -> 
+        ?assert(false) 
+    end,
+    AllReaderResults = lists:map(fun(ReaderNum) ->
+        receive
+            {reader_done, ReaderNum, Results} -> Results
+        after 5000 ->
+            ?assert(false),
+            []
+        end
+    end, lists:seq(1, 10)),
+    FinalSlots = list(ProcID, Opts),
+    ?event(testing, {final_verification, {slots_found, length(FinalSlots)}}),
+    ?assertEqual(100, length(FinalSlots)),
+    ?assertEqual(lists:seq(1, 100), lists:sort(FinalSlots)),
+    TotalSuccessfulReads = lists:sum([
+        length([R || R <- Results, R == success]) || Results <- AllReaderResults
+    ]),
+    ?event(testing, {
+        concurrent_read_stats,
+        {total_successful_reads, TotalSuccessfulReads}
+    }),
+    ?assert(TotalSuccessfulReads > 0).
+
+%% @doc Test writing a large volume of assignments to stress memory. Helps
+%% identify memory leaks and also, checks performance issues.
+large_assignment_volume_test() ->
+    VolStore = hb_test_utils:test_store(hb_store_fs, <<"volume-vol">>),
+    NonVolStore = hb_test_utils:test_store(hb_store_fs, <<"volume-nonvol">>),
+    Opts = #{
+        store => [NonVolStore],
+        scheduler_store => [VolStore]
+    },
+    hb_store:start(VolStore),
+    hb_store:start(NonVolStore),
+    VolumeSize = 1000,
+    ProcID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    StartTime = erlang:monotonic_time(millisecond),
+    lists:foreach(fun(Slot) ->
+        Assignment = #{
+            <<"process">> => ProcID,
+            <<"slot">> => Slot,
+            <<"hash-chain">> => crypto:strong_rand_bytes(64)
+        },
+        ?assertEqual(ok, write(Assignment, Opts))
+    end, lists:seq(1, VolumeSize)),
+    EndTime = erlang:monotonic_time(millisecond),
+    ?event(testing, {large_volume_write_time, EndTime - StartTime}),
+    AllSlots = list(ProcID, Opts),
+    ?assertEqual(VolumeSize, length(AllSlots)),
+    ?assertEqual(lists:seq(1, VolumeSize), lists:sort(AllSlots)),
+    ReadStartTime = erlang:monotonic_time(millisecond),
+    lists:foreach(fun(Slot) ->
+        ?assertMatch({ok, _}, read(ProcID, Slot, Opts))
+    end, lists:seq(1, VolumeSize)),
+    ReadEndTime = erlang:monotonic_time(millisecond),
+    ?event(testing, {large_volume_read_time, ReadEndTime - ReadStartTime}).
+
+%% @doc Test rapid store restarts under load.
+rapid_restart_test() ->
+    VolStore = hb_test_utils:test_store(hb_store_fs, <<"restart-vol">>),
+    NonVolStore = hb_test_utils:test_store(hb_store_fs, <<"restart-nonvol">>),
+    Opts = #{
+        store => [NonVolStore],
+        scheduler_store => [VolStore]
+    },
+    hb_store:start(VolStore),
+    hb_store:start(NonVolStore),
+    ProcID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    lists:foreach(fun(Cycle) ->
+        lists:foreach(fun(Slot) ->
+            Assignment = #{
+                <<"process">> => ProcID,
+                <<"slot">> => Slot + (Cycle * 10),
+                <<"hash-chain">> => <<"restart-cycle-", (integer_to_binary(Cycle))/binary>>
+            },
+            ?assertEqual(ok, write(Assignment, Opts))
+        end, lists:seq(1, 10)),
+        SlotsBeforeRestart = list(ProcID, Opts),
+        ?assertMatch([_|_], SlotsBeforeRestart),
+        ?event(testing, {
+            restart_cycle, Cycle, {slots_before, length(SlotsBeforeRestart)}
+        }),
+        hb_store:stop(VolStore),
+        timer:sleep(10),
+        hb_store:reset(VolStore),
+        hb_store:start(VolStore),
+        SlotsAfterRestart = list(ProcID, Opts),
+        ?assertEqual([], SlotsAfterRestart),
+        ?event(testing, {restart_verified, Cycle, {slots_after, length(SlotsAfterRestart)}})
+    end, lists:seq(1, 5)).
+
+%% @doc Test scheduler store behavior during reset store operations.
+mixed_store_reset_operations_test() ->
+    VolStore = hb_test_utils:test_store(hb_store_fs, <<"mixed-vol">>),
+    NonVolStore = hb_test_utils:test_store(hb_store_fs, <<"mixed-nonvol">>),
+    Opts = #{
+        store => [NonVolStore],
+        scheduler_store => [VolStore]
+    },
+    hb_store:start(VolStore),
+    hb_store:start(NonVolStore),
+    ProcID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    Assignment1 = #{
+        <<"process">> => ProcID,
+        <<"slot">> => 1,
+        <<"hash-chain">> => <<"mixed-test-1">>
+    },
+    ?assertEqual(ok, write(Assignment1, Opts)),
+    ?event(testing, {assignment_written, ProcID}),
+    hb_store:reset(NonVolStore),
+    ReadAfterNonVolReset = read(ProcID, 1, Opts),
+    ?assertMatch({ok, _}, ReadAfterNonVolReset),
+    ?event(testing, {after_nonvol_reset, ReadAfterNonVolReset}),
+    hb_store:reset(VolStore),
+    ReadAfterVolReset = read(ProcID, 1, Opts),
+    ?assertEqual(not_found, ReadAfterVolReset),
+    ?event(testing, {after_vol_reset, ReadAfterVolReset}).
+
+%% @doc Test handling of invalid assignment data.
+invalid_assignment_stress_test() ->
+    VolStore = hb_test_utils:test_store(hb_store_fs, <<"invalid-vol">>),
+    NonVolStore = hb_test_utils:test_store(hb_store_fs, <<"invalid-nonvol">>),
+    Opts = #{
+        store => [NonVolStore],
+        scheduler_store => [VolStore]
+    },
+    hb_store:start(VolStore),
+    hb_store:start(NonVolStore),
+    InvalidAssignments = [
+        #{},
+        #{<<"process">> => <<"invalid">>},
+        #{<<"slot">> => 1},
+        #{<<"process">> => <<>>, <<"slot">> => 1},
+        #{<<"process">> => <<"valid">>, <<"slot">> => -1},
+        #{<<"process">> => <<"valid">>, <<"slot">> => <<"not-integer">>}
+    ],
+    ?event(testing, {testing_invalid_assignments, length(InvalidAssignments)}),
+    Results = lists:map(fun(Assignment) ->
+        Result = try
+            write(Assignment, Opts)
+        catch
+            _:_ -> error
+        end,
+        ?assertNotEqual(ok, Result),
+        Result
+    end, InvalidAssignments),
+    
+    ErrorCount = length([R || R <- Results, R == error]),
+    ?event(testing, {invalid_assignment_results, {errors, ErrorCount}, {total, length(InvalidAssignments)}}),
+    ?assertEqual(6, ErrorCount).
+
+%% @doc Test scheduler location operations under stress.
+scheduler_location_stress_test() ->
+    VolStore = hb_test_utils:test_store(hb_store_fs, <<"location-vol">>),
+    NonVolStore = hb_test_utils:test_store(hb_store_fs, <<"location-nonvol">>),
+    Wallet = ar_wallet:new(),
+    Opts = #{
+        store => [NonVolStore],
+        scheduler_store => [VolStore],
+        priv_wallet => Wallet
+    },
+    hb_store:start(VolStore),
+    hb_store:start(NonVolStore),
+    LocationCount = 10,
+    ?event(testing, {location_stress_test_starting, LocationCount}),
+    Results = lists:map(fun(N) ->
+        LocationMsg = #{
+            <<"scheduler">> => hb_util:human_id(ar_wallet:to_address(Wallet)),
+            <<"location">> => <<"http://scheduler", (integer_to_binary(N))/binary, ".com">>,
+            <<"timestamp">> => erlang:system_time(millisecond),
+            <<"ttl">> => 3600000
+        },
+        Result = try
+            write_location(LocationMsg, Opts)     % TOASK: Is it okay that this returns ok even tho
+            % with wrong and unsigned scheduler location
+        catch
+            Res -> 
+                ?event(testing, {location_write_error, {error, Res}}),
+                ok 
+        end,
+        ?assert(Result == ok orelse element(1, Result) == error),
+        Result
+    end, lists:seq(1, LocationCount)),
+    SuccessCount = length([R || R <- Results, R == ok]),
+    ?event(testing, {location_stress_results, {successes, SuccessCount}, {total, LocationCount}}).
+
+%% @doc Test system behavior with corrupted data in volatile store.
+volatile_store_corruption_test() ->
+    VolStore = hb_test_utils:test_store(hb_store_fs, <<"corruption-vol">>),
+    NonVolStore = hb_test_utils:test_store(hb_store_fs, <<"corruption-nonvol">>),
+    Opts = #{
+        store => [NonVolStore],
+        scheduler_store => [VolStore]
+    },
+    hb_store:start(VolStore),
+    hb_store:start(NonVolStore),
+    ProcID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    Assignment = #{
+        <<"process">> => ProcID,
+        <<"slot">> => 1,
+        <<"hash-chain">> => <<"corruption-test">>
+    },
+    ?assertEqual(ok, write(Assignment, Opts)),
+    ReadBeforeCorruption = read(ProcID, 1, Opts),
+    ?assertMatch({ok, _}, ReadBeforeCorruption),
+    ?event(testing, {before_corruption, ReadBeforeCorruption}),
+    hb_store:reset(VolStore),
+    ?event(testing, {volatile_store_reset}),
+    ReadAfterCorruption = read(ProcID, 1, Opts),
+    SlotsAfterCorruption = list(ProcID, Opts),
+    LatestAfterCorruption = latest(ProcID, Opts),
+    ?assertEqual(not_found, ReadAfterCorruption),
+    ?assertEqual([], SlotsAfterCorruption),
+    ?assertEqual(not_found, LatestAfterCorruption),
+    ?event(testing,
+        { corruption_recovery_verified,
+            { read, ReadAfterCorruption },
+            { list, length(SlotsAfterCorruption) }, 
+            { latest, LatestAfterCorruption }
+    }).

--- a/src/dev_scheduler_server.erl
+++ b/src/dev_scheduler_server.erl
@@ -24,7 +24,7 @@ start(ProcID, Proc, Opts) ->
             end,
             % Write the process to the cache. We are the provider-of-last-resort
             % for this data.
-            hb_cache:write(Proc, Opts),
+            dev_scheduler_cache:write_spawn(Proc, Opts),
             case hb_opts:get(scheduling_mode, disabled, Opts) of
                 disabled ->
                     throw({scheduling_disabled_on_node, {requested_for, ProcID}});

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -266,11 +266,6 @@ default_message() ->
                     <<"name">> => <<"cache-mainnet">>
                 },
                 #{
-                    <<"store-module">> => hb_store_fs,
-                    <<"name">> => <<"cache-mainnet/scheduler">>,
-                    <<"access">> => [<<"read">>]
-                },
-                #{
                     <<"store-module">> => hb_store_gateway,
                     <<"subindex">> => [
                         #{
@@ -290,13 +285,6 @@ default_message() ->
                 #{
                     <<"store-module">> => hb_store_fs,
                     <<"name">> => <<"cache-priv">>
-                }
-            ],
-        scheduler_store =>
-            [
-                #{
-                    <<"store-module">> => hb_store_fs,
-                    <<"name">> => <<"cache-mainnet/scheduler">>
                 }
             ],
         %default_index => #{ <<"device">> => <<"hyperbuddy@1.0">> },

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -266,6 +266,11 @@ default_message() ->
                     <<"name">> => <<"cache-mainnet">>
                 },
                 #{
+                    <<"store-module">> => hb_store_fs,
+                    <<"name">> => <<"cache-mainnet/scheduler">>,
+                    <<"access">> => [<<"read">>]
+                },
+                #{
                     <<"store-module">> => hb_store_gateway,
                     <<"subindex">> => [
                         #{
@@ -285,6 +290,13 @@ default_message() ->
                 #{
                     <<"store-module">> => hb_store_fs,
                     <<"name">> => <<"cache-priv">>
+                }
+            ],
+        scheduler_store =>
+            [
+                #{
+                    <<"store-module">> => hb_store_fs,
+                    <<"name">> => <<"cache-mainnet/scheduler">>
                 }
             ],
         %default_index => #{ <<"device">> => <<"hyperbuddy@1.0">> },

--- a/src/hb_store.erl
+++ b/src/hb_store.erl
@@ -306,6 +306,20 @@ list(Modules, Path) -> call_function(Modules, list, [Path]).
 -ifdef(STORE_EVENTS).
 call_function(X, Function, Args) ->
     {Time, Result} = timer:tc(fun() -> do_call_function(X, Function, Args) end),
+    ?event(store_events,
+        {store_call,
+            {function, Function},
+            {args, Args},
+            {primary_store,
+                case X of
+                    [PrimaryStore | _] -> PrimaryStore;
+                    _ -> X
+                end
+            },
+            {time, Time},
+            {result, Result}
+        }
+    ),
     hb_event:increment(<<"store_duration">>, hb_util:bin(Function), #{}, Time),
     hb_event:increment(<<"store">>, hb_util:bin(Function), #{}, 1),
     Result.

--- a/src/hb_store.erl
+++ b/src/hb_store.erl
@@ -845,3 +845,191 @@ benchmark_message_read_write(Store, WriteOps, ReadOps) ->
         ReadTime / 1_000_000
     ),
     ?assertEqual(0, NotFoundCount, "Written keys not found in store.").
+
+%%% Access Control Tests
+
+%% @doc Test that read-only stores allow read operations but block write operations
+read_only_access_test() ->
+    TestStore = hb_test_utils:test_store(hb_store_fs, <<"access-read-only">>),
+    ReadOnlyStore = TestStore#{<<"access">> => [<<"read">>]},
+    WriteStore = hb_test_utils:test_store(hb_store_fs, <<"access-write">>),
+    StoreList = [ReadOnlyStore, WriteStore],
+    TestKey = <<"test-key">>,
+    TestValue = <<"test-value">>,
+    start(StoreList),
+    ?event(testing, {read_only_test_started}),
+    WriteResponse = write(StoreList, TestKey, TestValue),
+    ?assertEqual(ok, WriteResponse),
+    ?event(testing, {write_used_fallback_store, WriteResponse}),
+    ReadResponse = read(StoreList, TestKey),
+    ?assertEqual({ok, TestValue}, ReadResponse),
+    ?event(testing, {read_succeeded, ReadResponse}),
+    ReadOnlyStoreState = read([ReadOnlyStore], TestKey),
+    WriteStoreState = read([WriteStore], TestKey),
+    ?event(testing, {
+        store_state, {read_only, ReadOnlyStoreState},{ write, WriteStoreState}
+    }),
+    ?assertEqual(not_found, ReadOnlyStoreState),
+    ?assertEqual({ok, TestValue}, WriteStoreState).
+
+%% @doc Test that write-only stores allow write operations but block read operations  
+write_only_access_test() ->
+    WriteOnlyStore = (hb_test_utils:test_store(hb_store_fs, <<"access-write-only">>))#{
+        <<"access">> => [<<"write">>]
+    },
+    ReadStore = hb_test_utils:test_store(hb_store_fs, <<"access-read-fallback">>),
+    StoreList = [WriteOnlyStore, ReadStore],
+    TestKey = <<"write-test-key">>,
+    TestValue = <<"write-test-value">>,
+    start(StoreList),
+    ?event(testing, {write_only_test_started}),
+    ?assertEqual(ok, write(StoreList, TestKey, TestValue)),
+    ?event(testing, {write_succeeded_on_write_only}),
+    ReadStoreState = read(StoreList, TestKey),
+    ?assertEqual(not_found, ReadStoreState),
+    ?event(testing, {read_skipped_write_only_store, ReadStoreState}),
+    WriteOnlyStoreNoAccess = maps:remove(<<"access">>, WriteOnlyStore),
+    ReadStoreNoAccess = read([WriteOnlyStoreNoAccess], TestKey),
+    ?event(testing, {store, ReadStoreNoAccess}),
+    ?assertEqual({ok, TestValue}, ReadStoreNoAccess).
+
+%% @doc Test admin-only stores for start/stop/reset operations
+admin_only_access_test() ->
+    %% TOASK: this might be wrong so want know how to call admin-only store
+    AdminOnlyStore = (hb_test_utils:test_store(hb_store_fs, <<"access-admin-only">>))#{
+        <<"access">> => [<<"admin">>]
+    },
+    StoreList = [AdminOnlyStore],
+    TestKey = <<"admin-test-key">>,
+    TestValue = <<"admin-test-value">>,
+    ?event(testing, {admin_only_test_started}),
+    ResetResult = reset(StoreList),
+    ?event(testing, {reset_succeeded_on_admin_store, ResetResult}),
+    start(StoreList),
+    ?event(testing, {start_admin_store}),
+    ?assertEqual(not_found, write(StoreList, TestKey, TestValue)),
+    ?event(testing, {write_skipped_admin_store}),
+    ?assertEqual(not_found, read(StoreList, TestKey)),
+    ?event(testing, {read_skipped_admin_store}).
+
+%% @doc Test multiple access permissions
+multi_access_permissions_test() ->
+    ReadWriteStore = (hb_test_utils:test_store(hb_store_fs, <<"access-read-write">>))#{
+        <<"access">> => [<<"read">>, <<"write">>]
+    },
+    AdminStore = (hb_test_utils:test_store(hb_store_fs, <<"access-admin-fallback">>))#{
+        <<"access">> => [<<"admin">>]
+    },
+    StoreList = [ReadWriteStore, AdminStore],
+    TestKey = <<"multi-access-key">>,
+    TestValue = <<"multi-access-value">>,
+    start(StoreList),
+    ?event(testing, {multi_access_test_started}),
+    ?assertEqual(ok, write(StoreList, TestKey, TestValue)),
+    ?event(testing, {write_succeeded_on_read_write_store}),
+    ?assertEqual({ok, TestValue}, read(StoreList, TestKey)),
+    ?event(testing, {read_succeeded_on_read_write_store}).
+    % ResetResult2 = reset(StoreList),
+    % ?event(testing, {reset_used_admin_fallback, ResetResult2}),
+    % ?assert(ResetResult2 == ok orelse is_tuple(ResetResult2)).
+
+%% @doc Test that stores without access restrictions allow all operations
+unrestricted_access_test() ->
+    UnrestrictedStore = hb_test_utils:test_store(hb_store_fs, <<"access-unrestricted">>),
+    StoreList = [UnrestrictedStore],
+    TestKey = <<"unrestricted-key">>,
+    TestValue = <<"unrestricted-value">>,
+    start(StoreList),
+    ?event(testing, {unrestricted_test_started}),
+    ?assertEqual(ok, write(StoreList, TestKey, TestValue)),
+    ?event(testing, {unrestricted_write_ok}),
+    ?assertEqual({ok, TestValue}, read(StoreList, TestKey)),
+    ?event(testing, {unrestricted_read_ok}),
+    % ResetResult3 = reset(StoreList),
+    % ?event(testing, {unrestricted_reset_ok, ResetResult3}),
+    % ?assert(ResetResult3 == ok orelse is_tuple(ResetResult3)),
+    ?assertEqual({ok,TestValue}, read(StoreList, TestKey)).
+
+%% @doc Test access control with store fallback chains
+store_fallback_chain_test() ->
+    % Chain: Read-only -> Write-only -> Unrestricted
+    ReadOnlyStore = (hb_test_utils:test_store(hb_store_fs, <<"chain-read-only">>))#{
+        <<"access">> => [<<"read">>]
+    },
+    WriteOnlyStore = (hb_test_utils:test_store(hb_store_fs, <<"chain-write-only">>))#{
+        <<"access">> => [<<"write">>]
+    },
+    UnrestrictedStore = hb_test_utils:test_store(hb_store_fs, <<"chain-unrestricted">>),
+    StoreChain = [ReadOnlyStore, WriteOnlyStore, UnrestrictedStore],
+    TestKey = <<"chain-test-key">>,
+    TestValue = <<"chain-test-value">>,
+    start(StoreChain),
+    ?event(testing, {fallback_chain_test_started, length(StoreChain)}),
+    ?assertEqual(ok, write(StoreChain, TestKey, TestValue)),
+    ?event(testing, {write_used_second_store_in_chain}),
+    ?assertEqual(not_found, read(StoreChain, TestKey)),
+    ?event(testing, {read_fell_through_entire_chain}),
+    WriteOnlyNoAccess = maps:remove(<<"access">>, WriteOnlyStore),
+    ?assertEqual({ok, TestValue}, read([WriteOnlyNoAccess], TestKey)).
+
+%% @doc Test invalid access groups are ignored
+invalid_access_groups_test() ->
+    InvalidAccessStore = (hb_test_utils:test_store(hb_store_fs, <<"access-invalid">>))#{
+        <<"access">> => [<<"invalid-group">>, <<"nonexistent">>]
+    },
+    FallbackStore = hb_test_utils:test_store(hb_store_fs, <<"access-fallback">>),
+    StoreList = [InvalidAccessStore, FallbackStore],
+    TestKey = <<"invalid-access-key">>,
+    TestValue = <<"invalid-access-value">>,
+    start(StoreList),
+    ?event(testing, {invalid_access_test_started}),
+    ?assertEqual(ok, write(StoreList, TestKey, TestValue)),
+    ?event(testing, {write_used_fallback_store}),
+    ?assertEqual({ok, TestValue}, read(StoreList, TestKey)),
+    ?event(testing, {read_used_fallback_store}),
+    InvalidStoreNoAccess = maps:remove(<<"access">>, InvalidAccessStore),
+    start([InvalidStoreNoAccess]),
+    ?assertEqual(not_found, read([InvalidStoreNoAccess], TestKey)).
+
+%% @doc Test list operations with access control
+list_access_control_test() ->
+    ReadOnlyStore = (hb_test_utils:test_store(hb_store_fs, <<"list-read-only">>))#{
+        <<"access">> => [<<"read">>]
+    },
+    WriteStore = hb_test_utils:test_store(hb_store_fs, <<"list-write">>),
+    StoreList = [ReadOnlyStore, WriteStore],
+    ListGroup = <<"list-test-group">>,
+    TestKey = <<"list-test-key">>,
+    TestValue = <<"list-test-value">>,
+    start(StoreList),
+    ?event(testing, {list_access_test_started}),
+    GroupResult = make_group(StoreList, ListGroup),
+    ?assertEqual(ok, GroupResult),
+    ?event(testing, {group_created, GroupResult}),
+    WriteResponse = write(StoreList, [ListGroup, TestKey], TestValue),
+    ?assertEqual(ok, WriteResponse),
+    ListResult = list(StoreList, ListGroup),
+    ListValue = read(StoreList, [ListGroup, TestKey]),
+    ?event(testing, {list_result, ListResult, ListValue}),
+    ?assertEqual({ok,[TestKey]}, ListResult),
+    ?assertEqual({ok,TestValue}, ListValue).
+
+%% @doc Test make_link operations with write access
+make_link_access_test() ->
+    WriteOnlyStore = (hb_test_utils:test_store(hb_store_fs, <<"link-write-only">>))#{
+        <<"access">> => [<<"write">>,<<"read">>]
+    },
+    FallbackStore = hb_test_utils:test_store(hb_store_fs, <<"link-fallback">>),
+    StoreList = [WriteOnlyStore, FallbackStore],
+    SourceKey = <<"link-source">>,
+    TargetKey = <<"link-target">>,
+    TestValue = <<"link-test-value">>,
+    start(StoreList),
+    ?event(testing, {make_link_access_test_started}),
+    ?assertEqual(ok, write(StoreList, TargetKey, TestValue)),
+    LinkResult = make_link(StoreList, TargetKey, SourceKey),
+    ?event(testing, {make_link_result, LinkResult}),
+    ReadResult = read(StoreList, SourceKey),
+    ?event(testing, {read_linked_value, ReadResult}),
+    ?assertEqual({ok, TestValue}, ReadResult),
+    ?assertEqual(ok, LinkResult).


### PR DESCRIPTION
This PR introduces support for isolating `~scheduler@1.0` assignment stores from the default store options for a node. This allows a node operator to:
- Store their assignments on a different type of storage medium
- Clearly discern the messages that they are _required_ to store, from those that are only cached for convenience.

The scheduler store can be configured with the `scheduler_store` node message key. If none is set, the default stores are utilized.

Additionally, this PR introduces a system of permissions and policies for each store. They can be specified using the `access` key in a store definition message, providing a list of policy names:
- `read`: All store functions required to be able to read data from the store (including discerning type, resolving links, etc).
- `write`: The ability to write links, make groups, and persistent keys to the store.
- `admin`: Permission to reset the store.

If no `access` key is provided, the store is assumed to be permissive in all operations.