### PR TITLE
fix: a verification issue with ans104

### DIFF
--- a/src/dev_codec_ans104.erl
+++ b/src/dev_codec_ans104.erl
@@ -414,3 +414,15 @@ unsorted_tag_map_test() ->
     {ok, Decoded} = dev_codec_ans104:to(TABM, #{}, #{}),
     ?event(debug_test, {decoded, Decoded}),
     ?assert(ar_bundles:verify_item(Decoded)).
+
+field_and_tag_ordering_test() ->
+    UnsignedTABM = #{
+        <<"a">> => <<"value1">>,
+        <<"z">> => <<"value2">>,
+        <<"target">> => <<"NON-ID-TARGET">>
+    },
+        
+    Wallet = hb:wallet(),
+    SignedTABM = hb_message:commit(
+        UnsignedTABM, #{priv_wallet => Wallet}, <<"ans104@1.0">>),
+    ?assert(hb_message:verify(SignedTABM)).

--- a/src/dev_codec_ans104_from.erl
+++ b/src/dev_codec_ans104_from.erl
@@ -72,9 +72,9 @@ data(Item, Req, Tags, Opts) ->
 %% components (fields, tags, and data).
 committed(Item, Fields, Tags, Data, Opts) ->
     hb_util:unique(
-        field_keys(Fields, Tags, Data, Opts) ++
-            data_keys(Data, Opts) ++
-            tag_keys(Item, Opts)
+        data_keys(Data, Opts) ++
+        tag_keys(Item, Opts) ++
+        field_keys(Fields, Tags, Data, Opts)
     ).
 
 %% @doc Return the list of the keys from the fields TABM.


### PR DESCRIPTION
1. When converting from a TABM to a #tx when there is no commitment, we sort the #tx tags alphabetically.
2. However when generating the committed keys the base fields used to be placed first.

This can cause a verification failure when `target` is set to something that is not a valid #tx.target. In that case it gets moved into tags, and then the order can change between steps 1 and 2. This commit attempts to fix by rearranging the order so that field_keys is last instead of first (i.e. the tag ordering will be preserved in the event there's a tag named target)