### PR TITLE
impr: Remove wallets from debug prints

### DIFF
--- a/src/dev_hyperbuddy.erl
+++ b/src/dev_hyperbuddy.erl
@@ -146,7 +146,7 @@ return_error(ErrorMsg, Opts) ->
     return_file(
         <<"hyperbuddy@1.0">>,
         <<"500.html">>,
-        ErrorMsg#{ <<"body">> => hb_util:format_error(ErrorMsg, Opts) }
+        #{ <<"error">> => hb_util:format_error(ErrorMsg, Opts) }
     ).
 
 %% @doc Apply a template to a body.

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -727,7 +727,7 @@ encode_reply(Status, TABMReq, Message, Opts) ->
                 }
             ),
             {ok, ErrMsg} =
-                dev_hyperbuddy:return_error(Message),
+                dev_hyperbuddy:return_error(Message, Opts),
             {ok,
                 maps:without([<<"body">>], ErrMsg),
                 maps:get(<<"body">>, ErrMsg, <<>>)

--- a/src/hb_util.erl
+++ b/src/hb_util.erl
@@ -633,7 +633,7 @@ do_debug_fmt(
 ) ->
     format_address(Pub, Opts, Indent);
 do_debug_fmt(
-    { _,
+    { AtomValue,
       {
         { {rsa, _PublicExpnt1}, _Priv1, _Priv2 },
         { {rsa, _PublicExpnt2}, Pub }
@@ -641,7 +641,8 @@ do_debug_fmt(
     },
     Opts, Indent
 ) ->
-    format_address(Pub, Opts, Indent);
+    AddressString = format_address(Pub, Opts, Indent),
+    format_indented("~p: ~s", [AtomValue, AddressString], Opts, Indent);
 do_debug_fmt({explicit, X}, Opts, Indent) ->
     format_indented("[Explicit:] ~p", [X], Opts, Indent);
 do_debug_fmt({string, X}, Opts, Indent) ->

--- a/src/hb_util.erl
+++ b/src/hb_util.erl
@@ -602,10 +602,12 @@ debug_format(X, Opts) -> debug_format(X, Opts, 0).
 debug_format(X, Opts, Indent) ->
     try do_debug_fmt(X, Opts, Indent)
     catch A:B:C ->
-        case hb_opts:get(debug_print_fail_mode, quiet, Opts) of
-            quiet ->
+        Mode = hb_opts:get(mode, prod, Opts),
+        PrintFailPreference = hb_opts:get(debug_print_fail_mode, quiet, Opts),
+        case {Mode, PrintFailPreference} of
+            {debug, quiet} ->
                 format_indented("[!Format failed!] ~p", [X], Opts, Indent);
-            _ ->
+            {debug, _} ->
                 format_indented(
                     "[PRINT FAIL:] ~80p~n===== PRINT ERROR WAS ~p:~p =====~n~s",
                     [
@@ -621,7 +623,9 @@ debug_format(X, Opts, Indent) ->
                     ],
                     Opts,
                     Indent
-                )
+                );
+            _ ->
+                format_indented("[!Format failed!]", [], Opts, Indent)
         end
     end.
 
@@ -710,8 +714,8 @@ do_debug_fmt(X, Opts, Indent) ->
 
 %% @doc If the user attempts to print a wallet, format it as an address.
 format_address(Wallet, Opts, Indent) ->
-    format_indented("Address: ~s",
-        [human_id(ar_wallet:to_address(Wallet))], 
+    format_indented("Wallet [Addr: ~s]",
+        [short_id(human_id(ar_wallet:to_address(Wallet)))], 
         Opts, 
         Indent
     ).

--- a/src/hb_util.erl
+++ b/src/hb_util.erl
@@ -625,10 +625,23 @@ debug_format(X, Opts, Indent) ->
         end
     end.
 
-do_debug_fmt(Wallet = {{rsa, _PublicExpnt}, _Priv, _Pub}, Opts, Indent) ->
-    format_address(Wallet, Opts, Indent);
-do_debug_fmt({_, Wallet = {{rsa, _PublicExpnt}, _Priv, _Pub}}, Opts, Indent) ->
-    format_address(Wallet, Opts, Indent);
+do_debug_fmt(
+    { { {rsa, _PublicExpnt1}, _Priv1, _Priv2 },
+      { {rsa, _PublicExpnt2}, Pub }
+    },
+    Opts, Indent
+) ->
+    format_address(Pub, Opts, Indent);
+do_debug_fmt(
+    { _,
+      {
+        { {rsa, _PublicExpnt1}, _Priv1, _Priv2 },
+        { {rsa, _PublicExpnt2}, Pub }
+      }
+    },
+    Opts, Indent
+) ->
+    format_address(Pub, Opts, Indent);
 do_debug_fmt({explicit, X}, Opts, Indent) ->
     format_indented("[Explicit:] ~p", [X], Opts, Indent);
 do_debug_fmt({string, X}, Opts, Indent) ->
@@ -696,7 +709,11 @@ do_debug_fmt(X, Opts, Indent) ->
 
 %% @doc If the user attempts to print a wallet, format it as an address.
 format_address(Wallet, Opts, Indent) ->
-    format_indented(human_id(ar_wallet:to_address(Wallet)), Opts, Indent).
+    format_indented("Address: ~s",
+        [human_id(ar_wallet:to_address(Wallet))], 
+        Opts, 
+        Indent
+    ).
 
 %% @doc Helper function to format tuples with arity greater than 2.
 format_tuple(Tuple, Opts, Indent) ->


### PR DESCRIPTION
This PR re-activates the `hb_util:debug_format` mechanism for hiding wallet keys. Additionally, it makes print failure handling more stringent by omitting the value that caused a print failure if the HyperBEAM node message does not have `mode: debug`.