### PR TITLE
fix: ensure that messages from `~json@1.0` correctly encode lists as TABM

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -2,5 +2,12 @@
     "port": 1234,
     "example": 9001,
     "host": "https://ao.computer",
-    "await_inprogress": false
+    "await_inprogress": false,
+    "store": [
+        {
+            "store-module": "hb_store_fs",
+            "name": "cache-TEST/json-test-store",
+            "ao-types": "store-module=\"atom\""
+        }
+    ]
 }


### PR DESCRIPTION
Before this commit, lists decoded from `~json@1.0` encoded binaries would be emitted as lists in the resulting TABM. This is against the standards of the `~message@1.0` codec scheme. After this commit, messages from `~json@1.0` are correctly formatted as real TABMs, which can then be encoded with further codecs.