### PR TITLE
Enforce LMDB to put always with prefixes

### DIFF
--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -37,6 +37,9 @@
 -define(MAX_REDIRECTS, 1000).                   % Only resolve 1000 links to data
 -define(MAX_PENDING_WRITES, 400).               % Force flush after x pending
 -define(FOLD_YIELD_INTERVAL, 100).              % Yield every x keys
+-define(LINK_PREFIX, <<"link:">>).              
+-define(DATA_PREFIX, <<"data:">>).              
+-define(MIN_PREFIX_SIZE, 5).                    % Size of the "link:" and "data:" prefix
 
 %% @doc Start the LMDB storage system for a given database configuration.
 %%
@@ -88,21 +91,18 @@ start(_) ->
 -spec type(map(), binary()) -> composite | simple | not_found.
 type(Opts, Key) ->
     case read_direct(Opts, Key) of
+        {ok, <<"group">>} -> composite;
         {ok, Value} ->
-            case is_link(Value) of
-                {true, Link} ->
+            case strip_value(Value) of
+                {?LINK_PREFIX, Link} ->
                     % This is a link, check the target's type
                     type(Opts, Link);
-                false ->
-                    case Value of
-                        <<"group">> -> 
-                            composite;
-                        _ -> 
-                            simple
-                    end
+                _ ->
+                    simple
             end;
         not_found -> not_found
     end.
+
 
 %% @doc Write a key-value pair to the database asynchronously.
 %%
@@ -124,10 +124,15 @@ type(Opts, Key) ->
 write(Opts, PathParts, Value) when is_list(PathParts) ->
     % Convert to binary
     PathBin = to_path(PathParts),
-    write(Opts, PathBin, Value);
+    do_write(Opts, PathBin, <<?DATA_PREFIX/binary, Value/binary>>);
+
 write(Opts, Path, Value) ->
+    PrefixedValue = <<?DATA_PREFIX/binary, Value/binary>>,
+    do_write(Opts, Path, PrefixedValue).
+    
+do_write(Opts, Path, PrefixedValue) ->
     #{ <<"db">> := DBInstance } = find_env(Opts),
-    case elmdb:put(DBInstance, Path, Value) of
+    case elmdb:put(DBInstance, Path, PrefixedValue) of
         ok -> ok;
         {error, Type, Description} ->
             ?event(
@@ -196,21 +201,36 @@ read(Opts, Path) ->
             end
     end.
 
-%% @doc Helper function to check if a value is a link and extract the target.
-is_link(Value) ->
-    LinkPrefixSize = byte_size(<<"link:">>),
-    case byte_size(Value) > LinkPrefixSize andalso
-        binary:part(Value, 0, LinkPrefixSize) =:= <<"link:">> of
-        true -> 
-            Link =
+%% @doc Helper function to extract the link or data by removing the prefix.
+strip_value(Value) ->
+    case byte_size(Value) > ?MIN_PREFIX_SIZE of
+        true ->
+            case strip_with_prefix(Value, ?LINK_PREFIX) of
+                {ok, TaggedLink} -> TaggedLink;
+                error ->
+                    case strip_with_prefix(Value, ?DATA_PREFIX) of
+                        {ok, TaggedData} -> TaggedData;
+                        error -> Value
+                    end
+            end;
+        false ->
+            Value
+    end.
+
+% Helper to strip the RawValue tagging it with the prefix
+strip_with_prefix(Value, Prefix) ->
+    PrefixSize = byte_size(Prefix),
+    case binary:part(Value, 0, PrefixSize) =:= Prefix of
+        true ->
+            RawValue =
                 binary:part(
                     Value,
-                    LinkPrefixSize,
-                    byte_size(Value) - LinkPrefixSize
+                    PrefixSize,
+                    byte_size(Value) - PrefixSize
                 ),
-            {true, Link};
+            {ok, {Prefix, RawValue}};
         false ->
-            false
+            error
     end.
 
 %% @doc Helper function to convert to a path
@@ -233,19 +253,18 @@ read_direct(Opts, Path) ->
 %% This is the internal implementation that handles actual database reads.
 read_with_links(Opts, Path) ->
     case read_direct(Opts, Path) of
+        {ok, <<"group">>} -> not_found;
         {ok, Value} ->
             % Check if this value is actually a link to another key
-            case is_link(Value) of
-                {true, Link} -> 
+            case strip_value(Value) of
+                {?LINK_PREFIX, Link} -> 
                    % Extract the target key and recursively resolve the link
                    read_with_links(Opts, Link);
-                false ->
-                    % Check if this is a group marker - groups should not be
-                    % readable as simple values
-                    case Value of
-                        <<"group">> -> not_found;
-                        _ -> {ok, Value}
-                    end
+                {?DATA_PREFIX, Data} ->
+                    {ok, Data};
+                _ ->
+                    % Does not require migration, old data without prefix is returned
+                    {ok, Value}
             end;
         not_found ->
             not_found
@@ -279,15 +298,15 @@ resolve_path_links_acc(Opts, [Head | Tail], AccPath, Depth) ->
     % Check if the accumulated path (not just the segment) is a link
     case read_direct(Opts, CurrentPathBin) of
         {ok, Value} ->
-            case is_link(Value) of
-                {true, Link} ->
+            case strip_value(Value) of
+                {?LINK_PREFIX, Link} ->
                     % The accumulated path is a link! Resolve it
                     LinkSegments = binary:split(Link, <<"/">>, [global]),
                     % Replace the accumulated path with the link target and
                     % continue with remaining segments
                     NewPath = LinkSegments ++ Tail,
                     resolve_path_links(Opts, NewPath, Depth + 1);
-                false ->
+                _ ->
                     % Not a link, continue accumulating
                     resolve_path_links_acc(Opts, Tail, [Head | AccPath], Depth)
             end;
@@ -341,10 +360,12 @@ list(Opts, Path) ->
     ResolvedPath =
         case read_direct(Opts, Path) of
             {ok, Value} ->
-                case is_link(Value) of
-                    {true, Link} ->
+                case strip_value(Value) of
+                    {?LINK_PREFIX, Link} ->
                         Link;
-                    false ->
+                    {?DATA_PREFIX, Data} ->
+                        Data;
+                    _ ->
                         % Not a link; use original path
                         Path
                 end;
@@ -389,7 +410,7 @@ list(Opts, Path) ->
 %% @returns Result of the write operation
 -spec make_group(map(), binary()) -> ok | {error, term()}.
 make_group(Opts, GroupName) when is_map(Opts), is_binary(GroupName) ->
-    write(Opts, GroupName, <<"group">>);
+    do_write(Opts, GroupName, <<"group">>);
 make_group(_,_) ->
     {error, {badarg, <<"StoreOps must be map and GroupName must be a binary">>}}.
 
@@ -459,7 +480,7 @@ make_link(Opts, Existing, New) ->
    ExistingBin = hb_util:bin(Existing),
    % Ensure parent groups exist for the new link path (like filesystem ensure_dir)
    ensure_parent_groups(Opts, New),
-   write(Opts, New, <<"link:", ExistingBin/binary>>). 
+   do_write(Opts, New, <<?LINK_PREFIX/binary, ExistingBin/binary>>). 
 
 %% @doc Transform a path into the store's canonical form.
 %% For LMDB, paths are simply joined with "/" separators.
@@ -1044,6 +1065,7 @@ list_with_link_test() ->
     reset(StoreOpts),
     % Create a group with some children
     make_group(StoreOpts, <<"real-group">>),
+    ?assertEqual(not_found, read(StoreOpts, <<"real-group">>)),
     write(StoreOpts, <<"real-group/child1">>, <<"value1">>),
     write(StoreOpts, <<"real-group/child2">>, <<"value2">>),
     write(StoreOpts, <<"real-group/child3">>, <<"value3">>),


### PR DESCRIPTION
## Problem

Currently Data values are stored without prefix creating a security vulnerability where malicious users can forge link entries by writing data values with link: prefix.

## Changes

- `hb_store_lmdb:write` to always put keys on LMDB with values prefixed by ~"data:" or ~"link:".
- `hb_store_lmdb:read_with_links` accordingly to strip the raw value for data while keeping the previous behaviour to resolve the links (read the pointed data)

## Requirement
Refs [FOR-137](https://linear.app/forward-research/issue/FOR-137/impr-lmdb-low-level-storage-should-have-labels-for-both-data-and-link) impr - lmdb low level storage should have labels for both data and link

## Additional notes

This is a gradual implementation once it does not require the existing cache to be invalidated and migrated. However all new writes are prepended with either `data:` or `link:`.

After a migration strategy is defined to reach completely the FOR-137 goal, an additional implementation is needed so that:
- All reads should validate the first 5 characters of the raw value
- Reject reads with invalid/missing prefixes

This will require not only a migration but also decide how the handle links recursiveness (previous to this PR, links are already recursive and the real data is read when there is no more `link:` on the value).

