### PR TITLE
impr: Enforce LMDB to read and write always with a prefix (FOR-137)

### DIFF
--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -39,7 +39,7 @@
 -define(FOLD_YIELD_INTERVAL, 100).              % Yield every x keys
 -define(LINK_PREFIX, <<"link:">>).              
 -define(DATA_PREFIX, <<"data:">>).              
--define(MIN_PREFIX_SIZE, 5).                    % Size of the "link:" and "data:" prefix
+-define(PREFIX_SIZE, 5).                        % Size of the "link:" and "data:" prefix
 
 %% @doc Start the LMDB storage system for a given database configuration.
 %%
@@ -91,15 +91,9 @@ start(_) ->
 -spec type(map(), binary()) -> composite | simple | not_found.
 type(Opts, Key) ->
     case read_direct(Opts, Key) of
-        {ok, <<"group">>} -> composite;
-        {ok, Value} ->
-            case strip_value(Value) of
-                {?LINK_PREFIX, Link} ->
-                    % This is a link, check the target's type
-                    type(Opts, Link);
-                _ ->
-                    simple
-            end;
+        {link, Link} -> type(Opts, Link);
+        {data, _Data} -> simple;
+        {group, _Group} -> composite;
         not_found -> not_found
     end.
 
@@ -202,50 +196,21 @@ read(Opts, Path) ->
             end
     end.
 
-%% @doc Helper function to extract the link or data by removing the prefix.
-strip_value(Value) ->
-    case byte_size(Value) > ?MIN_PREFIX_SIZE of
-        true ->
-            case strip_with_prefix(Value, ?LINK_PREFIX) of
-                {ok, TaggedLink} -> TaggedLink;
-                error ->
-                    case strip_with_prefix(Value, ?DATA_PREFIX) of
-                        {ok, TaggedData} -> TaggedData;
-                        error -> Value
-                    end
-            end;
-        false ->
-            Value
-    end.
-
-% Helper to strip the RawValue tagging it with the prefix
-strip_with_prefix(Value, Prefix) ->
-    PrefixSize = byte_size(Prefix),
-    case binary:part(Value, 0, PrefixSize) =:= Prefix of
-        true ->
-            RawValue =
-                binary:part(
-                    Value,
-                    PrefixSize,
-                    byte_size(Value) - PrefixSize
-                ),
-            {ok, {Prefix, RawValue}};
-        false ->
-            error
-    end.
-
 %% @doc Helper function to convert to a path
 to_path(PathParts) ->
     hb_util:bin(lists:join(<<"/">>, PathParts)).
 
 %% @doc Unified read function that handles LMDB reads with fallback to the 
 %% in-process pending writes, if necessary.
-%% 
-%% Returns {ok, Value} or not_found.
+%%
+%% Returns a tagged tuple with {Type, RawValue} or not_found where Type is one of
+%% group, link, or data.
 read_direct(Opts, Path) ->
     #{ <<"db">> := DBInstance } = find_env(Opts),
     case elmdb:get(DBInstance, Path) of
-        {ok, Value} -> {ok, Value};
+        {ok, <<Prefix:?PREFIX_SIZE/binary, Data/binary>>} when Prefix == ?DATA_PREFIX -> {data, Data};
+        {ok, <<Prefix:?PREFIX_SIZE/binary, Link/binary>>} when Prefix == ?LINK_PREFIX -> {link, Link};
+        {ok, <<"group">>} -> {group, <<"group">>};
         {error, not_found} -> not_found;  % Normalize error format
         not_found -> not_found  % Handle both old and new format
     end.
@@ -254,19 +219,12 @@ read_direct(Opts, Path) ->
 %% This is the internal implementation that handles actual database reads.
 read_with_links(Opts, Path) ->
     case read_direct(Opts, Path) of
-        {ok, <<"group">>} -> not_found;
-        {ok, Value} ->
-            % Check if this value is actually a link to another key
-            case strip_value(Value) of
-                {?LINK_PREFIX, Link} -> 
-                   % Extract the target key and recursively resolve the link
-                   read_with_links(Opts, Link);
-                {?DATA_PREFIX, Data} ->
-                    {ok, Data};
-                _ ->
-                    % Does not require migration, old data without prefix is returned
-                    {ok, Value}
-            end;
+        {group, <<"group">>} -> not_found;
+        {link, Link} -> 
+            % Extract the target key and recursively resolve the link
+            read_with_links(Opts, Link);
+        {data, RawValue} ->
+            {ok, RawValue};
         not_found ->
             not_found
     end.
@@ -298,19 +256,16 @@ resolve_path_links_acc(Opts, [Head | Tail], AccPath, Depth) ->
     CurrentPathBin = to_path(CurrentPath),
     % Check if the accumulated path (not just the segment) is a link
     case read_direct(Opts, CurrentPathBin) of
-        {ok, Value} ->
-            case strip_value(Value) of
-                {?LINK_PREFIX, Link} ->
-                    % The accumulated path is a link! Resolve it
-                    LinkSegments = binary:split(Link, <<"/">>, [global]),
-                    % Replace the accumulated path with the link target and
-                    % continue with remaining segments
-                    NewPath = LinkSegments ++ Tail,
-                    resolve_path_links(Opts, NewPath, Depth + 1);
-                _ ->
-                    % Not a link, continue accumulating
-                    resolve_path_links_acc(Opts, Tail, [Head | AccPath], Depth)
-            end;
+        {link, Link} ->
+            % The accumulated path is a link! Resolve it
+            LinkSegments = binary:split(Link, <<"/">>, [global]),
+            % Replace the accumulated path with the link target and
+            % continue with remaining segments
+            NewPath = LinkSegments ++ Tail,
+            resolve_path_links(Opts, NewPath, Depth + 1);
+        {_Any, _Data} ->
+            % Not a link, continue accumulating
+            resolve_path_links_acc(Opts, Tail, [Head | AccPath], Depth);
         not_found ->
             % Path doesn't exist as a complete link, continue accumulating
             resolve_path_links_acc(Opts, Tail, [Head | AccPath], Depth)
@@ -360,17 +315,10 @@ list(Opts, Path) ->
     % Check if Path is a link and resolve it if necessary
     ResolvedPath =
         case read_direct(Opts, Path) of
-            {ok, Value} ->
-                case strip_value(Value) of
-                    {?LINK_PREFIX, Link} ->
-                        Link;
-                    {?DATA_PREFIX, Data} ->
-                        Data;
-                    _ ->
-                        % Not a link; use original path
-                        Path
-                end;
-            not_found ->
+            {link, Link} -> 
+                Link;
+            _Any -> 
+                % Not a link; use original path
                 Path
         end,
     % Ensure path ends with / for elmdb:list API
@@ -471,7 +419,7 @@ create_parent_groups(Opts, Current, [Next | Rest]) ->
     case read_direct(Opts, GroupPath) of
         not_found ->
             make_group(Opts, GroupPath);
-        {ok, _} ->
+        {_Type, _Value} ->
             % Already exists, skip
             ok
     end,

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -37,6 +37,9 @@
 -define(MAX_REDIRECTS, 1000).                   % Only resolve 1000 links to data
 -define(MAX_PENDING_WRITES, 400).               % Force flush after x pending
 -define(FOLD_YIELD_INTERVAL, 100).              % Yield every x keys
+-define(LINK_PREFIX, <<"link:">>).              
+-define(DATA_PREFIX, <<"data:">>).              
+-define(MIN_PREFIX_SIZE, 5).                    % Size of the "link:" and "data:" prefix
 
 %% @doc Start the LMDB storage system for a given database configuration.
 %%
@@ -88,21 +91,18 @@ start(_) ->
 -spec type(map(), binary()) -> composite | simple | not_found.
 type(Opts, Key) ->
     case read_direct(Opts, Key) of
+        {ok, <<"group">>} -> composite;
         {ok, Value} ->
-            case is_link(Value) of
-                {true, Link} ->
+            case strip_value(Value) of
+                {?LINK_PREFIX, Link} ->
                     % This is a link, check the target's type
                     type(Opts, Link);
-                false ->
-                    case Value of
-                        <<"group">> -> 
-                            composite;
-                        _ -> 
-                            simple
-                    end
+                _ ->
+                    simple
             end;
         not_found -> not_found
     end.
+
 
 %% @doc Write a key-value pair to the database asynchronously.
 %%
@@ -124,11 +124,16 @@ type(Opts, Key) ->
 write(Opts, PathParts, Value) when is_list(PathParts) ->
     % Convert to binary
     PathBin = to_path(PathParts),
-    write(Opts, PathBin, Value);
+    do_write(Opts, PathBin, <<?DATA_PREFIX/binary, Value/binary>>);
+
 write(Opts, Path, Value) ->
+    PrefixedValue = <<?DATA_PREFIX/binary, Value/binary>>,
+    do_write(Opts, Path, PrefixedValue).
+    
+do_write(Opts, Path, PrefixedValue) ->
     #{ <<"db">> := DBInstance } = find_env(Opts),
-    ?event({elmdb_write, {db, DBInstance}, {path, Path}, {value, Value}}),
-    case elmdb:put(DBInstance, Path, Value) of
+    ?event({elmdb_write, {db, DBInstance}, {path, Path}, {value, PrefixedValue}}),
+    case elmdb:put(DBInstance, Path, PrefixedValue) of
         ok -> ok;
         {error, Type, Description} ->
             ?event(
@@ -197,21 +202,36 @@ read(Opts, Path) ->
             end
     end.
 
-%% @doc Helper function to check if a value is a link and extract the target.
-is_link(Value) ->
-    LinkPrefixSize = byte_size(<<"link:">>),
-    case byte_size(Value) > LinkPrefixSize andalso
-        binary:part(Value, 0, LinkPrefixSize) =:= <<"link:">> of
-        true -> 
-            Link =
+%% @doc Helper function to extract the link or data by removing the prefix.
+strip_value(Value) ->
+    case byte_size(Value) > ?MIN_PREFIX_SIZE of
+        true ->
+            case strip_with_prefix(Value, ?LINK_PREFIX) of
+                {ok, TaggedLink} -> TaggedLink;
+                error ->
+                    case strip_with_prefix(Value, ?DATA_PREFIX) of
+                        {ok, TaggedData} -> TaggedData;
+                        error -> Value
+                    end
+            end;
+        false ->
+            Value
+    end.
+
+% Helper to strip the RawValue tagging it with the prefix
+strip_with_prefix(Value, Prefix) ->
+    PrefixSize = byte_size(Prefix),
+    case binary:part(Value, 0, PrefixSize) =:= Prefix of
+        true ->
+            RawValue =
                 binary:part(
                     Value,
-                    LinkPrefixSize,
-                    byte_size(Value) - LinkPrefixSize
+                    PrefixSize,
+                    byte_size(Value) - PrefixSize
                 ),
-            {true, Link};
+            {ok, {Prefix, RawValue}};
         false ->
-            false
+            error
     end.
 
 %% @doc Helper function to convert to a path
@@ -234,19 +254,18 @@ read_direct(Opts, Path) ->
 %% This is the internal implementation that handles actual database reads.
 read_with_links(Opts, Path) ->
     case read_direct(Opts, Path) of
+        {ok, <<"group">>} -> not_found;
         {ok, Value} ->
             % Check if this value is actually a link to another key
-            case is_link(Value) of
-                {true, Link} -> 
+            case strip_value(Value) of
+                {?LINK_PREFIX, Link} -> 
                    % Extract the target key and recursively resolve the link
                    read_with_links(Opts, Link);
-                false ->
-                    % Check if this is a group marker - groups should not be
-                    % readable as simple values
-                    case Value of
-                        <<"group">> -> not_found;
-                        _ -> {ok, Value}
-                    end
+                {?DATA_PREFIX, Data} ->
+                    {ok, Data};
+                _ ->
+                    % Does not require migration, old data without prefix is returned
+                    {ok, Value}
             end;
         not_found ->
             not_found
@@ -280,15 +299,15 @@ resolve_path_links_acc(Opts, [Head | Tail], AccPath, Depth) ->
     % Check if the accumulated path (not just the segment) is a link
     case read_direct(Opts, CurrentPathBin) of
         {ok, Value} ->
-            case is_link(Value) of
-                {true, Link} ->
+            case strip_value(Value) of
+                {?LINK_PREFIX, Link} ->
                     % The accumulated path is a link! Resolve it
                     LinkSegments = binary:split(Link, <<"/">>, [global]),
                     % Replace the accumulated path with the link target and
                     % continue with remaining segments
                     NewPath = LinkSegments ++ Tail,
                     resolve_path_links(Opts, NewPath, Depth + 1);
-                false ->
+                _ ->
                     % Not a link, continue accumulating
                     resolve_path_links_acc(Opts, Tail, [Head | AccPath], Depth)
             end;
@@ -342,10 +361,12 @@ list(Opts, Path) ->
     ResolvedPath =
         case read_direct(Opts, Path) of
             {ok, Value} ->
-                case is_link(Value) of
-                    {true, Link} ->
+                case strip_value(Value) of
+                    {?LINK_PREFIX, Link} ->
                         Link;
-                    false ->
+                    {?DATA_PREFIX, Data} ->
+                        Data;
+                    _ ->
                         % Not a link; use original path
                         Path
                 end;
@@ -414,7 +435,7 @@ match(Opts, MatchKVs) ->
 %% @returns Result of the write operation
 -spec make_group(map(), binary()) -> ok | {error, term()}.
 make_group(Opts, GroupName) when is_map(Opts), is_binary(GroupName) ->
-    write(Opts, GroupName, <<"group">>);
+    do_write(Opts, GroupName, <<"group">>);
 make_group(_,_) ->
     {error, {badarg, <<"StoreOps must be map and GroupName must be a binary">>}}.
 
@@ -484,7 +505,7 @@ make_link(Opts, Existing, New) ->
    ExistingBin = hb_util:bin(Existing),
    % Ensure parent groups exist for the new link path (like filesystem ensure_dir)
    ensure_parent_groups(Opts, New),
-   write(Opts, New, <<"link:", ExistingBin/binary>>). 
+   do_write(Opts, New, <<?LINK_PREFIX/binary, ExistingBin/binary>>). 
 
 %% @doc Transform a path into the store's canonical form.
 %% For LMDB, paths are simply joined with "/" separators.
@@ -1069,6 +1090,7 @@ list_with_link_test() ->
     reset(StoreOpts),
     % Create a group with some children
     make_group(StoreOpts, <<"real-group">>),
+    ?assertEqual(not_found, read(StoreOpts, <<"real-group">>)),
     write(StoreOpts, <<"real-group/child1">>, <<"value1">>),
     write(StoreOpts, <<"real-group/child2">>, <<"value2">>),
     write(StoreOpts, <<"real-group/child3">>, <<"value3">>),

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -121,8 +121,7 @@ write(Opts, PathParts, Value) when is_list(PathParts) ->
     do_write(Opts, PathBin, <<?DATA_PREFIX/binary, Value/binary>>);
 
 write(Opts, Path, Value) ->
-    PrefixedValue = <<?DATA_PREFIX/binary, Value/binary>>,
-    do_write(Opts, Path, PrefixedValue).
+    do_write(Opts, Path, <<?DATA_PREFIX/binary, Value/binary>>).
     
 do_write(Opts, Path, PrefixedValue) ->
     #{ <<"db">> := DBInstance } = find_env(Opts),
@@ -193,7 +192,15 @@ read(Opts, Path) ->
                     ),
                     % If link resolution fails, return not_found
                     not_found
-            end
+            end;
+        {error, badformat} ->
+            ?event(error,
+                        {
+                            resolve_path_links_failed, 
+                            data_missing_prefix
+                        }
+                    ),
+            {error, badformat}
     end.
 
 %% @doc Helper function to convert to a path
@@ -212,7 +219,8 @@ read_direct(Opts, Path) ->
         {ok, <<Prefix:?PREFIX_SIZE/binary, Link/binary>>} when Prefix == ?LINK_PREFIX -> {link, Link};
         {ok, <<"group">>} -> {group, <<"group">>};
         {error, not_found} -> not_found;  % Normalize error format
-        not_found -> not_found  % Handle both old and new format
+        not_found -> not_found;  % Handle both old and new format
+        _OldData -> error
     end.
 
 %% @doc Read a value directly from the database with link resolution.
@@ -226,7 +234,9 @@ read_with_links(Opts, Path) ->
         {data, RawValue} ->
             {ok, RawValue};
         not_found ->
-            not_found
+            not_found;
+        error ->
+            {error, badformat}
     end.
 
 %% @doc Resolve links in a path, checking each segment except the last.
@@ -1053,4 +1063,30 @@ list_with_link_test() ->
     {ok, LinkChildren} = list(StoreOpts, <<"link-to-group">>),
     ?event({link_children, LinkChildren}),
     ?assertEqual(ExpectedChildren, lists:sort(LinkChildren)),
+    stop(StoreOpts).
+
+%% @doc Test that data previously written without prefix returns {error, badformat}
+%%
+%% This test verifies that when data is written directly to LMDB without the
+%% required prefix, attempting to read it returns {error, badformat} rather
+%% than the raw unprefixed data. This ensures data integrity by rejecting
+%% improperly formatted entries.
+data_without_prefix_test() ->
+    StoreOpts = #{
+        <<"store-module">> => ?MODULE,
+        <<"name">> => <<"/tmp/store-no-prefix">>,
+        <<"capacity">> => ?DEFAULT_SIZE
+    },
+    reset(StoreOpts),
+    % Get the LMDB environment to write data directly without prefix
+    #{ <<"db">> := DBInstance } = find_env(StoreOpts),
+    % Write data directly to LMDB without the required "data:" prefix
+    Key = <<"test-key">>,
+    ValueWithoutPrefix = <<"raw-value-no-prefix">>,
+    ok = elmdb:put(DBInstance, Key, ValueWithoutPrefix),
+    % Attempt to read the data through the normal read function
+    % This should return {error, badformat} because the data lacks the prefix
+    Result = read(StoreOpts, Key),
+    ?event({data_without_prefix_result, Result}),
+    ?assertEqual({error, badformat}, Result),
     stop(StoreOpts).


### PR DESCRIPTION
## What

This is a more strict implementation of https://github.com/permaweb/HyperBEAM/pull/427 that "Reject reads with invalid/missing prefixes".

## Why

As such it satisfies all [FOR-137](https://linear.app/forward-research/issue/FOR-137/impr-lmdb-low-level-storage-should-have-labels-for-both-data-and-link) expected behaviour:
- All data values should be prefixed with data: when written
- All reads should validate the first 5 characters of the raw value (except for `group`)
- Parse prefix from binary string: data: or link:
- Reject reads with invalid/missing prefixes

## Additional Notes

~This PR is ready for review however it's on Draft once it can only be merged when a migration strategy is defined in regards to the existings caches without the prefix for data.~
There will be no migration and the `sync` is part of the scope of a following task.