### PR TITLE
refactor: allow store shallow reads for links (FOR-139)

### DIFF
--- a/src/hb_store_fs.erl
+++ b/src/hb_store_fs.erl
@@ -46,16 +46,16 @@ reset(#{ <<"name">> := DataDir }) ->
 
 %% @doc Read a key from the store, following symlinks as needed.
 read(Opts, Key) ->
-    FollowSymlink = maps:get(<<"follow-symlink">>, Opts, true),
-    read_path(add_prefix(Opts, resolve(Opts, Key)), FollowSymlink).
-read_path(Path, FollowSymlink) ->
+    FollowLink = maps:get(<<"follow-link">>, Opts, true),
+    read_path(add_prefix(Opts, resolve(Opts, Key)), FollowLink).
+read_path(Path, FollowLink) ->
 	?event({read, Path}),
 	case file:read_file_info(Path) of
 		{ok, #file_info{type = regular}} ->
 			{ok, _} = file:read_file(Path);
 		_ ->
 			case file:read_link(Path) of
-				{ok, Link} when FollowSymlink->
+				{ok, Link} when FollowLink->
 					?event({link_found, Path, Link}),
 					read_path(Link, true);
                 {ok, Link} ->
@@ -117,17 +117,17 @@ resolve(Opts, CurrPath, [Next|Rest]) ->
 
 %% @doc Determine the type of a key in the store.
 type(Opts, Key) ->
-    FollowSymlink = maps:get(<<"follow-symlink">>, Opts, true),
-    type_path(add_prefix(Opts, Key), FollowSymlink).
+    FollowLink = maps:get(<<"follow-link">>, Opts, true),
+    type_path(add_prefix(Opts, Key), FollowLink).
 
-type_path(Path, FollowSymlink) ->
+type_path(Path, FollowLink) ->
     ?event({type, Path}),
     case file:read_file_info(Path) of
         {ok, #file_info{type = directory}} -> composite;
         {ok, #file_info{type = regular}} -> simple;
         _ ->
             case file:read_link(Path) of
-                {ok, Link} when FollowSymlink ->
+                {ok, Link} when FollowLink ->
                     type_path(Link, true);
                 {ok, _Link} ->
                     link;

--- a/src/hb_store_fs.erl
+++ b/src/hb_store_fs.erl
@@ -46,17 +46,21 @@ reset(#{ <<"name">> := DataDir }) ->
 
 %% @doc Read a key from the store, following symlinks as needed.
 read(Opts, Key) ->
-    read(add_prefix(Opts, resolve(Opts, Key))).
-read(Path) ->
+    FollowSymlink = maps:get(<<"follow-symlink">>, Opts, true),
+    read_path(add_prefix(Opts, resolve(Opts, Key)), FollowSymlink).
+read_path(Path, FollowSymlink) ->
 	?event({read, Path}),
 	case file:read_file_info(Path) of
 		{ok, #file_info{type = regular}} ->
 			{ok, _} = file:read_file(Path);
 		_ ->
 			case file:read_link(Path) of
-				{ok, Link} ->
+				{ok, Link} when FollowSymlink->
 					?event({link_found, Path, Link}),
-					read(Link);
+					read_path(Link, true);
+                {ok, Link} ->
+					?event({link_found, Path, Link}),
+					{ok, Link};
 				_ ->
 					not_found
 			end
@@ -113,16 +117,20 @@ resolve(Opts, CurrPath, [Next|Rest]) ->
 
 %% @doc Determine the type of a key in the store.
 type(Opts, Key) ->
-    type(add_prefix(Opts, Key)).
-type(Path) ->
+    FollowSymlink = maps:get(<<"follow-symlink">>, Opts, true),
+    type_path(add_prefix(Opts, Key), FollowSymlink).
+
+type_path(Path, FollowSymlink) ->
     ?event({type, Path}),
     case file:read_file_info(Path) of
         {ok, #file_info{type = directory}} -> composite;
         {ok, #file_info{type = regular}} -> simple;
         _ ->
             case file:read_link(Path) of
-                {ok, Link} ->
-                    type(Link);
+                {ok, Link} when FollowSymlink ->
+                    type_path(Link, true);
+                {ok, _Link} ->
+                    link;
                 _ ->
                     not_found
             end

--- a/src/hb_store_fs.erl
+++ b/src/hb_store_fs.erl
@@ -45,7 +45,7 @@ reset(#{ <<"name">> := DataDir }) ->
     ?event({reset_store, {path, DataDir}}).
 
 %% @doc Read a key from the store, following symlinks as needed.
-read(#{<<"follow-link">> := false} = Opts, Key) ->
+read(#{<<"resolve">> := false} = Opts, Key) ->
     maybe {prefixed_link, Link} ?= read_path(add_prefix(Opts, Key), false),
         {ok, remove_prefix(Opts, Link)}
     end;
@@ -121,7 +121,7 @@ resolve(Opts, CurrPath, [Next|Rest]) ->
 
 %% @doc Determine the type of a key in the store.
 type(Opts, Key) ->
-    FollowLink = maps:get(<<"follow-link">>, Opts, true),
+    FollowLink = maps:get(<<"resolve">>, Opts, true),
     type_path(add_prefix(Opts, Key), FollowLink).
 
 type_path(Path, FollowLink) ->

--- a/src/hb_store_fs.erl
+++ b/src/hb_store_fs.erl
@@ -45,9 +45,13 @@ reset(#{ <<"name">> := DataDir }) ->
     ?event({reset_store, {path, DataDir}}).
 
 %% @doc Read a key from the store, following symlinks as needed.
+read(#{<<"follow-link">> := false} = Opts, Key) ->
+    maybe {prefixed_link, Link} ?= read_path(add_prefix(Opts, Key), false),
+        {ok, remove_prefix(Opts, Link)}
+    end;
 read(Opts, Key) ->
-    FollowLink = maps:get(<<"follow-link">>, Opts, true),
-    read_path(add_prefix(Opts, resolve(Opts, Key)), FollowLink).
+    read_path(add_prefix(Opts, resolve(Opts, Key)), true).
+
 read_path(Path, FollowLink) ->
 	?event({read, Path}),
 	case file:read_file_info(Path) of
@@ -59,8 +63,8 @@ read_path(Path, FollowLink) ->
 					?event({link_found, Path, Link}),
 					read_path(Link, true);
                 {ok, Link} ->
-					?event({link_found, Path, Link}),
-					{ok, Link};
+					?event({link_found_ret, Path, Link}),
+					{prefixed_link, Link};
 				_ ->
 					not_found
 			end

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -85,14 +85,17 @@ start(_) ->
 %% @param Opts Database configuration map
 %% @param Key The key to examine
 %% @returns 'composite' for group entries, 'simple' for regular values
--spec type(map(), binary()) -> composite | simple | not_found.
+-spec type(map(), binary()) -> composite | simple | link | not_found.
 type(Opts, Key) ->
+    FollowSymlink = maps:get(<<"follow-symlink">>, Opts, true),
     case read_direct(Opts, Key) of
         {ok, Value} ->
             case is_link(Value) of
-                {true, Link} ->
+                {true, Link} when FollowSymlink ->
                     % This is a link, check the target's type
                     type(Opts, Link);
+                {true, _Link} ->
+                    link;
                 false ->
                     case Value of
                         <<"group">> -> 
@@ -165,8 +168,11 @@ write(Opts, Path, Value) ->
 -spec read(map(), binary() | list()) -> {ok, binary()} | {error, term()}.
 read(Opts, PathParts) when is_list(PathParts) ->
     read(Opts, to_path(PathParts));
+read(#{<<"follow-symlink">> := false} = Opts, Path) ->
+    maybe {ok, <<"link:", RawValue/binary>>} ?= read_direct(Opts, Path),
+        {ok, RawValue}
+    end;
 read(Opts, Path) ->
-    % Try direct read first (fast path for non-link paths)
     case read_with_links(Opts, Path) of
         {ok, Value} -> 
             {ok, Value};
@@ -738,6 +744,26 @@ type_test() ->
     Type2 = type(StoreOpts, <<"assets/1">>),
     ?event({type2, Type2}),
     ?assertEqual(simple, Type2).
+    
+type_link_test() ->
+    StoreOpts = #{
+        <<"store-module">> => ?MODULE,
+        <<"name">> => <<"/tmp/store-7">>,
+        <<"capacity">> => ?DEFAULT_SIZE
+    },
+    reset(StoreOpts),
+    ?event(debug, step1_make_group),
+    make_group(StoreOpts, <<"test-dir1">>),
+    ?event(debug, step2_write_file),
+    write(StoreOpts, [<<"test-dir1">>, <<"test-file">>], <<"test-data">>),
+    ?event(debug, step3_make_link),
+    make_link(StoreOpts, [<<"test-dir1">>], <<"test-link">>),
+    Type1 = type(StoreOpts, <<"test-link">>),
+    ?assertEqual(composite, Type1),
+    StoreOpts2 = maps:put(<<"follow-symlink">>, false, StoreOpts),
+    Type2 = type(StoreOpts2, <<"test-link">>),
+    ?assertEqual(link, Type2).
+    
 
 %% @doc Link key list test - verifies symbolic link creation using structured key paths.
 %%
@@ -1059,3 +1085,22 @@ list_with_link_test() ->
     ?event({link_children, LinkChildren}),
     ?assertEqual(ExpectedChildren, lists:sort(LinkChildren)),
     stop(StoreOpts).
+
+
+%% @doc Read follow test - verifies shallow reads and reads with links.
+read_follow_test() ->
+    StoreOpts = #{
+        <<"store-module">> => ?MODULE,
+        <<"name">> => <<"/tmp/lmdb-read-follow">>
+    },
+    reset(StoreOpts),
+    write(StoreOpts, <<"Hello">>, <<"World">>),
+    make_link(StoreOpts, <<"Hello">>, <<"HelloLink">>),
+    {ok, Value} = read(StoreOpts, <<"Hello">>),
+    ?assertEqual(Value, <<"World">>),
+    {ok, Value2} = read(StoreOpts, <<"HelloLink">>),
+    ?assertEqual(Value2, <<"World">>),
+    StoreOpts2 = maps:put(<<"follow-symlink">>, false, StoreOpts),
+    {ok, Value3} = read(StoreOpts2, <<"HelloLink">>),
+    ?assertEqual(Value3, <<"Hello">>),
+    ok = stop(StoreOpts).

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -87,7 +87,7 @@ start(_) ->
 %% @returns 'composite' for group entries, 'simple' for regular values
 -spec type(map(), binary()) -> composite | simple | link | not_found.
 type(Opts, Key) ->
-    FollowLink = maps:get(<<"follow-link">>, Opts, true),
+    FollowLink = maps:get(<<"resolve">>, Opts, true),
     case read_direct(Opts, Key) of
         {ok, Value} ->
             case is_link(Value) of
@@ -168,7 +168,7 @@ write(Opts, Path, Value) ->
 -spec read(map(), binary() | list()) -> {ok, binary()} | {error, term()}.
 read(Opts, PathParts) when is_list(PathParts) ->
     read(Opts, to_path(PathParts));
-read(#{<<"follow-link">> := false} = Opts, Path) ->
+read(#{<<"resolve">> := false} = Opts, Path) ->
     maybe {ok, <<"link:", RawValue/binary>>} ?= read_direct(Opts, Path),
         {ok, RawValue}
     end;
@@ -760,7 +760,7 @@ type_link_test() ->
     make_link(StoreOpts, [<<"test-dir1">>], <<"test-link">>),
     Type1 = type(StoreOpts, <<"test-link">>),
     ?assertEqual(composite, Type1),
-    StoreOpts2 = maps:put(<<"follow-link">>, false, StoreOpts),
+    StoreOpts2 = maps:put(<<"resolve">>, false, StoreOpts),
     Type2 = type(StoreOpts2, <<"test-link">>),
     ?assertEqual(link, Type2).
     
@@ -1100,7 +1100,7 @@ read_follow_test() ->
     ?assertEqual(Value, <<"World">>),
     {ok, Value2} = read(StoreOpts, <<"HelloLink">>),
     ?assertEqual(Value2, <<"World">>),
-    StoreOpts2 = maps:put(<<"follow-link">>, false, StoreOpts),
+    StoreOpts2 = maps:put(<<"resolve">>, false, StoreOpts),
     {ok, Value3} = read(StoreOpts2, <<"HelloLink">>),
     ?assertEqual(Value3, <<"Hello">>),
     ok = stop(StoreOpts).

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -87,11 +87,11 @@ start(_) ->
 %% @returns 'composite' for group entries, 'simple' for regular values
 -spec type(map(), binary()) -> composite | simple | link | not_found.
 type(Opts, Key) ->
-    FollowSymlink = maps:get(<<"follow-symlink">>, Opts, true),
+    FollowLink = maps:get(<<"follow-link">>, Opts, true),
     case read_direct(Opts, Key) of
         {ok, Value} ->
             case is_link(Value) of
-                {true, Link} when FollowSymlink ->
+                {true, Link} when FollowLink ->
                     % This is a link, check the target's type
                     type(Opts, Link);
                 {true, _Link} ->
@@ -168,7 +168,7 @@ write(Opts, Path, Value) ->
 -spec read(map(), binary() | list()) -> {ok, binary()} | {error, term()}.
 read(Opts, PathParts) when is_list(PathParts) ->
     read(Opts, to_path(PathParts));
-read(#{<<"follow-symlink">> := false} = Opts, Path) ->
+read(#{<<"follow-link">> := false} = Opts, Path) ->
     maybe {ok, <<"link:", RawValue/binary>>} ?= read_direct(Opts, Path),
         {ok, RawValue}
     end;
@@ -760,7 +760,7 @@ type_link_test() ->
     make_link(StoreOpts, [<<"test-dir1">>], <<"test-link">>),
     Type1 = type(StoreOpts, <<"test-link">>),
     ?assertEqual(composite, Type1),
-    StoreOpts2 = maps:put(<<"follow-symlink">>, false, StoreOpts),
+    StoreOpts2 = maps:put(<<"follow-link">>, false, StoreOpts),
     Type2 = type(StoreOpts2, <<"test-link">>),
     ?assertEqual(link, Type2).
     
@@ -1100,7 +1100,7 @@ read_follow_test() ->
     ?assertEqual(Value, <<"World">>),
     {ok, Value2} = read(StoreOpts, <<"HelloLink">>),
     ?assertEqual(Value2, <<"World">>),
-    StoreOpts2 = maps:put(<<"follow-symlink">>, false, StoreOpts),
+    StoreOpts2 = maps:put(<<"follow-link">>, false, StoreOpts),
     {ok, Value3} = read(StoreOpts2, <<"HelloLink">>),
     ?assertEqual(Value3, <<"Hello">>),
     ok = stop(StoreOpts).


### PR DESCRIPTION
## What

Currently for a {key, value} of  {<<"mykey">>, <<"myvalue">>},  the call `type(Opts, <<"mylink">>)` returns the type of <<"myvalue">> when `mylink` points to `mykey`.

This PR changes `type/2` and `read/2` from `hb_store_lmdb` and `hb_store_fs` to accept a <<"follow-symlink">> option. When its `<<"follow-symlink">> := false`, the `read/2` doesn't follow the link (returns the link destination) and `type/2` returns `link` instead of `composite` or `simple` which is the type of the link destination.

## Why

This is PR is needed for the [FOR-139](https://linear.app/forward-research/issue/FOR-139/feat-add-sync-function-for-hb-store). 

During a sync, we need to call `hb_store:make_link` for links on the destination Store instead of `hb_store:write`.

## Additional notes

Please notice the default behaviour continues to be the same. Nothing changes for calls to `read(Opts, Key)` or `type(Opts, Key)` without the `<<"follow-symlink">>` (default true).
