### PR TITLE
impr: use LMDB env sync to enable flushing to disk (FOR-141)

### DIFF
--- a/src/hb_app.erl
+++ b/src/hb_app.erl
@@ -7,7 +7,7 @@
 
 -behaviour(application).
 
--export([start/2, stop/1]).
+-export([start/2, prep_stop/1, stop/1]).
 
 -include("include/hb.hrl").
 
@@ -18,5 +18,24 @@ start(_StartType, _StartArgs) ->
     _TimestampServer = ar_timestamp:start(),
     {ok, _} = hb_http_server:start().
 
+prep_stop(State) ->
+    maybe
+        {ok, Opts} ?= find_lmdb_store(),
+        hb_store_lmdb:flush(Opts) 
+    end,
+    State.
+
 stop(_State) ->
+    maybe
+        {ok, Opts} ?= find_lmdb_store(),
+        hb_store_lmdb:stop(Opts) 
+    end,
     ok.
+
+find_lmdb_store() ->
+    Stores = maps:get(store, hb_opts:default_message()),
+    Pred = fun(S) -> maps:get(<<"store-module">>, S) == hb_store_lmdb end,
+    case lists:search(Pred, Stores) of
+        {value, Opts} -> {ok, Opts};
+        false -> not_found
+    end.

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -55,13 +55,18 @@ start(Opts = #{ <<"name">> := DataDir }) ->
     % Ensure the directory exists before opening LMDB environment
     DataDirPath = hb_util:list(DataDir),
     ok = filelib:ensure_dir(filename:join(DataDirPath, "dummy")),
+    NoSyncParam =
+        case maps:get(<<"no-sync">>, Opts, true) of
+            true -> [no_sync];
+            false -> []
+        end,
     % Create the LMDB environment with specified size limit
     {ok, Env} =
         elmdb:env_open(
             DataDirPath,
             [
                 {map_size, maps:get(<<"capacity">>, Opts, ?MAX_SIZE)},
-                no_mem_init, no_sync
+                no_mem_init, NoSyncParam
             ]
         ),
     {ok, DBInstance} = elmdb:db_open(Env, [create]),

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -21,7 +21,7 @@
 
 %% Public API exports
 -export([start/1, stop/1, scope/0, scope/1, reset/1]).
--export([read/2, write/3, list/2, match/2]).
+-export([read/2, write/3, flush/1, list/2, match/2]).
 -export([make_group/2, make_link/3, type/2]).
 -export([path/2, add_path/3, resolve/2]).
 
@@ -139,6 +139,22 @@ write(Opts, Path, Value) ->
                 }
             ),
             retry
+    end.
+
+-spec flush(map()) -> ok | {error, flush_failed}.
+flush(Opts) ->
+    #{ <<"env">> := DBEnv } = find_env(Opts),
+    case elmdb:env_sync(DBEnv) of
+        ok -> ok;
+        {error, Type, Description} ->
+            ?event(
+                error,
+                {lmdb_error,
+                    {type, Type},
+                    {description, Description}
+                }
+            ),
+            {error, flush_failed}
     end.
 
 %% @doc Read a value from the database by key, with automatic link resolution.
@@ -1084,4 +1100,19 @@ list_with_link_test() ->
     {ok, LinkChildren} = list(StoreOpts, <<"link-to-group">>),
     ?event({link_children, LinkChildren}),
     ?assertEqual(ExpectedChildren, lists:sort(LinkChildren)),
+    stop(StoreOpts).
+
+%% @doc Test that list function resolves links correctly
+flush_test() ->
+    StoreOpts = #{
+        <<"store-module">> => ?MODULE,
+        <<"name">> => <<"/tmp/flush">>,
+        <<"capacity">> => ?DEFAULT_SIZE
+    },
+    reset(StoreOpts),
+    write(StoreOpts, <<"key1">>, <<"value1">>),
+    write(StoreOpts, <<"key2">>, <<"value2">>),
+    write(StoreOpts, <<"key3">>, <<"value3">>),
+    ?assertEqual(ok, flush(StoreOpts)),
+    ?assertEqual({ok, <<"value1">>}, read(StoreOpts, <<"key1">>)),
     stop(StoreOpts).


### PR DESCRIPTION
## What

- Implements `hb_store_lmdb:flush/1` to allow HyperBEAM to decide when to write LMDB buffers to disk
- Uses a new function on the `elmdb-rs` called `env_sync`

## Why

- This is particularly important once the LMDB is currently opened with NO_SYNC
- Ensures data persistence at critical points (will potentially make the snapshots more accurate)

 