### PR TITLE
impr: Allow ANS-104 encoded messages to be bundled in `~httpsig@1.0`

### DIFF
--- a/src/dev_codec_ans104.erl
+++ b/src/dev_codec_ans104.erl
@@ -220,7 +220,7 @@ ao_data_key_test() ->
     ?event({dec, Dec}),
     ?assert(hb_message:verify(Dec, all, #{})).
         
-simple_signed_to_httpsig_test() ->
+simple_signed_to_httpsig_test_disabled() ->
     Structured =
         hb_message:commit(
             #{ <<"test-tag">> => <<"test-value">> },
@@ -423,7 +423,6 @@ codec_insensitive_get_test() ->
     ?assertEqual(hb_ao:get(<<"hello">>, Structured, #{}), <<"World">>).
 
 httpsig_bundle_with_nested_ans104_test() ->
-    hb:init(),
     Inner =
         hb_message:commit(
             #{
@@ -436,17 +435,8 @@ httpsig_bundle_with_nested_ans104_test() ->
             }
         ),
     Outer = #{ <<"inner">> => Inner },
-        % hb_message:commit(
-        %     #{ <<"inner">> => Inner },
-        %     #{ priv_wallet => ar_wallet:new() },
-        %     #{
-        %         <<"commitment-device">> => <<"httpsig@1.0">>,
-        %         <<"bundle">> => true
-        %     }
-        % ),
     ?assert(hb_message:verify(Outer, all, #{})),
     ?event(debug_test, {outer, Outer}),
-    ?hr(),
     Enc =
         hb_message:convert(
             Outer,
@@ -454,7 +444,6 @@ httpsig_bundle_with_nested_ans104_test() ->
             <<"structured@1.0">>,
             #{}
         ),
-    ?hr(),
     ?event(debug_test, {full_encoded_msg, Enc}),
     ?event(debug_test,
         {encoded_body,

--- a/src/dev_codec_ans104.erl
+++ b/src/dev_codec_ans104.erl
@@ -220,31 +220,37 @@ ao_data_key_test() ->
     ?event({dec, Dec}),
     ?assert(hb_message:verify(Dec, all, #{})).
         
-simple_signed_to_httpsig_test_disabled() ->
-    TX =
-        ar_bundles:sign_item(
-            #tx {
-                tags = [
-                    {<<"test-tag">>, <<"test-value">>},
-                    {<<"test-tag-2">>, <<"test-value-2">>},
-                    {<<"Capitalized-Tag">>, <<"test-value-3">>}
-                ]
-            },
-            ar_wallet:new()
+simple_signed_to_httpsig_test() ->
+    Structured =
+        hb_message:commit(
+            #{ <<"test-tag">> => <<"test-value">> },
+            #{ priv_wallet => ar_wallet:new() },
+            #{
+                <<"commitment-device">> => <<"ans104@1.0">>
+            }
         ),
-    Structured1 = hb_message:convert(TX, <<"structured@1.0">>, <<"ans104@1.0">>, #{}),
-    ?event(debug, {tx, TX}),
-    TABM = hb_message:convert(TX, tabm, <<"ans104@1.0">>, #{}),
-    ?event(debug, {tabm, TABM}),
-    HTTPSig = hb_message:convert(TABM, <<"httpsig@1.0">>, tabm, #{}),
-    ?event(debug, {httpsig, HTTPSig}),
-    Structured2 = hb_message:convert(HTTPSig, <<"structured@1.0">>, <<"httpsig@1.0">>, #{}),
-	Match = hb_message:match(Structured1, Structured2, #{}),
-    ?event(debug, {match, Match}),
+    ?event(debug_test, {msg, Structured}),
+    HTTPSig =
+        hb_message:convert(
+            Structured,
+            <<"httpsig@1.0">>,
+            <<"structured@1.0">>,
+            #{}
+        ),
+    ?event(debug_test, {httpsig, HTTPSig}),
+    Structured2 =
+        hb_message:convert(
+            HTTPSig,
+            <<"structured@1.0">>,
+            <<"httpsig@1.0">>,
+            #{}
+        ),
+    ?event(debug_test, {decoded, Structured2}),
+	Match = hb_message:match(Structured, Structured2, #{}),
     ?assert(Match),
     ?assert(hb_message:verify(Structured2, all, #{})),
     HTTPSig2 = hb_message:convert(Structured2, <<"httpsig@1.0">>, <<"structured@1.0">>, #{}),
-    ?event(debug, {httpsig2, HTTPSig2}),
+    ?event(debug_test, {httpsig2, HTTPSig2}),
     ?assert(hb_message:verify(HTTPSig2, all, #{})),
     ?assert(hb_message:match(HTTPSig, HTTPSig2)).
 
@@ -415,3 +421,48 @@ codec_insensitive_get_test() ->
     Structured = hb_message:convert(TX, <<"structured@1.0">>, <<"ans104@1.0">>, #{}),
     ?assertEqual(hb_ao:get(<<"Hello">>, Structured, #{}), <<"World">>),
     ?assertEqual(hb_ao:get(<<"hello">>, Structured, #{}), <<"World">>).
+
+httpsig_bundle_with_nested_ans104_test() ->
+    hb:init(),
+    Inner =
+        hb_message:commit(
+            #{ <<"test-key">> => <<"test-value">> },
+            #{ priv_wallet => ar_wallet:new() },
+            #{
+                <<"commitment-device">> => <<"ans104@1.0">>
+            }
+        ),
+    Outer = #{ <<"inner">> => Inner },
+        % hb_message:commit(
+        %     #{ <<"inner">> => Inner },
+        %     #{ priv_wallet => ar_wallet:new() },
+        %     #{
+        %         <<"commitment-device">> => <<"httpsig@1.0">>,
+        %         <<"bundle">> => true
+        %     }
+        % ),
+    ?assert(hb_message:verify(Outer, all, #{})),
+    ?event(debug_test, {outer, Outer}),
+    ?hr(),
+    Enc =
+        hb_message:convert(
+            Outer,
+            #{ <<"device">> => <<"httpsig@1.0">>, <<"bundle">> => true },
+            <<"structured@1.0">>,
+            #{}
+        ),
+    ?hr(),
+    ?event(debug_test, {full_encoded_msg, Enc}),
+    ?event(debug_test,
+        {encoded_body,
+            {string, hb_maps:get(<<"body">>, Enc, undefined, #{})}
+        }
+    ),
+    Outer2 = hb_message:convert(Enc, <<"structured@1.0">>, <<"httpsig@1.0">>, #{}),
+    Inner2 = hb_maps:get(<<"inner">>, Outer2, undefined, #{}),
+    ?event(debug_test, {converted, {original, Outer}, {decoded, Outer2}}),
+    ?assert(hb_message:verify(Outer2, all, #{})),
+    ?assert(hb_message:verify(Inner2, all, #{})),
+    ?assert(hb_message:match(Outer, Outer2)),
+    ?assert(hb_message:match(Inner, Inner2)),
+    ok.

--- a/src/dev_codec_ans104.erl
+++ b/src/dev_codec_ans104.erl
@@ -426,7 +426,10 @@ httpsig_bundle_with_nested_ans104_test() ->
     hb:init(),
     Inner =
         hb_message:commit(
-            #{ <<"test-key">> => <<"test-value">> },
+            #{
+                <<"test-key">> => <<"test-value">>,
+                <<"rand-key">> => hb_util:encode(crypto:strong_rand_bytes(32))
+            },
             #{ priv_wallet => ar_wallet:new() },
             #{
                 <<"commitment-device">> => <<"ans104@1.0">>

--- a/src/dev_codec_httpsig_siginfo.erl
+++ b/src/dev_codec_httpsig_siginfo.erl
@@ -6,6 +6,7 @@
 -export([add_derived_specifiers/1, remove_derived_specifiers/1]).
 -export([commitment_to_sig_name/1]).
 -include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
 
 %%% A list of components that are `derived' in the context of RFC-9421 from the
 %%% request message.
@@ -484,4 +485,24 @@ remove_derived_specifiers(ComponentIdentifiers) ->
             Key
         end,
         ComponentIdentifiers
+    ).
+
+%%% Tests.
+
+parse_alg_test() ->
+    ?assertEqual(
+        commitment_to_device_specifiers(#{ <<"alg">> => <<"rsa-pss-sha512">> }, #{}),
+        #{
+            <<"commitment-device">> => <<"httpsig@1.0">>,
+            <<"type">> => <<"rsa-pss-sha512">>
+        }
+    ),
+    ?assertEqual(
+        commitment_to_device_specifiers(
+            #{ <<"alg">> => <<"ans104@1.0/rsa-pss-sha256">> },
+            #{}),
+        #{
+            <<"commitment-device">> => <<"ans104@1.0">>,
+            <<"type">> => <<"rsa-pss-sha256">>
+        }
     ).

--- a/src/dev_hyperbuddy.erl
+++ b/src/dev_hyperbuddy.erl
@@ -1,6 +1,6 @@
 %%% @doc A device that renders a REPL-like interface for AO-Core via HTML.
 -module(dev_hyperbuddy).
--export([info/0, format/3, return_file/2, return_error/1]).
+-export([info/0, format/3, return_file/2, return_error/2]).
 -export([metrics/3, events/3]).
 -export([throw/3]).
 -include_lib("include/hb.hrl").
@@ -140,11 +140,13 @@ return_file(Device, Name, Template) ->
     end.
 
 %% @doc Return an error page, with the `{{error}}` template variable replaced.
-return_error(Error) ->
+return_error(Error, Opts) when not is_map(Error) ->
+    return_error(#{ <<"body">> => Error }, Opts);
+return_error(ErrorMsg, Opts) ->
     return_file(
         <<"hyperbuddy@1.0">>,
         <<"500.html">>,
-        #{ <<"error">> => Error }
+        ErrorMsg#{ <<"body">> => hb_util:format_error(ErrorMsg, Opts) }
     ).
 
 %% @doc Apply a template to a body.

--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -227,35 +227,10 @@ handle_resolve(Req, Msgs, NodeMsg) ->
 				NodeMsg
             ),
             Res =
-                try
-                    hb_ao:resolve_many(
-                        PreProcessedMsg,
-                        HTTPOpts#{ force_message => true, trace => TracePID }
-                    )
-                catch
-                    throw:{necessary_message_not_found, RefPath, Link} ->
-                        BaseBody =
-                            <<
-                                "Data necessary to load message was not found. "
-                            >>,
-                        Body =
-                            try 
-                                <<
-                                    BaseBody/binary,
-                                    "Error occurred at relative path `",
-                                    RefPath/binary, "'. Link was: ",
-                                    Link/binary
-                                >>
-                            catch
-                                _:_ -> BaseBody
-                            end,
-                        {error, #{
-                            <<"status">> => 404,
-                            <<"unavailable">> => Link,
-                            <<"while-resolving">> => RefPath,
-                            <<"body">> => Body
-                        }}
-                end,
+                hb_ao:resolve_many(
+                    PreProcessedMsg,
+                    HTTPOpts#{ force_message => true, trace => TracePID }
+                ),
             {ok, StatusEmbeddedRes} =
                 embed_status(
                     Res,

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -108,7 +108,7 @@ do_push(PrimaryProcess, Assignment, Opts) ->
         {push_computed,
             {status, Status},
             {assignment, Assignment},
-            {request, hb_maps:get(<<"body">>, Assignment, Assignment)},
+            {request, hb_maps:get(<<"body">>, Assignment, Assignment, Opts)},
             {result,
                 if is_list(Result) ->
                     hb_ao:normalize_keys(Result);

--- a/src/dev_relay.erl
+++ b/src/dev_relay.erl
@@ -298,3 +298,76 @@ commit_request_test() ->
         ),
     ?event({res, Res}),
     ?assertEqual(<<"value">>, Res).
+
+%% @doc Test that we can schedule an ANS-104 data item on a relayed node. The
+%% input to the relaying server comes in the form of a serialized ANS-104
+%% data item, which should then be correctly deserialized and sent to the
+%% scheduler node.
+relay_schedule_ans104_test() ->
+    Port = 10000 + rand:uniform(10000),
+    Wallet = ar_wallet:new(),
+    Scheduler =
+        hb_http_server:start_node(
+            #{
+                store => [hb_test_utils:test_store()],
+                priv_wallet => Wallet,
+                port => Port
+            }
+        ),
+    Node =
+        hb_http_server:start_node(#{
+            relay_allow_commit_request => true,
+            store => [hb_test_utils:test_store()],
+            routes =>
+                [
+                    #{
+                        <<"template">> => <<"/push">>,
+                        <<"strategy">> => <<"Nearest">>,
+                        <<"nodes">> => [
+                            #{
+                                <<"wallet">> => hb_util:human_id(Wallet),
+                                <<"prefix">> => Scheduler
+                            }
+                        ]
+                    }
+                ],
+            on => #{
+                <<"request">> =>
+                    #{
+                        <<"device">> => <<"router@1.0">>,
+                        <<"path">> => <<"preprocess">>,
+                        <<"commit-request">> => true
+                    }
+            }
+        }),
+    ClientOpts =
+        #{
+            store => [hb_test_utils:test_store()],
+            priv_wallet => ar_wallet:new()
+        },
+    % Create process to schedule, then send it to the relaying server as
+    % a serialized ANS-104 data item.
+    Process =
+        hb_message:commit(
+            #{
+                <<"device">> => <<"process@1.0">>,
+                <<"execution-device">> => <<"test-device@1.0">>,
+                <<"push-device">> => <<"push@1.0">>,
+                <<"scheduler">> => hb_util:human_id(Wallet),
+                <<"scheduler-device">> => <<"scheduler@1.0">>,
+                <<"module">> => <<"URgYpPQzvxxfYQtjrIQ116bl3YBfcImo3JEnNo8Hlrk">>
+            },
+            ClientOpts,
+            #{ <<"commitment-device">> => <<"ans104@1.0">> }
+        ),
+    Res =
+        hb_http:post(
+            Node,
+            Process#{
+                <<"path">> => <<"push">>,
+                <<"codec-device">> => <<"ans104@1.0">>
+            },
+            ClientOpts
+        ),
+    ?event({post_result, Res}),
+    ?assertMatch({ok, #{ <<"status">> := 200, <<"slot">> := _ }}, Res).

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -718,6 +718,20 @@ encode_reply(Status, TABMReq, Message, Opts) ->
     % aside the default `httpsig@1.0' codec, which expresses its form in HTTP
     % documents, and subsequently must set its own headers.
     case {Status, Codec, AcceptBundle} of
+        {500, <<"httpsig@1.0">>, false} ->
+            ?event(debug_accept,
+                {returning_500_error,
+                    {status, Status},
+                    {codec, Codec},
+                    {bundle, AcceptBundle}
+                }
+            ),
+            {ok, ErrMsg} =
+                dev_hyperbuddy:return_error(Message),
+            {ok,
+                maps:without([<<"body">>], ErrMsg),
+                maps:get(<<"body">>, ErrMsg, <<>>)
+            };
         {404, <<"httpsig@1.0">>, false} ->
             {ok, ErrMsg} =
                 dev_hyperbuddy:return_file(

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -381,8 +381,18 @@ handle_request(RawReq, Body, ServerID) ->
             ),
             TracePID = hb_tracer:start_trace(),
             % Parse the HTTP request into HyerBEAM's message format.
+            ReqSingleton =
+                try hb_http:req_to_tabm_singleton(Req, Body, NodeMsg)
+                catch ParseError:ParseDetails:ParseStacktrace ->
+                    {parse_error, ParseError, ParseDetails, ParseStacktrace}
+                end,
             try 
-                ReqSingleton = hb_http:req_to_tabm_singleton(Req, Body, NodeMsg),
+                case ReqSingleton of
+                    {parse_error, PType, PDetails, PStacktrace} ->
+                        erlang:raise(PType, PDetails, PStacktrace);
+                    _ ->
+                        ok
+                end,
                 CommitmentCodec = hb_http:accept_to_codec(ReqSingleton, NodeMsg),
                 ?event(http,
                     {parsed_singleton,
@@ -403,37 +413,39 @@ handle_request(RawReq, Body, ServerID) ->
                 hb_http:reply(Req, ReqSingleton, Res, NodeMsg)
             catch
                 Type:Details:Stacktrace ->
-                    FormattedError =
-                        hb_util:bin(
-                            [
-                                <<"Termination type: '">>,
-                                hb_message:format(Type),
-                                <<"'\n\nStacktrace:\n\n">>,
-                                hb_util:format_trace(Stacktrace),
-                                <<"\n\nError details:\n\n">>,
-                                hb_message:format(Details, NodeMsg, 1)
-                            ]
-                        ),
-                    {ok, ErrorPage} = dev_hyperbuddy:return_error(FormattedError),
-                    ?event(
-                        http_error,
-                        {unexpected_http_request_termination,
-                            {string,
-                                hb_util:indent(
-                                    <<"\n", FormattedError/binary, "\n">>,
-                                    1
-                                )
-                            }
-                        }
-                    ),
-                    hb_http:reply(
+                    handle_error(
                         Req,
-                        #{},
-                        ErrorPage#{ <<"status">> => 500 },
+                        ReqSingleton,
+                        Type,
+                        Details,
+                        Stacktrace,
                         NodeMsg
                     )
             end
-end.
+    end.
+
+%% @doc Return a 500 error response to the client.
+handle_error(Req, Singleton, Type, Details, Stacktrace, NodeMsg) ->
+    ErrorMsg =
+        #{
+            <<"status">> => 500,
+            <<"type">> => hb_message:format(Type),
+            <<"details">> => hb_message:format(Details, NodeMsg, 1),
+            <<"stacktrace">> => hb_util:bin(hb_util:format_trace(Stacktrace))
+        },
+    ErrorBin = hb_util:format_error(ErrorMsg, NodeMsg),
+    ?event(
+        http_error,
+        {returning_500_error,
+            {string,
+                hb_util:indent(
+                    <<"\n", ErrorBin/binary, "\n">>,
+                    1
+                )
+            }
+        }
+    ),
+    hb_http:reply(Req, Singleton, ErrorMsg, NodeMsg).
 
 %% @doc Return the list of allowed methods for the HTTP server.
 allowed_methods(Req, State) ->

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -525,10 +525,7 @@ set_default_opts(Opts) ->
         end,
     Store =
         case hb_opts:get(store, no_store, TempOpts) of
-            no_store ->
-                TestDir = <<"cache-TEST/run-fs-", (integer_to_binary(Port))/binary>>,
-                filelib:ensure_dir(binary_to_list(TestDir)),
-                #{ <<"store-module">> => hb_store_fs, <<"name">> => TestDir };
+            no_store -> [hb_test_utils:test_store()];
             PassedStore -> PassedStore
         end,
     ?event({set_default_opts,

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -565,9 +565,11 @@ format(RawMap, Opts, Indent) when is_map(RawMap) ->
                             hb_util:format_maybe_multiline(NextMap, Opts, Indent + 2);
                         NextList when is_list(NextList) ->
                             hb_util:debug_format(NextList, Opts, Indent + 2);
-                        _ when (byte_size(Val) == 32) or (byte_size(Val) == 43) ->
+                        _ when (byte_size(Val) == 32) ->
                             Short = hb_util:short_id(Val),
                             io_lib:format("~s [*]", [Short]);
+                        _ when byte_size(Val) == 43 ->
+                            hb_util:short_id(Val);
                         _ when byte_size(Val) == 87 ->
                             io_lib:format("~s [#p]", [hb_util:short_id(Val)]);
                         Bin when is_binary(Bin) ->

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -215,7 +215,7 @@ default_message() ->
         debug_ids => true,
         debug_committers => true,
         debug_show_priv => if_present,
-        debug_resolve_links => false,
+        debug_resolve_links => true,
 		trusted => #{},
         snp_enforced_keys => [
             firmware, kernel, 

--- a/src/hb_util.erl
+++ b/src/hb_util.erl
@@ -17,6 +17,7 @@
 -export([remove_common/2, to_lower/1]).
 -export([maybe_throw/2]).
 -export([indent/1, indent/2, escape_format/1]).
+-export([format_error/2]).
 -export([format_indented/2, format_indented/3, format_indented/4, format_binary/1]).
 -export([format_maybe_multiline/3, remove_trailing_noise/2]).
 -export([debug_print/1, debug_print/2, debug_print/4, eunit_print/2]).
@@ -842,6 +843,19 @@ escape_format(Str) when is_list(Str) ->
         [global, {return, list}]
     );
 escape_format(Else) -> Else.
+
+%% @doc Format an error message as a string.
+format_error(ErrorMsg, Opts) ->
+    Type = hb_ao:get(<<"type">>, ErrorMsg, <<"">>, Opts),
+    Details = hb_ao:get(<<"details">>, ErrorMsg, <<"">>, Opts),
+    Stacktrace = hb_ao:get(<<"stacktrace">>, ErrorMsg, <<"">>, Opts),
+    hb_util:bin(
+        [
+            <<"Termination type: '">>, Type,
+            <<"'\n\nStacktrace:\n\n">>, Stacktrace,
+            <<"\n\nError details:\n\n">>, Details
+        ]
+    ).
 
 %% @doc Take a series of strings or a combined string and format as a
 %% single string with newlines and indentation to the given level. Note: This


### PR DESCRIPTION
Enables bundling of ANS-104 signed messages in `~httpsig@1.0`. This PR achieves this by ensuring that embedded hsig body parts do not undergo the same `siginfo` conversions as the root headers do.