### PR TITLE
chore: Tidy event groups

### DIFF
--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -208,10 +208,8 @@ do_push(PrimaryProcess, Assignment, Opts) ->
 maybe_evaluate_message(Message, Opts) ->
     case hb_ao:get(<<"resolve">>, Message, Opts) of
         not_found -> 
-            ?event(x, {not_found, {msg, Message}    }),
             {ok, Message};
         ResolvePath ->
-            ?event(x, {resolve_path, ResolvePath, {msg, Message}}),
             ReqMsg =
                 maps:without(
                     [<<"target">>],

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -1002,10 +1002,14 @@ nested_push_prompts_encoding_change() ->
     Msg = hb_message:commit(#{
         <<"path">> => <<"push">>,
         <<"method">> => <<"POST">>,
-        <<"body">> => #{
-            <<"target">> => hb_message:id(Msg1, all, Opts),
-            <<"action">> => <<"Ping">>
-        }
+        <<"body">> =>
+            hb_message:commit(
+                #{
+                    <<"target">> => hb_message:id(Msg1, all, Opts),
+                    <<"action">> => <<"Ping">>
+                },
+                Opts
+            )
     }, Opts),
     ?event(push, {msg1, Msg}),
     Res2 =

--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -141,8 +141,21 @@ scheduler_location(Address, Opts) ->
         {ok, GqlMsg} ->
             ?event({scheduler_location_req, {query, Query}, {response, GqlMsg}}),
             case hb_ao:get(<<"data/transactions/edges/1/node">>, GqlMsg, Opts) of
-                not_found -> {error, not_found};
-                Item = #{ <<"id">> := ID } -> result_to_message(ID, Item, Opts)
+                not_found ->
+                    ?event(scheduler_location,
+                        {graphql_scheduler_location_not_found,
+                            {address, Address}
+                        }
+                    ),
+                    {error, not_found};
+                Item = #{ <<"id">> := ID } ->
+                    ?event(scheduler_location,
+                        {found_via_graphql,
+                            {address, Address},
+                            {id, ID}
+                        }
+                    ),
+                    result_to_message(ID, Item, Opts)
             end
     end.
         


### PR DESCRIPTION
This PR tidies a few of the event groups in preparation for m3-b2. You can now track remote and gateway store accesses via the `~hyperbuddy@1.0/events` key.