### PR TITLE
feat: Rich querying of HyperBEAM stores

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -115,7 +115,7 @@
 ]}.
 
 {deps, [
-    {elmdb, { git, "https://github.com/twilson63/elmdb-rs.git", { ref, "de062ac813b8576512a59aa0b4c289899b99ba71" }}},
+    {elmdb, { git, "https://github.com/twilson63/elmdb-rs.git", {branch, "feat/match" }}},
 	{b64fast, {git, "https://github.com/ArweaveTeam/b64fast.git", {ref, "58f0502e49bf73b29d95c6d02460d1fb8d2a5273"}}},
 	{cowboy, {git, "https://github.com/ninenines/cowboy", {ref, "022013b6c4e967957c7e0e7e7cdefa107fc48741"}}},
 	{gun, {git, "https://github.com/ninenines/gun", {ref, "8efcedd3a089e6ab5317e4310fed424a4ee130f8"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -14,7 +14,7 @@
   1},
  {<<"elmdb">>,
   {git,"https://github.com/twilson63/elmdb-rs.git",
-       {ref,"de062ac813b8576512a59aa0b4c289899b99ba71"}},
+       {ref,"90c8857cd4ccff341fbe415b96bc5703d17ff7f0"}},
   0},
  {<<"gun">>,
   {git,"https://github.com/ninenines/gun",

--- a/src/dev_query.erl
+++ b/src/dev_query.erl
@@ -1,0 +1,301 @@
+%%% @doc A discovery engine for searching for and returning messages found in
+%%% a node's cache, through supported stores.
+%%% 
+%%% This device supports various modes of matching, including:
+%%%
+%%% - `all' (default): Match all keys in the request message.
+%%% - `base': Match all keys in the base message.
+%%% - `only': Match only the key(s) specified in the `only' key.
+%%% 
+%%% The `only' key can be a binary, a map, or a list of keys. If it is a binary,
+%%% it is split on commas to get a list of keys to search for. If it is a message,
+%%% it is used directly as the match spec. If it is a list, it is assumed to be
+%%% a list of keys that we should select from the request or base message and
+%%% use as the match spec.
+%%%
+%%% The `return' key can be used to specify the type of data to return.
+%%%
+%%% - `count': Return the number of matches.
+%%% - `paths': Return the paths of the matches in a list.
+%%% - `messages': Return the messages associated with each match in a list.
+%%% - `first-path': Return the first path of the matches.
+%%% - `first-message': Return the first message of the matches.
+%%% - `boolean': Return a boolean indicating whether any matches were found.
+-module(dev_query).
+-export([info/1, only/3, all/3, base/3]).
+-include_lib("eunit/include/eunit.hrl").
+-include("include/hb.hrl").
+
+%%% Keys that should typically be excluded from searches.
+-define(
+    DEFAULT_EXCLUDES,
+    [<<"path">>, <<"commitments">>, <<"return">>, <<"exclude">>, <<"only">>]
+).
+
+info(_Opts) ->
+    #{
+        excludes => [<<"keys">>, <<"set">>],
+        default => fun default/4
+    }.
+
+%% @doc Search for the keys specified in the request message.
+default(_, Base, Req, Opts) ->
+    all(Base, Req, Opts).
+
+%% @doc Search the node's store for all of the keys and values in the request,
+%% aside from the `commitments' and `path' keys.
+all(Base, Req, Opts) ->
+    match(Req, Base, Req, Opts).
+
+%% @doc Search the node's store for all of the keys and values in the base
+%% message, aside from the `commitments' and `path' keys.
+base(Base, Req, Opts) ->
+    match(Base, Base, Req, Opts).
+
+%% @doc Search only for the (list of) key(s) specified in `only' in the request.
+%% The `only' key can be a binary, a map, or a list of keys. See the moduledoc
+%% for semantics.
+only(Base, Req, Opts) ->
+    case hb_maps:get(<<"only">>, Req, not_found, Opts) of
+        KeyBin when is_binary(KeyBin) ->
+            % The descriptor is a binary, so we split it on commas to get a
+            % list of keys to search for. If there is only one key, we
+            % return a list with that key.
+            match(binary:split(KeyBin, <<",">>, [global]), Base, Req, Opts);
+        Spec when is_map(Spec) ->
+            % The descriptor is a map, so we use it as the match spec.
+            match(Spec, Base, Req, Opts);
+        Keys when is_list(Keys) ->
+            % The descriptor is a list, so we assume that it is a list of
+            % keys that we should select from the request and use as the
+            % match spec.
+            match(Keys, Base, Req, Opts);
+        not_found ->
+            % We cannot find the key to match upon. Return an error.
+            {error, not_found}
+    end.
+
+%% @doc Match the request against the base message, using the keys to select
+%% the values from the request and (if not found) the values from the base
+%% message.
+match(Keys, Base, Req, Opts) when is_list(Keys) ->
+    UserSpec =
+        maps:from_list(
+            lists:filtermap(
+                fun(Key) ->
+                    % Search for the value in the request. If not found,
+                    % look in the base message.
+                    Value =
+                        hb_maps:get(
+                            Key,
+                            Req,
+                            hb_maps:get(Key, Base, not_found, Opts),
+                            Opts
+                        ),
+                    if Value == not_found -> false;
+                    true -> {true, {Key, Value}}
+                    end
+                end,
+                Keys
+            )
+        ),
+    match(UserSpec, Base, Req, Opts);
+match(UserSpec, _Base, Req, Opts) ->
+    ?event({matching, {spec, UserSpec}}),
+    FilteredSpec =
+        hb_maps:without(
+            hb_maps:get(<<"exclude">>, Req, ?DEFAULT_EXCLUDES, Opts),
+            UserSpec
+        ),
+    ReturnType = hb_maps:get(<<"return">>, Req, <<"paths">>, Opts),
+    ?event({matching, {spec, FilteredSpec}, {return, ReturnType}}),
+    case hb_cache:match(FilteredSpec, Opts) of
+        {ok, Matches} when ReturnType == <<"count">> ->
+            ?event({matched, {paths, Matches}}),
+            {ok, length(Matches)};
+        {ok, Matches} when ReturnType == <<"paths">> ->
+            ?event({matched, {paths, Matches}}),
+            {ok, Matches};
+        {ok, Matches} when ReturnType == <<"messages">> ->
+            ?event({matched, {paths, Matches}}),
+            Messages =
+                lists:map(
+                    fun(Path) ->
+                        hb_util:ok(hb_cache:read(Path, Opts))
+                    end,
+                    Matches
+                ),
+            ?event({matched, {messages, Messages}}),
+            {ok, Messages};
+        {ok, Matches} when ReturnType == <<"first-path">> ->
+            ?event({matched, {paths, Matches}}),
+            {ok, hd(Matches)};
+        {ok, Matches} when ReturnType == <<"first">>
+                orelse ReturnType == <<"first-message">> ->
+            ?event({matched, {paths, Matches}}),
+            {ok, hb_util:ok(hb_cache:read(hd(Matches), Opts))};
+        {ok, Matches} when ReturnType == <<"boolean">> ->
+            ?event({matched, {paths, Matches}}),
+            {ok, length(Matches) > 0};
+        not_found when ReturnType == <<"boolean">> ->
+            {ok, false};
+        not_found ->
+            {error, not_found}
+    end.
+
+%%% Tests
+
+%% @doc Return test options with a test store.
+setup() ->
+    Store = hb_test_utils:test_store(hb_store_lmdb),
+    Opts = #{ store => Store, priv_wallet => hb:wallet() },
+    % Write a simple message.
+    hb_cache:write(
+        #{
+            <<"basic">> => <<"binary-value">>,
+            <<"basic-2">> => <<"binary-value-2">>
+        },
+        Opts
+    ),
+    % Write a nested and committed message.
+    hb_cache:write(
+        hb_message:commit(
+            #{
+                <<"test-key">> => <<"test-value">>,
+                <<"test-key-2">> => <<"test-value-2">>,
+                <<"nested">> => Nested = #{
+                    <<"test-key-3">> => <<"test-value-3">>,
+                    <<"test-key-4">> => <<"test-value-4">>
+                }
+            },
+            Opts
+        ),
+        Opts
+    ),
+    % Write a list message with complex keys.
+    hb_cache:write([<<"a">>, 2, ok], Opts),
+    {ok, Opts, #{ <<"nested">> => hb_message:id(Nested, all, Opts) }}.
+
+%% @doc Search for and find a basic test key.
+basic_test() ->
+    {ok, Opts, _} = setup(),
+    {ok, [ID]} = hb_ao:resolve(<<"~query@1.0/all?basic=binary-value">>, Opts),
+    {ok, Read} = hb_cache:read(ID, Opts),
+    ?assertEqual(<<"binary-value">>, hb_maps:get(<<"basic">>, Read)),
+    ?assertEqual(<<"binary-value-2">>, hb_maps:get(<<"basic-2">>, Read)),
+    {ok, [Msg]} =
+        hb_ao:resolve(
+            <<"~query@1.0/all?basic-2=binary-value-2&return=messages">>,
+            Opts
+        ),
+    ?assertEqual(<<"binary-value-2">>, hb_maps:get(<<"basic-2">>, Msg)),
+    ok.
+
+%% @doc Ensure that we can search for and match only a single key.
+only_test() ->
+    {ok, Opts, _} = setup(),
+    {ok, [Msg]} =
+        hb_ao:resolve(
+            <<"~query@1.0/only=basic&basic=binary-value&wrong=1&return=messages">>,
+            Opts
+        ),
+    ?assertEqual(<<"binary-value">>, hb_maps:get(<<"basic">>, Msg)),
+    ok.
+
+%% @doc Ensure that we can specify multiple keys to match.
+multiple_test() ->
+    {ok, Opts, _} = setup(),
+    {ok, [Msg]} =
+        hb_ao:resolve(
+            <<
+                "~query@1.0/only=basic,basic-2",
+                "&basic=binary-value&basic-2=binary-value-2",
+                "&return=messages"
+            >>,
+            Opts
+        ),
+    ?assertEqual(<<"binary-value">>, hb_maps:get(<<"basic">>, Msg)),
+    ?assertEqual(<<"binary-value-2">>, hb_maps:get(<<"basic-2">>, Msg)),
+    ok.
+
+%% @doc Search for and find a nested test key.
+nested_test() ->
+    {ok, Opts, _} = setup(),
+    {ok, [MsgWithNested]} =
+        hb_ao:resolve(
+            <<"~query@1.0/all?test-key=test-value&return=messages">>,
+            Opts
+        ),
+    ?assert(hb_maps:is_key(<<"nested">>, MsgWithNested, Opts)),
+    Nested = hb_maps:get(<<"nested">>, MsgWithNested, undefined, Opts),
+    ?assertEqual(<<"test-value-3">>, hb_maps:get(<<"test-key-3">>, Nested, Opts)),
+    ?assertEqual(<<"test-value-4">>, hb_maps:get(<<"test-key-4">>, Nested, Opts)),
+    ok.
+
+%% @doc Search for and find a list message with typed elements.
+list_test() ->
+    {ok, Opts, _} = setup(),
+    {ok, [Msg]} =
+        hb_ao:resolve(
+            <<"~query@1.0/all?2+integer=2&3+atom=ok&return=messages">>,
+            Opts
+        ),
+    ?assertEqual([<<"a">>, 2, ok], Msg),
+    ok.
+
+%% @doc Ensure user's can opt not to specify a key to resolve, instead specifying
+%% only the matchable keys in the message.
+return_key_test() ->
+    {ok, Opts, _} = setup(),
+    {ok, [ID]} =
+        hb_ao:resolve(
+            <<"~query@1.0/basic=binary-value">>,
+            Opts
+        ),
+    {ok, Msg} = hb_cache:read(ID, Opts),
+    ?assertEqual(<<"binary-value">>, hb_maps:get(<<"basic">>, Msg, Opts)),
+    ok.
+
+%% @doc Validate the functioning of various return types.
+return_types_test() ->
+    {ok, Opts, _} = setup(),
+    {ok, [Msg]} =
+        hb_ao:resolve(
+            <<"~query@1.0/basic=binary-value&return=messages">>,
+            Opts
+        ),
+    ?assertEqual(<<"binary-value">>, hb_maps:get(<<"basic">>, Msg, Opts)),
+    ?assertEqual(
+        {ok, 1},
+        hb_ao:resolve(
+            <<"~query@1.0/basic=binary-value&return=count">>,
+            Opts
+        )
+    ),
+    ?assertEqual(
+        {ok, true},
+        hb_ao:resolve(
+            <<"~query@1.0/basic=binary-value&return=boolean">>,
+            Opts
+        )
+    ),
+    ?assertEqual(
+        {ok, <<"binary-value">>},
+        hb_ao:resolve(
+            <<"~query@1.0/basic=binary-value&return=first-message/basic">>,
+            Opts
+        )
+    ),
+    ok.
+
+http_test() ->
+    {ok, Opts, _} = setup(),
+    Node = hb_http_server:start_node(Opts),
+    {ok, Msg} =
+        hb_http:get(
+            Node,
+            <<"~query@1.0/only=basic&basic=binary-value?return=first">>,
+            Opts
+        ),
+    ?assertEqual(<<"binary-value">>, hb_maps:get(<<"basic">>, Msg, Opts)),
+    ok.

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -40,7 +40,7 @@
 -module(hb_cache).
 -export([ensure_loaded/1, ensure_loaded/2, ensure_all_loaded/1, ensure_all_loaded/2]).
 -export([read/2, read_resolved/3, write/2, write_binary/3, write_hashpath/2, link/3]).
--export([list/2, list_numbered/2]).
+-export([match/2, list/2, list_numbered/2]).
 -export([test_unsigned/1, test_signed/1]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -176,6 +176,29 @@ list(Path, Store) ->
         {error, _} -> [];
         not_found -> []
     end.
+
+%% @doc Match a template message against the cache, returning a list of IDs
+%% that match the template. We match on the binary representation of values,
+%% rather than their types explicitly, such that 'AO-Types' keys that are
+%% only partial matches do not cause the match to fail.
+match(MatchSpec, Opts) ->
+    Spec = hb_message:convert(MatchSpec, tabm, <<"structured@1.0">>, Opts),
+    ConvertedMatchSpec =
+        maps:map(
+            fun(_, Value) ->
+                generate_binary_path(Value, Opts)
+            end,
+            maps:without([<<"ao-types">>], hb_ao:normalize_keys(Spec, Opts))
+        ),
+    case hb_store:match(hb_opts:get(store, no_viable_store, Opts), ConvertedMatchSpec) of
+        {ok, Matches} -> {ok, Matches};
+        _ -> not_found
+    end.
+
+%% @doc Generate the path at which a binary value should be stored.
+generate_binary_path(Bin, Opts) ->
+    Hashpath = hb_path:hashpath(Bin, Opts),
+    <<"data/", Hashpath/binary>>.
 
 %% @doc Write a message to the cache. For raw binaries, we write the data at
 %% the hashpath of the data (by default the SHA2-256 hash of the data). We link
@@ -795,6 +818,73 @@ test_message_with_list(Store) ->
     {ok, RetrievedItem} = read(Path, Opts),
     ?assert(hb_message:match(Msg, RetrievedItem, strict, Opts)).
 
+test_match_message(Store) when map_get(<<"store-module">>, Store) =/= hb_store_lmdb ->
+    skip;
+test_match_message(Store) ->
+    hb_store:reset(Store),
+    Opts = #{ store => Store },
+    % Write two messages that match the template, and a third that does not.
+    {ok, ID1} = hb_cache:write(#{ <<"x">> => <<"1">> }, Opts),
+    {ok, ID2} = hb_cache:write(#{ <<"y">> => <<"2">>, <<"z">> => <<"3">> }, Opts),
+    {ok, ID2b} = hb_cache:write(#{ <<"x">> => <<"4">>, <<"z">> => <<"3">> }, Opts),
+    {ok, ID3} = hb_cache:write(#{ <<"z">> => <<"5">>, <<"c">> => <<"d">> }, Opts),
+    % Match the template, and ensure that we get two matches.
+    {ok, MatchedItems} = match(#{ <<"z">> => <<"3">> }, Opts),
+    ?assertEqual(2, length(MatchedItems)),
+    ?assert(
+        lists:all(
+            fun(ID) ->
+                {ok, Msg} = read(ID, Opts),
+                hb_maps:get(<<"z">>, Msg, Opts) =:= <<"3">> andalso
+                    lists:member(ID, [ID2, ID2b])
+            end,
+            MatchedItems
+        )
+    ),
+    {ok, MatchedItems2} = match(#{ <<"x">> => <<"4">> }, Opts),
+    ?assertEqual(1, length(MatchedItems2)),
+    ?assertEqual([ID2b], MatchedItems2).
+
+test_match_linked_message(Store) when map_get(<<"store-module">>, Store) =/= hb_store_lmdb ->
+    skip;
+test_match_linked_message(Store) ->
+    hb_store:reset(Store),
+    Opts = #{ store => Store },
+    Msg = #{ <<"a">> => Inner = #{ <<"b">> => <<"c">>, <<"d">> => <<"e">> } },
+    {ok, _ID} = write(Msg, Opts),
+    {ok, [MatchedID]} = match(#{ <<"b">> => <<"c">> }, Opts),
+    {ok, Read1} = read(MatchedID, Opts),
+    ?assertEqual(
+        #{ <<"b">> => <<"c">>, <<"d">> => <<"e">> },
+        hb_cache:ensure_all_loaded(Read1, Opts)
+    ),
+    {ok, [MatchedID2]} = match(#{ <<"a">> => Inner }, Opts),
+    {ok, Read2} = read(MatchedID2, Opts),
+    ?assertEqual(#{ <<"a">> => Inner }, ensure_all_loaded(Read2, Opts)).
+
+test_match_typed_message(Store) when map_get(<<"store-module">>, Store) =/= hb_store_lmdb ->
+    skip;
+test_match_typed_message(Store) ->
+    hb_store:reset(Store),
+    Opts = #{ store => Store },
+    % Add some messages that should not match the template, as well as the main
+    % message that should match the template.
+    write(#{ <<"atom-value">> => atom, <<"wrong">> => <<"wrong">> }, Opts),
+    write(#{ <<"integer-value">> => 1337, <<"wrong">> => <<"wrong-2">> }, Opts),
+    Msg =
+        #{
+            <<"int-key">> => 1337,
+            <<"other-key">> => <<"other-test-value">>,
+            <<"atom-key">> => atom
+        },
+    {ok, _ID} = write(Msg, Opts),
+    {ok, [MatchedID]} = match(#{ <<"int-key">> => 1337 }, Opts),
+    {ok, Read1} = read(MatchedID, Opts),
+    ?assertEqual(Msg, ensure_all_loaded(Read1, Opts)),
+    {ok, [MatchedID2]} = match(#{ <<"atom-key">> => atom }, Opts),
+    {ok, Read2} = read(MatchedID2, Opts),
+    ?assertEqual(Msg, ensure_all_loaded(Read2, Opts)).
+
 cache_suite_test_() ->
     hb_store:generate_test_suite([
         {"store unsigned empty message",
@@ -805,7 +895,10 @@ cache_suite_test_() ->
         {"store simple unsigned message", fun test_store_simple_unsigned_message/1},
         {"store simple signed message", fun test_store_simple_signed_message/1},
         {"deeply nested complex message", fun test_deeply_nested_complex_message/1},
-        {"message with list", fun test_message_with_list/1}
+        {"message with list", fun test_message_with_list/1},
+        {"match message", fun test_match_message/1},
+        {"match linked message", fun test_match_linked_message/1},
+        {"match typed message", fun test_match_typed_message/1}
     ]).
 
 %% @doc Test that message whose device is `#{}' cannot be written. If it were to
@@ -821,3 +914,8 @@ test_device_map_cannot_be_written_test() ->
     catch
         _:_:_ -> ?assert(true)
     end.
+
+%% @doc Run a specific test with a given store module.
+run_test() ->
+    Store = hb_test_utils:test_store(hb_store_lmdb),
+    test_match_message(Store).

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -157,6 +157,7 @@ default_message() ->
             #{<<"name">> => <<"process@1.0">>, <<"module">> => dev_process},
             #{<<"name">> => <<"profile@1.0">>, <<"module">> => dev_profile},
             #{<<"name">> => <<"push@1.0">>, <<"module">> => dev_push},
+            #{<<"name">> => <<"query@1.0">>, <<"module">> => dev_query},
             #{<<"name">> => <<"relay@1.0">>, <<"module">> => dev_relay},
             #{<<"name">> => <<"router@1.0">>, <<"module">> => dev_router},
             #{<<"name">> => <<"scheduler@1.0">>, <<"module">> => dev_scheduler},

--- a/src/hb_store.erl
+++ b/src/hb_store.erl
@@ -46,7 +46,7 @@
 -export([behavior_info/1]).
 -export([start/1, stop/1, reset/1]).
 -export([filter/2, scope/2, sort/2]).
--export([type/2, read/2, write/3, list/2]).
+-export([type/2, read/2, write/3, list/2, match/2]).
 -export([path/1, path/2, add_path/2, add_path/3, join/1]).
 -export([make_group/2, make_link/3, resolve/2]).
 -export([find/1]).
@@ -68,7 +68,7 @@ behavior_info(callbacks) ->
     [
         {start, 1}, {stop, 1}, {reset, 1}, {make_group, 2}, {make_link, 3},
         {type, 2}, {read, 2}, {write, 3},
-        {list, 2}, {path, 2}, {add_path, 3}
+        {list, 2}, {match, 2}, {path, 2}, {add_path, 3}
     ].
 
 -define(DEFAULT_SCOPE, local).
@@ -299,6 +299,12 @@ resolve(Modules, Path) -> call_function(Modules, resolve, [Path]).
 %% structures, so this is likely to be very slow for most stores.
 list(Modules, Path) -> call_function(Modules, list, [Path]).
 
+%% @doc Match a series of keys and values against the store. Returns 
+%% `{ok, Matches}' if the match is successful, or `not_found' if there are no
+%% messages in the store that feature all of the given key-value pairs. `Matches'
+%% is given as a list of IDs.
+match(Modules, Match) -> call_function(Modules, match, [Match]).
+
 %% @doc Call a function on the first store module that succeeds. Returns its
 %% result, or `not_found` if none of the stores succeed. If `TIME_CALLS` is set,
 %% this function will also time the call and increment the appropriate event
@@ -422,19 +428,13 @@ call_all([Store = #{<<"store-module">> := Mod} | Rest], Function, Args) ->
 %% default into all HyperBEAM distributions.
 test_stores() ->
     [
-        #{
-            <<"store-module">> => hb_store_fs,
-            <<"name">> => <<"cache-TEST/fs">>,
+        (hb_test_utils:test_store(hb_store_fs))#{
             <<"benchmark-scale">> => 0.001
         },
-        #{
-            <<"store-module">> => hb_store_lmdb,
-            <<"name">> => <<"cache-TEST/lmdb">>,
+        (hb_test_utils:test_store(hb_store_lmdb))#{
             <<"benchmark-scale">> => 0.5
         },
-        #{
-            <<"store-module">> => hb_store_lru,
-            <<"name">> => <<"cache-TEST/lru">>,
+        (hb_test_utils:test_store(hb_store_lru))#{
             <<"persistent-store">> => [
                 #{
                     <<"store-module">> => hb_store_fs,

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -1084,37 +1084,3 @@ list_with_link_test() ->
     ?event({link_children, LinkChildren}),
     ?assertEqual(ExpectedChildren, lists:sort(LinkChildren)),
     stop(StoreOpts).
-
-match_test() ->
-    StoreOpts = #{
-        <<"store-module">> => ?MODULE,
-        <<"name">> => <<"/tmp/store-match">>,
-        <<"capacity">> => ?DEFAULT_SIZE
-    },
-    reset(StoreOpts),
-    write(StoreOpts, <<"id1/key1">>, <<"value1">>),
-    write(StoreOpts, <<"id1/key2">>, <<"value2">>),
-    write(StoreOpts, <<"id2/key2">>, <<"value2">>),
-    write(StoreOpts, <<"id3/key2">>, <<"value3">>),
-    ?assertEqual(
-        {ok, [<<"id1">>]},
-        match(StoreOpts, #{ <<"key1">> => <<"value1">> })
-    ),
-    ?assertEqual(
-        {ok, [<<"id1">>]},
-        match(
-            StoreOpts,
-            #{
-                <<"key1">> => <<"value1">>,
-                <<"key2">> => <<"value2">>
-            }
-        )
-    ),
-    ?assertEqual(
-        {ok, [<<"id1">>, <<"id2">>]},
-        match(
-            StoreOpts,
-            #{ <<"key2">> => <<"value2">> }
-        )
-    ),
-    stop(StoreOpts).


### PR DESCRIPTION
This PR adds the `~query@1.0` device, allowing for key and value searches for messages across HyperBEAM stores using a simple AO-Core HTTP interface. As the moduledoc describes, the interface is as follows:

```
A discovery engine for searching for and returning messages found in
a node's cache, through supported stores.

This device supports various modes of matching, including:

- `all' (default): Match all keys in the request message.
- `base': Match all keys in the base message.
- `only': Match only the key(s) specified in the `only' key.

The `only' key can be a binary, a map, or a list of keys. If it is a binary,
it is split on commas to get a list of keys to search for. If it is a message,
it is used directly as the match spec. If it is a list, it is assumed to be
a list of keys that we should select from the request or base message and
use as the match spec.

The `return' key can be used to specify the type of data to return.

- `count': Return the number of matches.
- `paths': Return the paths of the matches in a list.
- `messages': Return the messages associated with each match in a list.
- `first-path': Return the first path of the matches.
- `first-message': Return the first message of the matches.
- `boolean': Return a boolean indicating whether any matches were found.
```

As HyperBEAM already acts as a cache of Arweave data, this feature is intended as a baseline for future work on full support for Arweave and AO search using a GraphQL-based interface.

Presently, only the LMDB store (HyperBEAM's default) offers the necessary querying engine.
