### PR TITLE
fix: correctly parse signature in message_to_json_struct

### DIFF
--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -446,7 +446,8 @@ schedule_aos_call(Msg1, Code, Action, Opts) ->
             #{
                 <<"action">> => Action,
                 <<"data">> => Code,
-                <<"target">> => ProcID
+                <<"target">> => ProcID,
+                <<"timestamp">> => os:system_time(millisecond)
             },
             #{ priv_wallet => Wallet }
         ),


### PR DESCRIPTION
2 changes:
1. In message_to_json_struct, we attempt to parse the signature from the message without commitments. The signature is not present, resulting in HB posting the message to the genesis wasm with the signature field blank. However, when the same message is run through legacy net, the signature field is correctly parsed. While this does not affect individual evaluations, and thus hasn't mattered so far, it does affect the wasm memory. These inconsistencies led to the table key ordering wonkiness.
2. Add timestamp to dev_genesis_wasm dryrun test, as it was failing due to the "double commitment" on identical messages.

Prior to changes, running @parthks script:
```
Numbers = {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20","21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "55", "56", "57", "58", "59", "60", "61", "62", "63", "64", "65", "66", "67", "68", "69", "70", "71", "72", "73", "74", "75", "76", "77", "78", "79", "80", "81", "82", "83", "84", "85", "86", "87", "88", "89", "90", "91", "92", "93", "94", "95", "96", "97", "98", "99", "100"}


MainNumbers = {}
local counter = 0
for _, number in ipairs(Numbers) do
    MainNumbers[number] = {count = counter}
    counter = counter + 1
end

ListOfNumbers = {}
for number, _ in pairs(MainNumbers) do
    table.insert(ListOfNumbers, number)
end

FirstNumber = ListOfNumbers[1]
print(FirstNumber)
```
HB and CU have different results before these changes, after changes they are the same