### PR TITLE
fix: Empty Lua tables are messages in AO; misc. Lua fixes

### DIFF
--- a/src/dev_lua_lib.erl
+++ b/src/dev_lua_lib.erl
@@ -55,7 +55,11 @@ install(Base, State, Opts) ->
                 )
         end,
     ?event({adding_ao_core_resolver, {device_sandbox, AdmissibleDevs}}),
-    ExecOpts = Opts#{ preloaded_devices => AdmissibleDevs },
+    ExecOpts =
+        Opts#{
+            preloaded_devices => AdmissibleDevs,
+            hashpath => ignore
+        },
     % Initialize the AO-Core resolver.
     BaseAOTable =
         case luerl:get_table_keys_dec([ao], State) of

--- a/src/dev_lua_test.erl
+++ b/src/dev_lua_test.erl
@@ -154,7 +154,7 @@ exec_test(State, Function) ->
     case Status of
         ok -> ok;
         error ->
-            hb_format:debug_print(Result, <<"Lua">>, Function, 1),
+            hb_format:print(Result, <<"Lua">>, Function, 1),
             ?assertEqual(
                 ok,
                 Status


### PR DESCRIPTION
Changes the semantics of `~lua@5.3a` such that empty Lua tables are encoded as messages rather than lists in HyperBEAM's AO data structures.

Additionally, three further changes are made:
- Run `hb.ao` resolutions with `hashpath => ignore`, avoiding the generation of a `priv` element in Lua. This may need to be revisited later.
- Fix an invalid reference in `dev_lua_tests` for error printing.
- Add the Lua module ID/name as the filename given to Luerl, such that error prints/stacktraces contain complete references.
