### PR TITLE
impr: Explicit map parsing in HTTP messages; multi-tag search in copycat

### DIFF
--- a/src/dev_copycat.erl
+++ b/src/dev_copycat.erl
@@ -184,7 +184,8 @@ parse_query(Base, Req, Opts) ->
     end.
 
 %% @doc Return a default query for a given filter type.
-default_query(<<"tags">>, Message, Opts) ->
+default_query(<<"tags">>, RawMessage, Opts) ->
+    Message = hb_cache:ensure_all_loaded(RawMessage, Opts),
     BinaryPairs =
         lists:map(
             fun({Key, Value}) -> {hb_util:bin(Key), hb_util:bin(Value)} end,

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -888,7 +888,7 @@ dynamic_router_pricing() ->
                         #{
                             <<"registration-peer">> => <<"http://localhost:10010">>,         
                             <<"template">> => <<"/c">>,  
-                            <<"prefix">> => <<"http://localhost:10009">>,                   
+                            <<"prefix">> => <<"http://localhost:10009">>,
                             <<"price">> => 0                   
                         },
                         #{

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -55,6 +55,8 @@ ensure_loaded(Msg) ->
     ensure_loaded(Msg, #{}).
 ensure_loaded(Msg, Opts) ->
     ensure_loaded([], Msg, Opts).
+ensure_loaded(Ref, {Status, Msg}, Opts) when Status == ok; Status == error ->
+    {Status, ensure_loaded(Ref, Msg, Opts)};
 ensure_loaded(Ref,
         Lk = {link, ID, LkOpts = #{ <<"type">> := <<"link">>, <<"lazy">> := Lazy }},
         RawOpts) ->

--- a/src/hb_escape.erl
+++ b/src/hb_escape.erl
@@ -33,6 +33,7 @@ decode_quotes(String) when is_binary(String) ->
     list_to_binary(decode_quotes(binary_to_list(String)));
 decode_quotes([]) -> [];
 decode_quotes([$\\, $\" | Rest]) -> [$\" | decode_quotes(Rest)];
+decode_quotes([$\" | Rest]) -> decode_quotes(Rest);
 decode_quotes([C | Rest]) -> [C | decode_quotes(Rest)].
 
 %% @doc Return a message with all of its keys decoded.

--- a/src/hb_singleton.erl
+++ b/src/hb_singleton.erl
@@ -437,8 +437,9 @@ maybe_typed(Key, Value, Opts) ->
                         OnlyKey,
                         {resolve, from(#{ <<"path">> => Subpath }, Opts)}
                     };
-                {_T, Bin} when is_binary(Bin) ->
-                    {typed, OnlyKey, dev_codec_structured:decode_value(Type, Bin)}
+                {_T, RawValue} when is_binary(RawValue) ->
+                    Decoded = hb_escape:decode_quotes(RawValue),
+                    {typed, OnlyKey, dev_codec_structured:decode_value(Type, Decoded)}
             end
     end.
 

--- a/src/hb_structured_fields.erl
+++ b/src/hb_structured_fields.erl
@@ -153,7 +153,12 @@ from_bare_item(BareItem) ->
                 )
             );
         {string, S} -> S;
-        {token, T} -> binary_to_existing_atom(T);
+        {token, T} ->
+            try binary_to_existing_atom(T) of
+                Atom -> Atom
+            catch
+                error:badarg -> T
+            end;
         {binary, B} -> B
     end.
 


### PR DESCRIPTION
This PR refreshes the code paths for parsing explicit Structured Fields (RFC 8941) maps in paths and headers, then utilizes that capability in `~copycat@1.0`. This allows users to easily specify multiple tag/key patterns to match against when producing subindexes of other sources (ex: Arweave GraphQL), as well as querying nodes.

For example, to index all known AO processes from another GraphQL server, the user may run:
```
http://localhost:8734/~copycat@1.0/graphql/format~hyperbuddy@1.0?query+map="data-protocol=ao,type=Process"
```
After allowing this to run for some time, we can then run the following on the node in order to match and return the processes:
```
http://localhost:8734/~query@1.0/only+map="data-protocol=ao,type=Process"/format~hyperbuddy@1.0?return=messages
```