### PR TITLE
misc: router fixes

### DIFF
--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -66,10 +66,15 @@ request(Method, Config = #{ <<"nodes">> := Nodes }, Path, Message, Opts) when is
     % The request has a `route' (see `dev_router' for more details), so we use the
     % `multirequest' functionality, rather than a single request.
     multirequest(Config, Method, Path, Message, Opts);
-request(Method, #{ <<"opts">> := NodeOpts, <<"uri">> := URI }, _Path, Message, Opts) ->
+request(Method, #{ <<"opts">> := ReqOpts, <<"uri">> := URI }, _Path, Message, Opts) ->
     % The request has a set of additional options, so we apply them to the
     % request.
-    MergedOpts = hb_maps:merge(Opts, NodeOpts, Opts),
+    MergedOpts =
+        hb_maps:merge(
+            Opts,
+            hb_opts:mimic_default_types(ReqOpts, new_atoms, Opts),
+            Opts
+        ),
     % We also recalculate the request. The order of precidence here is subtle:
     % We favor the args given to the function, but the URI rules take precidence
     % over that.

--- a/src/hb_path.erl
+++ b/src/hb_path.erl
@@ -312,7 +312,11 @@ matches(Key1, Key2) ->
 %% @doc Check if two keys match using regex.
 regex_matches(Path1, Path2) ->
     NormP1 = normalize(hb_ao:normalize_key(Path1)),
-    NormP2 = normalize(hb_ao:normalize_key(Path2)),
+    NormP2 =
+        case hb_ao:normalize_key(Path2) of
+            Normalized = <<"^", _/binary>> -> Normalized;
+            Normalized -> normalize(Normalized)
+        end,
     try re:run(NormP1, NormP2) =/= nomatch
     catch _A:_B:_C -> false
     end.


### PR DESCRIPTION
Fixes two issues with `~router@1.0` and associated machinery:
1. Regular expressions with `^` at the start now work correctly.
2. Routes with additional node message options now mimic the types of the default node message.