### PR TITLE
impr: bump LMDB by adopting lmdb-master-sys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,11 @@ ifeq ($(UNAME_S),Darwin)
     endif
 else
     WAMR_BUILD_PLATFORM = linux
-    WAMR_BUILD_TARGET = X86_64
+    ifeq ($(UNAME_M),aarch64)
+        WAMR_BUILD_TARGET = AARCH64
+    else
+        WAMR_BUILD_TARGET = X86_64
+    endif
 endif
 
 wamr: $(WAMR_DIR)/lib/libvmlib.a

--- a/README.md
+++ b/README.md
@@ -43,12 +43,15 @@ payments information, amongst other configuration options.
 
 To begin using HyperBeam, you will need to install:
 
-- The Erlang runtime (OTP 27)
+- Erlang runtime and compiler (OTP 27)
 - Rebar3
 - Git
+- NodeJs (for the Compute Unit on genesis_wasm profile)
 - Docker (optional, for containerized deployment)
 
 You will also need:
+- Cmake (recommended version is 3.31)
+- Rust (latest)
 - A wallet and it's keyfile *(generate a new wallet and keyfile with https://www.wander.app)*
 
 Then you can clone the HyperBEAM source and build it:

--- a/rebar.config
+++ b/rebar.config
@@ -117,7 +117,7 @@
 ]}.
 
 {deps, [
-    {elmdb, { git, "https://github.com/twilson63/elmdb-rs.git", {branch, "feat/match" }}},
+    {elmdb, { git, "https://github.com/twilson63/elmdb-rs.git", {branch, "main" }}},
 	{b64fast, {git, "https://github.com/ArweaveTeam/b64fast.git", {ref, "58f0502e49bf73b29d95c6d02460d1fb8d2a5273"}}},
     {cowlib, "2.16.0"},
 	{cowboy, "2.14.0"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -9,7 +9,7 @@
  {<<"ddskerl">>,{pkg,<<"ddskerl">>,<<"0.4.2">>},1},
  {<<"elmdb">>,
   {git,"https://github.com/twilson63/elmdb-rs.git",
-       {ref,"90c8857cd4ccff341fbe415b96bc5703d17ff7f0"}},
+       {ref, "5255868638e91b4dff24163467765d780f8a6f4a"}},
   0},
  {<<"graphql">>,{pkg,<<"graphql_erl">>,<<"0.17.1">>},0},
  {<<"gun">>,{pkg,<<"gun">>,<<"2.2.0">>},0},

--- a/src/hb_app.erl
+++ b/src/hb_app.erl
@@ -7,7 +7,7 @@
 
 -behaviour(application).
 
--export([start/2, stop/1]).
+-export([start/2, prep_stop/1, stop/1]).
 
 -include("include/hb.hrl").
 
@@ -18,5 +18,24 @@ start(_StartType, _StartArgs) ->
     _TimestampServer = ar_timestamp:start(),
     {ok, _} = hb_http_server:start().
 
+prep_stop(State) ->
+    maybe
+        {ok, Opts} ?= find_lmdb_store(),
+        hb_store_lmdb:flush(Opts) 
+    end,
+    State.
+
 stop(_State) ->
+    maybe
+        {ok, Opts} ?= find_lmdb_store(),
+        hb_store_lmdb:stop(Opts) 
+    end,
     ok.
+
+find_lmdb_store() ->
+    Stores = maps:get(store, hb_opts:default_message()),
+    Pred = fun(S) -> maps:get(<<"store-module">>, S) == hb_store_lmdb end,
+    case lists:search(Pred, Stores) of
+        {value, Opts} -> {ok, Opts};
+        false -> not_found
+    end.

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -30,7 +30,7 @@
 -include("include/hb.hrl").
 
 %% Configuration constants with reasonable defaults
--define(MAX_SIZE, 512 * 1024 * 1024 * 1024). % 16GB default database size
+-define(DEFAULT_SIZE, 16 * 1024 * 1024 * 1024). % 16GB default database size
 -define(CONNECT_TIMEOUT, 6000).                 % Timeout for server communication
 -define(DEFAULT_IDLE_FLUSH_TIME, 5).            % Idle server time before auto-flush
 -define(DEFAULT_MAX_FLUSH_TIME, 50).            % Maximum time between flushes
@@ -65,7 +65,7 @@ start(Opts = #{ <<"name">> := DataDir }) ->
         elmdb:env_open(
             DataDirPath,
             [
-                {map_size, maps:get(<<"capacity">>, Opts, ?MAX_SIZE)},
+                {map_size, maps:get(<<"capacity">>, Opts, ?DEFAULT_SIZE)},
                 no_mem_init, NoSyncParam
             ]
         ),
@@ -723,7 +723,7 @@ group_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/store3">>,
-        <<"capacity">> => ?MAX_SIZE
+        <<"capacity">> => ?DEFAULT_SIZE
     },
     reset(StoreOpts),
     make_group(StoreOpts, <<"colors">>),
@@ -741,7 +741,7 @@ link_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/store3">>,
-        <<"capacity">> => ?MAX_SIZE
+        <<"capacity">> => ?DEFAULT_SIZE
     },
     reset(StoreOpts),
     write(StoreOpts, <<"foo/bar/baz">>, <<"Bam">>),
@@ -754,7 +754,7 @@ link_fragment_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/store3">>,
-        <<"capacity">> => ?MAX_SIZE
+        <<"capacity">> => ?DEFAULT_SIZE
     },
     reset(StoreOpts),
     write(StoreOpts, [<<"data">>, <<"bar">>, <<"baz">>], <<"Bam">>),
@@ -772,7 +772,7 @@ type_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/store-6">>,
-        <<"capacity">> => ?MAX_SIZE
+        <<"capacity">> => ?DEFAULT_SIZE
     },
     reset(StoreOpts),
     make_group(StoreOpts, <<"assets">>),
@@ -804,7 +804,7 @@ link_key_list_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/store-7">>,
-        <<"capacity">> => ?MAX_SIZE
+        <<"capacity">> => ?DEFAULT_SIZE
     },
     reset(StoreOpts),
     write(StoreOpts, [ <<"parent">>, <<"key">> ], <<"value">>),
@@ -827,7 +827,7 @@ path_traversal_link_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/store-8">>,
-        <<"capacity">> => ?MAX_SIZE
+        <<"capacity">> => ?DEFAULT_SIZE
     },
     reset(StoreOpts),
     % Create the actual data at group/key
@@ -845,7 +845,7 @@ exact_hb_store_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/store-exact">>,
-        <<"capacity">> => ?MAX_SIZE
+        <<"capacity">> => ?DEFAULT_SIZE
     },
     % Follow exact same pattern as hb_store test
     ?event(step1_make_group),
@@ -877,7 +877,7 @@ cache_style_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/store-cache-style">>,
-        <<"capacity">> => ?MAX_SIZE
+        <<"capacity">> => ?DEFAULT_SIZE
     },
     reset(StoreOpts),
     % Start the store
@@ -900,7 +900,7 @@ nested_map_cache_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/store-nested-cache">>,
-        <<"capacity">> => ?MAX_SIZE
+        <<"capacity">> => ?DEFAULT_SIZE
     },
     % Clean up any previous test data
     reset(StoreOpts),

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -30,7 +30,7 @@
 -include("include/hb.hrl").
 
 %% Configuration constants with reasonable defaults
--define(DEFAULT_SIZE, 16 * 1024 * 1024 * 1024). % 16GB default database size
+-define(MAX_SIZE, 512 * 1024 * 1024 * 1024). % 16GB default database size
 -define(CONNECT_TIMEOUT, 6000).                 % Timeout for server communication
 -define(DEFAULT_IDLE_FLUSH_TIME, 5).            % Idle server time before auto-flush
 -define(DEFAULT_MAX_FLUSH_TIME, 50).            % Maximum time between flushes
@@ -60,7 +60,7 @@ start(Opts = #{ <<"name">> := DataDir }) ->
         elmdb:env_open(
             DataDirPath,
             [
-                {map_size, maps:get(<<"capacity">>, Opts, ?DEFAULT_SIZE)},
+                {map_size, maps:get(<<"capacity">>, Opts, ?MAX_SIZE)},
                 no_mem_init, no_sync
             ]
         ),
@@ -658,7 +658,7 @@ list_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/store-2">>,
-        <<"capacity">> => ?DEFAULT_SIZE
+        <<"capacity">> => ?MAX_SIZE
     },
     reset(StoreOpts),
     ?assertEqual(list(StoreOpts, <<"colors">>), {ok, []}),
@@ -703,7 +703,7 @@ group_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/store3">>,
-        <<"capacity">> => ?DEFAULT_SIZE
+        <<"capacity">> => ?MAX_SIZE
     },
     reset(StoreOpts),
     make_group(StoreOpts, <<"colors">>),
@@ -721,7 +721,7 @@ link_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/store3">>,
-        <<"capacity">> => ?DEFAULT_SIZE
+        <<"capacity">> => ?MAX_SIZE
     },
     reset(StoreOpts),
     write(StoreOpts, <<"foo/bar/baz">>, <<"Bam">>),
@@ -734,7 +734,7 @@ link_fragment_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/store3">>,
-        <<"capacity">> => ?DEFAULT_SIZE
+        <<"capacity">> => ?MAX_SIZE
     },
     reset(StoreOpts),
     write(StoreOpts, [<<"data">>, <<"bar">>, <<"baz">>], <<"Bam">>),
@@ -752,7 +752,7 @@ type_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/store-6">>,
-        <<"capacity">> => ?DEFAULT_SIZE
+        <<"capacity">> => ?MAX_SIZE
     },
     reset(StoreOpts),
     make_group(StoreOpts, <<"assets">>),
@@ -763,6 +763,7 @@ type_test() ->
     Type2 = type(StoreOpts, <<"assets/1">>),
     ?event({type2, Type2}),
     ?assertEqual(simple, Type2).
+    
 
 %% @doc Link key list test - verifies symbolic link creation using structured key paths.
 %%
@@ -783,7 +784,7 @@ link_key_list_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/store-7">>,
-        <<"capacity">> => ?DEFAULT_SIZE
+        <<"capacity">> => ?MAX_SIZE
     },
     reset(StoreOpts),
     write(StoreOpts, [ <<"parent">>, <<"key">> ], <<"value">>),
@@ -806,7 +807,7 @@ path_traversal_link_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/store-8">>,
-        <<"capacity">> => ?DEFAULT_SIZE
+        <<"capacity">> => ?MAX_SIZE
     },
     reset(StoreOpts),
     % Create the actual data at group/key
@@ -824,7 +825,7 @@ exact_hb_store_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/store-exact">>,
-        <<"capacity">> => ?DEFAULT_SIZE
+        <<"capacity">> => ?MAX_SIZE
     },
     % Follow exact same pattern as hb_store test
     ?event(step1_make_group),
@@ -856,7 +857,7 @@ cache_style_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/store-cache-style">>,
-        <<"capacity">> => ?DEFAULT_SIZE
+        <<"capacity">> => ?MAX_SIZE
     },
     reset(StoreOpts),
     % Start the store
@@ -879,7 +880,7 @@ nested_map_cache_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/store-nested-cache">>,
-        <<"capacity">> => ?DEFAULT_SIZE
+        <<"capacity">> => ?MAX_SIZE
     },
     % Clean up any previous test data
     reset(StoreOpts),
@@ -986,7 +987,7 @@ cache_debug_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/cache-debug">>,
-        <<"capacity">> => ?DEFAULT_SIZE
+        <<"capacity">> => ?MAX_SIZE
     },
     reset(StoreOpts),
     % Simulate what the cache does:
@@ -1024,7 +1025,7 @@ isolated_type_debug_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/isolated-debug">>,
-        <<"capacity">> => ?DEFAULT_SIZE
+        <<"capacity">> => ?MAX_SIZE
     },
     reset(StoreOpts),
     % Create the exact scenario from user's description:
@@ -1064,7 +1065,7 @@ list_with_link_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
         <<"name">> => <<"/tmp/store-list-link">>,
-        <<"capacity">> => ?DEFAULT_SIZE
+        <<"capacity">> => ?MAX_SIZE
     },
     reset(StoreOpts),
     % Create a group with some children

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -21,7 +21,7 @@
 
 %% Public API exports
 -export([start/1, stop/1, scope/0, scope/1, reset/1]).
--export([read/2, write/3, list/2, match/2]).
+-export([read/2, write/3, flush/1, list/2, match/2]).
 -export([make_group/2, make_link/3, type/2]).
 -export([path/2, add_path/3, resolve/2]).
 
@@ -55,13 +55,18 @@ start(Opts = #{ <<"name">> := DataDir }) ->
     % Ensure the directory exists before opening LMDB environment
     DataDirPath = hb_util:list(DataDir),
     ok = filelib:ensure_dir(filename:join(DataDirPath, "dummy")),
+    NoSyncParam =
+        case maps:get(<<"no-sync">>, Opts, true) of
+            true -> [no_sync];
+            false -> []
+        end,
     % Create the LMDB environment with specified size limit
     {ok, Env} =
         elmdb:env_open(
             DataDirPath,
             [
                 {map_size, maps:get(<<"capacity">>, Opts, ?MAX_SIZE)},
-                no_mem_init, no_sync
+                no_mem_init, NoSyncParam
             ]
         ),
     {ok, DBInstance} = elmdb:db_open(Env, [create]),
@@ -139,6 +144,22 @@ write(Opts, Path, Value) ->
                 }
             ),
             retry
+    end.
+
+-spec flush(map()) -> ok | {error, flush_failed}.
+flush(Opts) ->
+    #{ <<"env">> := DBEnv } = find_env(Opts),
+    case elmdb:env_sync(DBEnv) of
+        ok -> ok;
+        {error, Type, Description} ->
+            ?event(
+                error,
+                {lmdb_error,
+                    {type, Type},
+                    {description, Description}
+                }
+            ),
+            {error, flush_failed}
     end.
 
 %% @doc Read a value from the database by key, with automatic link resolution.
@@ -657,8 +678,7 @@ basic_test() ->
 list_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
-        <<"name">> => <<"/tmp/store-2">>,
-        <<"capacity">> => ?MAX_SIZE
+        <<"name">> => <<"/tmp/store-2">>
     },
     reset(StoreOpts),
     ?assertEqual(list(StoreOpts, <<"colors">>), {ok, []}),
@@ -986,8 +1006,7 @@ reconstruct_map(StoreOpts, Path) ->
 cache_debug_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
-        <<"name">> => <<"/tmp/cache-debug">>,
-        <<"capacity">> => ?MAX_SIZE
+        <<"name">> => <<"/tmp/cache-debug">>
     },
     reset(StoreOpts),
     % Simulate what the cache does:
@@ -1024,8 +1043,7 @@ cache_debug_test() ->
 isolated_type_debug_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
-        <<"name">> => <<"/tmp/isolated-debug">>,
-        <<"capacity">> => ?MAX_SIZE
+        <<"name">> => <<"/tmp/isolated-debug">>
     },
     reset(StoreOpts),
     % Create the exact scenario from user's description:
@@ -1064,8 +1082,7 @@ isolated_type_debug_test() ->
 list_with_link_test() ->
     StoreOpts = #{
         <<"store-module">> => ?MODULE,
-        <<"name">> => <<"/tmp/store-list-link">>,
-        <<"capacity">> => ?MAX_SIZE
+        <<"name">> => <<"/tmp/store-list-link">>
     },
     reset(StoreOpts),
     % Create a group with some children
@@ -1084,4 +1101,18 @@ list_with_link_test() ->
     {ok, LinkChildren} = list(StoreOpts, <<"link-to-group">>),
     ?event({link_children, LinkChildren}),
     ?assertEqual(ExpectedChildren, lists:sort(LinkChildren)),
+    stop(StoreOpts).
+
+%% @doc Test that list function resolves links correctly
+flush_test() ->
+    StoreOpts = #{
+        <<"store-module">> => ?MODULE,
+        <<"name">> => <<"/tmp/flush">>
+    },
+    reset(StoreOpts),
+    write(StoreOpts, <<"key1">>, <<"value1">>),
+    write(StoreOpts, <<"key2">>, <<"value2">>),
+    write(StoreOpts, <<"key3">>, <<"value3">>),
+    ?assertEqual(ok, flush(StoreOpts)),
+    ?assertEqual({ok, <<"value1">>}, read(StoreOpts, <<"key1">>)),
     stop(StoreOpts).

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -55,18 +55,13 @@ start(Opts = #{ <<"name">> := DataDir }) ->
     % Ensure the directory exists before opening LMDB environment
     DataDirPath = hb_util:list(DataDir),
     ok = filelib:ensure_dir(filename:join(DataDirPath, "dummy")),
-    NoSyncParam =
-        case maps:get(<<"no-sync">>, Opts, true) of
-            true -> [no_sync];
-            false -> []
-        end,
     % Create the LMDB environment with specified size limit
     {ok, Env} =
         elmdb:env_open(
             DataDirPath,
             [
                 {map_size, maps:get(<<"capacity">>, Opts, ?DEFAULT_SIZE)},
-                no_mem_init, NoSyncParam
+                no_mem_init, no_sync
             ]
         ),
     {ok, DBInstance} = elmdb:db_open(Env, [create]),


### PR DESCRIPTION
The `elmdb-rs` will now depend on *`lmdb-master-rs`,* a fork of `lmdb-rs` that uses  `lmdb-master-sys`.

It has the FOR-141 merged on it to avoid loosing data of huge hydrations after restarting HB frequently.