### PR TITLE
chore: Update default gateway stores to include `local-store` key

### DIFF
--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -273,11 +273,11 @@ default_message() ->
                             <<"value">> => <<"ao">>
                         }
                     ],
-                    <<"store">> => [?DEFAULT_PRIMARY_STORE]
+                    <<"local-store">> => [?DEFAULT_PRIMARY_STORE]
                 },
                 #{
                     <<"store-module">> => hb_store_gateway,
-                    <<"store">> => [?DEFAULT_PRIMARY_STORE]
+                    <<"local-store">> => [?DEFAULT_PRIMARY_STORE]
                 }
             ],
         priv_store =>


### PR DESCRIPTION
This PR updates the default gateway store configurations to correctly use the new `local-store` key, rather than the old `store`, to reference the local cache that the gateway should write to.
