### PR TITLE
feat: Allow logging with AO-Core stacktraces

### DIFF
--- a/src/hb_event.erl
+++ b/src/hb_event.erl
@@ -121,17 +121,19 @@ increment(Topic, Message, _Opts, Count) ->
 %% **extremely** expensive, so it should only be used in very specific cases.
 %% Do not ship code that calls this function to prod.
 increment_callers(Topic) ->
+    increment_callers(Topic, erlang).
+increment_callers(Topic, Type) ->
     BinTopic = hb_util:bin(Topic),
     increment(
         <<BinTopic/binary, "-call-paths">>,
-        hb_format:trace_short(),
+        hb_format:trace_short(Type),
         #{}
     ),
     lists:foreach(
         fun(Caller) ->
             increment(<<BinTopic/binary, "-callers">>, Caller, #{})
         end,
-        hb_format:trace_to_list(hb_format:get_trace())
+        hb_format:trace_to_list(hb_format:get_trace(Type))
     ).
 
 %% @doc Return a message containing the current counter values for all logged

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -27,6 +27,13 @@
     [error, http_error, http_short, compute_short, push_short]
 ).
 -endif.
+
+-ifdef(AO_PROFILING).
+-define(DEFAULT_TRACE_TYPE, ao).
+-else.
+-define(DEFAULT_TRACE_TYPE, erlang).
+-endif.
+
 -define(DEFAULT_PRIMARY_STORE, #{
     <<"name">> => <<"cache-mainnet/lmdb">>,
     <<"store-module">> => hb_store_lmdb
@@ -211,6 +218,7 @@ default_message() ->
         debug_print_indent => 2,
         stack_print_prefixes => ["hb", "dev", "ar", "maps"],
         debug_print_trace => short, % `short` | `false`. Has performance impact.
+        debug_trace_type => ?DEFAULT_TRACE_TYPE,
         short_trace_len => 20,
         debug_metadata => true,
         debug_ids => true,


### PR DESCRIPTION
This PR enables developers to print `?event` logs with an AO-Core call stacktrace listing the device, path, and method, rather than the traditional Erlang Module:Line form. This option currently depends on starting HyperBEAM with the `as ao_profiling` option and can be controlled using `debug_trace_type`. By default, if `ao_profiiling` is enabled at build, AO-Core stacktraces are enabled.

Note that all `ao_profiling` functionality comes with a non-zero performance impact, so should be used only during debugging.
