### PR TITLE
impr: Support `content-type`-based decoding of inbound messages; misc fixes

### DIFF
--- a/scripts/schema.gql
+++ b/scripts/schema.gql
@@ -155,7 +155,7 @@ type Bundle {
 # Transaction Structure
 type Transaction {
   id: ID!
-  anchor: String
+  anchor: String!
   signature: String!
   recipient: String!
   owner: Owner!

--- a/src/dev_codec_json.erl
+++ b/src/dev_codec_json.erl
@@ -5,29 +5,59 @@
 -export([to/3, from/3, commit/3, verify/3, committed/3, content_type/1]).
 -export([deserialize/3, serialize/3]).
 -include_lib("eunit/include/eunit.hrl").
+-include("include/hb.hrl").
 
 %% @doc Return the content type for the codec.
 content_type(_) -> {ok, <<"application/json">>}.
 
-%% @doc Encode a message to a JSON string.
+%% @doc Encode a message to a JSON string, using JSON-native typing.
 to(Msg, _Req, _Opts) when is_binary(Msg) ->
     {ok, hb_util:bin(json:encode(Msg))};
-to(Msg, _Req, _Opts) ->
-    {
-        ok,
-        hb_util:bin(
-            json:encode(
-                hb_private:reset(
-                    hb_cache:ensure_all_loaded(Msg)
-                )
-            )
-        )
-    }.
+to(Msg, Req, Opts) ->
+    % The input to this function will be a TABM message, so we:
+    % 1. Convert it to a structured message.
+    % 2. Load any linked items if we are in `bundle' mode.
+    % 3. Convert it back to a TABM message, this time preserving all types
+    %    aside `atom's -- for which JSON has no native support.
+    Restructured =
+        hb_message:convert(
+            hb_private:reset(Msg),
+            <<"structured@1.0">>,
+            tabm,
+            Opts
+        ),
+    Loaded =
+        case hb_maps:get(<<"bundle">>, Req, false, Opts) of
+            true ->
+                hb_cache:ensure_all_loaded(Restructured, Opts);
+            false ->
+                Restructured
+        end,
+    {ok, JSONStructured} =
+        dev_codec_structured:from(
+            Loaded,
+            Req#{ <<"encode-types">> => [<<"atom">>] },
+            Opts
+        ),
+    {ok, hb_json:encode(JSONStructured)}.
 
 %% @doc Decode a JSON string to a message.
 from(Map, _Req, _Opts) when is_map(Map) -> {ok, Map};
-from(JSON, Req, Opts) ->
-    dev_codec_structured:from(json:decode(JSON), Req, Opts).
+from(JSON, _Req, Opts) ->
+    % The JSON string will be a partially-TABM encoded message: Rich number
+    % and list types, but no `atom's. Subsequently, we convert it to a fully
+    % structured message after decoding, then turn the result back into a TABM.
+    % This is resource-intensive and could be improved, but ensures that the
+    % results are fully normalized.
+    Decoded = json:decode(JSON),
+    {ok, Structured} =
+        dev_codec_structured:to(
+            Decoded,
+            #{},
+            Opts
+        ),
+    {ok, TABM} = dev_codec_structured:from(Structured, #{}, Opts),
+    {ok, TABM}.
 
 commit(Msg, Req, Opts) -> dev_codec_httpsig:commit(Msg, Req, Opts).
 

--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -240,7 +240,6 @@ handle_resolve(Req, Msgs, NodeMsg) ->
                     HTTPOpts#{ force_message => true, trace => TracePID }
                 ),
             {ok, StatusEmbeddedRes} = embed_status(Res, NodeMsg),
-            ?event(http_request, {res, StatusEmbeddedRes}),
             AfterResolveOpts = hb_http_server:get_opts(NodeMsg),
             % Apply the post-processor to the result.
             Output = maybe_sign(
@@ -255,7 +254,12 @@ handle_resolve(Req, Msgs, NodeMsg) ->
                 ),
                 NodeMsg
             ),
-            ?event(http_request, {response, Output}),
+            ?event(http_request,
+                {http_request,
+                    {request, Req},
+                    {result, Output}
+                }
+            ),
             Output;
         Res -> embed_status(hb_ao:force_message(Res, NodeMsg), NodeMsg)
     end.

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -699,12 +699,7 @@ push_as_identity_test_() ->
             identities => #{
                 SchedulingID => #{
                     priv_wallet => SchedulingWallet,
-                    store => [
-                        #{
-                            <<"store-module">> => hb_store_fs,
-                            <<"name">> => <<"cache-TEST/scheduler">>
-                        }
-                    ]
+                    store => [hb_test_utils:test_store()]
                 },
                 ComputeID => #{
                     priv_wallet => ComputeWallet

--- a/src/dev_query_arweave.erl
+++ b/src/dev_query_arweave.erl
@@ -87,10 +87,13 @@ query(#{ <<"key">> := Key }, <<"key">>, _Args, _Opts) ->
 query(#{ <<"address">> := Address }, <<"address">>, _Args, _Opts) ->
     {ok, Address};
 query(Msg, <<"recipient">>, _Args, Opts) ->
-    find_field_key(<<"field-target">>, Msg, Opts);
+    case find_field_key(<<"field-target">>, Msg, Opts) of
+        {ok, null} -> {ok, <<"">>};
+        OkRes -> OkRes
+    end;
 query(Msg, <<"anchor">>, _Args, Opts) ->
     case find_field_key(<<"field-anchor">>, Msg, Opts) of
-        {ok, null} -> {ok, null};
+        {ok, null} -> {ok, <<"">>};
         {ok, Anchor} -> {ok, hb_util:human_id(Anchor)}
     end;
 query(Msg, <<"data">>, _Args, Opts) ->

--- a/src/dev_query_test_vectors.erl
+++ b/src/dev_query_test_vectors.erl
@@ -544,7 +544,7 @@ transaction_query_full_test() ->
                 <<"transaction">> := #{
                     <<"id">> := ExpectedID,
                     <<"recipient">> := AliceAddress,
-                    <<"anchor">> := null,
+                    <<"anchor">> := <<"">>,
                     <<"owner">> := #{
                         <<"address">> := SenderAddress,
                         <<"key">> := SenderPubKey

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -678,6 +678,13 @@ do_post_schedule(ProcID, PID, Msg2, Opts) ->
             ),
             {ok, dev_scheduler_server:schedule(PID, Msg2)};
         {true, _} ->
+            ?event(
+                {scheduling_message,
+                    {proc_id, ProcID},
+                    {pid, PID},
+                    {is_alive, is_process_alive(PID)}
+                }
+            ),
             % If Message2 is not a process, use the ID of Message1 as the PID
             {ok, dev_scheduler_server:schedule(PID, Msg2)}
     end.

--- a/src/dev_scheduler_server.erl
+++ b/src/dev_scheduler_server.erl
@@ -7,6 +7,13 @@
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
 
+%%% By default, we wait 10 seconds for a response from the scheduler before
+%%% throwing an error on the client. If the scheduler is not able to sequence
+%%% the message within this time, it will be discarded upon recipient by the
+%%% server. This avoids situations in which the client did not receive 
+%%% confirmation of the assignment, but the scheduler still processes it.
+-define(DEFAULT_TIMEOUT, 10000).
+
 %% @doc Start a scheduling server for a given computation.
 start(ProcID, Proc, Opts) ->
     ?event(scheduling, {starting_scheduling_server, {proc_id, ProcID}}),
@@ -96,10 +103,20 @@ commitment_wallets(ProcMsg, Opts) ->
 schedule(AOProcID, Message) when is_binary(AOProcID) ->
     schedule(dev_scheduler_registry:find(AOProcID), Message);
 schedule(ErlangProcID, Message) ->
-    ErlangProcID ! {schedule, Message, self()},
+    ?event(
+        {scheduling_message,
+            {proc_id, ErlangProcID},
+            {message, Message},
+            {is_alive, is_process_alive(ErlangProcID)}
+        }
+    ),
+    AbortTime = scheduler_time() + ?DEFAULT_TIMEOUT,
+    ErlangProcID ! {schedule, Message, self(), AbortTime},
     receive
         {scheduled, Message, Assignment} ->
             Assignment
+    after ?DEFAULT_TIMEOUT ->
+        throw({scheduler_timeout, {proc_id, ErlangProcID}, {message, Message}})
     end.
 
 %% @doc Get the current slot from the scheduling server.
@@ -116,8 +133,23 @@ stop(ProcID) ->
 %% returns the current slot.
 server(State) ->
     receive
-        {schedule, Message, Reply} ->
-            server(assign(State, Message, Reply));
+        {schedule, Message, Reply, AbortTime} ->
+            case SchedTime = scheduler_time() > AbortTime of
+                true ->
+                    % Ignore scheduling requests if they are too old. The
+                    % `abort-time' signals to us that the client has already
+                    % given up on the request, so in order to maintain
+                    % predictability we ignore it.
+                    ?event(error,
+                        {received_old_schedule_request,
+                            {abort_time, AbortTime},
+                            {sched_time, SchedTime}
+                        }
+                    ),
+                    server(State);
+                false ->
+                    server(assign(State, Message, Reply))
+            end;
         {info, Reply} ->
             Reply ! {info, State},
             server(State);
@@ -172,7 +204,7 @@ do_assign(State, Message, ReplyPID) ->
                         <<"block-hash">> => hb_util:human_id(Hash),
                         <<"block-timestamp">> => Timestamp,
                         % Note: Local time on the SU, not Arweave
-                        <<"timestamp">> => erlang:system_time(millisecond),
+                        <<"timestamp">> => scheduler_time(),
                         <<"hash-chain">> => hb_util:id(HashChain),
                         <<"body">> => OnlyAttested
                     },
@@ -257,6 +289,10 @@ next_hashchain(HashChain, Message, Opts) ->
         sha256,
         << HashChain/binary, ID/binary >>
     ).
+
+%% @doc Return the current time in milliseconds.
+scheduler_time() ->
+    erlang:system_time(millisecond).
 
 %% TESTS
 

--- a/src/hb_ao.erl
+++ b/src/hb_ao.erl
@@ -96,8 +96,7 @@
 %%% Main AO-Core API:
 -export([resolve/2, resolve/3, resolve_many/2]).
 -export([normalize_key/1, normalize_key/2, normalize_keys/1, normalize_keys/2]).
--export([message_to_fun/3, message_to_device/2, load_device/2, get_device_name/2,
-        find_exported_function/5]).
+-export([message_to_fun/3, message_to_device/2, load_device/2, find_exported_function/5]).
 -export([force_message/2]).
 %%% Shortcuts and tools:
 -export([info/2, keys/1, keys/2, keys/3, truncate_args/2]).
@@ -1479,16 +1478,6 @@ load_device(ID, Opts) ->
     ) of
         false -> {error, {module_not_admissable, NormKey, Preloaded}};
         {value, #{ <<"module">> := Mod }} -> load_device(Mod, Opts)
-    end.
-
-%% @doc Get the name of a device from its ID.
-get_device_name(DeviceId, Opts) ->
-    case lists:search(
-        fun (#{ <<"module">> := Mod }) -> Mod =:= DeviceId end,
-        hb_opts:get(preloaded_devices, [], Opts)
-    ) of
-        false -> {error, {module_not_admissable, DeviceId}};
-        {value, #{ <<"name">> := Name }} -> Name
     end.
 
 %% @doc Verify that a device is compatible with the current machine.

--- a/src/hb_format.erl
+++ b/src/hb_format.erl
@@ -13,8 +13,8 @@
 -export([print/1, print/3, print/4, print/5, eunit_print/2]).
 -export([message/1, message/2, message/3]).
 -export([binary/1, error/2, trace/1, trace_short/0, trace_short/1]).
--export([indent/2, indent/3, indent/4, indent_lines/2]).
--export([maybe_multiline/3, remove_leading_noise/1, remove_trailing_noise/1]).
+-export([indent/2, indent/3, indent/4, indent_lines/2, maybe_multiline/3]).
+-export([remove_leading_noise/1, remove_trailing_noise/1, remove_noise/1]).
 %%% Public Utility Functions.
 -export([escape_format/1, short_id/1, trace_to_list/1]).
 -export([get_trace/0, print_trace/4, trace_macro_helper/5, print_trace_short/4]).
@@ -311,11 +311,16 @@ do_to_lines(In =[RawElem | Rest]) ->
         false -> Elem ++ ", " ++ do_to_lines(Rest)
     end.
 
+%% @doc Remove any leading or trailing noise from a string.
+remove_noise(Str) ->
+    remove_leading_noise(remove_trailing_noise(Str)).
+
 %% @doc Remove any leading whitespace from a string.
 remove_leading_noise(Str) ->
     remove_leading_noise(Str, ?NOISE_CHARS).
 remove_leading_noise(Bin, Noise) when is_binary(Bin) ->
     remove_leading_noise(binary:bin_to_list(Bin), Noise);
+remove_leading_noise([], _Noise) -> [];
 remove_leading_noise([Char|Str], Noise) ->
     case lists:member(Char, Noise) of
         true ->

--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -77,18 +77,20 @@ read(ID, Opts) ->
 %% @doc Gives the fields of a transaction that are needed to construct an
 %% ANS-104 message.
 item_spec() ->
-    <<"node { ",
-        "id ",
-        "anchor ",
-        "signature ",
-        "recipient ",
-        "owner { key } ",
-        "fee { winston } ",
-        "quantity { winston } ",
-        "tags { name value } ",
-        "data { size } "
-    "} ",
-    "cursor ">>.
+    <<"""
+        node {
+            id
+            anchor
+            signature
+            recipient
+            owner { key }
+            fee { winston }
+            quantity { winston }
+            tags { name value }
+            data { size }
+        }
+        cursor
+    """>>.
 
 %% @doc Get the data associated with a transaction by its ID, using the node's
 %% Arweave `gateway' peers. The item is expected to be available in its 

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -11,6 +11,8 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-define(DEFAULT_FILTER_KEYS, [<<"content-length">>]).
+
 start() ->
     httpc:set_options([{max_keep_alive_length, 0}]),
     ok.
@@ -533,7 +535,7 @@ add_cors_headers(Msg, ReqHdr, Opts) ->
 
 %% @doc Generate the headers and body for a HTTP response message.
 encode_reply(Status, TABMReq, Message, Opts) ->
-    Codec = accept_to_codec(TABMReq, Opts),
+    Codec = accept_to_codec(TABMReq, Message, Opts),
     ?event(http, {encoding_reply, {codec, Codec}, {message, Message}}),
     BaseHdrs =
         hb_maps:merge(
@@ -550,6 +552,14 @@ encode_reply(Status, TABMReq, Message, Opts) ->
         hb_util:atom(
             hb_maps:get(<<"accept-bundle">>, TABMReq, false, Opts)
         ),
+    ?event(http,
+        {encoding_reply,
+            {status, Status},
+            {codec, Codec},
+            {should_bundle, AcceptBundle},
+            {response_message, Message}
+        }
+    ),
     % Codecs generally do not need to specify headers outside of the content-type,
     % aside the default `httpsig@1.0' codec, which expresses its form in HTTP
     % documents, and subsequently must set its own headers.
@@ -642,44 +652,56 @@ encode_reply(Status, TABMReq, Message, Opts) ->
             % the message to the codec. We also include all of the top-level 
             % fields, except for maps and lists, in the message and return them 
             % as headers.
-            ExtraHdrs = hb_maps:filter(fun(_, V) ->
-                not is_map(V) andalso 
-                not is_list(V)
-            end, Message, Opts),
+            ExtraHdrs =
+                hb_maps:filter(
+                    fun(_, V) -> not is_map(V) andalso not is_list(V) end,
+                    Message,
+                    Opts
+                ),
             % Encode all header values as strings.
-            EncodedExtraHdrs = maps:map(fun(K, V) ->
-                case is_binary(V) of
-                    true -> V;
-                    false -> hb_util:bin(V)
-                end
-            end, ExtraHdrs),
+            EncodedExtraHdrs =
+                maps:map(
+                    fun(_K, V) -> hb_util:bin(V) end,
+                    ExtraHdrs
+                ),
             {ok,
                 hb_maps:merge(EncodedExtraHdrs, BaseHdrs, Opts),
                 hb_message:convert(
                     Message,
-                    Codec,
+                    #{ <<"device">> => Codec, <<"bundle">> => AcceptBundle },
                     <<"structured@1.0">>,
                     Opts#{ topic => ao_internal }
                 )
             }
     end.
 
-%% @doc Calculate the codec name to use for a reply given its initiating Cowboy
-%% request, the parsed TABM request, and the response message. The precidence
+%% @doc Calculate the codec name to use for a reply given the original parsed 
+%% singleton TABM request and the response message. The precidence
 %% order for finding the codec is:
-%% 1. The `accept-codec' field in the message
-%% 2. The `accept' field in the request headers
-%% 3. The default codec
+%% 1. If the `content-type' field is present in the response message, we always
+%%    use `httpsig@1.0', as the device is expected to have already encoded the
+%%    message and the `body' field.
+%% 2. The `accept-codec' field in the original request.
+%% 3. The `accept' field in the original request.
+%% 4. The default codec
 %% Options can be specified in mime-type format (`application/*') or in
 %% AO device format (`device@1.0').
-accept_to_codec(TABMReq, Opts) ->
-    Singleton = lists:last(hb_singleton:from(TABMReq, Opts)),
-    Accept = hb_ao:get(<<"accept">>, Singleton, <<"*/*">>, Opts),
-    ?event(only, {accept_to_codec, {tabm_req, TABMReq}}),
+accept_to_codec(OriginalReq, Opts) ->
+    accept_to_codec(OriginalReq, undefined, Opts).
+accept_to_codec(_OriginalReq, #{ <<"content-type">> := _ }, _Opts) ->
+    <<"httpsig@1.0">>;
+accept_to_codec(OriginalReq, _, Opts) ->
+    Accept = hb_ao:get(<<"accept">>, OriginalReq, <<"*/*">>, Opts),
+    ?event(debug_accept,
+        {accept_to_codec,
+            {original_req, OriginalReq},
+            {accept, Accept}
+        }
+    ),
     AcceptCodec =
         hb_ao:get(
             <<"accept-codec">>,
-            Singleton,
+            OriginalReq,
             mime_to_codec(Accept, Opts),
 			Opts
         ),
@@ -734,12 +756,48 @@ codec_to_content_type(Codec, Opts) ->
         CT -> CT
     end.
 
-%% @doc Convert a cowboy request to a normalized message.
+%% @doc Convert a cowboy request to a normalized message. We first parse the
+%% `primitive' message from the request: A message (represented as an Erlang
+%% map) of binary keys and values for the request headers and query parameters.
+%% We then determine the codec to use for the request, decode it, and merge it
+%% overriding the keys of the `primitive' message.
 req_to_tabm_singleton(Req, Body, Opts) ->
-    case cowboy_req:header(<<"codec-device">>, Req, <<"httpsig@1.0">>) of
+    FullPath =
+        <<
+            (cowboy_req:path(Req))/binary,
+            "?",
+            (cowboy_req:qs(Req))/binary
+        >>,
+    Headers = cowboy_req:headers(Req),
+    {ok, _Path, QueryKeys} = hb_singleton:from_path(FullPath),
+    PrimitiveMsg = maps:merge(Headers, QueryKeys),
+    Codec =
+        case hb_maps:find(<<"codec-device">>, PrimitiveMsg, Opts) of
+            {ok, ExplicitCodec} -> ExplicitCodec;
+            error ->
+                case hb_maps:find(<<"content-type">>, PrimitiveMsg, Opts) of
+                    {ok, ContentType} -> mime_to_codec(ContentType, Opts);
+                    error -> default_codec(Opts)
+                end
+        end,
+    ?event(http,
+        {parsing_req,
+            {path, FullPath},
+            {query, QueryKeys},
+            {headers, Headers},
+            {primitive_message, PrimitiveMsg}
+        }
+    ),
+    ?event({req_to_tabm_singleton, {codec, Codec}}),
+    case Codec of
         <<"httpsig@1.0">> ->
-			?event({req_to_tabm_singleton, {request, {explicit, Req}, {body, {string, Body}}}}),
-            httpsig_to_tabm_singleton(Req, Body, Opts);
+			?event(
+                {req_to_tabm_singleton,
+                    {request, {explicit, Req},
+                    {body, {string, Body}}
+                }}
+            ),
+            httpsig_to_tabm_singleton(PrimitiveMsg, Req, Body, Opts);
         <<"ans104@1.0">> ->
             Item = ar_bundles:deserialize(Body),
             ?event(debug_accept,
@@ -758,12 +816,13 @@ req_to_tabm_singleton(Req, Body, Opts) ->
                             <<"ans104@1.0">>,
                             Opts
                         ),
-                    normalize_unsigned(Req, ANS104, Opts);
+                    normalize_unsigned(PrimitiveMsg, Req, ANS104, Opts);
                 false ->
                     throw({invalid_ans104_signature, Item})
             end;
         Codec ->
             % Assume that the codec stores the encoded message in the `body' field.
+            ?event(http, {decoding_body, {codec, Codec}, {body, {string, Body}}}),
             Decoded =
                 hb_message:convert(
                     Body,
@@ -771,17 +830,19 @@ req_to_tabm_singleton(Req, Body, Opts) ->
                     Codec,
                     Opts
                 ),
+            ReqMessage = hb_maps:merge(PrimitiveMsg, Decoded, Opts),
             ?event(
                 {verifying_encoded_message,
+                    {codec, Codec},
                     {body, {string, Body}},
-                    {decoded, Decoded}
+                    {decoded, ReqMessage}
                 }
             ),
-            case hb_message:verify(Decoded, all) of
+            case hb_message:verify(ReqMessage, all) of
                 true ->
-                    normalize_unsigned(Req, Decoded, Opts);
+                    normalize_unsigned(PrimitiveMsg, Req, ReqMessage, Opts);
                 false ->
-                    throw({invalid_signature, Decoded})
+                    throw({invalid_commitment, ReqMessage})
             end
     end.
 
@@ -790,27 +851,28 @@ req_to_tabm_singleton(Req, Body, Opts) ->
 %% In particular, the signatures are verified if present and required by the 
 %% node configuration. Additionally, non-committed fields are removed from the
 %% message if it is signed, with the exception of the `path' and `method' fields.
-httpsig_to_tabm_singleton(Req = #{ headers := RawHeaders }, Body, Opts) ->
-    {ok, SignedMsg} =
+httpsig_to_tabm_singleton(PrimMsg, Req, Body, Opts) ->
+    {ok, Decoded} =
         hb_message:with_only_committed(
             hb_message:convert(
-                RawHeaders#{ <<"body">> => Body },
+                PrimMsg#{ <<"body">> => Body },
                 <<"structured@1.0">>,
                 <<"httpsig@1.0">>,
                 Opts
             ),
             Opts
         ),
+    ?event(http, {decoded, Decoded}, Opts),
     ForceSignedRequests = hb_opts:get(force_signed_requests, false, Opts),
-    case (not ForceSignedRequests) orelse hb_message:verify(SignedMsg, all, Opts) of
+    case (not ForceSignedRequests) orelse hb_message:verify(Decoded, all, Opts) of
         true ->
-            ?event(http_verify, {verified_signature, SignedMsg}),
-            Signers = hb_message:signers(SignedMsg, Opts),
+            ?event(http_verify, {verified_signature, Decoded}),
+            Signers = hb_message:signers(Decoded, Opts),
             case Signers =/= [] andalso hb_opts:get(store_all_signed, false, Opts) of
                 true ->
-                    ?event(http_verify, {storing_signed_from_wire, SignedMsg}),
+                    ?event(http_verify, {storing_signed_from_wire, Decoded}),
                     {ok, _} =
-                        hb_cache:write(SignedMsg,
+                        hb_cache:write(Decoded,
                             Opts#{
                                 store =>
                                     #{
@@ -822,16 +884,15 @@ httpsig_to_tabm_singleton(Req = #{ headers := RawHeaders }, Body, Opts) ->
                 false ->
                     do_nothing
             end,
-            normalize_unsigned(Req, SignedMsg, Opts);
+            normalize_unsigned(PrimMsg, Req, Decoded, Opts);
         false ->
             ?event(http_verify,
                 {invalid_signature,
-                    {raw, RawHeaders},
-                    {signed, SignedMsg},
+                    {signed, Decoded},
                     {force, ForceSignedRequests}
                 }
             ),
-            throw({invalid_signature, SignedMsg})
+            throw({invalid_commitments, Decoded})
     end.
 
 %% @doc Add the method and path to a message, if they are not already present.
@@ -840,7 +901,7 @@ httpsig_to_tabm_singleton(Req = #{ headers := RawHeaders }, Body, Opts) ->
 %% The precidence order for finding the path is:
 %% 1. The path in the message
 %% 2. The path in the request URI
-normalize_unsigned(Req = #{ headers := RawHeaders }, Msg, Opts) ->
+normalize_unsigned(PrimMsg, Req = #{ headers := RawHeaders }, Msg, Opts) ->
     ?event({adding_method_and_path_from_request, {explicit, Req}}),
     Method = cowboy_req:method(Req),
     MsgPath =
@@ -863,26 +924,43 @@ normalize_unsigned(Req = #{ headers := RawHeaders }, Msg, Opts) ->
             ),
             Opts
         ),
-    WithoutPeer =
-        (hb_message:without_unless_signed([<<"content-length">>], Msg, Opts))#{
+    FilterKeys = hb_opts:get(http_inbound_filter_keys, ?DEFAULT_FILTER_KEYS, Opts),
+    FilteredMsg = hb_message:without_unless_signed(FilterKeys, Msg, Opts),
+    BaseMsg =
+        FilteredMsg#{
             <<"method">> => Method,
             <<"path">> => MsgPath,
             <<"accept-bundle">> =>
                 maps:get(
                     <<"accept-bundle">>,
                     Msg,
-                    maps:get(<<"accept-bundle">>, RawHeaders, false)
+                    maps:get(
+                        <<"accept-bundle">>,
+                        PrimMsg,
+                        maps:get(<<"accept-bundle">>, RawHeaders, false)
+                    )
+                ),
+            <<"accept">> =>
+                Accept = maps:get(
+                    <<"accept">>,
+                    Msg,
+                    maps:get(
+                        <<"accept">>,
+                        PrimMsg,
+                        maps:get(<<"accept">>, RawHeaders, <<"*/*">>)
+                    )
                 )
         },
+    ?event(debug_accept, {normalize_unsigned, {accept, Accept}}),
     % Parse and add the cookie from the request, if present. We reinstate the
     % `cookie' field in the message, as it is not typically signed, yet should
     % be honored by the node anyway.
     {ok, WithCookie} =
         case maps:get(<<"cookie">>, RawHeaders, undefined) of
-            undefined -> {ok, WithoutPeer};
+            undefined -> {ok, BaseMsg};
             Cookie ->
                 dev_codec_cookie:from(
-                    WithoutPeer#{ <<"cookie">> => Cookie },
+                    BaseMsg#{ <<"cookie">> => Cookie },
                     Req,
                     Opts
                 )

--- a/src/hb_link.erl
+++ b/src/hb_link.erl
@@ -98,7 +98,7 @@ normalize(OtherVal, _Mode, _Opts) ->
     OtherVal.
 
 %% @doc Decode links embedded in the headers of a message.
-decode_all_links(Msg) ->
+decode_all_links(Msg) when is_map(Msg) ->
     maps:from_list(
         lists:map(
             fun({Key, MaybeID}) ->
@@ -120,7 +120,11 @@ decode_all_links(Msg) ->
             end,
             maps:to_list(Msg)
         )
-    ).
+    );
+decode_all_links(List) when is_list(List) ->
+    lists:map(fun(X) -> decode_all_links(X) end, List);
+decode_all_links(OtherVal) ->
+    OtherVal.
 
 %% @doc Determine if a key is an encoded link.
 is_link_key(Key) when byte_size(Key) >= 5 ->

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -142,7 +142,6 @@ restore_priv(Msg, OldPriv, Opts) ->
     ?event({new_priv, NewPriv}),
     Msg#{ <<"priv">> => NewPriv }.
 
-
 %% @doc Get a codec device and request params from the given conversion request. 
 %% Expects conversion spec to either be a binary codec name, or a map with a
 %% `device' key and other parameters. Additionally honors the `always_bundle'
@@ -440,8 +439,8 @@ match(Map1, Map2, Mode, Opts) ->
     catch _:Details -> Details
     end.
 
-
-
+%% @doc Match two maps, returning `true' if they match, or throwing an error
+%% if they do not.
 unsafe_match(Map1, Map2, Mode, Path, Opts) ->
     Keys1 =
         hb_maps:keys(
@@ -478,8 +477,16 @@ unsafe_match(Map1, Map2, Mode, Path, Opts) ->
             lists:all(
                 fun(Key) ->
                     ?event(match, {matching_key, Key}),
-                    Val1 = hb_ao:normalize_keys(hb_maps:get(Key, NormMap1, not_found, Opts), Opts),
-                    Val2 = hb_ao:normalize_keys(hb_maps:get(Key, NormMap2, not_found, Opts), Opts),
+                    Val1 =
+                        hb_ao:normalize_keys(
+                            hb_maps:get(Key, NormMap1, not_found, Opts),
+                            Opts
+                        ),
+                    Val2 =
+                        hb_ao:normalize_keys(
+                            hb_maps:get(Key, NormMap2, not_found, Opts),
+                            Opts
+                        ),
                     BothPresent = (Val1 =/= not_found) and (Val2 =/= not_found),
                     case (not BothPresent) and (Mode == only_present) of
                         true -> true;
@@ -490,8 +497,8 @@ unsafe_match(Map1, Map2, Mode, Path, Opts) ->
                                 false ->
                                     case {Val1, Val2} of
                                         {V, V} -> true;
-                                        {_V, '_'} -> true;
-                                        {'_', _V} -> true;
+                                        {V, '_'} when V =/= not_found -> true;
+                                        {'_', V} when V =/= not_found -> true;
                                         {'_', '_'} -> true;
                                         _ ->
                                             throw(

--- a/src/hb_singleton.erl
+++ b/src/hb_singleton.erl
@@ -33,7 +33,7 @@
 %%%         - N.Key+res=(/a/b/c) => #{ Key => (resolve /a/b/c), ... }
 %%% </pre>
 -module(hb_singleton).
--export([from/2, to/1]).
+-export([from/2, from_path/1, to/1]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -define(MAX_SEGMENT_LENGTH, 512).
@@ -137,12 +137,13 @@ from(RawMsg, Opts) when is_binary(RawMsg) ->
 from(RawMsg, Opts) ->
     RawPath = hb_maps:get(<<"path">>, RawMsg, <<>>),
     ?event(parsing, {raw_path, RawPath}),
-    {ok, Path, Query} = parse_full_path(RawPath),
+    {ok, Path, Query} = from_path(RawPath),
     ?event(parsing, {parsed_path, Path, Query}),
-    MsgWithoutBasePath = hb_maps:merge(
-        hb_maps:remove(<<"path">>, RawMsg),
-        Query
-    ),
+    MsgWithoutBasePath =
+        hb_maps:merge(
+            hb_maps:remove(<<"path">>, RawMsg),
+            Query
+        ),
     % 2. Decode, split, and sanitize path segments. Each yields one step message.
     RawMsgs =
         lists:flatten(
@@ -166,7 +167,7 @@ from(RawMsg, Opts) ->
     Result.
 
 %% @doc Parse the relative reference into path, query, and fragment.
-parse_full_path(RelativeRef) ->
+from_path(RelativeRef) ->
     %?event(parsing, {raw_relative_ref, RawRelativeRef}),
     %RelativeRef = hb_escape:decode(RawRelativeRef),
     Decoded = decode_string(RelativeRef),


### PR DESCRIPTION
This PR allows users to specify the codec that should be utilized to decode their messages using the `content-type` field of their requests. For example, a user may opt to send a JSON-encoded request with `content-type: application/json`, allowing them to quickly produce valid deeply nested/typed AO-Core messages from environments in which they lack HTTPSig/ANS-104 libraries.

Additionally, this PR fixes a number of smaller issues -- see the commit log for details.