### PR TITLE
fix: return correct tuple format from cowboy handler

### DIFF
--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -358,7 +358,7 @@ handle_request(RawReq, Body, ServerID) ->
         {<<"/">>, <<>>} ->
             % If the request is for the root path, serve a redirect to the default 
             % request of the node.
-            cowboy_req:reply(
+            Req2 = cowboy_req:reply(
                 302,
                 #{
                     <<"location">> =>
@@ -369,7 +369,8 @@ handle_request(RawReq, Body, ServerID) ->
                         )
                 },
                 RawReq
-            );
+            ),
+            {ok, Req2, no_state};
         _ ->
             % The request is of normal AO-Core form, so we parse it and invoke
             % the meta@1.0 device to handle it.


### PR DESCRIPTION
## Fix Cowboy Handler Return Format

### Problem
The HTTP server was experiencing `try_clause` errors when handling requests to the root path (`/`). The error occurred because the Cowboy handler's `init/2` function wasn't returning the expected tuple format.

### Root Cause
In `src/hb_http_server.erl`, the root path handler (lines 358-372) was calling:
```erlang
cowboy_req:reply(302, Headers, RawReq);
```

This returns just the modified request object, but Cowboy expects handlers to return `{ok, Req, State}`.

### Solution
Modified the root path handler to properly return the expected tuple:
```erlang
Req2 = cowboy_req:reply(302, Headers, RawReq),
{ok, Req2, no_state};
```

### Changes
- **File:** `src/hb_http_server.erl`
- **Lines:** 358-373
- **Change:** Added proper tuple return format for root path redirect handler