### PR TITLE
feat: `~manifest@1.0` deep path evaluation

### DIFF
--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -239,11 +239,7 @@ handle_resolve(Req, Msgs, NodeMsg) ->
                     PreProcessedMsg,
                     HTTPOpts#{ force_message => true, trace => TracePID }
                 ),
-            {ok, StatusEmbeddedRes} =
-                embed_status(
-                    Res,
-                    NodeMsg
-                ),
+            {ok, StatusEmbeddedRes} = embed_status(Res, NodeMsg),
             ?event(http_request, {res, StatusEmbeddedRes}),
             AfterResolveOpts = hb_http_server:get_opts(NodeMsg),
             % Apply the post-processor to the result.

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -60,7 +60,8 @@ ensure_loaded(Ref,
         RawOpts) ->
     % The link is to a submessage; either in lazy (unresolved) form, or direct
     % form.
-    Opts = hb_store:scope(RawOpts, local),
+    UnscopedOpts = hb_util:deep_merge(RawOpts, LkOpts, RawOpts),
+    Opts = hb_store:scope(UnscopedOpts, hb_opts:get(scope, local, LkOpts)),
     Store = hb_opts:get(store, no_viable_store, Opts),
     ?event(debug_cache,
         {loading_multi_link,
@@ -101,9 +102,9 @@ ensure_loaded(Ref,
 ensure_loaded(Ref, Link = {link, ID, LinkOpts = #{ <<"lazy">> := true }}, RawOpts) ->
     % If the user provided their own options, we merge them and _overwrite_
     % the options that are already set in the link.
-    Opts = hb_store:scope(RawOpts, local),
-    MergedOpts = hb_util:deep_merge(Opts, LinkOpts, Opts),
-    case hb_cache:read(ID, MergedOpts) of
+    UnscopedOpts = hb_util:deep_merge(RawOpts, LinkOpts, RawOpts),
+    Opts = hb_store:scope(UnscopedOpts, hb_opts:get(scope, local, LinkOpts)),
+    case hb_cache:read(ID, Opts) of
         {ok, LoadedMsg} ->
             ?event(caching,
                 {lazy_loaded,


### PR DESCRIPTION
This PR introduces support for deep indexing inside Arweave manifest namespaces. Previously manifest paths that were found outside of the base `paths` JSON object were not accessible. After this PR, the lazy-loading system of HyperBEAM is used in order to return a deeply nested `paths` object, which the user can then traverse.

For example, if a user goes to `/C6Gdo6QQtOgJOXKbgM6nbYyd_2LzJJGCFBhzQ7yk1a8~manifest@1.0/index#/sign-in` on a HyperBEAM node, they will see the ArDrive UI rendered for them. Once each key has been accessed, it is cached locally leading to secondary loads occurring far faster than the first.