### PR TITLE
Feat/import checkpoints genesis

### DIFF
--- a/src/dev_delegated_compute.erl
+++ b/src/dev_delegated_compute.erl
@@ -23,24 +23,26 @@ normalize(Msg1, _Msg2, Opts) ->
             case hb_maps:get(<<"type">>, Snapshot, Opts) == <<"Checkpoint">> of
                 false -> Unset;
                 true ->
-                    load_snapshot(Snapshot, Opts),
+                    load_state(Snapshot, Opts),
                     Unset
             end
     end.
 
 %% @doc Attempt to load a snapshot into the delegated compute server.
-load_snapshot(Snapshot, Opts) ->
-    ?event({loading_snapshot, {snapshot, Snapshot}}),
-    do_relay(
+load_state(Snapshot, Opts) ->
+    ?event(debug_load_snapshot, {loading_snapshot, {snapshot, Snapshot}}),
+    Res = do_relay(
         <<"POST">>,
-        <<"/checkpoint">>,
+        <<"/state">>,
         hb_maps:get(<<"data">>, Snapshot, Opts),
         hb_maps:without([<<"data">>], Snapshot, Opts),
         Opts#{
             hashpath => ignore,
             cache_control => [<<"no-store">>, <<"no-cache">>]
         }
-    ).
+    ),
+    ?event(debug_load_snapshot, {load_result, Res}),
+    Res.
 
 %% @doc Call the delegated server to compute the result. The endpoint is
 %% `POST /compute' and the body is the JSON-encoded message that we want to

--- a/src/dev_delegated_compute.erl
+++ b/src/dev_delegated_compute.erl
@@ -31,11 +31,13 @@ normalize(Msg1, _Msg2, Opts) ->
 %% @doc Attempt to load a snapshot into the delegated compute server.
 load_state(Snapshot, Opts) ->
     ?event(debug_load_snapshot, {loading_snapshot, {snapshot, Snapshot}}),
+    Body = hb_maps:get(<<"data">>, Snapshot, Opts),
+    Headers = hb_maps:without([<<"data">>], Snapshot, Opts),
     Res = do_relay(
         <<"POST">>,
         <<"/state">>,
-        hb_maps:get(<<"data">>, Snapshot, Opts),
-        hb_maps:without([<<"data">>], Snapshot, Opts),
+        Body,
+        Headers,
         Opts#{
             hashpath => ignore,
             cache_control => [<<"no-store">>, <<"no-cache">>]
@@ -139,6 +141,7 @@ do_relay(Method, Path, Body, Headers, Opts) ->
             <<"relay-method">> => Method,
             <<"relay-body">> => Body,
             <<"relay-path">> => Path,
+            <<"relay-headers">> => Headers,
             <<"content-type">> => ContentType
         },
         Opts

--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -2,7 +2,8 @@
 %%% processes, using HyperBEAM infrastructure. This allows existing `legacynet'
 %%% AO process definitions to be used in HyperBEAM.
 -module(dev_genesis_wasm).
--export([init/3, compute/3, normalize/3, snapshot/3]).
+-export([init/3, compute/3, normalize/3, snapshot/3, import/3]).
+-export([latest_checkpoint/2]).
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("include/hb.hrl").
 
@@ -246,6 +247,138 @@ ensure_started(Opts) ->
             true
     end.
 
+%% @doc Find either a specific checkpoint by its ID, or find the most recent
+%% checkpoint via GraphQL.
+import(ProcMsg, Req, Opts) ->
+    case hb_maps:find(<<"import">>, Req, Opts) of
+        {ok, ImportID} ->
+            case hb_cache:read(ImportID, Opts) of
+                {ok, CheckpointMessage} ->
+                    do_import(ProcMsg, CheckpointMessage, Opts);
+                not_found -> {error, not_found}
+            end;
+        error ->
+            ProcID = dev_process:process_id(ProcMsg, #{}, Opts),
+            case latest_checkpoint(ProcID, Opts) of
+                {ok, CheckpointMessage} ->
+                    do_import(ProcMsg, CheckpointMessage, Opts);
+                Err -> Err
+            end
+    end.
+
+%% @doc Find the most recent legacy checkpoint for a process.
+latest_checkpoint(ProcID, Opts) ->
+    case hb_opts:get(genesis_wasm_import_authorities, [], Opts) of
+        [] -> {error, no_import_authorities};
+        TrustedSigners -> latest_checkpoint(ProcID, TrustedSigners, Opts)
+    end.
+latest_checkpoint(ProcID, TrustedSigners, Opts) ->
+    Query =
+        <<
+            <<"""
+            query($ProcID: String!, $TrustedSigners: [String!]) {
+                transactions(
+                    tags: [
+                        { name: "Type" values: ["Checkpoint"] },
+                        { name: "Process" values: [$ProcID] }
+                    ],
+                    owners: $TrustedSigners,
+                    first: 1,
+                    sort: HEIGHT_DESC
+                ){
+                edges {
+            """>>/binary,
+            (hb_gateway_client:item_spec())/binary,
+            """
+                }
+            }}
+        """>>,
+    Variables =
+        #{
+            <<"ProcID">> => ProcID,
+            <<"TrustedSigners">> => TrustedSigners
+        },
+    case hb_gateway_client:query(Query, Variables, Opts) of
+        {error, Reason} ->
+            {error, Reason};
+        {ok, GqlMsg} ->
+            case hb_ao:get(<<"data/transactions/edges/1/node">>, GqlMsg, Opts) of
+                not_found -> {error, not_found};
+                Item -> hb_gateway_client:result_to_message(Item, Opts)
+            end
+    end.
+
+%% @doc Validate whether a checkpoint message is signed by a trusted snapshot
+%% authority and is for a `ao.TN.1' process or has `execution-device' set to
+%% `genesis-wasm@1.0', then normalize into a state snapshot.
+%% Save the state snapshot into the store.
+do_import(Proc, CheckpointMessage, Opts) ->
+    maybe
+        % Validate that the process is a valid target for importing a checkpoint.
+        Variant = hb_maps:get(<<"variant">>, Proc, false, Opts),
+        ExecutionDevice = hb_maps:get(<<"execution-device">>, Proc, false, Opts),
+        true ?=
+            (Variant == <<"ao.TN.1">>) orelse
+            (ExecutionDevice == <<"genesis-wasm@1.0">>) orelse
+            invalid_import_target,
+        CheckpointSigners = hb_message:signers(CheckpointMessage, Opts),
+        % Validate that the checkpoint message is signed by a trusted snapshot
+        % authority, and targets this process.
+        TrustedSigners = hb_opts:get(genesis_wasm_import_authorities, [], Opts),
+        true ?=
+            lists:any(
+                fun(Signer) -> lists:member(Signer, TrustedSigners) end,
+                CheckpointSigners
+            ) orelse untrusted,
+        true ?= hb_message:verify(CheckpointMessage, all, Opts) orelse unverified,
+        CheckpointTargetProcID = hb_maps:get(<<"process">>, CheckpointMessage, Opts),
+        ProcID = dev_process:process_id(Proc, #{}, Opts),
+        true ?= CheckpointTargetProcID == ProcID orelse process_mismatch,
+        % Normalize the checkpoint message into a process state message with 
+        % a state snapshot.
+        {ok, SlotBin} ?= hb_maps:find(<<"nonce">>, CheckpointMessage, Opts),
+        Slot = hb_util:int(SlotBin),
+        InitializedProc = dev_process:ensure_process_key(Proc, Opts),
+        WithSnapshot =
+            InitializedProc#{
+                <<"at-slot">> => Slot,
+                <<"snapshot">> => CheckpointMessage
+            },
+        % Save the state snapshot into the store.
+        {ok, _} ?= dev_process_cache:write(ProcID, Slot, WithSnapshot, Opts),
+        % Return the normalized process message.
+        {ok, WithSnapshot}
+    else
+        invalid_import_target ->
+            {error, #{
+                <<"status">> => 400,
+                <<"body">> =>
+                    <<
+                        "Process is not a valid target for importing a "
+                        "`~genesis-wasm@1.0' checkpoint."
+                    >>
+            }};
+        process_mismatch ->
+            {error, #{
+                <<"status">> => 400,
+                <<"body">> =>
+                    <<"Checkpoint message targets a different process.">>
+            }};
+        unverified ->
+            {error, #{
+                <<"status">> => 400,
+                <<"body">> =>
+                    <<"Checkpoint message is not verifiable.">>
+            }};
+        untrusted ->
+            {error, #{
+                <<"status">> => 400,
+                <<"body">> =>
+                    <<"Checkpoint message is not signed by a trusted snapshot "
+                        "authority.">>
+            }}
+    end.
+
 %% @doc Check if the genesis-wasm server is running, using the cached process ID
 %% if available.
 is_genesis_wasm_server_running(Opts) ->
@@ -320,6 +453,35 @@ log_server_events([Line | Rest]) ->
     log_server_events(Rest).
 
 %%% Tests
+
+import_legacy_checkpoint_test_() ->
+    { timeout, 900, fun import_legacy_checkpoint/0 }.
+import_legacy_checkpoint() ->
+    application:ensure_all_started(hb),
+    Opts = #{
+        priv_wallet => hb:wallet(),
+        genesis_wasm_import_authorities =>
+            [<<"fcoN_xJeisVsPXA-trzVAuIiqO3ydLQxM-L4XbrQKzY">>]
+    },
+    ProcID = <<"DM3FoZUq_yebASPhgd8pEIRIzDW6muXEhxz5-JwbZwo">>,
+    {ok, ProcWithCheckpoint} =
+        hb_ao:resolve(
+           << ProcID/binary, "~genesis-wasm@1.0/import">>,
+           Opts
+        ),
+    ?assertMatch(
+        Slot when Slot > 0,
+        hb_maps:get(<<"at-slot">>, ProcWithCheckpoint)
+    ),
+    ?assertMatch(
+        #{ <<"data">> := Data } when byte_size(Data) > 0,
+        hb_maps:get(<<"snapshot">>, ProcWithCheckpoint)
+    ),
+    ?assertMatch(
+        {ok, Slot, _} when Slot > 0,
+        dev_process_cache:latest(ProcID, Opts)
+    ),
+    hb_ao:resolve(<<ProcID/binary, "~process@1.0/now">>, Opts).
 
 -ifdef(ENABLE_GENESIS_WASM).
 test_base_process() ->

--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -15,7 +15,15 @@ init(Msg, _Msg2, _Opts) -> {ok, Msg}.
 
 %% @doc Normalize the device.
 normalize(Msg, Msg2, Opts) ->
-    dev_delegated_compute:normalize(Msg, Msg2, Opts).
+    case ensure_started(Opts) of
+        true ->
+            dev_delegated_compute:normalize(Msg, Msg2, Opts);
+        false ->
+            {error, #{
+                <<"status">> => 500,
+                <<"message">> => <<"Genesis-wasm server not running.">>
+            }}
+    end.
 
 %% @doc Genesis-wasm device compute handler.
 %% Normal compute execution through external CU with state persistence

--- a/src/dev_relay.erl
+++ b/src/dev_relay.erl
@@ -153,7 +153,6 @@ call(M1, RawM2, Opts) ->
     ?event(debug_relay, {relay_call, {without_http_params, TargetMod4}}),
     ?event(debug_relay, {relay_call, {with_http_params, TargetMod5}}),
     true = hb_message:verify(TargetMod5),
-
     ?event(debug_relay, {relay_call, {verified, true}}),
     Client =
         case hb_maps:get(<<"http-client">>, BaseTarget, not_found, Opts) of

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -265,15 +265,19 @@ outbound_result_to_message(<<"httpsig@1.0">>, Status, Headers, Body, Opts) ->
 
 %% @doc Convert a HTTP response to a httpsig message.
 http_response_to_httpsig(Status, HeaderMap, Body, Opts) ->
-    (hb_message:convert(
+    BinStatus = hb_util:bin(Status),
+    BodyMap = case byte_size(Body) of
+        0 -> #{};
+        _ -> #{ <<"body">> => Body }
+    end,
+    ConvertFrom = 
         hb_maps:merge(
-            HeaderMap#{ <<"status">> => hb_util:bin(Status) },
-            case Body of
-                <<>> -> #{};
-                _ -> #{ <<"body">> => Body }
-            end,
+            HeaderMap#{ <<"status">> => BinStatus },
+            BodyMap,
 			Opts
         ),
+    (hb_message:convert(
+        ConvertFrom,
         #{ <<"device">> => <<"structured@1.0">>, <<"bundle">> => true },
         <<"httpsig@1.0">>,
         Opts

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -356,7 +356,12 @@ default_message() ->
                             #{ <<"device">> => <<"http-auth@1.0">> }
                     }
             }
-        }
+        },
+        genesis_wasm_import_authorities =>
+            [
+                <<"fcoN_xJeisVsPXA-trzVAuIiqO3ydLQxM-L4XbrQKzY">>,
+                <<"WjnS-s03HWsDSdMnyTdzB1eHZB2QheUWP_FVRVYxkXk">>
+            ]
         % Should the node track and expose prometheus metrics?
         % We do not set this explicitly, so that the hb_features:test() value
         % can be used to determine if we should expose metrics instead,

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -251,7 +251,7 @@ default_message() ->
             },
             #{
                 % Routes for the genesis-wasm device to use a local CU, if requested.
-                <<"template">> => <<"/checkpoint.*">>,
+                <<"template">> => <<"/state.*">>,
                 <<"node">> => #{ <<"prefix">> => <<"http://localhost:6363">> }
             },
             #{

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -250,6 +250,11 @@ default_message() ->
                 <<"node">> => #{ <<"prefix">> => <<"http://localhost:6363">> }
             },
             #{
+                % Routes for the genesis-wasm device to use a local CU, if requested.
+                <<"template">> => <<"/checkpoint.*">>,
+                <<"node">> => #{ <<"prefix">> => <<"http://localhost:6363">> }
+            },
+            #{
                 % Routes for GraphQL requests to use a remote GraphQL API.
                 <<"template">> => <<"/graphql">>,
                 <<"nodes">> =>


### PR DESCRIPTION
Can now import a checkpoint to HB cache, subsequent genesis wasm calls will start from that checkpoint. For example, to load the AO token:
`http://localhost:8734/genesis-wasm@1.0/import&process-id=0syT13r0s0tgPmIed95bJnuSqaD29HQNN8D3ElLSrsc`
`http://localhost:8734/0syT13r0s0tgPmIed95bJnuSqaD29HQNN8D3ElLSrsc~process@1.0/compute/now`
allows you to hydrate the AO token in <10 minutes. 

Must be run with CU branch: `jfrain99/force-process-cache` (https://github.com/permaweb/ao/pull/1259)