### PR TITLE
impr: `require-codec` replaces `accept-codec` forces codec for encoding

### DIFF
--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -502,8 +502,8 @@ post_location(Msg1, RawReq, RawOpts) ->
             Codec =
                 hb_ao:get_first(
                     [
-                        {Msg1, <<"accept-codec">>},
-                        {OnlyCommitted, <<"accept-codec">>}
+                        {Msg1, <<"require-codec">>},
+                        {OnlyCommitted, <<"require-codec">>}
                     ],
                     <<"httpsig@1.0">>,
                     Opts
@@ -1701,7 +1701,7 @@ register_location_on_boot_test() ->
                         <<"path">> => <<"location">>,
                         <<"method">> => <<"POST">>,
                         <<"target">> => <<"self">>,
-                        <<"accept-codec">> => <<"ans104@1.0">>,
+                        <<"require-codec">> => <<"ans104@1.0">>,
                         <<"url">> => <<"https://hyperbeam-test-ignore.com">>,
                         <<"hook">> => #{
                             <<"result">> => <<"ignore">>,
@@ -1874,7 +1874,7 @@ register_scheduler_test() ->
         <<"url">> => <<"https://hyperbeam-test-ignore.com">>,
         <<"method">> => <<"POST">>,
         <<"nonce">> => 1,
-        <<"accept-codec">> => <<"ans104@1.0">>
+        <<"require-codec">> => <<"ans104@1.0">>
     }, Wallet),
     {ok, Res} = hb_http:post(Node, Msg1, #{}),
     ?assertMatch(#{ <<"url">> := Location } when is_binary(Location), Res).

--- a/src/hb_examples.erl
+++ b/src/hb_examples.erl
@@ -228,7 +228,7 @@ relay_schedule_ans104_test() ->
                         <<"path">> => <<"location">>,
                         <<"method">> => <<"POST">>,
                         <<"target">> => <<"self">>,
-                        <<"accept-codec">> => <<"ans104@1.0">>,
+                        <<"require-codec">> => <<"ans104@1.0">>,
                         <<"hook">> => #{
                             <<"result">> => <<"ignore">>,
                             <<"commit-request">> => true


### PR DESCRIPTION
This PR modifies the encoding rules used in the HTTP response codepaths. Previously, the precedence order for determining the reply codec to use was: `content-type of reply > accept-codec of request > accept of request`. Additionally, the `accept-codec` key was assumed to always be an explicit device name.

This PR removes the `accept-codec` key and adds `require-codec` in its place; yielding a precedence order of: `require-codec of request > content-type of reply > accept of request`. Further, both the `require-codec` and `accept` keys can now handle both mime types and raw codec names -- determined by the presence of an `@` symbol in the key's value.