### PR TITLE
fix(httpsig_proxy): handle {ok, Map} from with_only_committed/2 before uncommitted()

### DIFF
--- a/src/dev_codec_httpsig_proxy.erl
+++ b/src/dev_codec_httpsig_proxy.erl
@@ -27,10 +27,8 @@ commit(Device, Secret, Base, Req, Opts) ->
         case map_size(ExistingComms) of
             0 -> Base;
             _ ->
-                hb_message:uncommitted(
-                    hb_message:with_only_committed(Base, Opts),
-                    Opts
-                )
+                {ok, CommittedBase} = hb_message:with_only_committed(Base, Opts),
+                hb_message:uncommitted(CommittedBase, Opts)
         end,
     % Commit the message with the given key.
     CommittedMsg =


### PR DESCRIPTION
### Problem
Calling ~http-auth@1.0/commit (and other httpsig-based commit paths) could fail or return unexpected output because the proxy fed the result of hb_message:with_only_committed/2 directly into hb_message:uncommitted/2.

### Root Cause
hb_message:with_only_committed/2 returns {ok, Map}, but the code assumed it returned Map. Passing the tuple to hb_message:uncommitted/2 caused errors (e.g., badmap/function_clause) and broken outputs.

### Solution
Pattern match the {ok, Map} return and pass the unwrapped Map to hb_message:uncommitted/2.

### Notes
No config changes required.
Similar to a previous PR I made #446 
