### PR TITLE
fix: block hash encoding in `~scheduler@1.0`

### DIFF
--- a/src/ar_timestamp.erl
+++ b/src/ar_timestamp.erl
@@ -57,10 +57,6 @@ cache(Current) ->
 %% @doc Refresh the timestamp cache periodically.
 refresher(TSServer) ->
     timer:sleep(?TIMEOUT),
-    TS =
-        case hb_opts:get(mode) of
-            debug -> { 0, 0, << 0:256 >> };
-            prod -> hb_client:arweave_timestamp()
-        end,
+    TS = hb_client:arweave_timestamp(),
     TSServer ! {refresh, TS},
     refresher(TSServer).

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -902,7 +902,7 @@ slot(M1, M2, Opts) ->
     case find_server(ProcID, M1, Opts) of
         {local, PID} ->
             ?event({getting_current_slot, {proc_id, ProcID}}),
-            {Timestamp, Hash, Height} = ar_timestamp:get(),
+            {Timestamp, Height, Hash} = ar_timestamp:get(),
             #{ current := CurrentSlot, wallets := Wallets } =
                 dev_scheduler_server:info(PID),
             {ok, #{

--- a/src/hb_client.erl
+++ b/src/hb_client.erl
@@ -71,13 +71,13 @@ add_route(Node, Route, Opts) ->
 %% @doc Grab the latest block information from the Arweave gateway node.
 arweave_timestamp() ->
     case hb_opts:get(mode) of
-        debug -> {0, 0, <<0:256>>};
+        debug -> {0, 0, hb_util:human_id(<<0:256>>)};
         prod ->
             {ok, {{_, 200, _}, _, Body}} =
                 httpc:request(
                     <<(hb_opts:get(gateway))/binary, "/block/current">>
                 ),
-            Fields = hb_json:decode(Body),
+            Fields = hb_json:decode(hb_util:bin(Body)),
             Timestamp = hb_maps:get(<<"timestamp">>, Fields),
             Hash = hb_maps:get(<<"indep_hash">>, Fields),
             Height = hb_maps:get(<<"height">>, Fields),


### PR DESCRIPTION
This PR fixes two issues:
1. Block hash and block height were incorrectly mixed in a call to `ar_timestamp`.
2. Block hashes were not encoded as human-readable strings, leading to invalid bytes being emitted from the HTTP server, causing connection termination issues on clients.