### PR TITLE
impr: Other HyperBEAM peers are valid `hb_store_gateway` nodes

### DIFF
--- a/src/dev_query_arweave.erl
+++ b/src/dev_query_arweave.erl
@@ -113,6 +113,12 @@ query(#{ <<"key">> := Key }, <<"key">>, _Args, _Opts) ->
     {ok, Key};
 query(#{ <<"address">> := Address }, <<"address">>, _Args, _Opts) ->
     {ok, Address};
+query(Msg, <<"fee">>, _Args, Opts) ->
+    {ok, hb_maps:get(<<"fee">>, Msg, 0, Opts)};
+query(Msg, <<"quantity">>, _Args, Opts) ->
+    {ok, hb_maps:get(<<"quantity">>, Msg, 0, Opts)};
+query(Number, <<"winston">>, _Args, _Opts) when is_number(Number) ->
+    {ok, Number};
 query(Msg, <<"recipient">>, _Args, Opts) ->
     case find_field_key(<<"field-target">>, Msg, Opts) of
         {ok, null} -> {ok, <<"">>};

--- a/src/dev_query_graphql.erl
+++ b/src/dev_query_graphql.erl
@@ -22,7 +22,8 @@
         <<"keys">>,
         <<"tags">>,
         <<"name">>,
-        <<"value">>
+        <<"value">>,
+        <<"cursor">>
     ]
 ).
 
@@ -213,6 +214,8 @@ message_query(Msg = #{ <<"independent_hash">> := _ }, <<"id">>, _Args, Opts) ->
 message_query(Msg, <<"id">>, _Args, Opts) ->
     ?event({message_query_id, {object, Msg}}),
     {ok, hb_message:id(Msg, all, Opts)};
+message_query(_Msg, <<"cursor">>, _Args, _Opts) ->
+    {ok, <<"">>};
 message_query(_Obj, _Field, _, _) ->
     {ok, <<"Not found.">>}.
 

--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -69,8 +69,12 @@ read(ID, Opts) ->
         {error, Reason} -> {error, Reason};
         {ok, GqlMsg} ->
             case hb_ao:get(<<"data/transactions/edges/1/node">>, GqlMsg, Opts) of
-                not_found -> {error, not_found};
-                Item = #{<<"id">> := ID} -> result_to_message(ID, Item, Opts)
+                not_found ->
+                    ?event({read_not_found, {id, ID}, {gql_msg, GqlMsg}}),
+                    {error, not_found};
+                Item ->
+                    ?event({read_found, {id, ID}, {item, Item}}),
+                    result_to_message(ID, Item, Opts)
             end
     end.
 

--- a/src/hb_store.erl
+++ b/src/hb_store.erl
@@ -386,14 +386,12 @@ apply_store_function(Mod, Store, Function, Args, AttemptsRemaining) ->
     catch Class:Reason:Stacktrace ->
         ?event(store_error,
             {store_call_failed_retrying,
-                #{
-                    store => Store,
-                    function => Function,
-                    args => Args,
-                    class => Class,
-                    reason => Reason,
-                    stacktrace => Stacktrace
-                }
+                {store, Store},
+                {function, Function},
+                {args, Args},
+                {class, Class},
+                {reason, Reason},
+                {stacktrace, {trace, Stacktrace}}
             }
         ),
         retry(Mod, Store, Function, Args, AttemptsRemaining)


### PR DESCRIPTION
Improves the interface for using other HyperBEAM nodes as sources of messages for `hb_store_gateway`. Additionally, this PR fixes some compatibility issues between the expected inputs and outputs in the local and remote side of `~query@1.0/graphql`.