### PR TITLE
[WIP] Feat/import genesis checkpoints

### DIFF
--- a/src/dev_cron.erl
+++ b/src/dev_cron.erl
@@ -1,13 +1,13 @@
 %%% @doc A device that inserts new messages into the schedule to allow processes
 %%% to passively 'call' themselves without user interaction.
 -module(dev_cron).
--export([once/3, every/3, stop/3, info/1, info/3]).
+-export([once/3, every/3, stop/3, list/3, info/1, info/3]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 %% @doc Exported function for getting device info.
 info(_) -> 
-	#{ exports => [info, once, every, stop] }.
+	#{ exports => [info, once, every, stop, list] }.
 
 info(_Msg1, _Msg2, _Opts) ->
 	InfoBody = #{
@@ -17,7 +17,8 @@ info(_Msg1, _Msg2, _Opts) ->
 			<<"info">> => <<"Get device info">>,
 			<<"once">> => <<"Schedule a one-time message">>,
 			<<"every">> => <<"Schedule a recurring message">>,
-			<<"stop">> => <<"Stop a scheduled task {task}">>
+			<<"stop">> => <<"Stop a scheduled task {task}">>,
+			<<"list">> => <<"List all active cron tasks">>
 		}
 	},
 	{ok, #{<<"status">> => 200, <<"body">> => InfoBody}}.
@@ -36,26 +37,33 @@ once(_Msg1, Msg2, Opts) ->
                     maps:put(<<"path">>, CronPath, Msg2)
                 ),
 			Name = {<<"cron@1.0">>, ReqMsgID},
-			Pid = spawn(fun() -> once_worker(CronPath, ModifiedMsg2, Opts) end),
+			CreatedAt = erlang:system_time(millisecond),
+			Pid = spawn(fun() -> once_worker(CronPath, ModifiedMsg2, Opts, CreatedAt) end),
 			hb_name:register(Name, Pid),
 			{ok, ReqMsgID}
 	end.
 
 %% @doc Internal function for scheduling a one-time message.
-once_worker(Path, Req, Opts) ->
-	% Directly call the meta device on the newly constructed 'singleton', just
-    % as hb_http_server does.
-    TracePID = hb_tracer:start_trace(),
+once_worker(Path, Req, Opts, CreatedAt) ->
+	% Store metadata in process dictionary for instant access
+	put(cron_metadata, #{
+		<<"type">> => <<"once">>,
+		<<"path">> => Path,
+		<<"created_at">> => CreatedAt
+	}),
+	
+	% Execute the task
+	TracePID = hb_tracer:start_trace(),
 	try
 		dev_meta:handle(Opts#{ trace => TracePID }, Req#{ <<"path">> => Path})
 	catch
 		Class:Reason:Stacktrace ->
 			?event(
-                {cron_every_worker_error,
-                    {path, Path},
-                    {error, Class, Reason, Stacktrace}
-                }
-            ),
+				{cron_once_worker_error,
+					{path, Path},
+					{error, Class, Reason, Stacktrace}
+				}
+			),
 			throw({error, Class, Reason, Stacktrace})
 	end.
 
@@ -85,6 +93,7 @@ every(_Msg1, Msg2, Opts) ->
                         maps:remove(<<"interval">>, Msg2)
                     ),
 				TracePID = hb_tracer:start_trace(),
+				CreatedAt = erlang:system_time(millisecond),
 				Pid =
                     spawn(
                         fun() ->
@@ -92,7 +101,9 @@ every(_Msg1, Msg2, Opts) ->
                                 CronPath,
                                 ModifiedMsg2,
                                 Opts#{ trace => TracePID },
-                                IntervalMillis
+                                IntervalMillis,
+                                CreatedAt,
+                                IntervalString
                             )
                         end
                     ),
@@ -137,7 +148,68 @@ stop(_Msg1, Msg2, Opts) ->
 			end
 	end.
 
-every_worker_loop(CronPath, Req, Opts, IntervalMillis) ->
+%% @doc List all active cron tasks.
+list(_Msg1, _Msg2, _Opts) ->
+	AllNames = hb_name:all(),
+	CronTasks = lists:filtermap(
+		fun
+			({{<<"cron@1.0">>, TaskID}, Pid}) when is_pid(Pid) ->
+				% Try to get metadata from process dictionary first (non-blocking)
+				Info = case erlang:process_info(Pid, dictionary) of
+					{dictionary, Dict} ->
+						case lists:keyfind(cron_metadata, 1, Dict) of
+							{cron_metadata, Metadata} ->
+								% Found metadata in process dictionary
+								Metadata#{
+									<<"task_id">> => TaskID,
+									<<"pid">> => list_to_binary(pid_to_list(Pid))
+								};
+							false ->
+								% No metadata in process dictionary, try messaging
+								Pid ! {info, self()},
+								receive
+									{cron_info, Metadata} ->
+										Metadata#{
+											<<"task_id">> => TaskID,
+											<<"pid">> => list_to_binary(pid_to_list(Pid))
+										}
+								after 50 ->
+									% Timeout - return basic info
+									#{
+										<<"task_id">> => TaskID,
+										<<"pid">> => list_to_binary(pid_to_list(Pid)),
+										<<"type">> => <<"unknown">>,
+										<<"path">> => <<"unknown">>
+									}
+								end
+						end;
+					undefined ->
+						% Process doesn't exist anymore
+						false
+				end,
+				case Info of
+					false -> false;
+					_ -> {true, Info}
+				end;
+			(_) ->
+				false
+		end,
+		AllNames
+	),
+	{ok, #{<<"status">> => 200, <<"body">> => CronTasks}}.
+
+
+every_worker_loop(CronPath, Req, Opts, IntervalMillis, CreatedAt, IntervalString) ->
+    % Store metadata in process dictionary for instant access
+    put(cron_metadata, #{
+        <<"type">> => <<"every">>,
+        <<"path">> => CronPath,
+        <<"interval">> => IntervalString,
+        <<"interval_ms">> => IntervalMillis,
+        <<"created_at">> => CreatedAt
+    }),
+    
+    % Execute the task
     Req1 = Req#{<<"path">> => CronPath},
     ?event(
         {cron_every_worker_executing,
@@ -154,8 +226,29 @@ every_worker_loop(CronPath, Req, Opts, IntervalMillis) ->
                     {path, CronPath},
                     {error, Class, Reason, Stack}})
     end,
-    timer:sleep(IntervalMillis),
-    every_worker_loop(CronPath, Req, Opts, IntervalMillis).
+    
+    % Wait for interval, checking for info requests
+    wait_with_info(IntervalMillis),
+    every_worker_loop(CronPath, Req, Opts, IntervalMillis, CreatedAt, IntervalString).
+
+%% @doc Wait for a given time while responding to info requests.
+wait_with_info(TimeLeft) when TimeLeft =< 0 ->
+    ok;
+wait_with_info(TimeLeft) ->
+    Start = erlang:monotonic_time(millisecond),
+    receive
+        {info, From} ->
+            % Get metadata from process dictionary
+            case get(cron_metadata) of
+                undefined -> From ! {cron_info, #{}};
+                Metadata -> From ! {cron_info, Metadata}
+            end,
+            % Calculate remaining time and continue waiting
+            Elapsed = erlang:monotonic_time(millisecond) - Start,
+            wait_with_info(TimeLeft - Elapsed)
+    after TimeLeft ->
+        ok
+    end.
 
 %% @doc Parse a time string into milliseconds.
 parse_time(BinString) ->
@@ -311,6 +404,68 @@ every_worker_loop_test() ->
 		?event({'cron:every:test:timeout', {pid, PID}, {lookup_result, FinalLookup}}),
 		throw({test_timeout_waiting_for_state, {id, ID}})
 	end.
+
+%% @doc Test the list functionality for cron tasks.
+list_tasks_test() ->
+	Node = hb_http_server:start_node(),
+	
+	% Clean up any existing cron tasks first
+	AllNames = hb_name:all(),
+	lists:foreach(
+		fun
+			({{<<"cron@1.0">>, TaskID}, Pid}) ->
+				exit(Pid, kill),
+				hb_name:unregister({<<"cron@1.0">>, TaskID});
+			(_) -> ok
+		end,
+		AllNames
+	),
+	
+	% Spawn and register a test worker
+	Pid = spawn(fun test_worker/0),
+	ID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+	hb_name:register({<<"test">>, ID}, Pid),
+	
+	% Schedule a recurring cron task that will stay alive
+	UrlPath = <<"/~cron@1.0/every?test-id=", ID/binary,
+				"&interval=10-seconds",
+				"&cron-path=/~test-device@1.0/update_state">>,
+	{ok, TaskID} = hb_http:get(Node, UrlPath, #{}),
+	?assertEqual(true, is_binary(TaskID)),
+	
+	% Wait for task to be registered and ready
+	timer:sleep(1000),
+	
+	% Check if task is registered
+	TaskPid = hb_name:lookup({<<"cron@1.0">>, TaskID}),
+	?assert(is_pid(TaskPid)),
+	
+	% List tasks
+	{ok, Response} = hb_http:get(Node, <<"/~cron@1.0/list">>, #{}),
+	?assertEqual(true, is_map(Response)),
+	Body = maps:get(<<"body">>, Response, not_found),
+	
+	?assert(is_list(Body)),
+	
+	% Find the task and verify its metadata
+	TaskInfo = lists:filter(
+		fun(#{<<"task_id">> := TID}) -> TID =:= TaskID;
+		   (_) -> false
+		end, Body),
+	
+	?assertEqual(1, length(TaskInfo)),
+	[Task] = TaskInfo,
+	
+	% Verify the metadata fields
+	?assertEqual(<<"every">>, maps:get(<<"type">>, Task)),
+	?assertEqual(<<"/~test-device@1.0/update_state">>, maps:get(<<"path">>, Task)),
+	?assertEqual(<<"10-seconds">>, maps:get(<<"interval">>, Task)),
+	?assertEqual(10000, maps:get(<<"interval_ms">>, Task)),
+	?assert(is_integer(maps:get(<<"created_at">>, Task))),
+	
+	% Stop the task
+	exit(TaskPid, kill),
+	hb_name:unregister({<<"cron@1.0">>, TaskID}).
 	
 %% @doc This is a helper function that is used to test the cron device.
 %% It is used to increment a counter and update the state of the worker.

--- a/src/dev_cron.erl
+++ b/src/dev_cron.erl
@@ -1,13 +1,13 @@
 %%% @doc A device that inserts new messages into the schedule to allow processes
 %%% to passively 'call' themselves without user interaction.
 -module(dev_cron).
--export([once/3, every/3, stop/3, list/3, info/1, info/3]).
+-export([once/3, every/3, stop/3, list/3, json/3, info/1, info/3]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 %% @doc Exported function for getting device info.
 info(_) -> 
-	#{ exports => [info, once, every, stop, list] }.
+	#{ exports => [info, once, every, stop, list, json] }.
 
 info(_Msg1, _Msg2, _Opts) ->
 	InfoBody = #{
@@ -198,6 +198,60 @@ list(_Msg1, _Msg2, _Opts) ->
 	),
 	{ok, #{<<"status">> => 200, <<"body">> => CronTasks}}.
 
+%% @doc Return list as raw JSON array
+json(_Msg1, _Msg2, _Opts) ->
+	AllNames = hb_name:all(),
+	CronTasks = lists:filtermap(
+		fun
+			({{<<"cron@1.0">>, TaskID}, Pid}) when is_pid(Pid) ->
+				% Try to get metadata from process dictionary first (non-blocking)
+				Info = case erlang:process_info(Pid, dictionary) of
+					{dictionary, Dict} ->
+						case lists:keyfind(cron_metadata, 1, Dict) of
+							{cron_metadata, Metadata} ->
+								% Found metadata in process dictionary
+								Metadata#{
+									<<"task_id">> => TaskID,
+									<<"pid">> => list_to_binary(pid_to_list(Pid))
+								};
+							false ->
+								% No metadata in process dictionary, try messaging
+								Pid ! {info, self()},
+								receive
+									{cron_info, Metadata} ->
+										Metadata#{
+											<<"task_id">> => TaskID,
+											<<"pid">> => list_to_binary(pid_to_list(Pid))
+										}
+								after 50 ->
+									% Timeout - return basic info
+									#{
+										<<"task_id">> => TaskID,
+										<<"pid">> => list_to_binary(pid_to_list(Pid)),
+										<<"type">> => <<"unknown">>,
+										<<"path">> => <<"unknown">>
+									}
+								end
+						end;
+					undefined ->
+						% Process doesn't exist anymore
+						false
+				end,
+				case Info of
+					false -> false;
+					_ -> {true, Info}
+				end;
+			(_) ->
+				false
+		end,
+		AllNames
+	),
+	% Return as binary JSON string directly
+	JsonBinary = hb_json:encode(CronTasks),
+	{ok, #{
+		<<"content-type">> => <<"application/json">>,
+		<<"body">> => JsonBinary
+	}}.
 
 every_worker_loop(CronPath, Req, Opts, IntervalMillis, CreatedAt, IntervalString) ->
     % Store metadata in process dictionary for instant access

--- a/src/dev_delegated_compute.erl
+++ b/src/dev_delegated_compute.erl
@@ -23,24 +23,26 @@ normalize(Msg1, _Msg2, Opts) ->
             case hb_maps:get(<<"type">>, Snapshot, Opts) == <<"Checkpoint">> of
                 false -> Unset;
                 true ->
-                    load_snapshot(Snapshot, Opts),
+                    load_state(Snapshot, Opts),
                     Unset
             end
     end.
 
 %% @doc Attempt to load a snapshot into the delegated compute server.
-load_snapshot(Snapshot, Opts) ->
-    ?event({loading_snapshot, {snapshot, Snapshot}}),
-    do_relay(
+load_state(Snapshot, Opts) ->
+    ?event(debug_load_snapshot, {loading_snapshot, {snapshot, Snapshot}}),
+    Res = do_relay(
         <<"POST">>,
-        <<"/checkpoint">>,
+        <<"/state">>,
         hb_maps:get(<<"data">>, Snapshot, Opts),
         hb_maps:without([<<"data">>], Snapshot, Opts),
         Opts#{
             hashpath => ignore,
             cache_control => [<<"no-store">>, <<"no-cache">>]
         }
-    ).
+    ),
+    ?event(debug_load_snapshot, {load_result, Res}),
+    Res.
 
 %% @doc Call the delegated server to compute the result. The endpoint is
 %% `POST /compute' and the body is the JSON-encoded message that we want to

--- a/src/dev_delegated_compute.erl
+++ b/src/dev_delegated_compute.erl
@@ -31,11 +31,13 @@ normalize(Msg1, _Msg2, Opts) ->
 %% @doc Attempt to load a snapshot into the delegated compute server.
 load_state(Snapshot, Opts) ->
     ?event(debug_load_snapshot, {loading_snapshot, {snapshot, Snapshot}}),
+    Body = hb_maps:get(<<"data">>, Snapshot, Opts),
+    Headers = hb_maps:without([<<"data">>], Snapshot, Opts),
     Res = do_relay(
         <<"POST">>,
         <<"/state">>,
-        hb_maps:get(<<"data">>, Snapshot, Opts),
-        hb_maps:without([<<"data">>], Snapshot, Opts),
+        Body,
+        Headers,
         Opts#{
             hashpath => ignore,
             cache_control => [<<"no-store">>, <<"no-cache">>]
@@ -139,6 +141,7 @@ do_relay(Method, Path, Body, Headers, Opts) ->
             <<"relay-method">> => Method,
             <<"relay-body">> => Body,
             <<"relay-path">> => Path,
+            <<"relay-headers">> => Headers,
             <<"content-type">> => ContentType
         },
         Opts

--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -2,7 +2,8 @@
 %%% processes, using HyperBEAM infrastructure. This allows existing `legacynet'
 %%% AO process definitions to be used in HyperBEAM.
 -module(dev_genesis_wasm).
--export([init/3, compute/3, normalize/3, snapshot/3]).
+-export([init/3, compute/3, normalize/3, snapshot/3, import/3]).
+-export([latest_checkpoint/2]).
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("include/hb.hrl").
 
@@ -246,6 +247,138 @@ ensure_started(Opts) ->
             true
     end.
 
+%% @doc Find either a specific checkpoint by its ID, or find the most recent
+%% checkpoint via GraphQL.
+import(ProcMsg, Req, Opts) ->
+    case hb_maps:find(<<"import">>, Req, Opts) of
+        {ok, ImportID} ->
+            case hb_cache:read(ImportID, Opts) of
+                {ok, CheckpointMessage} ->
+                    do_import(ProcMsg, CheckpointMessage, Opts);
+                not_found -> {error, not_found}
+            end;
+        error ->
+            ProcID = dev_process:process_id(ProcMsg, #{}, Opts),
+            case latest_checkpoint(ProcID, Opts) of
+                {ok, CheckpointMessage} ->
+                    do_import(ProcMsg, CheckpointMessage, Opts);
+                Err -> Err
+            end
+    end.
+
+%% @doc Find the most recent legacy checkpoint for a process.
+latest_checkpoint(ProcID, Opts) ->
+    case hb_opts:get(genesis_wasm_import_authorities, [], Opts) of
+        [] -> {error, no_import_authorities};
+        TrustedSigners -> latest_checkpoint(ProcID, TrustedSigners, Opts)
+    end.
+latest_checkpoint(ProcID, TrustedSigners, Opts) ->
+    Query =
+        <<
+            <<"""
+            query($ProcID: String!, $TrustedSigners: [String!]) {
+                transactions(
+                    tags: [
+                        { name: "Type" values: ["Checkpoint"] },
+                        { name: "Process" values: [$ProcID] }
+                    ],
+                    owners: $TrustedSigners,
+                    first: 1,
+                    sort: HEIGHT_DESC
+                ){
+                edges {
+            """>>/binary,
+            (hb_gateway_client:item_spec())/binary,
+            """
+                }
+            }}
+        """>>,
+    Variables =
+        #{
+            <<"ProcID">> => ProcID,
+            <<"TrustedSigners">> => TrustedSigners
+        },
+    case hb_gateway_client:query(Query, Variables, Opts) of
+        {error, Reason} ->
+            {error, Reason};
+        {ok, GqlMsg} ->
+            case hb_ao:get(<<"data/transactions/edges/1/node">>, GqlMsg, Opts) of
+                not_found -> {error, not_found};
+                Item -> hb_gateway_client:result_to_message(Item, Opts)
+            end
+    end.
+
+%% @doc Validate whether a checkpoint message is signed by a trusted snapshot
+%% authority and is for a `ao.TN.1' process or has `execution-device' set to
+%% `genesis-wasm@1.0', then normalize into a state snapshot.
+%% Save the state snapshot into the store.
+do_import(Proc, CheckpointMessage, Opts) ->
+    maybe
+        % Validate that the process is a valid target for importing a checkpoint.
+        Variant = hb_maps:get(<<"variant">>, Proc, false, Opts),
+        ExecutionDevice = hb_maps:get(<<"execution-device">>, Proc, false, Opts),
+        true ?=
+            (Variant == <<"ao.TN.1">>) orelse
+            (ExecutionDevice == <<"genesis-wasm@1.0">>) orelse
+            invalid_import_target,
+        CheckpointSigners = hb_message:signers(CheckpointMessage, Opts),
+        % Validate that the checkpoint message is signed by a trusted snapshot
+        % authority, and targets this process.
+        TrustedSigners = hb_opts:get(genesis_wasm_import_authorities, [], Opts),
+        true ?=
+            lists:any(
+                fun(Signer) -> lists:member(Signer, TrustedSigners) end,
+                CheckpointSigners
+            ) orelse untrusted,
+        true ?= hb_message:verify(CheckpointMessage, all, Opts) orelse unverified,
+        CheckpointTargetProcID = hb_maps:get(<<"process">>, CheckpointMessage, Opts),
+        ProcID = dev_process:process_id(Proc, #{}, Opts),
+        true ?= CheckpointTargetProcID == ProcID orelse process_mismatch,
+        % Normalize the checkpoint message into a process state message with 
+        % a state snapshot.
+        {ok, SlotBin} ?= hb_maps:find(<<"nonce">>, CheckpointMessage, Opts),
+        Slot = hb_util:int(SlotBin),
+        InitializedProc = dev_process:ensure_process_key(Proc, Opts),
+        WithSnapshot =
+            InitializedProc#{
+                <<"at-slot">> => Slot,
+                <<"snapshot">> => CheckpointMessage
+            },
+        % Save the state snapshot into the store.
+        {ok, _} ?= dev_process_cache:write(ProcID, Slot, WithSnapshot, Opts),
+        % Return the normalized process message.
+        {ok, WithSnapshot}
+    else
+        invalid_import_target ->
+            {error, #{
+                <<"status">> => 400,
+                <<"body">> =>
+                    <<
+                        "Process is not a valid target for importing a "
+                        "`~genesis-wasm@1.0' checkpoint."
+                    >>
+            }};
+        process_mismatch ->
+            {error, #{
+                <<"status">> => 400,
+                <<"body">> =>
+                    <<"Checkpoint message targets a different process.">>
+            }};
+        unverified ->
+            {error, #{
+                <<"status">> => 400,
+                <<"body">> =>
+                    <<"Checkpoint message is not verifiable.">>
+            }};
+        untrusted ->
+            {error, #{
+                <<"status">> => 400,
+                <<"body">> =>
+                    <<"Checkpoint message is not signed by a trusted snapshot "
+                        "authority.">>
+            }}
+    end.
+
 %% @doc Check if the genesis-wasm server is running, using the cached process ID
 %% if available.
 is_genesis_wasm_server_running(Opts) ->
@@ -320,6 +453,35 @@ log_server_events([Line | Rest]) ->
     log_server_events(Rest).
 
 %%% Tests
+
+import_legacy_checkpoint_test_() ->
+    { timeout, 900, fun import_legacy_checkpoint/0 }.
+import_legacy_checkpoint() ->
+    application:ensure_all_started(hb),
+    Opts = #{
+        priv_wallet => hb:wallet(),
+        genesis_wasm_import_authorities =>
+            [<<"fcoN_xJeisVsPXA-trzVAuIiqO3ydLQxM-L4XbrQKzY">>]
+    },
+    ProcID = <<"DM3FoZUq_yebASPhgd8pEIRIzDW6muXEhxz5-JwbZwo">>,
+    {ok, ProcWithCheckpoint} =
+        hb_ao:resolve(
+           << ProcID/binary, "~genesis-wasm@1.0/import">>,
+           Opts
+        ),
+    ?assertMatch(
+        Slot when Slot > 0,
+        hb_maps:get(<<"at-slot">>, ProcWithCheckpoint)
+    ),
+    ?assertMatch(
+        #{ <<"data">> := Data } when byte_size(Data) > 0,
+        hb_maps:get(<<"snapshot">>, ProcWithCheckpoint)
+    ),
+    ?assertMatch(
+        {ok, Slot, _} when Slot > 0,
+        dev_process_cache:latest(ProcID, Opts)
+    ),
+    hb_ao:resolve(<<ProcID/binary, "~process@1.0/now">>, Opts).
 
 -ifdef(ENABLE_GENESIS_WASM).
 test_base_process() ->

--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -15,7 +15,15 @@ init(Msg, _Msg2, _Opts) -> {ok, Msg}.
 
 %% @doc Normalize the device.
 normalize(Msg, Msg2, Opts) ->
-    dev_delegated_compute:normalize(Msg, Msg2, Opts).
+    case ensure_started(Opts) of
+        true ->
+            dev_delegated_compute:normalize(Msg, Msg2, Opts);
+        false ->
+            {error, #{
+                <<"status">> => 500,
+                <<"message">> => <<"Genesis-wasm server not running.">>
+            }}
+    end.
 
 %% @doc Genesis-wasm device compute handler.
 %% Normal compute execution through external CU with state persistence

--- a/src/dev_process_list.erl
+++ b/src/dev_process_list.erl
@@ -1,0 +1,353 @@
+%%% @doc A device that provides listing and tracking of computed AO processes
+%%% on the current node. Similar to dev_cron's list functionality but for processes.
+%%% This device allows users to:
+%%% - List all computed processes on the node
+%%% - Get statistics about process computation
+%%% - Get detailed information about specific processes
+%%% - Track which processes have active workers
+-module(dev_process_list).
+-export([info/1, info/3, list/3, stats/3, details/3, json/3]).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%% @doc Device info for path discovery
+info(_) -> 
+    #{ exports => [info, list, stats, details, json] }.
+
+%% @doc Detailed device information
+info(_Msg1, _Msg2, _Opts) ->
+    InfoBody = #{
+        <<"description">> => <<"Process listing device for tracking computed processes">>,
+        <<"version">> => <<"1.0">>,
+        <<"paths">> => #{
+            <<"info">> => <<"Get device info">>,
+            <<"list">> => <<"List all computed processes on this node">>,
+            <<"stats">> => <<"Get statistics about computed processes">>,
+            <<"details">> => <<"Get details for a specific process {process}">>,
+            <<"json">> => <<"Get process list as raw JSON array">>
+        }
+    },
+    {ok, InfoBody}.
+
+%% @doc List all computed processes on this node
+list(_Msg1, _Msg2, Opts) ->
+    Store = hb_opts:get(store, no_viable_store, Opts),
+    ComputedPath = hb_store:path(Store, [<<"computed">>]),
+    AllProcessIDs = hb_cache:list(ComputedPath, Opts),
+    
+    ?event({process_list_found_processes, {count, length(AllProcessIDs)}}),
+    
+    ProcessList = lists:filtermap(
+        fun(RawProcID) ->
+            ProcID = hb_util:human_id(RawProcID),
+            case dev_process_cache:latest(RawProcID, [], Opts) of
+                {ok, Slot, StateMsg} ->
+                    %% Check for active worker using the process group name
+                    WorkerPid = hb_name:lookup(ProcID),
+                    
+                    %% Get process metadata if available
+                    ProcessType = get_process_type(StateMsg, Opts),
+                    
+                    Info = #{
+                        <<"process_id">> => ProcID,
+                        <<"latest_slot">> => Slot,
+                        <<"has_worker">> => is_pid(WorkerPid),
+                        <<"worker_pid">> => format_pid(WorkerPid),
+                        <<"type">> => ProcessType,
+                        <<"status">> => <<"computed">>
+                    },
+                    {true, Info};
+                _ ->
+                    %% Process exists but no slots computed yet
+                    Info = #{
+                        <<"process_id">> => ProcID,
+                        <<"latest_slot">> => 0,
+                        <<"has_worker">> => false,
+                        <<"worker_pid">> => null,
+                        <<"status">> => <<"uncomputed">>
+                    },
+                    {true, Info}
+            end
+        end,
+        AllProcessIDs
+    ),
+    
+    ?event({process_list_returning, {process_count, length(ProcessList)}}),
+    %% Return as a simple list - JSON serializer will handle it
+    {ok, ProcessList}.
+
+%% @doc Get statistics about computed processes
+stats(_Msg1, _Msg2, Opts) ->
+    Store = hb_opts:get(store, no_viable_store, Opts),
+    ComputedPath = hb_store:path(Store, [<<"computed">>]),
+    AllProcessIDs = hb_cache:list(ComputedPath, Opts),
+    
+    %% Count active workers
+    ActiveWorkers = length(lists:filter(
+        fun(RawProcID) ->
+            ProcID = hb_util:human_id(RawProcID),
+            is_pid(hb_name:lookup(ProcID))
+        end,
+        AllProcessIDs
+    )),
+    
+    %% Get slot statistics
+    {TotalSlots, MaxSlot, ProcessesWithSlots} = lists:foldl(
+        fun(RawProcID, {TotalAcc, MaxAcc, CountAcc}) ->
+            case dev_process_cache:latest(RawProcID, [], Opts) of
+                {ok, Slot, _} -> 
+                    {TotalAcc + Slot, max(MaxAcc, Slot), CountAcc + 1};
+                _ -> 
+                    {TotalAcc, MaxAcc, CountAcc}
+            end
+        end,
+        {0, 0, 0},
+        AllProcessIDs
+    ),
+    
+    Stats = #{
+        <<"total_processes">> => length(AllProcessIDs),
+        <<"processes_with_slots">> => ProcessesWithSlots,
+        <<"active_workers">> => ActiveWorkers,
+        <<"total_computed_slots">> => TotalSlots,
+        <<"max_slot">> => MaxSlot,
+        <<"average_slots_per_process">> => 
+            case ProcessesWithSlots of
+                0 -> 0;
+                N -> TotalSlots div N
+            end
+    },
+    
+    {ok, Stats}.
+
+%% @doc Get detailed info for a specific process
+details(_Msg1, Msg2, Opts) ->
+    case hb_ao:get(<<"{process}">>, Msg2, Opts) of
+        not_found ->
+            case hb_ao:get(<<"process">>, Msg2, Opts) of
+                not_found ->
+                    {error, <<"No process ID provided. Use ?process=PROCESS_ID">>};
+                ProcIDParam ->
+                    get_process_details(ProcIDParam, Opts)
+            end;
+        ProcIDParam ->
+            get_process_details(ProcIDParam, Opts)
+    end.
+
+%% @doc Internal function to get process details
+get_process_details(RawProcID, Opts) ->
+    ProcID = hb_util:human_id(RawProcID),
+    
+    %% Get all slots for this process
+    Store = hb_opts:get(store, no_viable_store, Opts),
+    SlotPath = hb_store:path(Store, [<<"computed">>, ProcID, <<"slot">>]),
+    AllSlots = hb_cache:list_numbered(SlotPath, Opts),
+    
+    case dev_process_cache:latest(RawProcID, [], Opts) of
+        {ok, LatestSlot, StateMsg} ->
+            %% Check for active worker
+            WorkerPid = hb_name:lookup(ProcID),
+            
+            %% Get process info from state
+            Process = hb_ao:get(<<"process">>, StateMsg, #{}, Opts),
+            
+            Details = #{
+                <<"process_id">> => ProcID,
+                <<"latest_slot">> => LatestSlot,
+                <<"total_slots">> => length(AllSlots),
+                <<"all_slots">> => lists:sort(AllSlots),
+                <<"has_worker">> => is_pid(WorkerPid),
+                <<"worker_info">> => get_worker_info(WorkerPid),
+                <<"process_metadata">> => #{
+                    <<"type">> => hb_maps:get(<<"type">>, Process, <<"unknown">>, Opts),
+                    <<"variant">> => hb_maps:get(<<"variant">>, Process, <<"unknown">>, Opts),
+                    <<"scheduler">> => hb_maps:get(<<"scheduler">>, Process, <<"unknown">>, Opts),
+                    <<"execution_device">> => hb_maps:get(<<"execution-device">>, Process, <<"unknown">>, Opts)
+                }
+            },
+            
+            {ok, Details};
+        _ ->
+            %% Check if process exists at all
+            case hb_cache:list(hb_store:path(Store, [<<"computed">>, ProcID]), Opts) of
+                [] ->
+                    {error, <<"Process not found or not computed">>};
+                _ ->
+                    %% Process exists but no latest state
+                    Details = #{
+                        <<"process_id">> => ProcID,
+                        <<"latest_slot">> => 0,
+                        <<"total_slots">> => 0,
+                        <<"all_slots">> => [],
+                        <<"has_worker">> => false,
+                        <<"status">> => <<"uncomputed">>
+                    },
+                    {ok, Details}
+            end
+    end.
+
+%% @doc Return list as raw JSON array
+json(_Msg1, _Msg2, Opts) ->
+    Store = hb_opts:get(store, no_viable_store, Opts),
+    ComputedPath = hb_store:path(Store, [<<"computed">>]),
+    AllProcessIDs = hb_cache:list(ComputedPath, Opts),
+    
+    ProcessList = lists:filtermap(
+        fun(RawProcID) ->
+            ProcID = hb_util:human_id(RawProcID),
+            case dev_process_cache:latest(RawProcID, [], Opts) of
+                {ok, Slot, StateMsg} ->
+                    WorkerPid = hb_name:lookup(ProcID),
+                    ProcessType = get_process_type(StateMsg, Opts),
+                    
+                    Info = #{
+                        <<"process_id">> => ProcID,
+                        <<"latest_slot">> => Slot,
+                        <<"has_worker">> => is_pid(WorkerPid),
+                        <<"worker_pid">> => format_pid(WorkerPid),
+                        <<"type">> => ProcessType,
+                        <<"status">> => <<"computed">>
+                    },
+                    {true, Info};
+                _ ->
+                    Info = #{
+                        <<"process_id">> => ProcID,
+                        <<"latest_slot">> => 0,
+                        <<"has_worker">> => false,
+                        <<"worker_pid">> => null,
+                        <<"status">> => <<"uncomputed">>
+                    },
+                    {true, Info}
+            end
+        end,
+        AllProcessIDs
+    ),
+    
+    %% Return as binary JSON string directly
+    JsonBinary = hb_json:encode(ProcessList),
+    {ok, #{
+        <<"content-type">> => <<"application/json">>,
+        <<"body">> => JsonBinary
+    }}.
+
+%%% Helper functions
+
+%% @doc Extract process type from state message
+get_process_type(StateMsg, Opts) ->
+    case hb_ao:get(<<"process">>, StateMsg, not_found, Opts) of
+        not_found -> <<"unknown">>;
+        Process ->
+            case hb_maps:get(<<"type">>, Process, not_found, Opts) of
+                not_found -> <<"Process">>;
+                Type -> Type
+            end
+    end.
+
+%% @doc Format PID for JSON output
+format_pid(undefined) -> null;
+format_pid(Pid) when is_pid(Pid) -> 
+    list_to_binary(pid_to_list(Pid)).
+
+%% @doc Get detailed worker information
+get_worker_info(undefined) -> null;
+get_worker_info(Pid) when is_pid(Pid) ->
+    #{
+        <<"pid">> => format_pid(Pid),
+        <<"message_queue_len">> => 
+            case erlang:process_info(Pid, message_queue_len) of
+                {message_queue_len, Len} -> Len;
+                _ -> 0
+            end,
+        <<"memory">> =>
+            case erlang:process_info(Pid, memory) of
+                {memory, Mem} -> Mem;
+                _ -> 0
+            end,
+        <<"reductions">> =>
+            case erlang:process_info(Pid, reductions) of
+                {reductions, Red} -> Red;
+                _ -> 0
+            end,
+        <<"status">> =>
+            case erlang:process_info(Pid, status) of
+                {status, Status} -> atom_to_binary(Status, utf8);
+                _ -> <<"unknown">>
+            end
+    }.
+
+%%% Tests
+
+%% @doc Test listing processes
+list_processes_test() ->
+    %% Initialize
+    application:ensure_all_started(hb),
+    
+    %% Create and compute a test process
+    Proc = dev_process:test_aos_process(),
+    dev_process:schedule_aos_call(Proc, <<"return 1+1">>),
+    
+    ProcID = hb_message:id(Proc, all),
+    ProcIDStr = hb_util:human_id(ProcID),
+    
+    %% Compute to slot 0
+    {ok, _} = hb_ao:resolve(
+        Proc,
+        #{<<"path">> => <<"compute">>, <<"slot">> => 0},
+        #{}
+    ),
+    
+    %% List processes
+    {ok, ProcessList} = list(#{}, #{}, #{}),
+    
+    %% Verify the process is listed
+    ?assert(is_list(ProcessList)),
+    ProcessFound = lists:any(
+        fun(#{<<"process_id">> := ID}) -> 
+            ID =:= ProcIDStr
+        end,
+        ProcessList
+    ),
+    ?assert(ProcessFound, "Process should be in the list").
+
+%% @doc Test getting process details
+details_test() ->
+    %% Initialize
+    application:ensure_all_started(hb),
+    
+    %% Create and compute a test process
+    Proc = dev_process:test_aos_process(),
+    dev_process:schedule_aos_call(Proc, <<"return 1+1">>),
+    dev_process:schedule_aos_call(Proc, <<"return 2+2">>),
+    
+    ProcID = hb_message:id(Proc, all),
+    ProcIDStr = hb_util:human_id(ProcID),
+    
+    %% Compute to slot 1
+    {ok, _} = hb_ao:resolve(
+        Proc,
+        #{<<"path">> => <<"compute">>, <<"slot">> => 1},
+        #{}
+    ),
+    
+    %% Get details
+    {ok, Details} = details(#{}, #{<<"process">> => ProcIDStr}, #{}),
+    
+    %% Verify details
+    ?assertEqual(ProcIDStr, maps:get(<<"process_id">>, Details)),
+    ?assertEqual(1, maps:get(<<"latest_slot">>, Details)),
+    ?assert(lists:member(0, maps:get(<<"all_slots">>, Details))),
+    ?assert(lists:member(1, maps:get(<<"all_slots">>, Details))).
+
+%% @doc Test statistics
+stats_test() ->
+    %% Initialize
+    application:ensure_all_started(hb),
+    
+    %% Get initial stats
+    {ok, Stats} = stats(#{}, #{}, #{}),
+    
+    %% Verify stats structure
+    ?assert(maps:is_key(<<"total_processes">>, Stats)),
+    ?assert(maps:is_key(<<"active_workers">>, Stats)),
+    ?assert(maps:is_key(<<"total_computed_slots">>, Stats)),
+    ?assert(is_integer(maps:get(<<"total_processes">>, Stats))).

--- a/src/dev_profile.erl
+++ b/src/dev_profile.erl
@@ -178,7 +178,7 @@ eflame_profile(Fun, Req, Opts) ->
     % path is not set, we use Erlang's short string encoding of the function.
     Name =
         case hb_maps:get(<<"path">>, Req, undefined, Opts) of
-            undefined -> hb_util:bin(io_lib:format("~p", [Fun]));
+            undefined -> hb_escape:encode(hb_util:bin(io_lib:format("~p", [Fun])));
             Path ->
                 case hb_maps:get(Path, Req, undefined, Opts) of
                     undefined -> hb_util:bin(Path);

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -265,15 +265,19 @@ outbound_result_to_message(<<"httpsig@1.0">>, Status, Headers, Body, Opts) ->
 
 %% @doc Convert a HTTP response to a httpsig message.
 http_response_to_httpsig(Status, HeaderMap, Body, Opts) ->
-    (hb_message:convert(
+    BinStatus = hb_util:bin(Status),
+    BodyMap = case byte_size(Body) of
+        0 -> #{};
+        _ -> #{ <<"body">> => Body }
+    end,
+    ConvertFrom = 
         hb_maps:merge(
-            HeaderMap#{ <<"status">> => hb_util:bin(Status) },
-            case Body of
-                <<>> -> #{};
-                _ -> #{ <<"body">> => Body }
-            end,
+            HeaderMap#{ <<"status">> => BinStatus },
+            BodyMap,
 			Opts
         ),
+    (hb_message:convert(
+        ConvertFrom,
         #{ <<"device">> => <<"structured@1.0">>, <<"bundle">> => true },
         <<"httpsig@1.0">>,
         Opts

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -252,7 +252,7 @@ default_message() ->
             },
             #{
                 % Routes for the genesis-wasm device to use a local CU, if requested.
-                <<"template">> => <<"/checkpoint.*">>,
+                <<"template">> => <<"/state.*">>,
                 <<"node">> => #{ <<"prefix">> => <<"http://localhost:6363">> }
             },
             #{

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -357,7 +357,12 @@ default_message() ->
                             #{ <<"device">> => <<"http-auth@1.0">> }
                     }
             }
-        }
+        },
+        genesis_wasm_import_authorities =>
+            [
+                <<"fcoN_xJeisVsPXA-trzVAuIiqO3ydLQxM-L4XbrQKzY">>,
+                <<"WjnS-s03HWsDSdMnyTdzB1eHZB2QheUWP_FVRVYxkXk">>
+            ]
         % Should the node track and expose prometheus metrics?
         % We do not set this explicitly, so that the hb_features:test() value
         % can be used to determine if we should expose metrics instead,

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -251,6 +251,11 @@ default_message() ->
                 <<"node">> => #{ <<"prefix">> => <<"http://localhost:6363">> }
             },
             #{
+                % Routes for the genesis-wasm device to use a local CU, if requested.
+                <<"template">> => <<"/checkpoint.*">>,
+                <<"node">> => #{ <<"prefix">> => <<"http://localhost:6363">> }
+            },
+            #{
                 % Routes for GraphQL requests to use a remote GraphQL API.
                 <<"template">> => <<"/graphql">>,
                 <<"nodes">> =>

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -164,6 +164,7 @@ default_message() ->
             #{<<"name">> => <<"patch@1.0">>, <<"module">> => dev_patch},
             #{<<"name">> => <<"poda@1.0">>, <<"module">> => dev_poda},
             #{<<"name">> => <<"process@1.0">>, <<"module">> => dev_process},
+            #{<<"name">> => <<"process-list@1.0">>, <<"module">> => dev_process_list},
             #{<<"name">> => <<"profile@1.0">>, <<"module">> => dev_profile},
             #{<<"name">> => <<"push@1.0">>, <<"module">> => dev_push},
             #{<<"name">> => <<"query@1.0">>, <<"module">> => dev_query},


### PR DESCRIPTION
Can now import a checkpoint to HB cache, subsequent genesis wasm calls will start from that checkpoint. For example, to load the AO token:
`http://localhost:8734/genesis-wasm@1.0/import&process-id=0syT13r0s0tgPmIed95bJnuSqaD29HQNN8D3ElLSrsc`
`http://localhost:8734/0syT13r0s0tgPmIed95bJnuSqaD29HQNN8D3ElLSrsc~process@1.0/compute/now`
allows you to hydrate the AO token in <10 minutes. 

Must be run with CU branch: `jfrain99/force-process-cache` (https://github.com/permaweb/ao/pull/1259)