### PR TITLE
fix: HTTP client

### DIFF
--- a/src/hb_http_client.erl
+++ b/src/hb_http_client.erl
@@ -35,11 +35,13 @@ httpc_req(Args, _, Opts) ->
         body := Body
     } = Args,
     ?event({httpc_req, Args}),
-    {Host, Port} = parse_peer(Peer, Opts),
-    Scheme = case Port of
-        443 -> "https";
-        _ -> "http"
+    ParsedPeer = uri_string:parse(iolist_to_binary(Peer)),
+    #{ scheme := Scheme, host := Host } = ParsedPeer,
+    DefaultPort = case Scheme of
+        <<"https">> -> 443;
+        <<"http">> -> 80
     end,
+    Port = maps:get(port, ParsedPeer, DefaultPort),
     ?event(http_client, {httpc_req, {explicit, Args}}),
     URL = binary_to_list(iolist_to_binary([Scheme, "://", Host, ":", integer_to_binary(Port), Path])),
     FilteredHeaders = hb_maps:without([<<"content-type">>, <<"cookie">>], Headers, Opts),
@@ -522,7 +524,7 @@ open_connection(#{ peer := Peer }, Opts) ->
     DefaultPort = case Scheme of
         <<"https">> -> 443;
         <<"http">> -> 80
-      end,
+    end,
     Port = maps:get(port, ParsedPeer, DefaultPort),
     ?event(http_outbound, {parsed_peer, {peer, Peer}, {host, Host}, {port, Port}}),
     BaseGunOpts =
@@ -569,21 +571,6 @@ open_connection(#{ peer := Peer }, Opts) ->
         }
     ),
     gun:open(hb_util:list(Host), Port, GunOpts).
-
-parse_peer(Peer, Opts) ->
-    Parsed = uri_string:parse(Peer),
-    case Parsed of
-        #{ host := Host, port := Port } ->
-            {hb_util:list(Host), Port};
-        URI = #{ host := Host } ->
-            {
-                hb_util:list(Host),
-                case hb_maps:get(scheme, URI, undefined, Opts) of
-                    <<"https">> -> 443;
-                    _ -> hb_opts:get(port, 8734, Opts)
-                end
-            }
-    end.
 
 reply_error([], _Reason) ->
 	ok;

--- a/src/hb_http_client.erl
+++ b/src/hb_http_client.erl
@@ -80,9 +80,11 @@ httpc_req(Args, _, Opts) ->
                 }
         end,
     ?event({http_client_outbound, Method, URL, Request}),
+    FollowRedirects = hb_maps:get(http_follow_redirects, Opts, true),
+    ReqOpts = [{autoredirect, FollowRedirects}],
     HTTPCOpts = [{full_result, true}, {body_format, binary}],
 	StartTime = os:system_time(millisecond),
-    case httpc:request(Method, Request, [], HTTPCOpts) of
+    case httpc:request(Method, Request, ReqOpts, HTTPCOpts) of
         {ok, {{_, Status, _}, RawRespHeaders, RespBody}} ->
 	        EndTime = os:system_time(millisecond),
             RespHeaders =
@@ -122,8 +124,9 @@ gun_req(Args, ReestablishedConnection, Opts) ->
                                 req(Args, true, Opts)
                         end;
                     Reply ->
+                        FollowRedirects = hb_maps:get(http_follow_redirects, Opts, true),
                         case Reply of
-                            {_Ok, 301, RedirectRes, _} ->
+                            {_Ok, 301, RedirectRes, _} when FollowRedirects ->
                                 handle_redirect(
                                   Args,
                                   ReestablishedConnection,

--- a/src/hb_http_client.erl
+++ b/src/hb_http_client.erl
@@ -126,20 +126,19 @@ gun_req(Args, ReestablishedConnection, Opts) ->
                             false ->
                                 req(Args, true, Opts)
                         end;
-                    Reply ->
+                    Reply = {_Ok, StatusCode, RedirectRes, _} ->
                         FollowRedirects = hb_maps:get(http_follow_redirects, Opts, true),
-                        case Reply of
-                            {_Ok, 301, RedirectRes, _} when FollowRedirects, RedirectsLeft > 0 ->
-                                RedirectArgs = Args#{ redirects_left := RedirectsLeft - 1 },
-                                handle_redirect(
-                                  RedirectArgs,
-                                  ReestablishedConnection,
-                                  Opts,
-                                  RedirectRes,
-                                  Reply
-                                );
-                            _ ->
-                                Reply
+                        case lists:member(StatusCode, [301, 302, 307, 308]) of
+                            true when FollowRedirects, RedirectsLeft > 0 ->
+                            RedirectArgs = Args#{ redirects_left := RedirectsLeft - 1 },
+                            handle_redirect(
+                              RedirectArgs,
+                              ReestablishedConnection,
+                              Opts,
+                              RedirectRes,
+                              Reply
+                            );
+                            _ -> Reply
                         end
                   end;
             {'EXIT', _} ->

--- a/src/hb_http_client.erl
+++ b/src/hb_http_client.erl
@@ -470,7 +470,7 @@ terminate(Reason, #state{ status_by_pid = StatusByPID }) ->
 handle_redirect(Args, ReestablishedConnection, Opts, Res, Reply) ->
     case lists:keyfind(<<"location">>, 1, Res) of
         false ->
-            % Server returned a 301 but no Location header, so we can't follow the redirect.
+            % There's no Location header, so we can't follow the redirect.
             Reply;
         {_LocationHeaderName, Location} ->
             case uri_string:parse(Location) of
@@ -479,10 +479,15 @@ handle_redirect(Args, ReestablishedConnection, Opts, Res, Reply) ->
                     Reply;
                  Parsed ->
                     #{ scheme := NewScheme, host := NewHost, path := NewPath } = Parsed,
+                    Port = maps:get(port, Parsed, undefined),
+                    FormattedPort = case Port of
+                        undefined -> "";
+                        _ -> lists:flatten(io_lib:format(":~i", [Port]))
+                    end,
                     NewPeer = lists:flatten(
                         io_lib:format(
-                            "~s://~s~s",
-                            [NewScheme, NewHost, NewPath]
+                            "~s://~s~s~s",
+                            [NewScheme, NewHost, FormattedPort, NewPath]
                         )
                     ),
                     NewArgs = Args#{

--- a/src/hb_http_client.erl
+++ b/src/hb_http_client.erl
@@ -22,7 +22,10 @@ start_link(Opts) ->
 req(Args, Opts) -> req(Args, false, Opts).
 req(Args, ReestablishedConnection, Opts) ->
     case hb_opts:get(http_client, gun, Opts) of
-        gun -> gun_req(Args, ReestablishedConnection, Opts);
+        gun ->
+            MaxRedirects = hb_maps:get(gun_max_redirects, Opts, 5),
+            GunArgs = Args#{redirects_left => MaxRedirects},
+            gun_req(GunArgs, ReestablishedConnection, Opts);
         httpc -> httpc_req(Args, ReestablishedConnection, Opts)
     end.
 
@@ -110,7 +113,7 @@ httpc_req(Args, _, Opts) ->
 
 gun_req(Args, ReestablishedConnection, Opts) ->
     StartTime = os:system_time(millisecond),
-    #{ peer := Peer, path := Path, method := Method } = Args,
+    #{ peer := Peer, path := Path, method := Method, redirects_left := RedirectsLeft } = Args,
     Response =
         case catch gen_server:call(?MODULE, {get_connection, Args, Opts}, infinity) of
             {ok, PID} ->
@@ -126,9 +129,10 @@ gun_req(Args, ReestablishedConnection, Opts) ->
                     Reply ->
                         FollowRedirects = hb_maps:get(http_follow_redirects, Opts, true),
                         case Reply of
-                            {_Ok, 301, RedirectRes, _} when FollowRedirects ->
+                            {_Ok, 301, RedirectRes, _} when FollowRedirects, RedirectsLeft > 0 ->
+                                RedirectArgs = Args#{ redirects_left := RedirectsLeft - 1 },
                                 handle_redirect(
-                                  Args,
+                                  RedirectArgs,
                                   ReestablishedConnection,
                                   Opts,
                                   RedirectRes,

--- a/src/hb_http_client.erl
+++ b/src/hb_http_client.erl
@@ -105,15 +105,14 @@ httpc_req(Args, _, Opts) ->
     end.
 
 gun_req(Args, ReestablishedConnection, Opts) ->
-	StartTime = os:system_time(millisecond),
-	#{ peer := Peer, path := Path, method := Method } = Args,
-	Response =
+    StartTime = os:system_time(millisecond),
+    #{ peer := Peer, path := Path, method := Method } = Args,
+    Response =
         case catch gen_server:call(?MODULE, {get_connection, Args, Opts}, infinity) of
             {ok, PID} ->
                 ar_rate_limiter:throttle(Peer, Path, Opts),
                 case request(PID, Args, Opts) of
-                    {error, Error} when Error == {shutdown, normal};
-                            Error == noproc ->
+                    {error, Error} when Error == {shutdown, normal}; Error == noproc ->
                         case ReestablishedConnection of
                             true ->
                                 {error, client_error};
@@ -121,30 +120,41 @@ gun_req(Args, ReestablishedConnection, Opts) ->
                                 req(Args, true, Opts)
                         end;
                     Reply ->
-                        Reply
-                end;
+                        case Reply of
+                            {_Ok, 301, RedirectRes, _} ->
+                                handle_redirect(
+                                  Args,
+                                  ReestablishedConnection,
+                                  Opts,
+                                  RedirectRes,
+                                  Reply
+                                );
+                            _ ->
+                                Reply
+                        end
+                  end;
             {'EXIT', _} ->
                 {error, client_error};
             Error ->
                 Error
-	    end,
-	EndTime = os:system_time(millisecond),
-	%% Only log the metric for the top-level call to req/2 - not the recursive call
-	%% that happens when the connection is reestablished.
-	case ReestablishedConnection of
-		true ->
-			ok;
-		false ->
-            record_duration(#{
-                    <<"request-method">> => method_to_bin(Method),
-                    <<"request-path">> => hb_util:bin(Path),
-                    <<"status-class">> => get_status_class(Response),
-                    <<"duration">> => EndTime - StartTime
-                },
-                Opts
-            )
-	end,
-	Response.
+        end,
+    EndTime = os:system_time(millisecond),
+    %% Only log the metric for the top-level call to req/2 - not the recursive call
+    %% that happens when the connection is reestablished.
+    case ReestablishedConnection of
+      true ->
+          ok;
+      false ->
+          record_duration(#{
+              <<"request-method">> => method_to_bin(Method),
+              <<"request-path">> => hb_util:bin(Path),
+              <<"status-class">> => get_status_class(Response),
+              <<"duration">> => EndTime - StartTime
+              },
+              Opts
+          )
+    end,
+    Response.
 
 %% @doc Record the duration of the request in an async process. We write the 
 %% data to prometheus if the application is enabled, as well as invoking the
@@ -455,6 +465,32 @@ terminate(Reason, #state{ status_by_pid = StatusByPID }) ->
 %%% Private functions.
 %%% ==================================================================
 
+handle_redirect(Args, ReestablishedConnection, Opts, Res, Reply) ->
+    case lists:keyfind(<<"location">>, 1, Res) of
+        false ->
+            % Server returned a 301 but no Location header, so we can't follow the redirect.
+            Reply;
+        {_LocationHeaderName, Location} ->
+            case uri_string:parse(Location) of
+                {error, _Reason, _Detail} ->
+                    % Server returned a Location header but the URI was malformed.
+                    Reply;
+                 Parsed ->
+                    #{ scheme := NewScheme, host := NewHost, path := NewPath } = Parsed,
+                    NewPeer = lists:flatten(
+                        io_lib:format(
+                            "~s://~s~s",
+                            [NewScheme, NewHost, NewPath]
+                        )
+                    ),
+                    NewArgs = Args#{
+                        peer := NewPeer,
+                        path := NewPath
+                    },
+                    gun_req(NewArgs, ReestablishedConnection, Opts)
+            end
+    end.
+
 %% @doc Safe wrapper for prometheus_gauge:inc/2.
 inc_prometheus_gauge(Name) ->
     case application:get_application(prometheus) of
@@ -481,7 +517,13 @@ inc_prometheus_counter(Name, Labels, Value) ->
     end.
 
 open_connection(#{ peer := Peer }, Opts) ->
-    {Host, Port} = parse_peer(Peer, Opts),
+    ParsedPeer = uri_string:parse(iolist_to_binary(Peer)),
+    #{ scheme := Scheme, host := Host } = ParsedPeer,
+    DefaultPort = case Scheme of
+        <<"https">> -> 443;
+        <<"http">> -> 80
+      end,
+    Port = maps:get(port, ParsedPeer, DefaultPort),
     ?event(http_outbound, {parsed_peer, {peer, Peer}, {host, Host}, {port, Port}}),
     BaseGunOpts =
         #{
@@ -526,7 +568,7 @@ open_connection(#{ peer := Peer }, Opts) ->
             {transport, Transport}
         }
     ),
-	gun:open(Host, Port, GunOpts).
+    gun:open(hb_util:list(Host), Port, GunOpts).
 
 parse_peer(Peer, Opts) ->
     Parsed = uri_string:parse(Peer),

--- a/src/hb_http_client.erl
+++ b/src/hb_http_client.erl
@@ -552,8 +552,8 @@ open_connection(#{ peer := Peer }, Opts) ->
                 )
         },
     Transport =
-        case Port of
-            443 -> tls;
+        case Scheme of
+            <<"https">> -> tls;
             _ -> tcp
         end,
     DefaultProto =
@@ -565,7 +565,7 @@ open_connection(#{ peer := Peer }, Opts) ->
     GunOpts =
         case Proto = hb_opts:get(protocol, DefaultProto, Opts) of
             http3 -> BaseGunOpts#{protocols => [http3], transport => quic};
-            _ -> BaseGunOpts
+            _ -> BaseGunOpts#{transport => Transport}
         end,
     ?event(http_outbound,
         {gun_open,

--- a/src/hb_http_client.erl
+++ b/src/hb_http_client.erl
@@ -554,7 +554,7 @@ open_connection(#{ peer := Peer }, Opts) ->
     Transport =
         case Scheme of
             <<"https">> -> tls;
-            _ -> tcp
+            <<"http">> -> tcp
         end,
     DefaultProto =
         case hb_features:http3() of

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -107,6 +107,8 @@ default_message() ->
         %% What HTTP client should the node use?
         %% Options: gun, httpc
         http_client => gun,
+        %% Should the HTTP client automatically follow 3xx redirects?
+        http_follow_redirects => true,
         %% Scheduling mode: Determines when the SU should inform the recipient
         %% that an assignment has been scheduled for a message.
         %% Options: aggressive(!), local_confirmation, remote_confirmation,

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -109,6 +109,9 @@ default_message() ->
         http_client => gun,
         %% Should the HTTP client automatically follow 3xx redirects?
         http_follow_redirects => true,
+        %% For the gun HTTP client, to mitigate resource exhaustion attacks, what's
+        %% the maximum number of automatic 3xx redirects we'll allow?
+        gun_max_redirects => 5,
         %% Scheduling mode: Determines when the SU should inform the recipient
         %% that an assignment has been scheduled for a message.
         %% Options: aggressive(!), local_confirmation, remote_confirmation,

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -110,7 +110,8 @@ default_message() ->
         %% Should the HTTP client automatically follow 3xx redirects?
         http_follow_redirects => true,
         %% For the gun HTTP client, to mitigate resource exhaustion attacks, what's
-        %% the maximum number of automatic 3xx redirects we'll allow?
+        %% the maximum number of automatic 3xx redirects we'll allow when
+        %% http_follow_redirects = true?
         gun_max_redirects => 5,
         %% Scheduling mode: Determines when the SU should inform the recipient
         %% that an assignment has been scheduled for a message.


### PR DESCRIPTION
This PR introduces a number of changes which fix HTTP client bugs, implement correct SSL/TLS semantics, and make our two underlying HTTP client libraries -- `gun` and `httpc` -- match one another's behavior.

Changes:

- `gun` now automatically follows 3xx redirects, matching `httpc` behavior
- new `http_follow_redirects` option toggles autoredirect behavior, works for both `gun` and `httpc`
- new `gun_max_redirects` option mitigates redirect attacks on our bespoke `gun` redirect follower (`httpc` handles redirects out of the box and does not expose a twiddleable param)
- deriving transport (TLS over TCP vs. plaintext TCP) from port and scheme is fixed
- URLs without explicit ports now work the way you expect
- TLS over arbitrary ports now works

Now, you should be able to do something like this:

`hb_http_client:req(#{path => "/", method => <<"GET">>, peer => "http://nytimes.com", headers => #{}, body => <<>>}, #{http_client => gun}).`

And it should just work.  That request actually follows 2 redirects -- first, to the TLS encrypted `https://` URL, and then to the `www` subdomain.  So just for fun, if you twiddle the `gun_max_redirects` option, you can observe the client only follow the first redirect and return the 301:

`hb_http_client:req(#{path => "/", method => <<"GET">>, peer => "http://nytimes.com", headers => #{}, body => <<>>}, #{http_client => gun, gun_max_redirects => 1}).`