### PR TITLE
fix: single signature with multiple commitments

### DIFF
--- a/src/dev_json_iface.erl
+++ b/src/dev_json_iface.erl
@@ -111,8 +111,13 @@ message_to_json_struct(RawMsg, Features, Opts) ->
         case hb_message:signers(RawMsg, Opts) of
             [] -> {<<>>, <<>>};
             [Signer|_] ->
-                {ok, _, Commitment} =
-                    hb_message:commitment(Signer, RawMsg, Opts),
+                Commitment = case hb_message:commitment(Signer, RawMsg, Opts) of
+                  {ok, _, SingleCommitment} -> SingleCommitment;
+                  multiple_matches ->
+                    Commitments = hb_message:commitments(Signer, RawMsg, Opts),
+                    [FirstID | _] = hb_maps:keys(Commitments),
+                    hb_maps:get(FirstID, Commitments, Opts)
+                end,
                 CommitmentSignature =
                     hb_ao:get(<<"signature">>, Commitment, <<>>, Opts),
                 case lists:member(owner_as_address, Features) of


### PR DESCRIPTION
This PR aims to resolve when we have multiple commitments for the same message from the same signer when we are using `/push` 
The solution is to retrieve the first commitment to get the signature regardless of the number of commitments (the signature might change, but the committed keys will not).