### PR TITLE
feat: Aggressively skip data load on multi-step resolutions

### DIFF
--- a/scripts/dynamic-router.lua
+++ b/scripts/dynamic-router.lua
@@ -27,7 +27,7 @@ local function ensure_defaults(state)
     state.routes = state.routes or {}
     state["is-admissible"] =
         state["is-admissible"] or {
-			path = "/default",
+			path = "default",
             default = "true"
         }
     state["sampling-rate"] = state["sampling-rate"] or 0.1

--- a/src/dev_cron.erl
+++ b/src/dev_cron.erl
@@ -7,7 +7,7 @@
 
 %% @doc Exported function for getting device info.
 info(_) -> 
-	#{ exports => [info, once, every, stop] }.
+	#{ exports => [<<"info">>, <<"once">>, <<"every">>, <<"stop">>] }.
 
 info(_Msg1, _Msg2, _Opts) ->
 	InfoBody = #{

--- a/src/dev_cron.erl
+++ b/src/dev_cron.erl
@@ -74,7 +74,7 @@ every(_Msg1, Msg2, Opts) ->
 			try 
 				IntervalMillis = parse_time(IntervalString),
 				if IntervalMillis =< 0 ->
-					throw({error, invalid_interval_value});
+					throw(invalid_interval_value);
 				true ->
 					ok
 				end,
@@ -100,11 +100,11 @@ every(_Msg1, Msg2, Opts) ->
 				hb_name:register(Name, Pid),
 				{ok, ReqMsgID}
 			catch
-				error:{invalid_time_unit, Unit} ->
+				_:{invalid_time_unit, Unit} ->
                     {error, <<"Invalid time unit: ", Unit/binary>>};
-				error:{invalid_interval_value} ->
+				_:invalid_interval_value ->
                     {error, <<"Invalid interval value.">>};
-				error:{Reason, _Stack} ->
+				_:Reason:_Stack ->
 					{error, {<<"Error parsing interval">>, Reason}}
 			end
 	end.
@@ -168,7 +168,7 @@ parse_time(BinString) ->
 		"minute" ++ _ -> Amount * 60 * 1000;
 		"hour" ++ _ -> Amount * 60 * 60 * 1000;
 		"day" ++ _ -> Amount * 24 * 60 * 60 * 1000;
-		_ -> throw({error, invalid_time_unit, UnitStr})
+		_ -> throw({invalid_time_unit, UnitStr})
 	end.
 
 %%% Tests
@@ -184,7 +184,7 @@ stop_once_test() ->
 	OnceUrlPath = <<"/~cron@1.0/once?test-id=", TestWorkerNameId/binary,
 				 "&cron-path=/~test-device@1.0/delay">>,
 	{ok, OnceTaskID} = hb_http:get(Node, OnceUrlPath, #{}),
-	?event({'cron:stop_once:test:created', {task_id, OnceTaskID}}),
+	?event({cron_stop_once_test_created, {task_id, OnceTaskID}}),
 	% Give a short delay to ensure the task has started and called handle,
     % entering the sleep
 	timer:sleep(200),
@@ -195,7 +195,7 @@ stop_once_test() ->
 	% Call stop on the once task while it's sleeping
 	OnceStopPath = <<"/~cron@1.0/stop?task=", OnceTaskID/binary>>,
 	{ok, OnceStopResult} = hb_http:get(Node, OnceStopPath, #{}),
-	?event({'cron:stop_once:test:stopped', {result, OnceStopResult}}),
+	?event({cron_stop_once_test_stopped, OnceStopResult}),
 	% Verify success response from stop
 	?assertMatch(#{<<"status">> := 200}, OnceStopResult),
 	% Verify name is unregistered
@@ -204,7 +204,6 @@ stop_once_test() ->
 	timer:sleep(100),
 	% Verify process termination
 	?assertNot(erlang:is_process_alive(OncePid), "Process not killed by stop"),
-	
 	% Call stop again to verify 404 response
 	{error, <<"Task not found.">>} = hb_http:get(Node, OnceStopPath, #{}).
 
@@ -223,7 +222,7 @@ stop_every_test() ->
 				   "&interval=500-milliseconds",
 				   "&cron-path=/~test-device@1.0/increment_counter">>,
 	{ok, CronTaskID} = hb_http:get(Node, EveryUrlPath, #{}),
-	?event({'cron:stop_every:test:created', {task_id, CronTaskID}}),
+	?event({cron_stop_every_test_created, CronTaskID}),
 	% Verify the cron worker process was registered and is alive
 	CronWorkerPid = hb_name:lookup({<<"cron@1.0">>, CronTaskID}),
 	?assert(is_pid(CronWorkerPid)),
@@ -233,7 +232,7 @@ stop_every_test() ->
 	% Call stop on the cron task using its ID
 	EveryStopPath = <<"/~cron@1.0/stop?task=", CronTaskID/binary>>,
 	{ok, EveryStopResult} = hb_http:get(Node, EveryStopPath, #{}),
-	?event({'cron:stop_every:test:stopped', {result, EveryStopResult}}),
+	?event({cron_stop_every_test_stopped, EveryStopResult}),
 	% Verify success response
 	?assertMatch(#{<<"status">> := 200}, EveryStopResult),
 	% Verify the cron task name is unregistered (lookup returns undefined)
@@ -246,7 +245,7 @@ stop_every_test() ->
 	TestWorkerPid ! {get, self()},
 	receive
 		{state, State = #{count := Count}} ->
-			?event({'cron:stop_every:test:counter_state', {state, State}}),
+			?event({cron_stop_every_test_counter_state, State}),
 			?assert(Count > 0)
 	after 1000 ->
 		throw(no_response_from_worker)
@@ -279,7 +278,7 @@ once_executed_test() ->
 	% receive the state from the worker
 	receive
 		{state, State} ->
-			?event({once_executed_test_received_state, {state, State}}),
+			?event({once_executed_test_received_state, State}),
 			?assertMatch(#{ <<"test-id">> := ID }, State)
 	after 1000 ->
 		FinalLookup = hb_name:lookup({<<"test">>, ID}),
@@ -296,19 +295,19 @@ every_worker_loop_test() ->
 	UrlPath = <<"/~cron@1.0/every?test-id=", ID/binary, 
 		"&interval=500-milliseconds",
 		"&cron-path=/~test-device@1.0/increment_counter">>,
-	?event({'cron:every:test:sendUrl', {url_path, UrlPath}}),
+	?event({cron_every_test_send_url, UrlPath}),
 	{ok, ReqMsgId} = hb_http:get(Node, UrlPath, #{}),
-	?event({'cron:every:test:get_done', {req_id, ReqMsgId}}),
+	?event({cron_every_test_get_done, {req_id, ReqMsgId}}),
 	timer:sleep(1500),
 	PID ! {get, self()},
 	% receive the state from the worker
 	receive
 		{state, State = #{count := C}} ->
-			?event({'cron:every:test:received_state', {state, State}}),
+			?event({cron_every_test_received_state, State}),
 			?assert(C >= 3)
 	after 1000 ->
 		FinalLookup = hb_name:lookup({<<"test">>, ID}),
-		?event({'cron:every:test:timeout', {pid, PID}, {lookup_result, FinalLookup}}),
+		?event({cron_every_test_timeout, {pid, PID}, {lookup_result, FinalLookup}}),
 		throw({test_timeout_waiting_for_state, {id, ID}})
 	end.
 	
@@ -319,10 +318,10 @@ test_worker(State) ->
 	receive
 		{increment} ->
 			NewCount = maps:get(count, State, 0) + 1,
-			?event({'test_worker:incremented', {new_count, NewCount}}),
+			?event({test_worker_incremented, NewCount}),
 			test_worker(State#{count := NewCount});
 		{update, NewState} ->
-			 ?event({'test_worker:updated', {new_state, NewState}}),
+			 ?event({test_worker_updated, NewState}),
 			 test_worker(NewState);
 		{get, Pid} ->
 			Pid ! {state, State},

--- a/src/dev_green_zone.erl
+++ b/src/dev_green_zone.erl
@@ -18,7 +18,17 @@
 %% @param _ Ignored parameter
 %% @returns A map with the `exports' key containing a list of allowed functions
 info(_) -> 
-    #{ exports => [info, init, join, become, key, is_trusted] }.
+    #{
+        exports =>
+            [
+                <<"info">>,
+                <<"init">>,
+                <<"join">>,
+                <<"become">>,
+                <<"key">>,
+                <<"is_trusted">>
+            ]
+    }.
 
 %% @doc Provides information about the green zone device and its API.
 %%

--- a/src/dev_manifest.erl
+++ b/src/dev_manifest.erl
@@ -141,5 +141,5 @@ resolve_test() ->
     ),
     {ok, Res} = hb_http:get(Node, << ManifestID/binary, "/nested/page2" >>, Opts),
     ?event({manifest_resolve_test, Res}),
-    ?assertEqual(<<"Page 2">>, hb_maps:get(<<"body">>, Res, <<"NO BODY">>, Opts)),
+    ?assertEqual(<<"Page 2">>, Res),
     ok.

--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -148,9 +148,9 @@ calculate_id(Base, Req, NodeOpts) ->
     % set. We can tell if the device is not set (or is the default) by checking 
     % whether the device module is the same as this module.
     DevMod =
-        case hb_ao:message_to_device(#{ <<"device">> => IDMod }, NodeOpts) of
+        case hb_ao_device:message_to_device(#{ <<"device">> => IDMod }, NodeOpts) of
             ?MODULE ->
-                hb_ao:message_to_device(
+                hb_ao_device:message_to_device(
                     #{ <<"device">> => ?DEFAULT_ID_DEVICE },
                     NodeOpts
                 );
@@ -158,13 +158,13 @@ calculate_id(Base, Req, NodeOpts) ->
         end,
     % Apply the function's default `commit' function with the appropriate arguments.
     % If it doesn't exist, error.
-    case hb_ao:find_exported_function(Base, DevMod, commit, 3, NodeOpts) of
+    case hb_ao_device:find_exported_function(Base, DevMod, commit, 3, NodeOpts) of
         {ok, Fun} ->
             ?event(id, {called_id_device, IDMod}, NodeOpts),
             {ok, #{ <<"commitments">> := Comms} } = 
                 apply(
                     Fun,
-                    hb_ao:truncate_args(
+                    hb_ao_device:truncate_args(
                         Fun,
                         [Base, Req#{ <<"type">> => <<"unsigned">> }, NodeOpts]
                     )
@@ -249,8 +249,8 @@ commit(Self, Req, Opts) ->
     % part of the commitment. Instead, we find the device module's `commit'
     % function and apply it.
     CommitOpts = Opts#{ linkify_mode => offload },
-    AttMod = hb_ao:message_to_device(#{ <<"device">> => AttDev }, CommitOpts),
-    {ok, AttFun} = hb_ao:find_exported_function(Base, AttMod, commit, 3, CommitOpts),
+    AttMod = hb_ao_device:message_to_device(#{ <<"device">> => AttDev }, CommitOpts),
+    {ok, AttFun} = hb_ao_device:find_exported_function(Base, AttMod, commit, 3, CommitOpts),
     % Encode to a TABM
     Loaded =
         ensure_commitments_loaded(
@@ -260,7 +260,7 @@ commit(Self, Req, Opts) ->
     {ok, Committed} =
         apply(
             AttFun,
-            hb_ao:truncate_args(
+            hb_ao_device:truncate_args(
                 AttFun,
                 [
                     Loaded,
@@ -339,12 +339,12 @@ verify_commitment(Base, Commitment, Opts) ->
             Opts
         ),
     AttMod =
-        hb_ao:message_to_device(
+        hb_ao_device:message_to_device(
             #{ <<"device">> => AttDev },
             Opts
         ),
     {ok, AttFun} =
-        hb_ao:find_exported_function(
+        hb_ao_device:find_exported_function(
             Base,
             AttMod,
             verify,

--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -23,7 +23,7 @@
 %% info call will match the three-argument version of the function. If in the 
 %% future the `request' is added as an argument to AO-Core's internal `info'
 %% function, we will need to find a different approach.
-info(_) -> #{ exports => [info, build] }.
+info(_) -> #{ exports => [<<"info">>, <<"build">>] }.
 
 %% @doc Utility function for determining if a request is from the `operator' of
 %% the node.

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -75,15 +75,17 @@ info(_Msg1) ->
         worker => fun dev_process_worker:server/3,
         grouper => fun dev_process_worker:group/3,
         await => fun dev_process_worker:await/5,
-        excludes => [
-            <<"test">>,
-            <<"init">>,
-            <<"ping_ping_script">>,
-            <<"schedule_aos_call">>,
-            <<"test_aos_process">>,
-            <<"dev_test_process">>,
-            <<"test_wasm_process">>
-        ]
+        exports =>
+            [
+                <<"info">>,
+                <<"as">>,
+                <<"compute">>,
+                <<"now">>,
+                <<"schedule">>,
+                <<"slot">>,
+                <<"snapshot">>,
+                <<"push">>
+            ]
     }.
 
 %% @doc Return the process state with the device swapped out for the device

--- a/src/dev_process_cache.erl
+++ b/src/dev_process_cache.erl
@@ -26,7 +26,7 @@ write(ProcID, Slot, Msg, Opts) ->
     MsgIDPath =
         path(
             ProcID,
-            ID = hb_util:human_id(hb_ao:get(id, Msg, Opts)),
+            ID = hb_message:id(Msg, uncommitted, Opts),
             Opts
         ),
     ?event(

--- a/src/dev_process_worker.erl
+++ b/src/dev_process_worker.erl
@@ -171,7 +171,7 @@ test_init() ->
 info_test() ->
     test_init(),
     M1 = dev_process:test_wasm_process(<<"test/aos-2-pure-xs.wasm">>),
-    Res = hb_ao:info(M1, #{}),
+    Res = hb_ao_device:info(M1, #{}),
     ?assertEqual(fun dev_process_worker:group/3, hb_maps:get(grouper, Res, undefined, #{})).
 
 grouper_test() ->

--- a/src/dev_profile.erl
+++ b/src/dev_profile.erl
@@ -178,7 +178,7 @@ eflame_profile(Fun, Req, Opts) ->
     % path is not set, we use Erlang's short string encoding of the function.
     Name =
         case hb_maps:get(<<"path">>, Req, undefined, Opts) of
-            undefined -> hb_util:bin(io_lib:format("~p", [Fun]));
+            undefined -> hb_escape:encode(hb_util:bin(io_lib:format("~p", [Fun])));
             Path ->
                 case hb_maps:get(Path, Req, undefined, Opts) of
                     undefined -> hb_util:bin(Path);

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -360,7 +360,7 @@ calculate_base_id(GivenProcess, Opts) ->
     BaseProcess = maps:without([<<"authority">>, <<"scheduler">>], Process),
     {ok, BaseID} = hb_ao:resolve(
         BaseProcess,
-        #{ <<"path">> => <<"id">>, <<"commitments">> => <<"none">> },
+        #{ <<"path">> => <<"id">> },
         Opts
     ),
     ?event({push_generated_base, {id, BaseID}, {base, BaseProcess}}),

--- a/src/dev_query.erl
+++ b/src/dev_query.erl
@@ -65,8 +65,8 @@ has_results(Base, Req, Opts) ->
     case Decoded of
         #{ <<"data">> := #{ <<"transactions">> := #{ <<"edges">> := Nodes } } }
                 when length(Nodes) > 0 ->
-            true;
-        _ -> false
+            {ok, true};
+        _ -> {ok, false}
     end.
 
 %% @doc Search for the keys specified in the request message.

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -32,7 +32,17 @@
 %% @doc Exported function for getting device info, controls which functions are
 %% exposed via the device API.
 info(_) -> 
-    #{ exports => [info, routes, route, match, register, preprocess] }.
+    #{
+        exports =>
+            [
+                <<"info">>,
+                <<"routes">>,
+                <<"route">>,
+                <<"match">>,
+                <<"register">>,
+                <<"preprocess">>
+            ]
+    }.
 
 %% @doc HTTP info response providing information about this device
 info(_Msg1, _Msg2, _Opts) ->

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -48,13 +48,13 @@ info() ->
     #{
         exports =>
             [
-                location,
-                status,
-                next,
-                schedule,
-                slot,
-                init,
-                checkpoint
+                <<"location">>,
+                <<"status">>,
+                <<"next">>,
+                <<"schedule">>,
+                <<"slot">>,
+                <<"init">>,
+                <<"checkpoint">>
             ],
         excludes => [set, keys],
         default => fun router/4

--- a/src/dev_simple_pay.erl
+++ b/src/dev_simple_pay.erl
@@ -365,7 +365,7 @@ apply_price_test() ->
         hb_http:get(
             Node,
             hb_message:commit(
-                #{<<"path">> => <<"/~p4@1.0/balance">>},
+                #{ <<"path">> => <<"/~p4@1.0/balance">> },
                 Opts#{ priv_wallet => ClientWallet }
             ),
             Opts

--- a/src/dev_volume.erl
+++ b/src/dev_volume.erl
@@ -35,7 +35,7 @@
 %% are exposed via the device API.
 info(_) -> 
     ?event(debug_volume, {info, entry, device_info_requested}),
-    #{ exports => [info, mount, public_key] }.
+    #{ exports => [<<"info">>, <<"mount">>, <<"public_key">>] }.
 
 %% @doc HTTP info response providing information about this device
 info(_Msg1, _Msg2, _Opts) ->

--- a/src/hb_ao.erl
+++ b/src/hb_ao.erl
@@ -96,14 +96,13 @@
 %%% Main AO-Core API:
 -export([resolve/2, resolve/3, resolve_many/2]).
 -export([normalize_key/1, normalize_key/2, normalize_keys/1, normalize_keys/2]).
--export([message_to_fun/3, message_to_device/2, load_device/2, find_exported_function/5]).
 -export([force_message/2]).
 %%% Shortcuts and tools:
--export([info/2, keys/1, keys/2, keys/3, truncate_args/2]).
+-export([keys/1, keys/2, keys/3]).
 -export([get/2, get/3, get/4, get_first/2, get_first/3]).
 -export([set/3, set/4, remove/2, remove/3]).
 %%% Exports for tests in hb_ao_test_vectors.erl:
--export([deep_set/4, is_exported/4]).
+-export([deep_set/4]).
 -include("include/hb.hrl").
 
 -define(TEMP_OPTS, [add_key, force_message, cache_control, spawn_worker]).
@@ -466,7 +465,7 @@ resolve_stage(5, Msg1, Msg2, ExecName, Opts) ->
                     {opts, Opts}
                 }
             ),
-			{Status, _Mod, Func} = message_to_fun(Msg1, Key, UserOpts),
+			{Status, _Mod, Func} = hb_ao_device:message_to_fun(Msg1, Key, UserOpts),
 			?event(
 				{found_func_for_exec,
                     {key, Key},
@@ -536,7 +535,7 @@ resolve_stage(6, Func, Msg1, Msg2, ExecName, Opts) ->
     % Try to execute the function.
     Res = 
         try
-            TruncatedArgs = truncate_args(Func, Args),
+            TruncatedArgs = hb_ao_device:truncate_args(Func, Args),
             MsgRes =
                 maybe_force_message(
                     maybe_profiled_apply(Func, TruncatedArgs, Msg1, Msg2, Opts),
@@ -930,18 +929,18 @@ force_message({Status, Res}, Opts) when is_list(Res) ->
 force_message({Status, Subres = {resolve, _}}, _Opts) ->
     {Status, Subres};
 force_message({Status, Literal}, _Opts) when not is_map(Literal) ->
-    ?event({force_message_from_literal, Literal}),
+    ?event(encode_result, {force_message_from_literal, Literal}),
     {Status, #{ <<"ao-result">> => <<"body">>, <<"body">> => Literal }};
 force_message({Status, M = #{ <<"status">> := Status, <<"body">> := Body }}, _Opts)
         when map_size(M) == 2 ->
-    ?event({force_message_from_literal_with_status, M}),
+    ?event(encode_result, {force_message_from_literal_with_status, M}),
     {Status, #{
         <<"status">> => Status,
         <<"ao-result">> => <<"body">>,
         <<"body">> => Body
     }};
 force_message({Status, Map}, _Opts) ->
-    ?event({force_message_from_map, Map}),
+    ?event(encode_result, {force_message_from_map, Map}),
     {Status, Map}.
 
 %% @doc Shortcut for resolving a key in a message without its status if it is
@@ -1159,202 +1158,6 @@ remove(Msg, Key, Opts) ->
         Opts
     ).
 
-%% @doc Truncate the arguments of a function to the number of arguments it
-%% actually takes.
-truncate_args(Fun, Args) ->
-    {arity, Arity} = erlang:fun_info(Fun, arity),
-    lists:sublist(Args, Arity).
-
-%% @doc Calculate the Erlang function that should be called to get a value for
-%% a given key from a device.
-%%
-%% This comes in 7 forms:
-%% 1. The message does not specify a device, so we use the default device.
-%% 2. The device has a `handler' key in its `Dev:info()' map, which is a
-%% function that takes a key and returns a function to handle that key. We pass
-%% the key as an additional argument to this function.
-%% 3. The device has a function of the name `Key', which should be called
-%% directly.
-%% 4. The device does not implement the key, but does have a default handler
-%% for us to call. We pass it the key as an additional argument.
-%% 5. The device does not implement the key, and has no default handler. We use
-%% the default device to handle the key.
-%% Error: If the device is specified, but not loadable, we raise an error.
-%%
-%% Returns {ok | add_key, Fun} where Fun is the function to call, and add_key
-%% indicates that the key should be added to the start of the call's arguments.
-message_to_fun(Msg, Key, Opts) ->
-    % Get the device module from the message.
-	Dev = message_to_device(Msg, Opts),
-    Info = info(Dev, Msg, Opts),
-    % Is the key exported by the device?
-    Exported = is_exported(Info, Key, Opts),
-	?event(
-        ao_devices,
-        {message_to_fun,
-            {dev, Dev},
-            {key, Key},
-            {is_exported, Exported},
-            {opts, Opts}
-        },
-		Opts
-    ),
-    % Does the device have an explicit handler function?
-    case {hb_maps:find(handler, Info, Opts), Exported} of
-        {{ok, Handler}, true} ->
-			% Case 2: The device has an explicit handler function.
-			?event(
-                ao_devices,
-                {handler_found, {dev, Dev}, {key, Key}, {handler, Handler}}
-            ),
-			{Status, Func} = info_handler_to_fun(Handler, Msg, Key, Opts),
-            {Status, Dev, Func};
-		_ ->
-			?event(ao_devices, {no_override_handler, {dev, Dev}, {key, Key}}),
-			case {find_exported_function(Msg, Dev, Key, 3, Opts), Exported} of
-				{{ok, Func}, true} ->
-					% Case 3: The device has a function of the name `Key'.
-					{ok, Dev, Func};
-				_ ->
-					case {hb_maps:find(default, Info, Opts), Exported} of
-						{{ok, DefaultFunc}, true} when is_function(DefaultFunc) ->
-							% Case 4: The device has a default handler.
-                            ?event({found_default_handler, {func, DefaultFunc}}),
-							{add_key, Dev, DefaultFunc};
-                        {{ok, DefaultMod}, true} when is_atom(DefaultMod) ->
-							?event({found_default_handler, {mod, DefaultMod}}),
-                            {Status, Func} =
-                                message_to_fun(
-                                    Msg#{ <<"device">> => DefaultMod }, Key, Opts
-                                ),
-                            {Status, Dev, Func};
-						_ ->
-							% Case 5: The device has no default handler.
-							% We use the default device to handle the key.
-							case default_module() of
-								Dev ->
-									% We are already using the default device,
-									% so we cannot resolve the key. This should
-									% never actually happen in practice, but it
-									% resolves an infinite loop that can occur
-									% during development.
-									throw({
-										error,
-										default_device_could_not_resolve_key,
-										{key, Key}
-									});
-								DefaultDev ->
-                                    ?event(
-                                        {
-                                            using_default_device,
-                                            {dev, DefaultDev}
-                                        }),
-                                    message_to_fun(
-                                        Msg#{ <<"device">> => DefaultDev },
-                                        Key,
-                                        Opts
-                                    )
-							end
-					end
-			end
-	end.
-
-%% @doc Extract the device module from a message.
-message_to_device(Msg, Opts) ->
-    case dev_message:get(<<"device">>, Msg, Opts) of
-        {error, not_found} ->
-            % The message does not specify a device, so we use the default device.
-            default_module();
-        {ok, DevID} ->
-            case load_device(DevID, Opts) of
-                {error, Reason} ->
-                    % Error case: A device is specified, but it is not loadable.
-                    throw({error, {device_not_loadable, DevID, Reason}});
-                {ok, DevMod} -> DevMod
-            end
-    end.
-
-%% @doc Parse a handler key given by a device's `info'.
-info_handler_to_fun(Handler, _Msg, _Key, _Opts) when is_function(Handler) ->
-	{add_key, Handler};
-info_handler_to_fun(HandlerMap, Msg, Key, Opts) ->
-	case hb_maps:find(excludes, HandlerMap, Opts) of
-		{ok, Exclude} ->
-			case lists:member(Key, Exclude) of
-				true ->
-					{ok, MsgWithoutDevice} =
-						dev_message:remove(Msg, #{ item => device }, Opts),
-					message_to_fun(
-						MsgWithoutDevice#{ <<"device">> => default_module() },
-						Key,
-						Opts
-					);
-				false -> {add_key, hb_maps:get(func, HandlerMap, undefined, Opts)}
-			end;
-		error -> {add_key, hb_maps:get(func, HandlerMap, undefined, Opts)}
-	end.
-
-%% @doc Find the function with the highest arity that has the given name, if it
-%% exists.
-%%
-%% If the device is a module, we look for a function with the given name.
-%%
-%% If the device is a map, we look for a key in the map. First we try to find
-%% the key using its literal value. If that fails, we cast the key to an atom
-%% and try again.
-find_exported_function(Msg, Dev, Key, MaxArity, Opts) when is_map(Dev) ->
-	case hb_maps:get(normalize_key(Key), normalize_keys(Dev, Opts), not_found, Opts) of
-		not_found -> not_found;
-		Fun when is_function(Fun) ->
-			case erlang:fun_info(Fun, arity) of
-				{arity, Arity} when Arity =< MaxArity ->
-					case is_exported(Msg, Dev, Key, Opts) of
-						true -> {ok, Fun};
-						false -> not_found
-					end;
-				_ -> not_found
-			end
-	end;
-find_exported_function(_Msg, _Mod, _Key, Arity, _Opts) when Arity < 0 ->
-    not_found;
-find_exported_function(Msg, Mod, Key, Arity, Opts) when not is_atom(Key) ->
-	try hb_util:key_to_atom(Key, false) of
-		KeyAtom -> find_exported_function(Msg, Mod, KeyAtom, Arity, Opts)
-	catch _:_ -> not_found
-	end;
-find_exported_function(Msg, Mod, Key, Arity, Opts) ->
-	case erlang:function_exported(Mod, Key, Arity) of
-		true ->
-			case is_exported(Msg, Mod, Key, Opts) of
-				true -> {ok, fun Mod:Key/Arity};
-				false -> not_found
-			end;
-		false ->
-			find_exported_function(Msg, Mod, Key, Arity - 1, Opts)
-	end.
-
-%% @doc Check if a device is guarding a key via its `exports' list. Defaults to
-%% true if the device does not specify an `exports' list. The `info' function is
-%% always exported, if it exists. Elements of the `exludes' list are not
-%% exported. Note that we check for info _twice_ -- once when the device is
-%% given but the info result is not, and once when the info result is given.
-%% The reason for this is that `info/3' calls other functions that may need to
-%% check if a key is exported, so we must avoid infinite loops. We must, however,
-%% also return a consistent result in the case that only the info result is
-%% given, so we check for it in both cases.
-is_exported(_Msg, _Dev, info, _Opts) -> true;
-is_exported(Msg, Dev, Key, Opts) ->
-	is_exported(info(Dev, Msg, Opts), Key, Opts).
-is_exported(_, info, _Opts) -> true;
-is_exported(Info = #{ excludes := Excludes }, Key, Opts) ->
-    case lists:member(normalize_key(Key), lists:map(fun normalize_key/1, Excludes)) of
-        true -> false;
-        false -> is_exported(hb_maps:remove(excludes, Info, Opts), Key, Opts)
-    end;
-is_exported(#{ exports := Exports }, Key, _Opts) ->
-    lists:member(normalize_key(Key), lists:map(fun normalize_key/1, Exports));
-is_exported(_Info, _Key, _Opts) -> true.
-
 %% @doc Convert a key to a binary in normalized form.
 normalize_key(Key) -> normalize_key(Key, #{}).
 normalize_key(Key, _Opts) when is_binary(Key) -> Key;
@@ -1397,174 +1200,6 @@ normalize_keys(Map, Opts) when is_map(Map) ->
         )
     );
 normalize_keys(Other, _Opts) -> Other.
-
-%% @doc Load a device module from its name or a message ID.
-%% Returns {ok, Executable} where Executable is the device module. On error,
-%% a tuple of the form {error, Reason} is returned.
-load_device(Map, _Opts) when is_map(Map) -> {ok, Map};
-load_device(ID, _Opts) when is_atom(ID) ->
-    try ID:module_info(), {ok, ID}
-    catch _:_ -> {error, not_loadable}
-    end;
-load_device(ID, Opts) when ?IS_ID(ID) ->
-    ?event(device_load, {requested_load, {id, ID}}, Opts),
-	case hb_opts:get(load_remote_devices, false, Opts) of
-        false ->
-            {error, remote_devices_disabled};
-		true ->
-            ?event(device_load, {loading_from_cache, {id, ID}}, Opts),
-			{ok, Msg} = hb_cache:read(ID, Opts),
-            ?event(device_load, {received_device, {id, ID}, {msg, Msg}}, Opts),
-            TrustedSigners = hb_opts:get(trusted_device_signers, [], Opts),
-			Trusted =
-				lists:any(
-					fun(Signer) ->
-						lists:member(Signer, TrustedSigners)
-					end,
-					hb_message:signers(Msg, Opts)
-				),
-            ?event(device_load,
-                {verifying_device_trust,
-                    {id, ID},
-                    {trusted, Trusted},
-                    {signers, hb_message:signers(Msg, Opts)}
-                },
-                Opts
-            ),
-			case Trusted of
-				false -> {error, device_signer_not_trusted};
-				true ->
-                    ?event(device_load, {loading_device, {id, ID}}, Opts),
-					case hb_maps:get(<<"content-type">>, Msg, undefined, Opts) of
-						<<"application/beam">> ->
-                            case verify_device_compatibility(Msg, Opts) of
-                                ok ->
-                                    ModName =
-                                        hb_util:key_to_atom(
-                                            hb_maps:get(
-                                                <<"module-name">>,
-                                                Msg,
-                                                undefined,
-                                                Opts
-                                            ),
-                                            new_atoms
-                                        ),
-                                    LoadRes = 
-                                        erlang:load_module(
-                                            ModName,
-                                            hb_maps:get(
-                                                <<"body">>,
-                                                Msg,
-                                                undefined,
-                                                Opts
-                                            )
-                                        ),
-                                    case LoadRes of
-                                        {module, _} ->
-                                            {ok, ModName};
-                                        {error, Reason} ->
-                                            {error, {device_load_failed, Reason}}
-                                    end;
-                                {error, Reason} ->
-                                    {error, {device_load_failed, Reason}}
-                            end;
-                        Other ->
-                            {error,
-                                {device_load_failed,
-                                    {incompatible_content_type, Other},
-                                    {expected, <<"application/beam">>},
-                                    {found, Other}
-                                }
-                            }
-                    end
-			end
-	end;
-load_device(ID, Opts) ->
-    NormKey =
-        case is_atom(ID) of
-            true -> ID;
-            false -> normalize_key(ID)
-        end,
-    case lists:search(
-        fun (#{ <<"name">> := Name }) -> Name =:= NormKey end,
-        Preloaded = hb_opts:get(preloaded_devices, [], Opts)
-    ) of
-        false -> {error, {module_not_admissable, NormKey, Preloaded}};
-        {value, #{ <<"module">> := Mod }} -> load_device(Mod, Opts)
-    end.
-
-%% @doc Verify that a device is compatible with the current machine.
-verify_device_compatibility(Msg, Opts) ->
-    ?event(device_load, {verifying_device_compatibility, {msg, Msg}}, Opts),
-    Required =
-        lists:filtermap(
-            fun({<<"requires-", Key/binary>>, Value}) ->
-                {true,
-                    {
-                        hb_util:key_to_atom(
-                            hb_ao:normalize_key(Key),
-                            new_atoms
-                        ),
-                        hb_cache:ensure_loaded(Value, Opts)
-                    }
-                };
-            (_) -> false
-            end,
-            hb_maps:to_list(Msg, Opts)
-        ),
-    ?event(device_load,
-        {discerned_requirements,
-            {required, Required},
-            {msg, Msg}
-        },
-        Opts
-    ),
-    FailedToMatch =
-        lists:filtermap(
-            fun({Property, Value}) ->
-                % The values of these properties are _not_ 'keys', but we normalize
-                % them as such in order to make them comparable.
-                SystemValue = erlang:system_info(Property),
-                Res = normalize_key(SystemValue) == normalize_key(Value),
-                % If the property matched, we remove it from the list of required
-                % properties. If it doesn't we return it with the found value, such
-                % that the caller knows which properties were not satisfied.
-                case Res of
-                    true -> false;
-                    false -> {true, {Property, Value}}
-                end
-            end,
-            Required
-        ),
-    case FailedToMatch of
-        [] -> ok;
-        _ -> {error, {failed_requirements, FailedToMatch}}
-    end.
-
-%% @doc Get the info map for a device, optionally giving it a message if the
-%% device's info function is parameterized by one.
-info(Msg, Opts) ->
-    info(message_to_device(Msg, Opts), Msg, Opts).
-info(DevMod, Msg, Opts) ->
-	%?event({calculating_info, {dev, DevMod}, {msg, Msg}}),
-    case find_exported_function(Msg, DevMod, info, 2, Opts) of
-		{ok, Fun} ->
-			Res = apply(Fun, truncate_args(Fun, [Msg, Opts])),
-			% ?event({
-            %     info_result,
-            %     {dev, DevMod},
-            %     {args, truncate_args(Fun, [Msg])},
-            %     {result, Res}
-            % }),
-			Res;
-		not_found -> #{}
-	end.
-
-%% @doc The default device is the identity device, which simply returns the
-%% value associated with any key as it exists in its Erlang map. It should also
-%% implement the `set' key, which returns a `Message3' with the values changed
-%% according to the `Message2' passed to it.
-default_module() -> dev_message.
 
 %% @doc The execution options that are used internally by this module
 %% when calling itself.

--- a/src/hb_ao_device.erl
+++ b/src/hb_ao_device.erl
@@ -7,6 +7,20 @@
 -export([find_exported_function/5, is_exported/4, info/2, info/3, default/0]).
 -include("include/hb.hrl").
 
+%%% All keys in the `message@1.0` device that are not resolved to underlying
+%%% data in the their Erlang map representations.
+-define(MESSAGE_KEYS, [
+    <<"get">>,
+    <<"set">>,
+    <<"remove">>,
+    <<"keys">>,
+    <<"id">>,
+    <<"commit">>,
+    <<"verify">>,
+    <<"committers">>,
+    <<"committed">>
+]).
+
 %% @doc Truncate the arguments of a function to the number of arguments it
 %% actually takes.
 truncate_args(Fun, Args) ->
@@ -380,25 +394,12 @@ is_direct_key_access(not_found, Key, Opts) ->
 is_direct_key_access(error, Key, Opts) ->
     is_direct_key_access(<<"message@1.0">>, Key, Opts);
 is_direct_key_access(<<"message@1.0">>, Key, _Opts) ->
-    not lists:member(
-        Key,
-        [
-            <<"get">>,
-            <<"set">>,
-            <<"remove">>,
-            <<"keys">>,
-            <<"id">>,
-            <<"commit">>,
-            <<"verify">>,
-            <<"committers">>,
-            <<"committed">>
-        ]
-    );
+    not lists:member(Key, ?MESSAGE_KEYS);
 is_direct_key_access(Dev, NormKey, Opts) ->
     ?event(read_cached, {calculating_info, {device, Dev}}),
     case info(#{ <<"device">> => Dev}, Opts) of
         Info = #{ exports := Exports } when not is_map_key(handler, Info) ->
-            not lists:member(NormKey, Exports);
+            not lists:member(NormKey, Exports ++ ?MESSAGE_KEYS);
         _ -> false
     end;
 is_direct_key_access(_, _, _) ->

--- a/src/hb_ao_device.erl
+++ b/src/hb_ao_device.erl
@@ -1,0 +1,374 @@
+%%% @doc A library for working with HyperBEAM-compatible AO-Core devices.
+%%% Offers services for loading, verifying executability, and extracting Erlang
+%%% functions from a device.
+-module(hb_ao_device).
+-export([truncate_args/2, message_to_fun/3, message_to_device/2, load/2]).
+-export([find_exported_function/5, is_exported/4, info/2, info/3, default/0]).
+-include("include/hb.hrl").
+
+%% @doc Truncate the arguments of a function to the number of arguments it
+%% actually takes.
+truncate_args(Fun, Args) ->
+    {arity, Arity} = erlang:fun_info(Fun, arity),
+    lists:sublist(Args, Arity).
+
+%% @doc Calculate the Erlang function that should be called to get a value for
+%% a given key from a device.
+%%
+%% This comes in 7 forms:
+%% 1. The message does not specify a device, so we use the default device.
+%% 2. The device has a `handler' key in its `Dev:info()' map, which is a
+%% function that takes a key and returns a function to handle that key. We pass
+%% the key as an additional argument to this function.
+%% 3. The device has a function of the name `Key', which should be called
+%% directly.
+%% 4. The device does not implement the key, but does have a default handler
+%% for us to call. We pass it the key as an additional argument.
+%% 5. The device does not implement the key, and has no default handler. We use
+%% the default device to handle the key.
+%% Error: If the device is specified, but not loadable, we raise an error.
+%%
+%% Returns {ok | add_key, Fun} where Fun is the function to call, and add_key
+%% indicates that the key should be added to the start of the call's arguments.
+message_to_fun(Msg, Key, Opts) ->
+    % Get the device module from the message.
+	Dev = message_to_device(Msg, Opts),
+    Info = info(Dev, Msg, Opts),
+    % Is the key exported by the device?
+    Exported = is_exported(Info, Key, Opts),
+	?event(
+        ao_devices,
+        {message_to_fun,
+            {dev, Dev},
+            {key, Key},
+            {is_exported, Exported},
+            {opts, Opts}
+        },
+		Opts
+    ),
+    % Does the device have an explicit handler function?
+    case {hb_maps:find(handler, Info, Opts), Exported} of
+        {{ok, Handler}, true} ->
+			% Case 2: The device has an explicit handler function.
+			?event(
+                ao_devices,
+                {handler_found, {dev, Dev}, {key, Key}, {handler, Handler}}
+            ),
+			{Status, Func} = info_handler_to_fun(Handler, Msg, Key, Opts),
+            {Status, Dev, Func};
+		_ ->
+			?event(ao_devices, {no_override_handler, {dev, Dev}, {key, Key}}),
+			case {find_exported_function(Msg, Dev, Key, 3, Opts), Exported} of
+				{{ok, Func}, true} ->
+					% Case 3: The device has a function of the name `Key'.
+					{ok, Dev, Func};
+				_ ->
+					case {hb_maps:find(default, Info, Opts), Exported} of
+						{{ok, DefaultFunc}, true} when is_function(DefaultFunc) ->
+							% Case 4: The device has a default handler.
+                            ?event({found_default_handler, {func, DefaultFunc}}),
+							{add_key, Dev, DefaultFunc};
+                        {{ok, DefaultMod}, true} when is_atom(DefaultMod) ->
+							?event({found_default_handler, {mod, DefaultMod}}),
+                            {Status, Func} =
+                                message_to_fun(
+                                    Msg#{ <<"device">> => DefaultMod }, Key, Opts
+                                ),
+                            {Status, Dev, Func};
+						_ ->
+							% Case 5: The device has no default handler.
+							% We use the default device to handle the key.
+							case default() of
+								Dev ->
+									% We are already using the default device,
+									% so we cannot resolve the key. This should
+									% never actually happen in practice, but it
+									% resolves an infinite loop that can occur
+									% during development.
+									throw({
+										error,
+										default_device_could_not_resolve_key,
+										{key, Key}
+									});
+								DefaultDev ->
+                                    ?event(
+                                        {
+                                            using_default_device,
+                                            {dev, DefaultDev}
+                                        }),
+                                    message_to_fun(
+                                        Msg#{ <<"device">> => DefaultDev },
+                                        Key,
+                                        Opts
+                                    )
+							end
+					end
+			end
+	end.
+
+%% @doc Extract the device module from a message.
+message_to_device(Msg, Opts) ->
+    case dev_message:get(<<"device">>, Msg, Opts) of
+        {error, not_found} ->
+            % The message does not specify a device, so we use the default device.
+            default();
+        {ok, DevID} ->
+            case load(DevID, Opts) of
+                {error, Reason} ->
+                    % Error case: A device is specified, but it is not loadable.
+                    throw({error, {device_not_loadable, DevID, Reason}});
+                {ok, DevMod} -> DevMod
+            end
+    end.
+
+%% @doc Parse a handler key given by a device's `info'.
+info_handler_to_fun(Handler, _Msg, _Key, _Opts) when is_function(Handler) ->
+	{add_key, Handler};
+info_handler_to_fun(HandlerMap, Msg, Key, Opts) ->
+	case hb_maps:find(excludes, HandlerMap, Opts) of
+		{ok, Exclude} ->
+			case lists:member(Key, Exclude) of
+				true ->
+					{ok, MsgWithoutDevice} =
+						dev_message:remove(Msg, #{ item => device }, Opts),
+					message_to_fun(
+						MsgWithoutDevice#{ <<"device">> => default() },
+						Key,
+						Opts
+					);
+				false -> {add_key, hb_maps:get(func, HandlerMap, undefined, Opts)}
+			end;
+		error -> {add_key, hb_maps:get(func, HandlerMap, undefined, Opts)}
+	end.
+
+%% @doc Find the function with the highest arity that has the given name, if it
+%% exists.
+%%
+%% If the device is a module, we look for a function with the given name.
+%%
+%% If the device is a map, we look for a key in the map. First we try to find
+%% the key using its literal value. If that fails, we cast the key to an atom
+%% and try again.
+find_exported_function(Msg, Dev, Key, MaxArity, Opts) when is_map(Dev) ->
+    NormKey = hb_ao:normalize_key(Key),
+    NormDev = hb_ao:normalize_keys(Dev, Opts),
+	case hb_maps:get(NormKey, NormDev, not_found, Opts) of
+		not_found -> not_found;
+		Fun when is_function(Fun) ->
+			case erlang:fun_info(Fun, arity) of
+				{arity, Arity} when Arity =< MaxArity ->
+					case is_exported(Msg, Dev, Key, Opts) of
+						true -> {ok, Fun};
+						false -> not_found
+					end;
+				_ -> not_found
+			end
+	end;
+find_exported_function(_Msg, _Mod, _Key, Arity, _Opts) when Arity < 0 ->
+    not_found;
+find_exported_function(Msg, Mod, Key, Arity, Opts) when not is_atom(Key) ->
+	try hb_util:key_to_atom(Key, false) of
+		KeyAtom -> find_exported_function(Msg, Mod, KeyAtom, Arity, Opts)
+	catch _:_ -> not_found
+	end;
+find_exported_function(Msg, Mod, Key, Arity, Opts) ->
+	case erlang:function_exported(Mod, Key, Arity) of
+		true ->
+			case is_exported(Msg, Mod, Key, Opts) of
+				true -> {ok, fun Mod:Key/Arity};
+				false -> not_found
+			end;
+		false ->
+			find_exported_function(Msg, Mod, Key, Arity - 1, Opts)
+	end.
+
+%% @doc Check if a device is guarding a key via its `exports' list. Defaults to
+%% true if the device does not specify an `exports' list. The `info' function is
+%% always exported, if it exists. Elements of the `exludes' list are not
+%% exported. Note that we check for info _twice_ -- once when the device is
+%% given but the info result is not, and once when the info result is given.
+%% The reason for this is that `info/3' calls other functions that may need to
+%% check if a key is exported, so we must avoid infinite loops. We must, however,
+%% also return a consistent result in the case that only the info result is
+%% given, so we check for it in both cases.
+is_exported(_Msg, _Dev, info, _Opts) -> true;
+is_exported(Msg, Dev, Key, Opts) ->
+	is_exported(info(Dev, Msg, Opts), Key, Opts).
+is_exported(_, info, _Opts) -> true;
+is_exported(Info = #{ excludes := Excludes }, Key, Opts) ->
+    NormKey = hb_ao:normalize_key(Key),
+    case lists:member(NormKey, lists:map(fun hb_ao:normalize_key/1, Excludes)) of
+        true -> false;
+        false -> is_exported(hb_maps:remove(excludes, Info, Opts), Key, Opts)
+    end;
+is_exported(#{ exports := Exports }, Key, _Opts) ->
+    lists:member(hb_ao:normalize_key(Key), lists:map(fun hb_ao:normalize_key/1, Exports));
+is_exported(_Info, _Key, _Opts) -> true.
+
+%% @doc Load a device module from its name or a message ID.
+%% Returns {ok, Executable} where Executable is the device module. On error,
+%% a tuple of the form {error, Reason} is returned.
+load(Map, _Opts) when is_map(Map) -> {ok, Map};
+load(ID, _Opts) when is_atom(ID) ->
+    try ID:module_info(), {ok, ID}
+    catch _:_ -> {error, not_loadable}
+    end;
+load(ID, Opts) when ?IS_ID(ID) ->
+    ?event(device_load, {requested_load, {id, ID}}, Opts),
+	case hb_opts:get(load_remote_devices, false, Opts) of
+        false ->
+            {error, remote_devices_disabled};
+		true ->
+            ?event(device_load, {loading_from_cache, {id, ID}}, Opts),
+			{ok, Msg} = hb_cache:read(ID, Opts),
+            ?event(device_load, {received_device, {id, ID}, {msg, Msg}}, Opts),
+            TrustedSigners = hb_opts:get(trusted_device_signers, [], Opts),
+			Trusted =
+				lists:any(
+					fun(Signer) ->
+						lists:member(Signer, TrustedSigners)
+					end,
+					hb_message:signers(Msg, Opts)
+				),
+            ?event(device_load,
+                {verifying_device_trust,
+                    {id, ID},
+                    {trusted, Trusted},
+                    {signers, hb_message:signers(Msg, Opts)}
+                },
+                Opts
+            ),
+			case Trusted of
+				false -> {error, device_signer_not_trusted};
+				true ->
+                    ?event(device_load, {loading_device, {id, ID}}, Opts),
+					case hb_maps:get(<<"content-type">>, Msg, undefined, Opts) of
+						<<"application/beam">> ->
+                            case verify_device_compatibility(Msg, Opts) of
+                                ok ->
+                                    ModName =
+                                        hb_util:key_to_atom(
+                                            hb_maps:get(
+                                                <<"module-name">>,
+                                                Msg,
+                                                undefined,
+                                                Opts
+                                            ),
+                                            new_atoms
+                                        ),
+                                    LoadRes = 
+                                        erlang:load_module(
+                                            ModName,
+                                            hb_maps:get(
+                                                <<"body">>,
+                                                Msg,
+                                                undefined,
+                                                Opts
+                                            )
+                                        ),
+                                    case LoadRes of
+                                        {module, _} ->
+                                            {ok, ModName};
+                                        {error, Reason} ->
+                                            {error, {device_load_failed, Reason}}
+                                    end;
+                                {error, Reason} ->
+                                    {error, {device_load_failed, Reason}}
+                            end;
+                        Other ->
+                            {error,
+                                {device_load_failed,
+                                    {incompatible_content_type, Other},
+                                    {expected, <<"application/beam">>},
+                                    {found, Other}
+                                }
+                            }
+                    end
+			end
+	end;
+load(ID, Opts) ->
+    NormKey =
+        case is_atom(ID) of
+            true -> ID;
+            false -> hb_ao:normalize_key(ID)
+        end,
+    case lists:search(
+        fun (#{ <<"name">> := Name }) -> Name =:= NormKey end,
+        Preloaded = hb_opts:get(preloaded_devices, [], Opts)
+    ) of
+        false -> {error, {module_not_admissable, NormKey, Preloaded}};
+        {value, #{ <<"module">> := Mod }} -> load(Mod, Opts)
+    end.
+
+%% @doc Verify that a device is compatible with the current machine.
+verify_device_compatibility(Msg, Opts) ->
+    ?event(device_load, {verifying_device_compatibility, {msg, Msg}}, Opts),
+    Required =
+        lists:filtermap(
+            fun({<<"requires-", Key/binary>>, Value}) ->
+                {true,
+                    {
+                        hb_util:key_to_atom(
+                            hb_ao:normalize_key(Key),
+                            new_atoms
+                        ),
+                        hb_cache:ensure_loaded(Value, Opts)
+                    }
+                };
+            (_) -> false
+            end,
+            hb_maps:to_list(Msg, Opts)
+        ),
+    ?event(device_load,
+        {discerned_requirements,
+            {required, Required},
+            {msg, Msg}
+        },
+        Opts
+    ),
+    FailedToMatch =
+        lists:filtermap(
+            fun({Property, Value}) ->
+                % The values of these properties are _not_ 'keys', but we normalize
+                % them as such in order to make them comparable.
+                SystemValue = erlang:system_info(Property),
+                Res = hb_ao:normalize_key(SystemValue) == hb_ao:normalize_key(Value),
+                % If the property matched, we remove it from the list of required
+                % properties. If it doesn't we return it with the found value, such
+                % that the caller knows which properties were not satisfied.
+                case Res of
+                    true -> false;
+                    false -> {true, {Property, Value}}
+                end
+            end,
+            Required
+        ),
+    case FailedToMatch of
+        [] -> ok;
+        _ -> {error, {failed_requirements, FailedToMatch}}
+    end.
+
+%% @doc Get the info map for a device, optionally giving it a message if the
+%% device's info function is parameterized by one.
+info(Msg, Opts) ->
+    info(message_to_device(Msg, Opts), Msg, Opts).
+info(DevMod, Msg, Opts) ->
+	%?event({calculating_info, {dev, DevMod}, {msg, Msg}}),
+    case find_exported_function(Msg, DevMod, info, 2, Opts) of
+		{ok, Fun} ->
+			Res = apply(Fun, truncate_args(Fun, [Msg, Opts])),
+			% ?event({
+            %     info_result,
+            %     {dev, DevMod},
+            %     {args, truncate_args(Fun, [Msg])},
+            %     {result, Res}
+            % }),
+			Res;
+		not_found -> #{}
+	end.
+
+%% @doc The default device is the identity device, which simply returns the
+%% value associated with any key as it exists in its Erlang map. It should also
+%% implement the `set' key, which returns a `Message3' with the values changed
+%% according to the `Message2' passed to it.
+default() -> dev_message.

--- a/src/hb_ao_test_vectors.erl
+++ b/src/hb_ao_test_vectors.erl
@@ -13,8 +13,7 @@
 %% `rebar3 eunit --test hb_ao_test_vectors:run_test'
 %% Comment/uncomment out as necessary.
 run_test() ->
-    hb_test_utils:run(resolve_id, normal, test_suite(), test_opts()),
-    hb_test_utils:run(resolve_id, only_if_cached, test_suite(), test_opts()).
+    skip.
 
 %% @doc Run each test in the file with each set of options. Start and reset
 %% the store for each test.
@@ -167,17 +166,27 @@ test_opts() ->
                 }
             },
             skip => [
-                % Exclude tests that return a list on its own for now, as raw 
-                % lists cannot be cached yet.
+                % Skip test with locally defined device, amongst others.
+                resolve_id,
+                start_as,
+                start_as_with_parameters,
+                as_path,
+                multiple_as_subresolutions,
+                key_from_id_device_with_args,
                 set_new_messages,
                 resolve_from_multiple_keys,
                 resolve_path_element,
+                device_with_default_handler_function,
+                device_with_handler_function,
                 denormalized_device_key,
-                % Skip test with locally defined device
+                get_with_device,
+                get_as_with_device,
+                set_with_device,
+                device_exports,
+                device_excludes,
                 deep_set_with_device,
-                as
-                % Skip tests that call hb_ao utils (which have their own 
-                % cache settings).
+                as,
+                step_hook
             ]
         }
     ].

--- a/src/hb_ao_test_vectors.erl
+++ b/src/hb_ao_test_vectors.erl
@@ -644,10 +644,10 @@ deep_set_with_device_test(Opts) ->
 
 device_exports_test(Opts) ->
 	Msg = #{ <<"device">> => dev_message },
-	?assert(hb_ao:is_exported(Msg, dev_message, info, Opts)),
-	?assert(hb_ao:is_exported(Msg, dev_message, set, Opts)),
+	?assert(hb_ao_device:is_exported(Msg, dev_message, info, Opts)),
+	?assert(hb_ao_device:is_exported(Msg, dev_message, set, Opts)),
 	?assert(
-        hb_ao:is_exported(
+        hb_ao_device:is_exported(
             Msg,
             dev_message,
             not_explicitly_exported,
@@ -659,9 +659,9 @@ device_exports_test(Opts) ->
 		set => fun(_, _) -> {ok, <<"SET">>} end
 	},
 	Msg2 = #{ <<"device">> => Dev },
-	?assert(hb_ao:is_exported(Msg2, Dev, info, Opts)),
-	?assert(hb_ao:is_exported(Msg2, Dev, set, Opts)),
-	?assert(not hb_ao:is_exported(Msg2, Dev, not_exported, Opts)),
+	?assert(hb_ao_device:is_exported(Msg2, Dev, info, Opts)),
+	?assert(hb_ao_device:is_exported(Msg2, Dev, set, Opts)),
+	?assert(not hb_ao_device:is_exported(Msg2, Dev, not_exported, Opts)),
     Dev2 = #{
         info =>
             fun() ->
@@ -700,8 +700,8 @@ device_excludes_test(Opts) ->
             end
     },
     Msg = #{ <<"device">> => Dev, <<"Test-Key">> => <<"Test-Value">> },
-    ?assert(hb_ao:is_exported(Msg, Dev, <<"test-key2">>, Opts)),
-    ?assert(not hb_ao:is_exported(Msg, Dev, set, Opts)),
+    ?assert(hb_ao_device:is_exported(Msg, Dev, <<"test-key2">>, Opts)),
+    ?assert(not hb_ao_device:is_exported(Msg, Dev, set, Opts)),
     ?assertEqual(<<"Handler-Value">>, hb_ao:get(<<"test-key2">>, Msg, Opts)),
     ?assertMatch(#{ <<"test-key2">> := <<"2">> },
         hb_ao:set(Msg, <<"test-key2">>, <<"2">>, Opts)).
@@ -712,7 +712,7 @@ denormalized_device_key_test(Opts) ->
 	?assertEqual(dev_test, hb_ao:get(<<"device">>, Msg, Opts)),
 	?assertEqual({module, dev_test},
 		erlang:fun_info(
-            element(3, hb_ao:message_to_fun(Msg, test_func, Opts)),
+            element(3, hb_ao_device:message_to_fun(Msg, test_func, Opts)),
             module
         )
     ).

--- a/src/hb_ao_test_vectors.erl
+++ b/src/hb_ao_test_vectors.erl
@@ -13,7 +13,8 @@
 %% `rebar3 eunit --test hb_ao_test_vectors:run_test'
 %% Comment/uncomment out as necessary.
 run_test() ->
-    multiple_as_subresolutions_test(#{}).
+    hb_test_utils:run(resolve_id, normal, test_suite(), test_opts()),
+    hb_test_utils:run(resolve_id, only_if_cached, test_suite(), test_opts()).
 
 %% @doc Run each test in the file with each set of options. Start and reset
 %% the store for each test.
@@ -262,7 +263,7 @@ resolve_simple_test(Opts) ->
 resolve_id_test(Opts) ->
     ?assertMatch(
         ID when byte_size(ID) == 43,
-        hb_ao:get(id, #{ test_key => <<"1">> }, Opts)
+        hb_ao:get(<<"id">>, #{ <<"test_key">> => <<"1">> }, Opts)
     ).
 
 resolve_key_twice_test(Opts) ->

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -671,7 +671,8 @@ read_in_memory_key(BaseMsg, Key, _Opts) ->
             {ok, Value}
     end.
 
-%% @doc Determine if a device is a direct access device.
+%% @doc Determine if a device is a `direct access': If there is a literal key
+%% in the message's Erlang map representation, will it always be returned?
 is_direct_access_message({_Status, DevRes}, Key, Opts) ->
     is_direct_access_message(DevRes, Key, Opts);
 is_direct_access_message(not_found, _, _) ->
@@ -684,10 +685,8 @@ is_direct_access_message(DevName, Key, Opts) ->
     ?event(read_cached, {calculating_info, {device, DevName}}),
     case hb_ao:info(#{ <<"device">> => DevName }, Opts) of
         Info = #{ exports := Exports } when not is_map_key(handler, Info) ->
-            ?event(read_cached, {testing_is_exported, {device, DevName}, {exports, Exports}}),
             not lists:member(Key, Exports);
-        Res ->
-            ?event(read_cached, {direct_access_message_not_found, {device, DevName}, {info, Res}}),
+        _ ->
             false
     end;
 is_direct_access_message(_, _, _) ->

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -687,7 +687,7 @@ is_direct_access_message(<<"message@1.0">>, Key, Opts) ->
     not lists:member(Key, [<<"id">>, <<"set">>, <<"get">>, <<"commit">>, <<"committers">>]);
 is_direct_access_message(DevName, NormKey, Opts) ->
     ?event(read_cached, {calculating_info, {device, DevName}}),
-    case hb_ao:info(#{ <<"device">> => DevName }, Opts) of
+    case hb_ao_device:info(#{ <<"device">> => DevName }, Opts) of
         Info = #{ exports := Exports } when not is_map_key(handler, Info) ->
             not lists:member(NormKey, Exports);
         _ ->

--- a/src/hb_cache_control.erl
+++ b/src/hb_cache_control.erl
@@ -57,6 +57,8 @@ lookup(Msg1, Msg2, Opts) ->
                     hb_opts:get(store_scope_resolved, local, Opts)
                 ),
             case hb_cache:read_resolved(Msg1, Msg2, OutputScopedOpts) of
+                {hit, not_found} ->
+                    {error, not_found};
                 {hit, Res} ->
                     ?event(caching,
                         {cache_hit,

--- a/src/hb_cache_control.erl
+++ b/src/hb_cache_control.erl
@@ -59,7 +59,7 @@ lookup(Msg1, Msg2, Opts) ->
             case hb_cache:read_resolved(Msg1, Msg2, OutputScopedOpts) of
                 {hit, not_found} ->
                     {error, not_found};
-                {hit, Res} ->
+                {hit, {ok, Res}} ->
                     ?event(caching,
                         {cache_hit,
                             {msg1, Msg1},
@@ -67,8 +67,8 @@ lookup(Msg1, Msg2, Opts) ->
                             {msg3, Res}
                         }
                     ),
-                    Res;
-                miss ->
+                    {ok, Res};
+                _ ->
                     ?event(caching, {result_cache_miss, Msg1, Msg2}),
                     case Settings of
                         #{ <<"only-if-cached">> := true } ->

--- a/src/hb_cache_control.erl
+++ b/src/hb_cache_control.erl
@@ -51,7 +51,12 @@ lookup(Msg1, Msg2, Opts) ->
             ?event({skip_cache_check, lookup_disabled}),
             {continue, Msg1, Msg2};
         Settings = #{ <<"lookup">> := true } ->
-            case hb_cache:read_resolved(Msg1, Msg2, Opts) of
+            OutputScopedOpts =
+                hb_store:scope(
+                    Opts,
+                    hb_opts:get(store_scope_resolved, local, Opts)
+                ),
+            case hb_cache:read_resolved(Msg1, Msg2, OutputScopedOpts) of
                 {hit, not_found} ->
                     {error, not_found};
                 {hit, {ok, Res}} ->

--- a/src/hb_cache_control.erl
+++ b/src/hb_cache_control.erl
@@ -51,12 +51,7 @@ lookup(Msg1, Msg2, Opts) ->
             ?event({skip_cache_check, lookup_disabled}),
             {continue, Msg1, Msg2};
         Settings = #{ <<"lookup">> := true } ->
-            OutputScopedOpts = 
-                hb_store:scope(
-                    Opts,
-                    hb_opts:get(store_scope_resolved, local, Opts)
-                ),
-            case hb_cache:read_resolved(Msg1, Msg2, OutputScopedOpts) of
+            case hb_cache:read_resolved(Msg1, Msg2, Opts) of
                 {hit, not_found} ->
                     {error, not_found};
                 {hit, {ok, Res}} ->

--- a/src/hb_cache_control.erl
+++ b/src/hb_cache_control.erl
@@ -57,20 +57,16 @@ lookup(Msg1, Msg2, Opts) ->
                     hb_opts:get(store_scope_resolved, local, Opts)
                 ),
             case hb_cache:read_resolved(Msg1, Msg2, OutputScopedOpts) of
-                {ok, Msg3} ->
+                {hit, Res} ->
                     ?event(caching,
                         {cache_hit,
-                            case is_binary(Msg3) of
-                                true -> hb_path:hashpath(Msg1, Msg2, Opts);
-                                false -> hb_path:hashpath(Msg3, Opts)
-                            end,
                             {msg1, Msg1},
                             {msg2, Msg2},
-                            {msg3, Msg3}
+                            {msg3, Res}
                         }
                     ),
-                    {ok, Msg3};
-                not_found ->
+                    Res;
+                miss ->
                     ?event(caching, {result_cache_miss, Msg1, Msg2}),
                     case Settings of
                         #{ <<"only-if-cached">> := true } ->
@@ -185,8 +181,8 @@ necessary_messages_not_found_error(Msg1, Msg2, Opts) ->
 
 %% @doc Determine whether we are likely to be faster looking up the result in
 %% our cache (hoping we have it), or executing it directly.
-exec_likely_faster_heuristic(M1, _M2, _) when (not ?IS_ID(M1)) ->
-    true;
+exec_likely_faster_heuristic(_M1, _M2, _) ->
+    false;
 exec_likely_faster_heuristic({as, _, Msg1}, Msg2, Opts) ->
     exec_likely_faster_heuristic(Msg1, Msg2, Opts);
 exec_likely_faster_heuristic(Msg1, Msg2, Opts) ->

--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -432,7 +432,7 @@ l2_dataitem_test() ->
 %% @doc Test optimistic index
 ao_dataitem_test() ->
     _Node = hb_http_server:start_node(#{}),
-    {ok, Res} = read(<<"oyo3_hCczcU7uYhfByFZ3h0ELfeMMzNacT-KpRoJK6g">>, #{ }),
+    {ok, Res} = read(<<"oyo3_hCczcU7uYhfByFZ3h0ELfeMMzNacT-KpRoJK6g">>, #{}),
     ?event(gateway, {l2_dataitem, Res}),
     Data = maps:get(<<"data">>, Res),
     ?assertEqual(<<"Hello World">>, Data).

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -754,7 +754,7 @@ mime_to_codec(<<"application/", Mime/binary>>, Opts) ->
             nomatch -> << Mime/binary, "@1.0" >>;
             _ -> Mime
         end,
-    case hb_ao:load_device(Name, Opts) of
+    case hb_ao_device:load(Name, Opts) of
         {ok, _} -> Name;
         {error, _} ->
             Default = default_codec(Opts),

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -161,7 +161,7 @@ conversion_spec_to_req(Spec, Opts) ->
             case Device of
                 tabm -> tabm;
                 _ ->
-                    hb_ao:message_to_device(
+                    hb_ao_device:message_to_device(
                         #{
                             <<"device">> => Device
                         },

--- a/src/hb_persistent.erl
+++ b/src/hb_persistent.erl
@@ -141,10 +141,15 @@ find_execution(Groupname, _Opts) ->
 %% `group' function if it is found in the `info', otherwise uses the default.
 group(Msg1, Msg2, Opts) ->
     Grouper =
-        hb_maps:get(grouper, hb_ao:info(Msg1, Opts), fun default_grouper/3, Opts),
+        hb_maps:get(
+            grouper,
+            hb_ao_device:info(Msg1, Opts),
+            fun default_grouper/3,
+            Opts
+        ),
     apply(
         Grouper,
-        hb_ao:truncate_args(Grouper, [Msg1, Msg2, Opts])
+        hb_ao_device:truncate_args(Grouper, [Msg1, Msg2, Opts])
     ).
 
 %% @doc Register for performing an AO-Core resolution.
@@ -168,7 +173,7 @@ await(Worker, Msg1, Msg2, Opts) ->
     AwaitFun =
         hb_maps:get(
             await,
-            hb_ao:info(Msg1, Opts),
+            hb_ao_device:info(Msg1, Opts),
             fun default_await/5,
 			Opts
         ),
@@ -271,7 +276,7 @@ start_worker(GroupName, Msg, Opts) ->
             WorkerFun =
                 hb_maps:get(
                     worker,
-                    hb_ao:info(Msg, Opts),
+                    hb_ao_device:info(Msg, Opts),
                     Def = fun default_worker/3,
 					Opts
                 ),
@@ -289,7 +294,7 @@ start_worker(GroupName, Msg, Opts) ->
             register_groupname(GroupName, Opts),
             apply(
                 WorkerFun,
-                hb_ao:truncate_args(
+                hb_ao_device:truncate_args(
                     WorkerFun,
                     [
                         GroupName,

--- a/src/hb_util.erl
+++ b/src/hb_util.erl
@@ -114,7 +114,7 @@ until(Condition, Count) ->
 until(Condition, Fun, Count) ->
     case Condition() of
         false ->
-            case apply(Fun, hb_ao:truncate_args(Fun, [Count])) of
+            case apply(Fun, hb_ao_device:truncate_args(Fun, [Count])) of
                 {count, AddToCount} ->
                     until(Condition, Fun, Count + AddToCount);
                 _ ->


### PR DESCRIPTION
This PR introduces improvements that remove the necessity for loading intermediate messages from caches in some circumstances. Rather than loading each intermediate step of a resolution, `hb_cache_control` is now able to return a `link` to the message, which allows the subsequently step to read only the accessed element, _if_ the message has a direct-key-access device.

For example, consider the following path:
```
GET /h5sI36OKIedXQJpO06vjDhTn_kALvppu40y3_IUGyXU~process@1.0/compute/balances/00BMT4e8hhslR6GdviQmRuBzjek9DSrcTnB3RJyTcOl
```

The initial execution of this path on an M2 macbook takes approximately 40 seconds. Before this PR, secondary evaluations also took a similar time period, as the 100,000 elements of the 'balances' table were all fully loaded into memory. After this PR, only a link to the balances table is produced by that step of the execution, leading to only a single, direct read of the address key in the following step. As a consequence, the secondary read speed is ~400ms instead of ~40s.