### PR TITLE
Feat: Add OVMF firmware support to test overlay

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -142,7 +142,9 @@
 	{extended_start_script, true},
 	{overlay, [
 		{mkdir, "bin/priv"},
+		{mkdir, "test"},
 		{copy, "priv", "bin/priv"},
+        {copy, "test/OVMF-1.55.fd", "test/OVMF-1.55.fd"},
 		{copy, "config.flat", "config.flat"}
 	]}
 ]}.


### PR DESCRIPTION
## Summary
Adds OVMF (Open Virtual Machine Firmware) support to the rebar overlay configuration for use by AMD sev-snp nif.

## Changes
- Copies `OVMF-1.55.fd` firmware file to the test directory during release packaging
- Ensures OVMF firmware is available in built releases for virtualization testing

