### PR TITLE
impr: Caching of messages and queries from remote peers

### DIFF
--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -897,13 +897,22 @@ find_remote_scheduler(ProcID, Scheduler, Opts) ->
                         {ok, SchedMsg} ->
                             % We have found the location. Cache it and use it to
                             % construct a redirect message.
-                            dev_scheduler_cache:write_location(
-                                SchedMsg,
-                                Opts
+                            Res =
+                                dev_scheduler_cache:write_location(
+                                    SchedMsg,
+                                    Opts
+                                ),
+                            ?event(scheduler_location,
+                                {cached_scheduler_location, {res, Res}}
                             ),
                             generate_redirect(ProcID, SchedMsg, Opts);
                         {error, Res} ->
-                            ?event({error_finding_scheduler, {error, Res}}),
+                            ?event(
+                                scheduler_location,
+                                {failed_to_find_scheduler_location_from_gateway,
+                                    {error, Res}
+                                }
+                            ),
                             {error, Res}
                     end
             end

--- a/src/dev_scheduler_cache.erl
+++ b/src/dev_scheduler_cache.erl
@@ -160,8 +160,8 @@ read_location(Address, RawOpts) ->
         ),
     Event =
         case Res of
-            {ok, _} -> found_locally;
-            not_found -> not_found_locally;
+            {ok, _} -> found_in_store;
+            not_found -> not_found_in_store;
             _ -> local_lookup_unexpected_result
         end,
     ?event(scheduler_location, {Event, {address, Address}, {res, Res}}),

--- a/src/dev_scheduler_cache.erl
+++ b/src/dev_scheduler_cache.erl
@@ -172,7 +172,7 @@ write_location(LocationMsg, RawOpts) ->
             {location_msg, LocationMsg}
         }
     ),
-    case hb_message:verify(LocationMsg, all) andalso hb_cache:write(LocationMsg, Opts) of
+    case hb_cache:write(LocationMsg, Opts) of
         {ok, RootPath} ->
             lists:foreach(
                 fun(Signer) ->

--- a/src/dev_scheduler_cache.erl
+++ b/src/dev_scheduler_cache.erl
@@ -1,12 +1,13 @@
+%%% @doc A module that provides a cache for scheduler assignments and locations.
 -module(dev_scheduler_cache).
 -export([write/2, write_spawn/2, write_location/2]).
 -export([read/3, read_location/2]).
 -export([list/2, latest/2]).
-
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-%%% Assignment cache functions
+%%% The pseudo-path prefix which the scheduler cache should use.
+-define(SCHEDULER_CACHE_PREFIX, <<"~scheduler@1.0">>).
 
 %% @doc Merge the scheduler store with the main store. Used before writing
 %% to the cache.
@@ -45,6 +46,7 @@ write(RawAssignment, RawOpts) ->
                 hb_store:path(
                     Store,
                     [
+                        ?SCHEDULER_CACHE_PREFIX,
                         <<"assignments">>,
                         hb_util:human_id(ProcID),
                         hb_ao:normalize_key(Slot)
@@ -72,6 +74,7 @@ read(ProcID, Slot, RawOpts) ->
         P2 = hb_store:resolve(
             Store,
             P1 = hb_store:path(Store, [
+                ?SCHEDULER_CACHE_PREFIX,
                 "assignments",
                 hb_util:human_id(ProcID),
                 Slot
@@ -108,6 +111,7 @@ list(ProcID, RawOpts) ->
     Opts = opts(RawOpts),
     hb_cache:list_numbered(
         hb_store:path(hb_opts:get(store, no_viable_store, Opts), [
+            ?SCHEDULER_CACHE_PREFIX,
             "assignments",
             hb_util:human_id(ProcID)
         ]),
@@ -145,13 +149,15 @@ latest(ProcID, RawOpts) ->
 %% @doc Read the latest known scheduler location for an address.
 read_location(Address, RawOpts) ->
     Opts = opts(RawOpts),
-    Res = hb_cache:read(
-        hb_store:path(hb_opts:get(store, no_viable_store, Opts), [
-            "scheduler-locations",
-            hb_util:human_id(Address)
-        ]),
-        Opts
-    ),
+    Res =
+        hb_cache:read(
+            hb_store:path(hb_opts:get(store, no_viable_store, Opts), [
+                ?SCHEDULER_CACHE_PREFIX,
+                "locations",
+                hb_util:human_id(Address)
+            ]),
+            Opts
+        ),
     Event =
         case Res of
             {ok, _} -> found_locally;
@@ -182,7 +188,8 @@ write_location(LocationMsg, RawOpts) ->
                         hb_store:path(
                             hb_opts:get(store, no_viable_store, Opts),
                             [
-                                "scheduler-locations",
+                                ?SCHEDULER_CACHE_PREFIX,
+                                "locations",
                                 hb_util:human_id(Signer)
                             ]
                         )

--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -238,6 +238,7 @@ result_to_message(ExpectedID, Item, Opts) ->
     Data =
         case hb_maps:get(<<"data">>, Item, not_found, GQLOpts) of
             BinData when is_binary(BinData) -> BinData;
+            #{ <<"size">> := 0 } -> <<>>;
             _ ->
                 {ok, Bytes} = data(ExpectedID, Opts),
                 Bytes

--- a/src/hb_store.erl
+++ b/src/hb_store.erl
@@ -385,7 +385,7 @@ apply_store_function(Mod, Store, Function, Args, AttemptsRemaining) ->
         Other -> Other
     catch Class:Reason:Stacktrace ->
         ?event(store_error,
-            {store_call_failed_attempting_retrying,
+            {store_call_failed_retrying,
                 #{
                     store => Store,
                     function => Function,

--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -52,32 +52,13 @@ read(StoreOpts, Key) ->
                     not_found;
                 {ok, Message} ->
                     ?event(store_gateway, {read_found, {key, ID}}),
-                    try maybe_cache(StoreOpts, Message) catch _:_ -> ignored end,
+                    try hb_store_remote_node:maybe_cache(StoreOpts, Message)
+                    catch _:_ -> ignored end,
                     {ok, Message}
             end;
         _ ->
             ?event({ignoring_non_id, Key}),
             not_found
-    end.
-
-%% @doc Cache the data if the cache is enabled. The `store' option may either
-%% be `false' to disable local caching, or a store definition to use as the
-%% cache.
-maybe_cache(StoreOpts, Data) ->
-    ?event({maybe_cache, StoreOpts, Data}),
-    % Check if the local store is in our store options.
-    case hb_maps:get(<<"local-store">>, StoreOpts, false, StoreOpts) of
-        false -> do_nothing;
-        Store ->
-            case hb_cache:write(Data, #{ store => Store }) of
-                {ok, _} ->
-                    ?event(store_gateway, cached_received),
-                    Data;
-                {error, Err} ->
-                    ?event(store_gateway, error_on_local_cache_write),
-                    ?event(warning, {error_writing_to_local_gateway_cache, Err}),
-                    Data
-            end
     end.
 
 %%% Tests

--- a/src/hb_store_remote_node.erl
+++ b/src/hb_store_remote_node.erl
@@ -5,6 +5,8 @@
 %%% to upload it to an Arweave bundler to ensure persistence, too.
 -module(hb_store_remote_node).
 -export([scope/1, type/2, read/2, write/3, make_link/3, resolve/2]).
+%%% Public utilities.
+-export([maybe_cache/2, maybe_cache/3]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -63,10 +65,55 @@ read(Opts = #{ <<"node">> := Node }, Key) ->
             % returning the whole response to get the test-key
             {ok, Msg} = hb_message:with_only_committed(Res, Opts),
             ?event(store_remote_node, {read_found, {result, Msg, response, Res}}),
+            maybe_cache(Opts, Msg, [Key]),
             {ok, Msg};
         {error, _Err} ->
             ?event(store_remote_node, {read_not_found, {key, Key}}),
             not_found
+    end.
+
+%% @doc Cache the data if the cache is enabled. The `local-store' option may
+%% either be `false' or a store definition to use as the local cache. Additional
+%% paths may be provided that should be linked to the data.
+maybe_cache(StoreOpts, Data) ->
+    maybe_cache(StoreOpts, Data, []).
+maybe_cache(StoreOpts, Data, Links) ->
+    ?event({maybe_cache, StoreOpts, Data}),
+    % Check if the local store is in our store options.
+    case hb_maps:get(<<"local-store">>, StoreOpts, false, StoreOpts) of
+        false ->
+            skipped;
+        Store ->
+            case hb_cache:write(Data, #{ store => Store }) of
+                {ok, RootPath} ->
+                    % Remove the base path from the links.
+                    LinksWithoutRootPath =
+                        lists:filter(
+                            fun(Link) -> Link /= RootPath end,
+                            Links
+                        ),
+                    ?event(store_gateway, cached_received),
+                    LinkResults =
+                        lists:filter(
+                            fun(Link) ->
+                                hb_store:make_link(Store, RootPath, Link) == false
+                            end,
+                            LinksWithoutRootPath
+                        ),
+                    ?event(store_gateway,
+                        {linked_cached,
+                            {failed_links, LinkResults}
+                        }
+                    ),
+                    case LinkResults of
+                        [] -> ok;
+                        _ -> {failed_links, LinkResults}
+                    end;
+                {error, Err} ->
+                    ?event(store_gateway, error_on_local_cache_write),
+                    ?event(warning, {error_writing_to_local_gateway_cache, Err}),
+                    {error, Err}
+            end
     end.
 
 %% @doc Write a key to the remote node.

--- a/src/hb_store_remote_node.erl
+++ b/src/hb_store_remote_node.erl
@@ -92,7 +92,7 @@ maybe_cache(StoreOpts, Data, Links) ->
                             fun(Link) -> Link /= RootPath end,
                             Links
                         ),
-                    ?event(store_gateway, cached_received),
+                    ?event(store_remote_node, cached_received),
                     LinkResults =
                         lists:filter(
                             fun(Link) ->
@@ -100,7 +100,7 @@ maybe_cache(StoreOpts, Data, Links) ->
                             end,
                             LinksWithoutRootPath
                         ),
-                    ?event(store_gateway,
+                    ?event(store_remote_node,
                         {linked_cached,
                             {failed_links, LinkResults}
                         }
@@ -110,8 +110,8 @@ maybe_cache(StoreOpts, Data, Links) ->
                         _ -> {failed_links, LinkResults}
                     end;
                 {error, Err} ->
-                    ?event(store_gateway, error_on_local_cache_write),
-                    ?event(warning, {error_writing_to_local_gateway_cache, Err}),
+                    ?event(store_remote_node, error_on_local_cache_write),
+                    ?event(warning, {error_caching_remote_node_data, Err}),
                     {error, Err}
             end
     end.


### PR DESCRIPTION
This PR introduces improvements to the caching of scheduler-location records and messages read from foreign peers.

Notably, it also normalizes the psuedo-paths used by `~scheduler@1.0` in the caches to be prefixed with the device name. In order to maintain backwards compatibility with existing processes scheduled locally on a node, it is critical that operators make a link from the `assignments` pseudo-path to `~scheduler@1.0/assignments`.