### PR TITLE
fix: normalize commitments after `~lua@5.3a` execution

### DIFF
--- a/scripts/hyper-token.lua
+++ b/scripts/hyper-token.lua
@@ -866,18 +866,25 @@ end
 --- Index function, called by the `~process@1.0` device for scheduled messages.
 --- We route any `action' to the appropriate function based on the request path.
 function compute(base, assignment)
-    ao.event({ "compute called",
-        { balance = base.balance, ledgers = base.ledgers } })
-
-    assignment.body.action = string.lower(assignment.body.action or "")
+    local action = string.lower(assignment.body.action or "")
+    ao.event(
+        {
+            "compute called",
+            {
+                balance = base.balance,
+                ledgers = base.ledgers,
+                action = action
+            }
+        }
+    )
     
-    if assignment.body.action == "credit-notice" then
+    if action == "credit-notice" then
         return _G["credit-notice"](base, assignment)
-    elseif assignment.body.action == "transfer" then
+    elseif action == "transfer" then
         return transfer(base, assignment)
-    elseif assignment.body.action == "register" then
+    elseif action == "register" then
         return register(base, assignment)
-    elseif assignment.body.action == "register-remote" then
+    elseif action == "register-remote" then
         return _G["register-remote"](base, assignment)
     else
         -- Handle unknown `action' values.

--- a/src/dev_lua.erl
+++ b/src/dev_lua.erl
@@ -488,7 +488,7 @@ post_invocation_message_validation_test() ->
     ?event({res_id, ResID}),
     {ok, ReadMsg} = hb_cache:read(UnsignedID, Opts),
     ?assertEqual(<<"test-value-1">>, hb_ao:get(<<"test-key">>, ReadMsg, Opts)),
-    ?assert(length(hb_message:signers(ReadMsg, Opts)) == 0),
+    ?assert(length(hb_message:signers(NormRes, Opts)) == 0),
     ?assert(hb_message:verify(NormRes, all, Opts)).
 
 load_modules_by_id_test_() ->

--- a/src/dev_lua_test_ledgers.erl
+++ b/src/dev_lua_test_ledgers.erl
@@ -207,7 +207,11 @@ balances(Mode, ProcMsg, Opts) when is_atom(Mode) ->
     balances(hb_util:bin(Mode), ProcMsg, Opts);
 balances(Prefix, ProcMsg, Opts) ->
     Balances = hb_ao:get(<<Prefix/binary, "/balance">>, ProcMsg, #{}, Opts),
-    hb_private:reset(hb_cache:ensure_all_loaded(Balances, Opts)).
+    hb_private:reset(
+        hb_message:uncommitted(
+            hb_cache:ensure_all_loaded(Balances, Opts)
+        )
+    ).
 
 %% @doc Get the supply of a ledger, either `now` or `initial`.
 supply(ProcMsg, Opts) ->

--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -248,7 +248,13 @@ commit(Self, Req, Opts) ->
     % We _do not_ set the `device' key in the message, as the device will be
     % part of the commitment. Instead, we find the device module's `commit'
     % function and apply it.
-    CommitOpts = Opts#{ linkify_mode => offload },
+    CommitOpts =
+        case hb_maps:get(<<"type">>, Req, <<"signed">>) of
+            <<"unsigned">> ->
+                Opts#{ linkify_mode => discard };
+            _ ->
+                Opts#{ linkify_mode => offload }
+        end,
     AttMod = hb_ao:message_to_device(#{ <<"device">> => AttDev }, CommitOpts),
     {ok, AttFun} = hb_ao:find_exported_function(Base, AttMod, commit, 3, CommitOpts),
     % Encode to a TABM

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -380,14 +380,7 @@ write_binary(Hashpath, Bin, Store, Opts) ->
 %% @doc Read the message at a path. Returns in `structured@1.0' format: Either a
 %% richly typed map or a direct binary.
 read(Path, Opts) ->
-    case store_read(Path, hb_opts:get(store, no_viable_store, Opts), Opts) of
-        not_found -> not_found;
-        {ok, Res} ->
-            %?event({applying_types_to_read_message, Res}),
-            %Structured = dev_codec_structured:to(Res),
-            %?event({finished_read, Structured}),
-            {ok, Res}
-    end.
+    store_read(Path, hb_opts:get(store, no_viable_store, Opts), Opts).
 
 %% @doc List all of the subpaths of a given path and return a map of keys and
 %% links to the subpaths, including their types.

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -201,7 +201,7 @@ id(Msg, RawCommitters, Opts) ->
 %% unsigned ID present. By forcing this work to occur in strategically positioned
 %% places, we avoid the need to recalculate the IDs for every `hb_message:id`
 %% call.
-normalize_commitments(Msg, Opts) when is_map(Msg) ->
+normalize_commitments(Msg, Opts) ->
     normalize_commitments(Msg, Opts, passive).
 normalize_commitments(Msg, Opts, Mode) when is_map(Msg) ->
     NormMsg = 

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -233,6 +233,8 @@ do_normalize_commitments(Msg, Opts, passive) ->
             Msg#{ <<"commitments">> => Commitments };
         _ -> Msg
     end;
+do_normalize_commitments(Msg, _Opts, verify) when ?IS_EMPTY_MESSAGE(Msg) ->
+    Msg;
 do_normalize_commitments(Msg, Opts, verify) ->
     {ok, #{ <<"commitments">> := NormCommitments }} =
         dev_message:commit(

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -204,6 +204,7 @@ id(Msg, RawCommitters, Opts) ->
 normalize_commitments(Msg, Opts) ->
     normalize_commitments(Msg, Opts, passive).
 normalize_commitments(Msg, Opts, Mode) when is_map(Msg) ->
+    ?event(debug_normalize_commitments, {normalize_commitments, {msg, Msg}}),
     NormMsg = 
         maps:map(
             fun(Key, Val) when Key == <<"commitments">> orelse Key == <<"priv">> ->
@@ -214,11 +215,13 @@ normalize_commitments(Msg, Opts, Mode) when is_map(Msg) ->
         ),
     do_normalize_commitments(NormMsg, Opts, Mode);
 normalize_commitments(Msg, Opts, Mode) when is_list(Msg) ->
+    ?event(debug_normalize_commitments, {normalize_commitments, {list, Msg}}),
     lists:map(fun(X) -> normalize_commitments(X, Opts, Mode) end, Msg);
 normalize_commitments(Msg, _Opts, _Mode) ->
     Msg.
 
 do_normalize_commitments(Msg, Opts, passive) ->
+    ?event(debug_normalize_commitments, {passive, {msg, Msg}}),
     case hb_maps:get(<<"commitments">>, Msg, not_found, Opts) of
         not_found ->
             {ok, #{ <<"commitments">> := Commitments }} =

--- a/src/hb_message_test_vectors.erl
+++ b/src/hb_message_test_vectors.erl
@@ -9,8 +9,8 @@
 %% Disable/enable as needed.
 run_test() ->
     hb:init(),
-    nested_structured_fields_test(
-        #{ <<"device">> => <<"json@1.0">>, <<"bundle">> => true },
+    encode_small_balance_table_test(
+        #{ <<"device">> => <<"httpsig@1.0">> },
         test_opts(normal)
     ).
 
@@ -1365,21 +1365,23 @@ priv_survives_conversion_test(Codec, Opts) ->
 
 encode_balance_table(Size, Codec, Opts) ->
     Msg =
-        #{
-            hb_util:encode(crypto:strong_rand_bytes(32)) =>
-                rand:uniform(1_000_000_000_000_000)
-        ||
-            _ <- lists:seq(1, Size)
-        },
-    Encoded = hb_message:convert(Msg, Codec, <<"structured@1.0">>, Opts),
-    ?event({encoded, {explicit, Encoded}}),
-    Decoded =
-        hb_message:uncommitted(
-            hb_message:convert(Encoded, <<"structured@1.0">>, Codec, Opts),
-            Opts
+        hb_message:commit(
+            #{
+                hb_util:encode(crypto:strong_rand_bytes(32)) =>
+                    rand:uniform(1_000_000_000_000_000)
+            ||
+                _ <- lists:seq(1, Size)
+            },
+            Opts,
+            Codec
         ),
-    ?event({decoded, {explicit, Decoded}}),
-    ?assert(hb_message:match(Msg, Decoded, if_present, Opts)).
+    Encoded = hb_message:convert(Msg, Codec, <<"structured@1.0">>, Opts),
+    ?event({encoded, Encoded}),
+    Decoded = hb_message:convert(Encoded, <<"structured@1.0">>, Codec, Opts),
+    ?event({decoded, Decoded}),
+    {ok, OnlyCommitted} = hb_message:with_only_committed(Decoded, Opts),
+    ?event({only_committed, OnlyCommitted}),
+    ?assert(hb_message:match(Msg, OnlyCommitted, if_present, Opts)).
 
 encode_small_balance_table_test(Codec, Opts) ->
     encode_balance_table(5, Codec, Opts).

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -35,8 +35,8 @@
 -endif.
 
 -define(DEFAULT_PRIMARY_STORE, #{
-    <<"name">> => <<"cache-mainnet/fs">>,
-    <<"store-module">> => hb_store_fs
+    <<"name">> => <<"cache-mainnet/lmdb">>,
+    <<"store-module">> => hb_store_lmdb
 }).
 -define(ENV_KEYS,
     #{

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -35,8 +35,8 @@
 -endif.
 
 -define(DEFAULT_PRIMARY_STORE, #{
-    <<"name">> => <<"cache-mainnet/lmdb">>,
-    <<"store-module">> => hb_store_lmdb
+    <<"name">> => <<"cache-mainnet/fs">>,
+    <<"store-module">> => hb_store_fs
 }).
 -define(ENV_KEYS,
     #{
@@ -222,10 +222,10 @@ default_message() ->
         debug_trace_type => ?DEFAULT_TRACE_TYPE,
         short_trace_len => 20,
         debug_metadata => true,
-        debug_ids => true,
+        debug_ids => false,
         debug_committers => true,
         debug_show_priv => if_present,
-        debug_resolve_links => true,
+        debug_resolve_links => false,
         debug_print_fail_mode => long,
 		trusted => #{},
         snp_enforced_keys => [

--- a/test/test.lua
+++ b/test/test.lua
@@ -13,6 +13,11 @@ function assoctable()
     }
 end
 
+function mutate_test_key(state)
+    state["test-key"] = "test-value-2"
+    return state
+end
+
 function error_response()
     return "error", "Very bad, but Lua caught it."
 end


### PR DESCRIPTION
This PR updates the `~lua@5.3a` execution flow to ensure that the resulting message contains a normalized set of commitments. Previously, in flows where the result of an execution is a message relating to the `base` input, changing values from inside Lua could lead to unverifiable outputs.