### PR TITLE
fix: Correctly remove snapshots from process state results

### DIFF
--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -598,7 +598,7 @@ ensure_loaded(Msg1, Msg2, Opts) ->
                             Opts#{ hashpath => ignore }
                         ),
                     NormalizedWithoutSnapshot = without_snapshot(Normalized, Opts),
-                    ?event(debug_snapshot,
+                    ?event(snapshot,
                         {loaded_state_checkpoint_result,
                             {proc_id, ProcID},
                             {slot, LoadedSlot},


### PR DESCRIPTION
This PR ensures that process snapshot messages are removed from compute results in the `~process@1.0` device. Emitting these binaries directly is against the intended behavior of the device, and led to downstream encoding issues. These manifested occasionally as HTTP hangups, due to attempts to send unencoded values in message headers.
