### PR TITLE
Introduce dev_inference for AI Inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ mkdocs-site-manifest.csv
 !test/admissible-report-wallet.json
 !test/admissible-report.json
 !test/config.json
+
+.qwen
+.specify
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ mkdocs-site-manifest.csv
 .qwen
 .specify
 .env
+specs
+models
+GEMINI.md
+native/hb_inference/build

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ GENESIS_WASM_BRANCH = feat/http-checkpoint
 GENESIS_WASM_REPO = https://github.com/permaweb/ao.git
 GENESIS_WASM_SERVER_DIR = _build/genesis_wasm/genesis-wasm-server
 
+LLAMACPP_REPO = https://github.com/ggml-org/llama.cpp
+LLAMACPP_DIR = _build/llama.cpp
+LLAMACPP_BUILD_DIR = $(LLAMACPP_DIR)/build
+
 ifdef HB_DEBUG
 	WAMR_FLAGS = -DWAMR_ENABLE_LOG=1 -DWAMR_BUILD_DUMP_CALL_STACK=1 -DCMAKE_BUILD_TYPE=Debug
 else
@@ -104,3 +108,22 @@ setup-genesis-wasm: $(GENESIS_WASM_SERVER_DIR)
 	fi
 	@cd $(GENESIS_WASM_SERVER_DIR) && npm install > /dev/null 2>&1 && \
 		echo "Installed genesis-wasm@1.0 server."
+
+.PHONY: llama-server
+llama-bin: llama-clean $(LLAMACPP_BUILD_DIR)/bin
+
+llama-cpp: $(LLAMACPP_DIR)
+
+llama-update: llama-cpp
+	cd $(LLAMACPP_DIR) && git pull origin main
+
+llama-clean:
+	rm -rf $(LLAMACPP_BUILD_DIR)
+
+# Clone llama.cpp into the build directory (shallow clone)
+$(LLAMACPP_DIR):
+	git clone --depth 1 $(LLAMACPP_REPO) $(LLAMACPP_DIR)
+
+$(LLAMACPP_BUILD_DIR)/bin: $(LLAMACPP_DIR)
+	cmake -S $(LLAMACPP_DIR) -B $(LLAMACPP_BUILD_DIR) -DGGML_CUDA=ON
+	cmake --build $(LLAMACPP_BUILD_DIR) --config Release -- -j$$(nproc)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GENESIS_WASM_SERVER_DIR = _build/genesis_wasm/genesis-wasm-server
 
 LLAMACPP_REPO = https://github.com/ggml-org/llama.cpp
 LLAMACPP_DIR = _build/llama.cpp
-LLAMACPP_BUILD_DIR = $(LLAMACPP_DIR)/build
+HB_INFERENCE_DIR = native/hb_inference
 
 ifdef HB_DEBUG
 	WAMR_FLAGS = -DWAMR_ENABLE_LOG=1 -DWAMR_BUILD_DUMP_CALL_STACK=1 -DCMAKE_BUILD_TYPE=Debug
@@ -109,21 +109,11 @@ setup-genesis-wasm: $(GENESIS_WASM_SERVER_DIR)
 	@cd $(GENESIS_WASM_SERVER_DIR) && npm install > /dev/null 2>&1 && \
 		echo "Installed genesis-wasm@1.0 server."
 
-.PHONY: llama-server
-llama-bin: llama-clean $(LLAMACPP_BUILD_DIR)/bin
-
-llama-cpp: $(LLAMACPP_DIR)
-
-llama-update: llama-cpp
-	cd $(LLAMACPP_DIR) && git pull origin main
-
-llama-clean:
-	rm -rf $(LLAMACPP_BUILD_DIR)
-
 # Clone llama.cpp into the build directory (shallow clone)
 $(LLAMACPP_DIR):
 	git clone --depth 1 $(LLAMACPP_REPO) $(LLAMACPP_DIR)
 
-$(LLAMACPP_BUILD_DIR)/bin: $(LLAMACPP_DIR)
-	cmake -S $(LLAMACPP_DIR) -B $(LLAMACPP_BUILD_DIR) -DGGML_CUDA=ON
-	cmake --build $(LLAMACPP_BUILD_DIR) --config Release -- -j$$(nproc)
+inference: $(LLAMACPP_DIR)
+	cd $(HB_INFERENCE_DIR)
+	cmake -S $(HB_INFERENCE_DIR) -B $(HB_INFERENCE_DIR)/build -DGGML_CUDA=ON
+	cmake --build $(HB_INFERENCE_DIR)/build --config Release -j$$(nproc)

--- a/native/hb_inference/CMakeLists.txt
+++ b/native/hb_inference/CMakeLists.txt
@@ -1,0 +1,22 @@
+# CMakeLists.txt for hb_inference
+
+cmake_minimum_required(VERSION 3.14)
+project(hb_inference C CXX)
+
+# Add llama.cpp as a subdirectory
+add_subdirectory(../../_build/llama.cpp llama_build)
+
+# Build the shared library
+add_library(hb_inference SHARED c_src/hb_inference.cpp)
+target_link_libraries(hb_inference PRIVATE llama)
+target_include_directories(hb_inference PUBLIC c_src)
+target_include_directories(hb_inference PRIVATE ../../_build/llama.cpp/include)
+target_include_directories(hb_inference PRIVATE ../../_build/llama.cpp/ggml/include)
+
+
+# Build the test executable
+add_executable(test c_src/test.c)
+target_link_libraries(test PRIVATE hb_inference)
+
+install(TARGETS hb_inference LIBRARY DESTINATION lib)
+install(TARGETS test RUNTIME DESTINATION bin)

--- a/native/hb_inference/CMakeLists.txt
+++ b/native/hb_inference/CMakeLists.txt
@@ -22,3 +22,15 @@ target_link_libraries(test PRIVATE hb_inference llama)
 
 install(TARGETS hb_inference LIBRARY DESTINATION lib)
 install(TARGETS test RUNTIME DESTINATION bin)
+
+# Erlang NIF specific paths
+set(ERLANG_INCLUDE_DIR "/usr/local/lib/erlang/usr/include")
+include_directories(${ERLANG_INCLUDE_DIR})
+
+# Build the NIF as a shared library
+add_library(hb_inference_nif MODULE c_src/hb_inference_nif.cpp)
+set_target_properties(hb_inference_nif PROPERTIES PREFIX "")
+target_link_libraries(hb_inference_nif PRIVATE hb_inference llama)
+
+# Install the NIF library
+install(TARGETS hb_inference_nif LIBRARY DESTINATION lib)

--- a/native/hb_inference/CMakeLists.txt
+++ b/native/hb_inference/CMakeLists.txt
@@ -17,10 +17,9 @@ target_include_directories(hb_inference PUBLIC
 
 
 # Build the test executable
-add_executable(test c_src/test.c)
+add_executable(test c_src/test.cpp)
 target_link_libraries(test PRIVATE hb_inference llama)
 
-install(TARGETS hb_inference LIBRARY DESTINATION lib)
 install(TARGETS test RUNTIME DESTINATION bin)
 
 # Erlang NIF specific paths

--- a/native/hb_inference/CMakeLists.txt
+++ b/native/hb_inference/CMakeLists.txt
@@ -9,14 +9,16 @@ add_subdirectory(../../_build/llama.cpp llama_build)
 # Build the shared library
 add_library(hb_inference SHARED c_src/hb_inference.cpp)
 target_link_libraries(hb_inference PRIVATE llama)
-target_include_directories(hb_inference PUBLIC c_src)
-target_include_directories(hb_inference PRIVATE ../../_build/llama.cpp/include)
-target_include_directories(hb_inference PRIVATE ../../_build/llama.cpp/ggml/include)
+target_include_directories(hb_inference PUBLIC 
+    c_src
+    ../../_build/llama.cpp/include
+    ../../_build/llama.cpp/ggml/include
+)
 
 
 # Build the test executable
 add_executable(test c_src/test.c)
-target_link_libraries(test PRIVATE hb_inference)
+target_link_libraries(test PRIVATE hb_inference llama)
 
 install(TARGETS hb_inference LIBRARY DESTINATION lib)
 install(TARGETS test RUNTIME DESTINATION bin)

--- a/native/hb_inference/c_src/hb_inference.cpp
+++ b/native/hb_inference/c_src/hb_inference.cpp
@@ -93,11 +93,22 @@ const char* chat(
         result = llama_chat_apply_template(tmpl, messages, n_messages, true, buf.data(), buf.size());
     }
 
-    // Call the completion function with the formatted prompt
-    return completion(instance, buf.data(), params);
+    // Call the generate function with the formatted prompt
+    return generate(instance, buf.data(), params);
 }
 
 const char* completion(
+    struct hb_instance* instance,
+    const char* prompt,
+    struct hb_generate_params params
+) {
+    struct llama_chat_message messages[] = {
+        {"user", prompt}
+    };
+    return chat(instance, messages, 1, params);
+}
+
+const char* generate(
     struct hb_instance* instance,
     const char* prompt,
     struct hb_generate_params params

--- a/native/hb_inference/c_src/hb_inference.cpp
+++ b/native/hb_inference/c_src/hb_inference.cpp
@@ -69,7 +69,7 @@ void free_model(struct hb_instance* instance) {
 }
 
 // Stubs for chat and completion
-const char* chat(
+std::string chat(
     struct hb_instance* instance,
     const struct llama_chat_message* messages,
     size_t n_messages,
@@ -97,7 +97,7 @@ const char* chat(
     return generate(instance, buf.data(), params);
 }
 
-const char* completion(
+std::string completion(
     struct hb_instance* instance,
     const char* prompt,
     struct hb_generate_params params
@@ -108,7 +108,7 @@ const char* completion(
     return chat(instance, messages, 1, params);
 }
 
-const char* generate(
+std::string generate(
     struct hb_instance* instance,
     const char* prompt,
     struct hb_generate_params params
@@ -128,10 +128,8 @@ const char* generate(
     llama_sampler_chain_add(smpl, llama_sampler_init_top_p(params.top_p, 1));
     llama_sampler_chain_add(smpl, llama_sampler_init_temp(0.0f));
     llama_sampler_chain_add(smpl, llama_sampler_init_dist(1234));
-    // llama_sampler_chain_add(smpl, llama_sampler_init_penalties(64, 1.5f, 0.0f, 0.0f));
 
-    static std::string result_str; // not thread safe
-    result_str = "";
+    std::string result_str; // Local string, not static
 
     const bool is_first = llama_memory_seq_pos_max(llama_get_memory(ctx), 0) == -1;
 
@@ -191,5 +189,5 @@ const char* generate(
     }
 
     llama_sampler_free(smpl);
-    return result_str.c_str();
+    return result_str;
 }

--- a/native/hb_inference/c_src/hb_inference.cpp
+++ b/native/hb_inference/c_src/hb_inference.cpp
@@ -1,0 +1,205 @@
+#include <string>
+#include <vector>
+#include <iostream>
+#include <algorithm>
+#include <cstring>
+#include "hb_inference.h"
+
+struct hb_instance {
+    llama_model* model = nullptr;
+    llama_context* ctx = nullptr;
+};
+
+extern "C" {
+
+struct hb_instance* init() {
+    llama_backend_init();
+    return new hb_instance;
+}
+
+void destroy(struct hb_instance* instance) {
+    if (instance) {
+        if (instance->ctx) {
+            llama_free(instance->ctx);
+        }
+        if (instance->model) {
+            llama_free_model(instance->model);
+        }
+        delete instance;
+    }
+    llama_backend_free();
+}
+
+int load_model(
+    struct hb_instance* instance,
+    const char* model_path,
+    struct llama_model_params model_params,
+    struct llama_context_params ctx_params
+) {
+    if (!instance) {
+        return 1;
+    }
+
+    instance->model = llama_load_model_from_file(model_path, model_params);
+    if (instance->model == nullptr) {
+        std::cerr << "Failed to load model" << std::endl;
+        return 1;
+    }
+
+    instance->ctx = llama_new_context_with_model(instance->model, ctx_params);
+    if (instance->ctx == nullptr) {
+        std::cerr << "Failed to create context" << std::endl;
+        llama_free_model(instance->model);
+        instance->model = nullptr;
+        return 1;
+    }
+
+    return 0;
+}
+
+void free_model(struct hb_instance* instance) {
+    if (instance) {
+        if (instance->ctx) {
+            llama_free(instance->ctx);
+            instance->ctx = nullptr;
+        }
+        if (instance->model) {
+            llama_free_model(instance->model);
+            instance->model = nullptr;
+        }
+    }
+}
+
+const char* chat(
+    struct hb_instance* instance,
+    const struct llama_chat_message* messages,
+    size_t n_messages,
+    struct hb_generate_params params
+) {
+    if (!instance || !instance->ctx) {
+        return "Error: instance not initialized";
+    }
+
+    // Use a large buffer for the formatted prompt
+    std::vector<char> buf(1024 * 8);
+
+    // Apply the chat template
+    int32_t result = llama_chat_apply_template(nullptr, messages, n_messages, true, buf.data(), buf.size());
+    if (result < 0) {
+        return "Error: failed to apply chat template";
+    }
+    if ((size_t)result > buf.size()) {
+        buf.resize(result);
+        result = llama_chat_apply_template(nullptr, messages, n_messages, true, buf.data(), buf.size());
+    }
+
+    // Call the completion function with the formatted prompt
+    return completion(instance, buf.data(), params);
+}
+
+const char* completion(
+    struct hb_instance* instance,
+    const char* prompt,
+    struct hb_generate_params params
+) {
+    if (!instance || !instance->ctx) {
+        return "Error: instance not initialized";
+    }
+
+    llama_context* ctx = instance->ctx;
+    llama_model* model = instance->model;
+    const auto vocab = llama_model_get_vocab(model);
+
+    const int n_ctx = llama_n_ctx(ctx);
+
+    // Tokenize the prompt
+    std::vector<llama_token> tokens_list(n_ctx);
+    int n_tokens = llama_tokenize(vocab, prompt, strlen(prompt), tokens_list.data(), tokens_list.size(), true, false);
+    if (n_tokens < 0) {
+        return "Error: failed to tokenize prompt";
+    }
+    tokens_list.resize(n_tokens);
+
+
+    if ((int)tokens_list.size() > n_ctx - 4) {
+        return "Error: prompt is too long";
+    }
+
+    // Clear the KV cache
+    llama_kv_cache_clear(ctx);
+
+    // Create a batch
+    llama_batch batch = llama_batch_init(tokens_list.size(), 0, 1);
+    for (size_t i = 0; i < tokens_list.size(); ++i) {
+        batch.token[i] = tokens_list[i];
+        batch.pos[i] = i;
+        batch.n_seq_id[i] = 1;
+        batch.seq_id[i][0] = 0;
+        batch.logits[i] = (i == tokens_list.size() - 1); // only get logits for the last token
+    }
+
+    // Feed the prompt to the model
+    if (llama_decode(ctx, batch)) {
+        llama_batch_free(batch);
+        return "Error: llama_decode failed";
+    }
+    llama_batch_free(batch);
+
+
+    // Main generation loop
+    static std::string result_str; // not thread safe
+    result_str = "";
+    int n_cur = tokens_list.size();
+    int n_predict = std::min(params.n_predict, n_ctx - n_tokens);
+
+
+    // Create sampler chain
+    auto sparams = llama_sampler_chain_default_params();
+    llama_sampler * smpl = llama_sampler_chain_init(sparams);
+    llama_sampler_chain_add(smpl, llama_sampler_init_top_k(40));
+    llama_sampler_chain_add(smpl, llama_sampler_init_top_p(params.top_p, 1));
+    llama_sampler_chain_add(smpl, llama_sampler_init_temp(params.temp));
+    llama_sampler_chain_add(smpl, llama_sampler_init_dist(llama_rng_get_seed(llama_get_rng(ctx))));
+
+
+    while (n_cur < n_tokens + n_predict) {
+        // Sample the next token
+        llama_token new_token_id = llama_sampler_sample(smpl, ctx, -1);
+        llama_sampler_accept(smpl, new_token_id);
+
+        // Check for EOS
+        if (new_token_id == llama_vocab_eos(vocab)) {
+            break;
+        }
+
+        // Append the new token to the result
+        char piece[8] = {0};
+        llama_token_to_piece(vocab, new_token_id, piece, sizeof(piece), 0, false);
+        result_str += piece;
+
+
+        // Prepare for the next iteration
+        llama_batch next_batch = llama_batch_init(1, 0, 1);
+        next_batch.token[0] = new_token_id;
+        next_batch.pos[0] = n_cur;
+        next_batch.n_seq_id[0] = 1;
+        next_batch.seq_id[0][0] = 0;
+        next_batch.logits[0] = 1;
+
+
+        if (llama_decode(ctx, next_batch)) {
+            llama_batch_free(next_batch);
+            llama_sampler_free(smpl);
+            return "Error: llama_decode failed";
+        }
+        llama_batch_free(next_batch);
+
+        n_cur++;
+    }
+
+    llama_sampler_free(smpl);
+
+    return result_str.c_str();
+}
+
+} // extern "C"

--- a/native/hb_inference/c_src/hb_inference.cpp
+++ b/native/hb_inference/c_src/hb_inference.cpp
@@ -10,8 +10,6 @@ struct hb_instance {
     llama_context* ctx = nullptr;
 };
 
-extern "C" {
-
 struct hb_instance* init() {
     llama_backend_init();
     return new hb_instance;
@@ -23,7 +21,7 @@ void destroy(struct hb_instance* instance) {
             llama_free(instance->ctx);
         }
         if (instance->model) {
-            llama_free_model(instance->model);
+            llama_model_free(instance->model);
         }
         delete instance;
     }
@@ -40,16 +38,16 @@ int load_model(
         return 1;
     }
 
-    instance->model = llama_load_model_from_file(model_path, model_params);
+    instance->model = llama_model_load_from_file(model_path, model_params);
     if (instance->model == nullptr) {
         std::cerr << "Failed to load model" << std::endl;
         return 1;
     }
 
-    instance->ctx = llama_new_context_with_model(instance->model, ctx_params);
+    instance->ctx = llama_init_from_model(instance->model, ctx_params);
     if (instance->ctx == nullptr) {
         std::cerr << "Failed to create context" << std::endl;
-        llama_free_model(instance->model);
+        llama_model_free(instance->model);
         instance->model = nullptr;
         return 1;
     }
@@ -64,12 +62,13 @@ void free_model(struct hb_instance* instance) {
             instance->ctx = nullptr;
         }
         if (instance->model) {
-            llama_free_model(instance->model);
+            llama_model_free(instance->model);
             instance->model = nullptr;
         }
     }
 }
 
+// Stubs for chat and completion
 const char* chat(
     struct hb_instance* instance,
     const struct llama_chat_message* messages,
@@ -84,13 +83,14 @@ const char* chat(
     std::vector<char> buf(1024 * 8);
 
     // Apply the chat template
-    int32_t result = llama_chat_apply_template(nullptr, messages, n_messages, true, buf.data(), buf.size());
+    const char * tmpl = llama_model_chat_template(instance->model, nullptr);
+    int32_t result = llama_chat_apply_template(tmpl, messages, n_messages, true, buf.data(), buf.size());
     if (result < 0) {
         return "Error: failed to apply chat template";
     }
     if ((size_t)result > buf.size()) {
         buf.resize(result);
-        result = llama_chat_apply_template(nullptr, messages, n_messages, true, buf.data(), buf.size());
+        result = llama_chat_apply_template(tmpl, messages, n_messages, true, buf.data(), buf.size());
     }
 
     // Call the completion function with the formatted prompt
@@ -109,97 +109,76 @@ const char* completion(
     llama_context* ctx = instance->ctx;
     llama_model* model = instance->model;
     const auto vocab = llama_model_get_vocab(model);
-
     const int n_ctx = llama_n_ctx(ctx);
-
-    // Tokenize the prompt
-    std::vector<llama_token> tokens_list(n_ctx);
-    int n_tokens = llama_tokenize(vocab, prompt, strlen(prompt), tokens_list.data(), tokens_list.size(), true, false);
-    if (n_tokens < 0) {
-        return "Error: failed to tokenize prompt";
-    }
-    tokens_list.resize(n_tokens);
-
-
-    if ((int)tokens_list.size() > n_ctx - 4) {
-        return "Error: prompt is too long";
-    }
-
-    // Clear the KV cache
-    llama_kv_cache_clear(ctx);
-
-    // Create a batch
-    llama_batch batch = llama_batch_init(tokens_list.size(), 0, 1);
-    for (size_t i = 0; i < tokens_list.size(); ++i) {
-        batch.token[i] = tokens_list[i];
-        batch.pos[i] = i;
-        batch.n_seq_id[i] = 1;
-        batch.seq_id[i][0] = 0;
-        batch.logits[i] = (i == tokens_list.size() - 1); // only get logits for the last token
-    }
-
-    // Feed the prompt to the model
-    if (llama_decode(ctx, batch)) {
-        llama_batch_free(batch);
-        return "Error: llama_decode failed";
-    }
-    llama_batch_free(batch);
-
-
-    // Main generation loop
-    static std::string result_str; // not thread safe
-    result_str = "";
-    int n_cur = tokens_list.size();
-    int n_predict = std::min(params.n_predict, n_ctx - n_tokens);
-
 
     // Create sampler chain
     auto sparams = llama_sampler_chain_default_params();
     llama_sampler * smpl = llama_sampler_chain_init(sparams);
-    llama_sampler_chain_add(smpl, llama_sampler_init_top_k(40));
     llama_sampler_chain_add(smpl, llama_sampler_init_top_p(params.top_p, 1));
-    llama_sampler_chain_add(smpl, llama_sampler_init_temp(params.temp));
-    llama_sampler_chain_add(smpl, llama_sampler_init_dist(llama_rng_get_seed(llama_get_rng(ctx))));
+    llama_sampler_chain_add(smpl, llama_sampler_init_temp(0.0f));
+    llama_sampler_chain_add(smpl, llama_sampler_init_dist(1234));
+    // llama_sampler_chain_add(smpl, llama_sampler_init_penalties(64, 1.5f, 0.0f, 0.0f));
 
+    static std::string result_str; // not thread safe
+    result_str = "";
 
-    while (n_cur < n_tokens + n_predict) {
-        // Sample the next token
-        llama_token new_token_id = llama_sampler_sample(smpl, ctx, -1);
-        llama_sampler_accept(smpl, new_token_id);
+    const bool is_first = llama_memory_seq_pos_max(llama_get_memory(ctx), 0) == -1;
 
-        // Check for EOS
-        if (new_token_id == llama_vocab_eos(vocab)) {
-            break;
+    // Tokenize the prompt
+    const int n_prompt_tokens = -llama_tokenize(vocab, prompt, strlen(prompt), NULL, 0, is_first, true);
+    if (n_prompt_tokens < 0) {
+        llama_sampler_free(smpl);
+        return "Error: failed to tokenize prompt (get size)";
+    }
+    std::vector<llama_token> prompt_tokens(n_prompt_tokens);
+    if (llama_tokenize(vocab, prompt, strlen(prompt), prompt_tokens.data(), prompt_tokens.size(), is_first, true) < 0) {
+        llama_sampler_free(smpl);
+        return "Error: failed to tokenize prompt (actual)";
+    }
+
+    // Prepare a batch for the prompt
+    llama_batch batch = llama_batch_get_one(prompt_tokens.data(), prompt_tokens.size());
+    llama_token new_token_id;
+
+    int n_predict = std::min(params.n_predict, n_ctx - (int)prompt_tokens.size());
+    int n_decoded = 0;
+
+    while (n_decoded < n_predict) {
+        // Check if we have enough space in the context to evaluate this batch
+        if (llama_memory_seq_pos_max(llama_get_memory(ctx), 0) + 1 + batch.n_tokens > n_ctx) {
+            llama_sampler_free(smpl);
+            return "Error: context size exceeded";
         }
 
-        // Append the new token to the result
-        char piece[8] = {0};
-        llama_token_to_piece(vocab, new_token_id, piece, sizeof(piece), 0, false);
-        result_str += piece;
-
-
-        // Prepare for the next iteration
-        llama_batch next_batch = llama_batch_init(1, 0, 1);
-        next_batch.token[0] = new_token_id;
-        next_batch.pos[0] = n_cur;
-        next_batch.n_seq_id[0] = 1;
-        next_batch.seq_id[0][0] = 0;
-        next_batch.logits[0] = 1;
-
-
-        if (llama_decode(ctx, next_batch)) {
-            llama_batch_free(next_batch);
+        int ret = llama_decode(ctx, batch);
+        if (ret != 0) {
             llama_sampler_free(smpl);
             return "Error: llama_decode failed";
         }
-        llama_batch_free(next_batch);
 
-        n_cur++;
+        // Sample the next token
+        new_token_id = llama_sampler_sample(smpl, ctx, -1);
+        llama_sampler_accept(smpl, new_token_id);
+
+        // Is it an end of generation?
+        if (llama_vocab_is_eog(vocab, new_token_id)) {
+            break;
+        }
+
+        // Convert the token to a string and add it to the response
+        char buf[256];
+        int n = llama_token_to_piece(vocab, new_token_id, buf, sizeof(buf), 0, true);
+        if (n < 0) {
+            llama_sampler_free(smpl);
+            return "Error: failed to convert token to piece";
+        }
+        result_str.append(buf, n);
+
+        // Prepare the next batch with the sampled token
+        batch = llama_batch_get_one(&new_token_id, 1);
+        n_decoded++;
     }
 
     llama_sampler_free(smpl);
-
     return result_str.c_str();
 }
-
-} // extern "C"

--- a/native/hb_inference/c_src/hb_inference.h
+++ b/native/hb_inference/c_src/hb_inference.h
@@ -1,0 +1,51 @@
+#ifndef HB_INFERENCE_H
+#define HB_INFERENCE_H
+
+#include "llama.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Opaque pointer to the wrapper instance
+struct hb_instance;
+
+// Parameters for text generation
+struct hb_generate_params {
+    float temp;
+    float top_p;
+    int32_t n_predict;
+    // Add other sampler parameters here
+};
+
+// API for the wrapper
+struct hb_instance* init();
+void destroy(struct hb_instance* instance);
+
+int load_model(
+    struct hb_instance* instance,
+    const char* model_path,
+    struct llama_model_params model_params,
+    struct llama_context_params ctx_params
+);
+void free_model(struct hb_instance* instance);
+
+// Chat and Completion APIs
+const char* chat(
+    struct hb_instance* instance,
+    const struct llama_chat_message* messages,
+    size_t n_messages,
+    struct hb_generate_params params
+);
+
+const char* completion(
+    struct hb_instance* instance,
+    const char* prompt,
+    struct hb_generate_params params
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // HB_INFERENCE_H

--- a/native/hb_inference/c_src/hb_inference.h
+++ b/native/hb_inference/c_src/hb_inference.h
@@ -12,7 +12,6 @@ struct hb_instance;
 
 // Parameters for text generation
 struct hb_generate_params {
-    float temp;
     float top_p;
     int32_t n_predict;
     // Add other sampler parameters here

--- a/native/hb_inference/c_src/hb_inference.h
+++ b/native/hb_inference/c_src/hb_inference.h
@@ -37,6 +37,12 @@ const char* chat(
     struct hb_generate_params params
 );
 
+const char* generate(
+    struct hb_instance* instance,
+    const char* prompt,
+    struct hb_generate_params params
+);
+
 const char* completion(
     struct hb_instance* instance,
     const char* prompt,

--- a/native/hb_inference/c_src/hb_inference.h
+++ b/native/hb_inference/c_src/hb_inference.h
@@ -2,6 +2,7 @@
 #define HB_INFERENCE_H
 
 #include "llama.h"
+#include <string>
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,20 +31,20 @@ int load_model(
 void free_model(struct hb_instance* instance);
 
 // Chat and Completion APIs
-const char* chat(
+std::string chat(
     struct hb_instance* instance,
     const struct llama_chat_message* messages,
     size_t n_messages,
     struct hb_generate_params params
 );
 
-const char* generate(
+std::string generate(
     struct hb_instance* instance,
     const char* prompt,
     struct hb_generate_params params
 );
 
-const char* completion(
+std::string completion(
     struct hb_instance* instance,
     const char* prompt,
     struct hb_generate_params params

--- a/native/hb_inference/c_src/hb_inference_nif.cpp
+++ b/native/hb_inference/c_src/hb_inference_nif.cpp
@@ -171,13 +171,15 @@ static ERL_NIF_TERM nif_completion(ErlNifEnv* env, int argc, const ERL_NIF_TERM 
         return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "no_model_loaded"));
     }
 
-    const char* result = completion(current_instance, prompt_str.c_str(), gen_params); // Use gen_params
-
-    ERL_NIF_TERM ret;
-    if (result) {
-        ret = enif_make_tuple2(env, enif_make_atom(env, "ok"), enif_make_string(env, result, ERL_NIF_LATIN1));
-    } else {
-        ret = enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "completion_failed"));
+            std::string result_str = completion(current_instance, prompt_str.c_str(), gen_params); // Now returns std::string
+    
+            ERL_NIF_TERM ret;
+            if (result_str.rfind("Error:", 0) == 0) { // Check if the string starts with "Error:"
+                ret = enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_string(env, result_str.c_str(), ERL_NIF_LATIN1));
+            } else {
+                ErlNifBinary output_bin;
+                enif_alloc_binary(result_str.length(), &output_bin);        memcpy(output_bin.data, result_str.c_str(), result_str.length());
+        ret = enif_make_tuple2(env, enif_make_atom(env, "ok"), enif_make_binary(env, &output_bin));
     }
 
     enif_mutex_unlock(mutex);
@@ -237,13 +239,16 @@ static ERL_NIF_TERM nif_chat(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]
         return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "no_model_loaded"));
     }
 
-    const char* result = chat(current_instance, messages_vec.data(), messages_vec.size(), gen_params); // Use gen_params
+    std::string result_str = chat(current_instance, messages_vec.data(), messages_vec.size(), gen_params); // Now returns std::string
 
     ERL_NIF_TERM ret;
-    if (result) {
-        ret = enif_make_tuple2(env, enif_make_atom(env, "ok"), enif_make_string(env, result, ERL_NIF_LATIN1));
+    if (result_str.rfind("Error:", 0) == 0) { // Check if the string starts with "Error:"
+        ret = enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_string(env, result_str.c_str(), ERL_NIF_LATIN1));
     } else {
-        ret = enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "chat_failed"));
+        ErlNifBinary output_bin;
+        enif_alloc_binary(result_str.length(), &output_bin);
+        memcpy(output_bin.data, result_str.c_str(), result_str.length());
+        ret = enif_make_tuple2(env, enif_make_atom(env, "ok"), enif_make_binary(env, &output_bin));
     }
 
     enif_mutex_unlock(mutex);

--- a/native/hb_inference/c_src/hb_inference_nif.cpp
+++ b/native/hb_inference/c_src/hb_inference_nif.cpp
@@ -1,0 +1,194 @@
+#include "erl_nif.h"
+#include "hb_inference.h"
+#include <string>
+#include <vector>
+#include <map>
+#include <iostream>
+#include <cstdlib>
+
+// Global state
+static std::map<std::string, hb_instance*> model_instances;
+static ErlNifMutex* mutex;
+
+// Forward declarations
+static ERL_NIF_TERM nif_completion(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+static ERL_NIF_TERM nif_chat(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+
+static ErlNifFunc nif_funcs[] = {
+    {"nif_completion", 3, nif_completion},
+    {"nif_chat", 3, nif_chat}
+};
+
+// Helper to get a string from an Erlang binary
+static bool get_string_from_binary(ErlNifEnv* env, ERL_NIF_TERM term, std::string& var) {
+    ErlNifBinary bin;
+    if (!enif_inspect_binary(env, term, &bin)) {
+        return false;
+    }
+    var.assign(reinterpret_cast<char*>(bin.data), bin.size);
+    return true;
+}
+
+// Helper to load a model, assuming the mutex is already locked
+static hb_instance* get_or_load_model_locked(ErlNifEnv* env, const std::string& model_path) {
+    auto it = model_instances.find(model_path);
+    if (it != model_instances.end()) {
+        return it->second;
+    }
+
+    hb_instance* instance = init();
+    if (!instance) {
+        return nullptr;
+    }
+
+    llama_model_params model_params = llama_model_default_params();
+    model_params.n_gpu_layers = 100;
+    llama_context_params ctx_params = llama_context_default_params();
+    ctx_params.n_ctx = 4096;
+
+    if (load_model(instance, model_path.c_str(), model_params, ctx_params) != 0) {
+        destroy(instance);
+        return nullptr;
+    }
+
+    model_instances[model_path] = instance;
+    return instance;
+}
+
+static ERL_NIF_TERM nif_completion(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
+    std::string model_path, prompt;
+    if (!get_string_from_binary(env, argv[0], model_path) || !get_string_from_binary(env, argv[1], prompt)) {
+        return enif_make_badarg(env);
+    }
+
+    hb_generate_params params;
+    params.n_predict = 512;
+    params.top_p = 0.9f;
+
+    ERL_NIF_TERM term_top_p;
+    if (enif_get_map_value(env, argv[2], enif_make_atom(env, "top_p"), &term_top_p)) {
+        double top_p;
+        if (enif_get_double(env, term_top_p, &top_p)) {
+            params.top_p = (float)top_p;
+        }
+    }
+    ERL_NIF_TERM term_n_predict;
+    if (enif_get_map_value(env, argv[2], enif_make_atom(env, "n_predict"), &term_n_predict)) {
+        int n_predict;
+        if (enif_get_int(env, term_n_predict, &n_predict)) {
+            params.n_predict = n_predict;
+        }
+    }
+
+    enif_mutex_lock(mutex);
+
+    hb_instance* instance = get_or_load_model_locked(env, model_path);
+    if (!instance) {
+        enif_mutex_unlock(mutex);
+        return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_string(env, "Failed to load model", ERL_NIF_LATIN1));
+    }
+
+    const char* result = completion(instance, prompt.c_str(), params);
+    std::string result_copy = result;
+
+    enif_mutex_unlock(mutex);
+
+    ERL_NIF_TERM result_term;
+    unsigned char* result_buf = enif_make_new_binary(env, result_copy.length(), &result_term);
+    memcpy(result_buf, result_copy.c_str(), result_copy.length());
+
+    return enif_make_tuple2(env, enif_make_atom(env, "ok"), result_term);
+}
+
+static ERL_NIF_TERM nif_chat(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
+    std::string model_path;
+    if (!get_string_from_binary(env, argv[0], model_path)) {
+        return enif_make_badarg(env);
+    }
+
+    unsigned int n_messages;
+    if (!enif_get_list_length(env, argv[1], &n_messages)) {
+        return enif_make_badarg(env);
+    }
+
+    std::vector<llama_chat_message> messages(n_messages);
+    std::vector<std::string> roles(n_messages), contents(n_messages);
+    ERL_NIF_TERM list = argv[1], head, tail;
+    int i = 0;
+    ERL_NIF_TERM role_key, content_key;
+    unsigned char* role_buf = enif_make_new_binary(env, 4, &role_key);
+    memcpy(role_buf, "role", 4);
+    unsigned char* content_buf = enif_make_new_binary(env, 7, &content_key);
+    memcpy(content_buf, "content", 7);
+
+    while (enif_get_list_cell(env, list, &head, &tail)) {
+        ERL_NIF_TERM role_term, content_term;
+        if (enif_get_map_value(env, head, role_key, &role_term) && enif_get_map_value(env, head, content_key, &content_term)) {
+            get_string_from_binary(env, role_term, roles[i]);
+            get_string_from_binary(env, content_term, contents[i]);
+        }
+        messages[i] = {roles[i].c_str(), contents[i].c_str()};
+        list = tail;
+        i++;
+    }
+
+    hb_generate_params params;
+    params.n_predict = 512;
+    params.top_p = 0.9f;
+
+    ERL_NIF_TERM term_top_p;
+    if (enif_get_map_value(env, argv[2], enif_make_atom(env, "top_p"), &term_top_p)) {
+        double top_p;
+        if (enif_get_double(env, term_top_p, &top_p)) {
+            params.top_p = (float)top_p;
+        }
+    }
+    ERL_NIF_TERM term_n_predict;
+    if (enif_get_map_value(env, argv[2], enif_make_atom(env, "n_predict"), &term_n_predict)) {
+        int n_predict;
+        if (enif_get_int(env, term_n_predict, &n_predict)) {
+            params.n_predict = n_predict;
+        }
+    }
+
+    enif_mutex_lock(mutex);
+
+    hb_instance* instance = get_or_load_model_locked(env, model_path);
+    if (!instance) {
+        enif_mutex_unlock(mutex);
+        return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_string(env, "Failed to load model", ERL_NIF_LATIN1));
+    }
+
+    const char* result = chat(instance, messages.data(), n_messages, params);
+    std::string result_copy = result;
+
+    enif_mutex_unlock(mutex);
+
+    ERL_NIF_TERM result_term;
+    unsigned char* result_buf = enif_make_new_binary(env, result_copy.length(), &result_term);
+    memcpy(result_buf, result_copy.c_str(), result_copy.length());
+
+    return enif_make_tuple2(env, enif_make_atom(env, "ok"), result_term);
+}
+
+void null_log_callback(ggml_log_level level, const char * text, void * user_data) {
+    // Do nothing.
+}
+
+static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info) {
+    llama_log_set(null_log_callback, NULL);
+    mutex = enif_mutex_create((char*)"hb_inference_mutex");
+    return 0;
+}
+
+static void unload(ErlNifEnv* env, void* priv_data) {
+    enif_mutex_lock(mutex);
+    for (auto const& [key, val] : model_instances) {
+        destroy(val);
+    }
+    model_instances.clear();
+    enif_mutex_unlock(mutex);
+    enif_mutex_destroy(mutex);
+}
+
+ERL_NIF_INIT(dev_inference, nif_funcs, load, NULL, NULL, unload)

--- a/native/hb_inference/c_src/hb_inference_nif.cpp
+++ b/native/hb_inference/c_src/hb_inference_nif.cpp
@@ -5,170 +5,89 @@
 #include <map>
 #include <iostream>
 #include <cstdlib>
+#include <algorithm>
 
 // Global state
-static std::map<std::string, hb_instance*> model_instances;
 static ErlNifMutex* mutex;
+static hb_instance* current_instance = nullptr;
+static std::string current_model_path;
 
-// Forward declarations
-static ERL_NIF_TERM nif_completion(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
-static ERL_NIF_TERM nif_chat(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+// Helper to convert Erlang map to C++ map
+std::map<std::string, std::string> parse_nif_params_map(ErlNifEnv* env, ERL_NIF_TERM map_term) {
+    std::map<std::string, std::string> params;
+    ErlNifMapIterator iter;
+    enif_map_iterator_create(env, map_term, &iter, ERL_NIF_MAP_ITERATOR_FIRST);
 
-static ErlNifFunc nif_funcs[] = {
-    {"nif_completion", 3, nif_completion},
-    {"nif_chat", 3, nif_chat}
-};
+    ERL_NIF_TERM key_term, value_term;
+    while (enif_map_iterator_get_pair(env, &iter, &key_term, &value_term)) {
+        ErlNifBinary key_bin, value_bin;
+        std::string key_str, value_str;
 
-// Helper to get a string from an Erlang binary
-static bool get_string_from_binary(ErlNifEnv* env, ERL_NIF_TERM term, std::string& var) {
-    ErlNifBinary bin;
-    if (!enif_inspect_binary(env, term, &bin)) {
-        return false;
+        if (enif_inspect_binary(env, key_term, &key_bin)) {
+            key_str = std::string(reinterpret_cast<const char*>(key_bin.data), key_bin.size);
+        } else {
+            char key_buf[256];
+            if (enif_get_string(env, key_term, key_buf, sizeof(key_buf), ERL_NIF_LATIN1) > 0) {
+                key_str = key_buf;
+            } else {
+                enif_map_iterator_next(env, &iter);
+                continue;
+            }
+        }
+
+        if (enif_inspect_binary(env, value_term, &value_bin)) {
+            value_str = std::string(reinterpret_cast<const char*>(value_bin.data), value_bin.size);
+        } else {
+            char value_buf[256];
+            if (enif_get_string(env, value_term, value_buf, sizeof(value_buf), ERL_NIF_LATIN1) > 0) {
+                value_str = value_buf;
+            } else {
+                enif_map_iterator_next(env, &iter);
+                continue;
+            }
+        }
+        params[key_str] = value_str;
+        enif_map_iterator_next(env, &iter);
     }
-    var.assign(reinterpret_cast<char*>(bin.data), bin.size);
-    return true;
+    enif_map_iterator_destroy(env, &iter);
+    return params;
 }
 
-// Helper to load a model, assuming the mutex is already locked
-static hb_instance* get_or_load_model_locked(ErlNifEnv* env, const std::string& model_path) {
-    auto it = model_instances.find(model_path);
-    if (it != model_instances.end()) {
-        return it->second;
-    }
-
-    hb_instance* instance = init();
-    if (!instance) {
-        return nullptr;
-    }
-
-    llama_model_params model_params = llama_model_default_params();
-    model_params.n_gpu_layers = 100;
-    llama_context_params ctx_params = llama_context_default_params();
-    ctx_params.n_ctx = 4096;
-
-    if (load_model(instance, model_path.c_str(), model_params, ctx_params) != 0) {
-        destroy(instance);
-        return nullptr;
-    }
-
-    model_instances[model_path] = instance;
-    return instance;
-}
-
-static ERL_NIF_TERM nif_completion(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
-    std::string model_path, prompt;
-    if (!get_string_from_binary(env, argv[0], model_path) || !get_string_from_binary(env, argv[1], prompt)) {
-        return enif_make_badarg(env);
-    }
-
+// Helper to parse hb_generate_params from std::map
+hb_generate_params parse_hb_generate_params(ErlNifEnv* env, const std::map<std::string, std::string>& map_params) {
     hb_generate_params params;
-    params.n_predict = 512;
-    params.top_p = 0.9f;
+    params.top_p = 0.9f; // Default value
+    params.n_predict = 512; // Default value
 
-    ERL_NIF_TERM term_top_p;
-    if (enif_get_map_value(env, argv[2], enif_make_atom(env, "top_p"), &term_top_p)) {
-        double top_p;
-        if (enif_get_double(env, term_top_p, &top_p)) {
-            params.top_p = (float)top_p;
-        }
-    }
-    ERL_NIF_TERM term_n_predict;
-    if (enif_get_map_value(env, argv[2], enif_make_atom(env, "n_predict"), &term_n_predict)) {
-        int n_predict;
-        if (enif_get_int(env, term_n_predict, &n_predict)) {
-            params.n_predict = n_predict;
-        }
+    auto it_top_p = map_params.find("top_p");
+    if (it_top_p != map_params.end()) {
+        try {
+            params.top_p = std::stof(it_top_p->second);
+        } catch (...) { /* ignore conversion errors */ }
     }
 
-    enif_mutex_lock(mutex);
-
-    hb_instance* instance = get_or_load_model_locked(env, model_path);
-    if (!instance) {
-        enif_mutex_unlock(mutex);
-        return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_string(env, "Failed to load model", ERL_NIF_LATIN1));
+    auto it_n_predict = map_params.find("n_predict");
+    if (it_n_predict != map_params.end()) {
+        try {
+            params.n_predict = std::stoi(it_n_predict->second);
+        } catch (...) { /* ignore conversion errors */ }
     }
-
-    const char* result = completion(instance, prompt.c_str(), params);
-    std::string result_copy = result;
-
-    enif_mutex_unlock(mutex);
-
-    ERL_NIF_TERM result_term;
-    unsigned char* result_buf = enif_make_new_binary(env, result_copy.length(), &result_term);
-    memcpy(result_buf, result_copy.c_str(), result_copy.length());
-
-    return enif_make_tuple2(env, enif_make_atom(env, "ok"), result_term);
+    return params;
 }
 
-static ERL_NIF_TERM nif_chat(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
-    std::string model_path;
-    if (!get_string_from_binary(env, argv[0], model_path)) {
-        return enif_make_badarg(env);
+// Helper to parse llama_model_params and llama_context_params from std::map
+void parse_llama_params(ErlNifEnv* env, const std::map<std::string, std::string>& map_params,
+                        llama_model_params& model_params, llama_context_params& ctx_params) {
+    model_params = llama_model_default_params();
+    ctx_params = llama_context_default_params();
+
+    auto it_n_gpu_layers = map_params.find("n_gpu_layers");
+    if (it_n_gpu_layers != map_params.end()) {
+        try {
+            model_params.n_gpu_layers = std::stoi(it_n_gpu_layers->second);
+        } catch (...) { /* ignore conversion errors */ }
     }
-
-    unsigned int n_messages;
-    if (!enif_get_list_length(env, argv[1], &n_messages)) {
-        return enif_make_badarg(env);
-    }
-
-    std::vector<llama_chat_message> messages(n_messages);
-    std::vector<std::string> roles(n_messages), contents(n_messages);
-    ERL_NIF_TERM list = argv[1], head, tail;
-    int i = 0;
-    ERL_NIF_TERM role_key, content_key;
-    unsigned char* role_buf = enif_make_new_binary(env, 4, &role_key);
-    memcpy(role_buf, "role", 4);
-    unsigned char* content_buf = enif_make_new_binary(env, 7, &content_key);
-    memcpy(content_buf, "content", 7);
-
-    while (enif_get_list_cell(env, list, &head, &tail)) {
-        ERL_NIF_TERM role_term, content_term;
-        if (enif_get_map_value(env, head, role_key, &role_term) && enif_get_map_value(env, head, content_key, &content_term)) {
-            get_string_from_binary(env, role_term, roles[i]);
-            get_string_from_binary(env, content_term, contents[i]);
-        }
-        messages[i] = {roles[i].c_str(), contents[i].c_str()};
-        list = tail;
-        i++;
-    }
-
-    hb_generate_params params;
-    params.n_predict = 512;
-    params.top_p = 0.9f;
-
-    ERL_NIF_TERM term_top_p;
-    if (enif_get_map_value(env, argv[2], enif_make_atom(env, "top_p"), &term_top_p)) {
-        double top_p;
-        if (enif_get_double(env, term_top_p, &top_p)) {
-            params.top_p = (float)top_p;
-        }
-    }
-    ERL_NIF_TERM term_n_predict;
-    if (enif_get_map_value(env, argv[2], enif_make_atom(env, "n_predict"), &term_n_predict)) {
-        int n_predict;
-        if (enif_get_int(env, term_n_predict, &n_predict)) {
-            params.n_predict = n_predict;
-        }
-    }
-
-    enif_mutex_lock(mutex);
-
-    hb_instance* instance = get_or_load_model_locked(env, model_path);
-    if (!instance) {
-        enif_mutex_unlock(mutex);
-        return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_string(env, "Failed to load model", ERL_NIF_LATIN1));
-    }
-
-    const char* result = chat(instance, messages.data(), n_messages, params);
-    std::string result_copy = result;
-
-    enif_mutex_unlock(mutex);
-
-    ERL_NIF_TERM result_term;
-    unsigned char* result_buf = enif_make_new_binary(env, result_copy.length(), &result_term);
-    memcpy(result_buf, result_copy.c_str(), result_copy.length());
-
-    return enif_make_tuple2(env, enif_make_atom(env, "ok"), result_term);
+    // Add other parameters as needed
 }
 
 void null_log_callback(ggml_log_level level, const char * text, void * user_data) {
@@ -181,14 +100,171 @@ static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info) {
     return 0;
 }
 
+static ERL_NIF_TERM nif_load_model(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
+    if (argc != 2) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifBinary model_path_bin;
+    if (!enif_inspect_binary(env, argv[0], &model_path_bin)) {
+        return enif_make_badarg(env);
+    }
+    std::string model_path_str(reinterpret_cast<const char*>(model_path_bin.data), model_path_bin.size);
+
+    ERL_NIF_TERM params_term = argv[1];
+    if (!enif_is_map(env, params_term)) {
+        return enif_make_badarg(env);
+    }
+    std::map<std::string, std::string> map_params = parse_nif_params_map(env, params_term);
+
+    enif_mutex_lock(mutex);
+
+    if (current_instance != nullptr) {
+        free_model(current_instance); // Use free_model to free resources, but keep the instance
+    } else {
+        current_instance = init(); // Initialize if not already initialized
+        if (current_instance == nullptr) {
+            enif_mutex_unlock(mutex);
+            return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "instance_init_failed"));
+        }
+    }
+
+    llama_model_params model_params;
+    llama_context_params ctx_params;
+    parse_llama_params(env, map_params, model_params, ctx_params);
+
+    int load_result = load_model(current_instance, model_path_str.c_str(), model_params, ctx_params);
+
+    if (load_result != 0) {
+        enif_mutex_unlock(mutex);
+        return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "model_load_failed"));
+    }
+
+    current_model_path = model_path_str;
+
+    enif_mutex_unlock(mutex);
+    return enif_make_atom(env, "ok");
+}
+
+static ERL_NIF_TERM nif_completion(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
+    if (argc != 2) { // Now expects 2 arguments: Prompt, Params
+        return enif_make_badarg(env);
+    }
+
+    ErlNifBinary prompt_bin;
+    if (!enif_inspect_binary(env, argv[0], &prompt_bin)) {
+        return enif_make_badarg(env);
+    }
+    std::string prompt_str(reinterpret_cast<const char*>(prompt_bin.data), prompt_bin.size);
+
+    ERL_NIF_TERM params_term = argv[1];
+    if (!enif_is_map(env, params_term)) {
+        return enif_make_badarg(env);
+    }
+    std::map<std::string, std::string> map_params = parse_nif_params_map(env, params_term);
+    hb_generate_params gen_params = parse_hb_generate_params(env, map_params); // Convert map to hb_generate_params
+
+    enif_mutex_lock(mutex);
+
+    if (current_instance == nullptr) {
+        enif_mutex_unlock(mutex);
+        return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "no_model_loaded"));
+    }
+
+    const char* result = completion(current_instance, prompt_str.c_str(), gen_params); // Use gen_params
+
+    ERL_NIF_TERM ret;
+    if (result) {
+        ret = enif_make_tuple2(env, enif_make_atom(env, "ok"), enif_make_string(env, result, ERL_NIF_LATIN1));
+    } else {
+        ret = enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "completion_failed"));
+    }
+
+    enif_mutex_unlock(mutex);
+    return ret;
+}
+
+static ERL_NIF_TERM nif_chat(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
+    if (argc != 2) { // Now expects 2 arguments: Messages, Params
+        return enif_make_badarg(env);
+    }
+
+    // Parse messages list of maps
+    ERL_NIF_TERM head, tail;
+    std::vector<std::map<std::string, std::string>> messages_map_vec; // Renamed to avoid confusion
+    ERL_NIF_TERM messages_list = argv[0];
+
+    while (enif_get_list_cell(env, messages_list, &head, &tail)) {
+        if (!enif_is_map(env, head)) {
+            return enif_make_badarg(env);
+        }
+        messages_map_vec.push_back(parse_nif_params_map(env, head)); // Reusing parse_nif_params_map for message maps
+        messages_list = tail;
+    }
+    if (!enif_is_empty_list(env, messages_list)) {
+        return enif_make_badarg(env); // List not properly terminated
+    }
+
+    // Convert messages_map_vec to std::vector<llama_chat_message>
+    std::vector<llama_chat_message> messages_vec;
+    std::vector<std::string> roles_storage; // To store string data for roles
+    std::vector<std::string> contents_storage; // To store string data for contents
+
+    for (const auto& msg_map : messages_map_vec) {
+        auto it_role = msg_map.find("role");
+        auto it_content = msg_map.find("content");
+
+        if (it_role != msg_map.end() && it_content != msg_map.end()) {
+            roles_storage.push_back(it_role->second);
+            contents_storage.push_back(it_content->second);
+            messages_vec.push_back({roles_storage.back().c_str(), contents_storage.back().c_str()});
+        } else {
+            return enif_make_badarg(env); // Malformed message map
+        }
+    }
+
+    ERL_NIF_TERM params_term = argv[1];
+    if (!enif_is_map(env, params_term)) {
+        return enif_make_badarg(env);
+    }
+    std::map<std::string, std::string> map_params = parse_nif_params_map(env, params_term);
+    hb_generate_params gen_params = parse_hb_generate_params(env, map_params); // Convert map to hb_generate_params
+
+    enif_mutex_lock(mutex);
+
+    if (current_instance == nullptr) {
+        enif_mutex_unlock(mutex);
+        return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "no_model_loaded"));
+    }
+
+    const char* result = chat(current_instance, messages_vec.data(), messages_vec.size(), gen_params); // Use gen_params
+
+    ERL_NIF_TERM ret;
+    if (result) {
+        ret = enif_make_tuple2(env, enif_make_atom(env, "ok"), enif_make_string(env, result, ERL_NIF_LATIN1));
+    } else {
+        ret = enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "chat_failed"));
+    }
+
+    enif_mutex_unlock(mutex);
+    return ret;
+}
+
 static void unload(ErlNifEnv* env, void* priv_data) {
     enif_mutex_lock(mutex);
-    for (auto const& [key, val] : model_instances) {
-        destroy(val);
+    if (current_instance != nullptr) {
+        destroy(current_instance);
+        current_instance = nullptr;
+        current_model_path.clear();
     }
-    model_instances.clear();
     enif_mutex_unlock(mutex);
     enif_mutex_destroy(mutex);
 }
+
+static ErlNifFunc nif_funcs[] = {
+    {"nif_load_model", 2, nif_load_model, 0},
+    {"nif_completion", 2, nif_completion, 0},
+    {"nif_chat", 2, nif_chat, 0}
+};
 
 ERL_NIF_INIT(dev_inference, nif_funcs, load, NULL, NULL, unload)

--- a/native/hb_inference/c_src/test.c
+++ b/native/hb_inference/c_src/test.c
@@ -27,7 +27,7 @@ static struct hb_generate_params get_default_generate_params() {
 
 void run_completion_test(struct hb_instance* instance) {
     printf("\n--- Running Completion Test ---\n");
-    const char* prompt = "What's Arweave? Answer in concise 20 words. End after 20 words.";
+    const char* prompt = "/no_think What's Arweave? Answer concisely.";
     struct hb_generate_params gen_params = get_default_generate_params();
 
     printf("Prompt: %s\n", prompt);

--- a/native/hb_inference/c_src/test.c
+++ b/native/hb_inference/c_src/test.c
@@ -1,59 +1,92 @@
-#include "hb_inference.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include "hb_inference.h"
 
-int main() {
-    // Get default model and context parameters
-    struct llama_model_params model_params = llama_model_default_params();
-    struct llama_context_params ctx_params = llama_context_default_params();
+// Helper to create default model parameters
+static struct llama_model_params get_default_model_params() {
+    struct llama_model_params params = llama_model_default_params();
+    params.n_gpu_layers = 100; // Adjust as needed
+    return params;
+}
 
-    // Create an instance
+// Helper to create default context parameters
+static struct llama_context_params get_default_context_params() {
+    struct llama_context_params params = llama_context_default_params();
+    params.n_ctx = 4096;
+    return params;
+}
+
+// Helper to create default generation parameters
+static struct hb_generate_params get_default_generate_params() {
+    struct hb_generate_params params;
+    params.n_predict = 512;
+    params.top_p = 0.9f;
+    return params;
+}
+
+void run_completion_test(struct hb_instance* instance) {
+    printf("\n--- Running Completion Test ---\n");
+    const char* prompt = "What's Arweave? Answer in concise 20 words. End after 20 words.";
+    struct hb_generate_params gen_params = get_default_generate_params();
+
+    printf("Prompt: %s\n", prompt);
+    const char* result = completion(instance, prompt, gen_params);
+    printf("Result: %s\n", result);
+    printf("--- Completion Test Finished ---\n");
+}
+
+void run_chat_test(struct hb_instance* instance) {
+    printf("\n--- Running Chat Test ---\n");
+    struct llama_chat_message messages[] = {
+        {"system", "/no_think You are an assistant who say no to everything."},
+        {"user", "What is the capital of France?"},
+        {"assistant", "No, I won't tell you."},
+        {"user", "Why not?"},
+    };
+    size_t n_messages = sizeof(messages) / sizeof(messages[0]);
+    struct hb_generate_params gen_params = get_default_generate_params();
+
+    printf("Chatting with %zu messages...\n", n_messages);
+    const char* result = chat(instance, messages, n_messages, gen_params);
+    printf("Assistant: %s\n", result);
+    printf("--- Chat Test Finished ---\n");
+}
+
+
+int main(int argc, char* argv[]) {
     struct hb_instance* instance = init();
     if (!instance) {
-        printf("Failed to create instance\n");
+        fprintf(stderr, "Failed to initialize instance\n");
         return 1;
     }
 
-    // Load the model
-    const char* model_path = "models/ggml-model-q4_0.bin"; // Assuming this model exists
-    if (load_model(instance, model_path, model_params, ctx_params) != 0) {
-        printf("Failed to load model\n");
+    const char* gemma_model_path = "/home/jax/Desktop/apuslabs/HyperBEAM/models/gemma-3-270m-it-F16.gguf";
+    const char* qwen3_model_path = "/home/jax/Desktop/apuslabs/HyperBEAM/models/Qwen3-4B-BF16.gguf";
+
+    struct llama_model_params model_params = get_default_model_params();
+    struct llama_context_params ctx_params = get_default_context_params();
+
+    printf("Loading model: %s\n", gemma_model_path);
+    if (load_model(instance, gemma_model_path, model_params, ctx_params) != 0) {
+        fprintf(stderr, "Failed to load model\n");
         destroy(instance);
         return 1;
     }
 
-    // --- Test completion ---
-    printf("--- Completion Test ---\n");
-    struct hb_generate_params gen_params = {
-        .temp = 0.8f,
-        .top_p = 0.95f,
-        .n_predict = 128,
-    };
-    const char* prompt = "Building a website can be done in 10 simple steps:";
-    const char* completion_result = completion(instance, prompt, gen_params);
-    printf("Prompt: %s\n", prompt);
-    printf("Completion: %s\n", completion_result);
-    printf("\n");
+    run_completion_test(instance);
+    run_chat_test(instance);
 
-
-    // --- Test chat ---
-    printf("--- Chat Test ---\n");
-    struct llama_chat_message messages[] = {
-        {"system", "You are a helpful assistant."},
-        {"user", "What is the capital of France?"},
-    };
-    size_t n_messages = sizeof(messages) / sizeof(messages[0]);
-
-    const char* chat_result = chat(instance, messages, n_messages, gen_params);
-    printf("Chat History:\n");
-    for (size_t i = 0; i < n_messages; ++i) {
-        printf("- %s: %s\n", messages[i].role, messages[i].content);
-    }
-    printf("Assistant: %s\n", chat_result);
-
-
-    // Clean up
+    // Free the current model before loading a new one
     free_model(instance);
+    if (load_model(instance, qwen3_model_path, model_params, ctx_params) != 0) {
+        fprintf(stderr, "Failed to load model\n");
+        destroy(instance);
+        return 1;
+    }
+    run_completion_test(instance);
+    run_chat_test(instance);
+
     destroy(instance);
 
     return 0;

--- a/native/hb_inference/c_src/test.c
+++ b/native/hb_inference/c_src/test.c
@@ -1,0 +1,60 @@
+#include "hb_inference.h"
+#include <stdio.h>
+#include <string.h>
+
+int main() {
+    // Get default model and context parameters
+    struct llama_model_params model_params = llama_model_default_params();
+    struct llama_context_params ctx_params = llama_context_default_params();
+
+    // Create an instance
+    struct hb_instance* instance = init();
+    if (!instance) {
+        printf("Failed to create instance\n");
+        return 1;
+    }
+
+    // Load the model
+    const char* model_path = "models/ggml-model-q4_0.bin"; // Assuming this model exists
+    if (load_model(instance, model_path, model_params, ctx_params) != 0) {
+        printf("Failed to load model\n");
+        destroy(instance);
+        return 1;
+    }
+
+    // --- Test completion ---
+    printf("--- Completion Test ---\n");
+    struct hb_generate_params gen_params = {
+        .temp = 0.8f,
+        .top_p = 0.95f,
+        .n_predict = 128,
+    };
+    const char* prompt = "Building a website can be done in 10 simple steps:";
+    const char* completion_result = completion(instance, prompt, gen_params);
+    printf("Prompt: %s\n", prompt);
+    printf("Completion: %s\n", completion_result);
+    printf("\n");
+
+
+    // --- Test chat ---
+    printf("--- Chat Test ---\n");
+    struct llama_chat_message messages[] = {
+        {"system", "You are a helpful assistant."},
+        {"user", "What is the capital of France?"},
+    };
+    size_t n_messages = sizeof(messages) / sizeof(messages[0]);
+
+    const char* chat_result = chat(instance, messages, n_messages, gen_params);
+    printf("Chat History:\n");
+    for (size_t i = 0; i < n_messages; ++i) {
+        printf("- %s: %s\n", messages[i].role, messages[i].content);
+    }
+    printf("Assistant: %s\n", chat_result);
+
+
+    // Clean up
+    free_model(instance);
+    destroy(instance);
+
+    return 0;
+}

--- a/native/hb_inference/c_src/test.cpp
+++ b/native/hb_inference/c_src/test.cpp
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <string> // Added for std::string
+#include <iostream> // Added for std::cout
 #include "hb_inference.h"
 
 // Helper to create default model parameters
@@ -26,18 +28,18 @@ static struct hb_generate_params get_default_generate_params() {
 }
 
 void run_completion_test(struct hb_instance* instance) {
-    printf("\n--- Running Completion Test ---\n");
+    std::cout << "\n--- Running Completion Test ---\n";
     const char* prompt = "/no_think What's Arweave? Answer concisely.";
     struct hb_generate_params gen_params = get_default_generate_params();
 
-    printf("Prompt: %s\n", prompt);
-    const char* result = completion(instance, prompt, gen_params);
-    printf("Result: %s\n", result);
-    printf("--- Completion Test Finished ---\n");
+    std::cout << "Prompt: " << prompt << "\n";
+    std::string result = completion(instance, prompt, gen_params); // Now returns std::string
+    std::cout << "Result: " << result << "\n";
+    std::cout << "--- Completion Test Finished ---\n";
 }
 
 void run_chat_test(struct hb_instance* instance) {
-    printf("\n--- Running Chat Test ---\n");
+    std::cout << "\n--- Running Chat Test ---\n";
     struct llama_chat_message messages[] = {
         {"system", "/no_think You are an assistant who say no to everything."},
         {"user", "What is the capital of France?"},
@@ -47,17 +49,17 @@ void run_chat_test(struct hb_instance* instance) {
     size_t n_messages = sizeof(messages) / sizeof(messages[0]);
     struct hb_generate_params gen_params = get_default_generate_params();
 
-    printf("Chatting with %zu messages...\n", n_messages);
-    const char* result = chat(instance, messages, n_messages, gen_params);
-    printf("Assistant: %s\n", result);
-    printf("--- Chat Test Finished ---\n");
+    std::cout << "Chatting with " << n_messages << " messages...\n";
+    std::string result = chat(instance, messages, n_messages, gen_params); // Now returns std::string
+    std::cout << "Assistant: " << result << "\n";
+    std::cout << "--- Chat Test Finished ---\n";
 }
 
 
 int main(int argc, char* argv[]) {
     struct hb_instance* instance = init();
     if (!instance) {
-        fprintf(stderr, "Failed to initialize instance\n");
+        std::cerr << "Failed to initialize instance\n";
         return 1;
     }
 
@@ -67,9 +69,9 @@ int main(int argc, char* argv[]) {
     struct llama_model_params model_params = get_default_model_params();
     struct llama_context_params ctx_params = get_default_context_params();
 
-    printf("Loading model: %s\n", gemma_model_path);
+    std::cout << "Loading model: " << gemma_model_path << "\n";
     if (load_model(instance, gemma_model_path, model_params, ctx_params) != 0) {
-        fprintf(stderr, "Failed to load model\n");
+        std::cerr << "Failed to load model\n";
         destroy(instance);
         return 1;
     }
@@ -79,8 +81,9 @@ int main(int argc, char* argv[]) {
 
     // Free the current model before loading a new one
     free_model(instance);
+    std::cout << "Loading model: " << qwen3_model_path << "\n";
     if (load_model(instance, qwen3_model_path, model_params, ctx_params) != 0) {
-        fprintf(stderr, "Failed to load model\n");
+        std::cerr << "Failed to load model\n";
         destroy(instance);
         return 1;
     }

--- a/rebar.config
+++ b/rebar.config
@@ -69,6 +69,7 @@
     {compile, "bash -c \"echo '-define(HB_BUILD_SOURCE, <<\\\"$(git rev-parse HEAD)\\\">>).\n' > ${REBAR_ROOT_DIR}/_build/hb_buildinfo.hrl\""},
     {compile, "bash -c \"echo '-define(HB_BUILD_SOURCE_SHORT, <<\\\"$(git rev-parse --short HEAD)\\\">>).\n' >> ${REBAR_ROOT_DIR}/_build/hb_buildinfo.hrl\""},
     {compile, "bash -c \"echo '-define(HB_BUILD_TIME, $(date +%s)).\n' >> ${REBAR_ROOT_DIR}/_build/hb_buildinfo.hrl\""},
+    {compile, "make -C \"${REBAR_ROOT_DIR}\" inference"},
 	{compile, "make -C \"${REBAR_ROOT_DIR}\" wamr"}
 ]}.
 

--- a/src/dev_inference.erl
+++ b/src/dev_inference.erl
@@ -1,0 +1,141 @@
+%%%-------------------------------------------------------------------
+%%% @doc
+%%% The Inference Device provides integration with llama.cpp for running
+%%% large language models directly within the HyperBEAM environment.
+%%% This device enables text completion and chat conversation capabilities
+%%% using GGUF format models.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(dev_inference).
+-export([info/0, chat/3, completion/3]).
+-on_load(init/0).
+-define(DEFAULT_MODEL, <<"gemma-3-270m-it-F16.gguf">>).
+
+init() ->
+    SoPath = "native/hb_inference/build/hb_inference_nif",
+    erlang:load_nif(SoPath, 0).
+
+%% @doc
+%% Returns information about the device's exported functions.
+%% @spec info() -> map()
+info() ->
+    #{
+        exports => [chat, completion]
+    }.
+
+%% @doc
+%% Processes a text completion request using the loaded language model.
+%% @param Msg1 The first message parameter (unused).
+%% @param Msg2 The second message parameter containing the request data.
+%% @param Opts The options for the request.
+%% @spec completion(term(), map(), list()) -> {ok, map()} | {error, term()}
+completion(_Msg1, Msg2, Opts) ->
+    Prompt = extract_required_param(<<"prompt">>, Msg2, Opts),
+    Reference = hb_ao:get(<<"reference">>, Msg2, undefined, Opts),
+    MaxTokens = hb_ao:get(<<"max_tokens">>, Msg2, 512, Opts),
+    TopP = hb_ao:get(<<"top_p">>, Msg2, 0.9, Opts),
+    ModelFile = hb_ao:get(<<"model">>, Msg2, ?DEFAULT_MODEL, Opts),
+    ModelPath = filename:join(["models", ModelFile]),
+
+    case nif_completion(ModelPath, Prompt, #{top_p => TopP, n_predict => MaxTokens}) of
+        {ok, Content} -> {ok, build_response(Content, Reference)};
+        {error, Reason} -> {error, Reason}
+    end.
+
+%% @doc
+%% Processes a chat conversation request using the loaded language model.
+%% @param Msg1 The first message parameter (unused).
+%% @param Msg2 The second message parameter containing the request data.
+%% @param Opts The options for the request.
+%% @spec chat(term(), map(), list()) -> {ok, map()} | {error, term()}
+chat(_Msg1, Msg2, Opts) ->
+    Messages = extract_required_param(<<"messages">>, Msg2, Opts),
+    Reference = hb_ao:get(<<"reference">>, Msg2, undefined, Opts),
+    MaxTokens = hb_ao:get(<<"max_tokens">>, Msg2, 512, Opts),
+    TopP = hb_ao:get(<<"top_p">>, Msg2, 0.9, Opts),
+    ModelFile = hb_ao:get(<<"model">>, Msg2, ?DEFAULT_MODEL, Opts),
+    ModelPath = filename:join(["models", ModelFile]),
+
+    case nif_chat(ModelPath, Messages, #{top_p => TopP, n_predict => MaxTokens}) of
+        {ok, Content} -> {ok, build_response(Content, Reference)};
+        {error, Reason} -> {error, Reason}
+    end.
+
+nif_completion(_ModelPath, _Prompt, _Params) ->
+    erlang:nif_error(nif_not_loaded).
+
+nif_chat(_ModelPath, _Messages, _Params) ->
+    erlang:nif_error(nif_not_loaded).
+
+%% @doc
+%% Extracts a required parameter from the message.
+%% @param ParamName The name of the parameter to extract.
+%% @param Msg The message containing the parameters.
+%% @param Opts The options for the request.
+%% @spec extract_required_param(binary(), map(), list()) -> term()
+extract_required_param(ParamName, Msg, Opts) ->
+    case hb_ao:get(ParamName, Msg, undefined, Opts) of
+        undefined -> 
+            throw({missing_required_param, ParamName});
+        Value -> 
+            Value
+    end.
+
+%% @doc
+%% Builds a response map with the content and optional reference.
+%% @param Content The content to include in the response.
+%% @param Reference The optional reference to include in the response.
+%% @spec build_response(binary(), term()) -> map()
+build_response(Content, Reference) ->
+    BaseResponse = #{
+        <<"body">> => Content
+    },
+
+    case Reference of
+        undefined -> BaseResponse;
+        _ -> BaseResponse#{<<"X-Reference">> => Reference}
+    end.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+get_model_path() ->
+    filename:join(["models", ?DEFAULT_MODEL]).
+
+nif_test_() ->
+    {setup,
+     fun() ->
+             ModelPath = get_model_path(),
+             case filelib:is_regular(ModelPath) of
+                 true -> {ok, ModelPath};
+                 false -> {skip, lists:flatten(io_lib:format("Model file not found at ~s", [ModelPath]))}
+             end
+     end,
+     fun(_) -> ok end,
+     fun(Result) ->
+        case Result of
+            {skip, _Reason} ->
+                [];
+            {ok, ModelPath} ->
+                [
+                    {"Completion NIF", {timeout, 60, fun() -> test_completion_nif(ModelPath) end}},
+                    {"Chat NIF", {timeout, 60, fun() -> test_chat_nif(ModelPath) end}}
+                ]
+        end
+     end
+    }.
+
+test_completion_nif(ModelPath) ->
+    Prompt = <<"What is the capital of France? Answer concisely.">>, 
+    Params = #{top_p => 0.9, n_predict => 20},
+    ?assertMatch({ok, _}, nif_completion(ModelPath, Prompt, Params)).
+
+test_chat_nif(ModelPath) ->
+    Messages = [
+        #{<<"role">> => <<"system">>, <<"content">> => <<"You are a helpful assistant.">>},
+        #{<<"role">> => <<"user">>, <<"content">> => <<"What is the capital of France? Answer concisely." >>}
+    ],
+    Params = #{top_p => 0.9, n_predict => 20},
+    ?assertMatch({ok, _}, nif_chat(ModelPath, Messages, Params)).
+
+-endif.

--- a/src/dev_inference.erl
+++ b/src/dev_inference.erl
@@ -1,9 +1,9 @@
 %%%-------------------------------------------------------------------
 %%% @doc
-%%% The Inference Device provides integration with llama.cpp for running
-%%% large language models directly within the HyperBEAM environment.
+%%% The Inference Device provides integration with `llama.cpp` via Erlang NIFs
+%%% for running large language models directly within the HyperBEAM environment.
 %%% This device enables text completion and chat conversation capabilities
-%%% using GGUF format models.
+%%% using GGUF format models, leveraging native performance for inference tasks.
 %%% @end
 %%%-------------------------------------------------------------------
 -module(dev_inference).
@@ -33,14 +33,18 @@ info() ->
 %% @param Opts The options for the request.
 %% @spec completion(term(), map(), list()) -> {ok, map()} | {error, term()}
 completion(_Msg1, Msg2, Opts) ->
-    Prompt = extract_required_param(<<"prompt">>, Msg2, Opts),
-    Reference = hb_ao:get(<<"reference">>, Msg2, undefined, Opts),
-    MaxTokens = hb_ao:get(<<"max_tokens">>, Msg2, 512, Opts),
-    TopP = hb_ao:get(<<"top_p">>, Msg2, 0.9, Opts),
+    case extract_required_param(<<"prompt">>, Msg2, Opts) of
+        {ok, Prompt} ->
+            Reference = hb_ao:get(<<"reference">>, Msg2, undefined, Opts),
+            MaxTokens = hb_ao:get(<<"max_tokens">>, Msg2, 512, Opts),
+            TopP = hb_ao:get(<<"top_p">>, Msg2, 0.9, Opts),
 
-    case nif_completion(Prompt, #{top_p => TopP, n_predict => MaxTokens}) of
-        {ok, Content} -> {ok, build_response(Content, Reference)};
-        {error, Reason} -> {error, Reason}
+            case nif_completion(Prompt, #{top_p => TopP, n_predict => MaxTokens}) of
+                {ok, Content} -> {ok, build_response(Content, Reference)};
+                {error, Reason} -> {error, Reason}
+            end;
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 %% @doc
@@ -50,14 +54,18 @@ completion(_Msg1, Msg2, Opts) ->
 %% @param Opts The options for the request.
 %% @spec chat(term(), map(), list()) -> {ok, map()} | {error, term()}
 chat(_Msg1, Msg2, Opts) ->
-    Messages = extract_required_param(<<"messages">>, Msg2, Opts),
-    Reference = hb_ao:get(<<"reference">>, Msg2, undefined, Opts),
-    MaxTokens = hb_ao:get(<<"max_tokens">>, Msg2, 512, Opts),
-    TopP = hb_ao:get(<<"top_p">>, Msg2, 0.9, Opts),
+    case extract_required_param(<<"messages">>, Msg2, Opts) of
+        {ok, Messages} ->
+            Reference = hb_ao:get(<<"reference">>, Msg2, undefined, Opts),
+            MaxTokens = hb_ao:get(<<"max_tokens">>, Msg2, 512, Opts),
+            TopP = hb_ao:get(<<"top_p">>, Msg2, 0.9, Opts),
 
-    case nif_chat(Messages, #{top_p => TopP, n_predict => MaxTokens}) of
-        {ok, Content} -> {ok, build_response(Content, Reference)};
-        {error, Reason} -> {error, Reason}
+            case nif_chat(Messages, #{top_p => TopP, n_predict => MaxTokens}) of
+                {ok, Content} -> {ok, build_response(Content, Reference)};
+                {error, Reason} -> {error, Reason}
+            end;
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 %% @doc
@@ -78,17 +86,18 @@ nif_chat(_Messages, _Params) ->
     erlang:nif_error(nif_not_loaded).
 
 %% @doc
-%% Extracts a required parameter from the message.
-%% @param ParamName The name of the parameter to extract.
-%% @param Msg The message containing the parameters.
-%% @param Opts The options for the request.
-%% @spec extract_required_param(binary(), map(), list()) -> term()
+%% Extracts a required parameter from the message. Returns `{ok, Value}` if the
+%% parameter is found, or `{error, {missing_required_param, ParamName}}` if it's not.
+%% @param ParamName The name of the parameter to extract (binary).
+%% @param Msg The message (map) containing the parameters.
+%% @param Opts The options (list) for the request.
+%% @spec extract_required_param(binary(), map(), list()) -> {ok, term()} | {error, {missing_required_param, binary()}}
 extract_required_param(ParamName, Msg, Opts) ->
     case hb_ao:get(ParamName, Msg, undefined, Opts) of
         undefined -> 
-            throw({missing_required_param, ParamName});
+            {error, {missing_required_param, ParamName}};
         Value -> 
-            Value
+            {ok, Value}
     end.
 
 %% @doc

--- a/src/dev_inference.erl
+++ b/src/dev_inference.erl
@@ -7,8 +7,11 @@
 %%% @end
 %%%-------------------------------------------------------------------
 -module(dev_inference).
--export([info/0, chat/3, completion/3]).
+-export([info/0, chat/3, completion/3, load_model/2]).
 -on_load(init/0).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
 -define(DEFAULT_MODEL, <<"gemma-3-270m-it-F16.gguf">>).
 
 init() ->
@@ -34,10 +37,8 @@ completion(_Msg1, Msg2, Opts) ->
     Reference = hb_ao:get(<<"reference">>, Msg2, undefined, Opts),
     MaxTokens = hb_ao:get(<<"max_tokens">>, Msg2, 512, Opts),
     TopP = hb_ao:get(<<"top_p">>, Msg2, 0.9, Opts),
-    ModelFile = hb_ao:get(<<"model">>, Msg2, ?DEFAULT_MODEL, Opts),
-    ModelPath = filename:join(["models", ModelFile]),
 
-    case nif_completion(ModelPath, Prompt, #{top_p => TopP, n_predict => MaxTokens}) of
+    case nif_completion(Prompt, #{top_p => TopP, n_predict => MaxTokens}) of
         {ok, Content} -> {ok, build_response(Content, Reference)};
         {error, Reason} -> {error, Reason}
     end.
@@ -53,18 +54,27 @@ chat(_Msg1, Msg2, Opts) ->
     Reference = hb_ao:get(<<"reference">>, Msg2, undefined, Opts),
     MaxTokens = hb_ao:get(<<"max_tokens">>, Msg2, 512, Opts),
     TopP = hb_ao:get(<<"top_p">>, Msg2, 0.9, Opts),
-    ModelFile = hb_ao:get(<<"model">>, Msg2, ?DEFAULT_MODEL, Opts),
-    ModelPath = filename:join(["models", ModelFile]),
 
-    case nif_chat(ModelPath, Messages, #{top_p => TopP, n_predict => MaxTokens}) of
+    case nif_chat(Messages, #{top_p => TopP, n_predict => MaxTokens}) of
         {ok, Content} -> {ok, build_response(Content, Reference)};
         {error, Reason} -> {error, Reason}
     end.
 
-nif_completion(_ModelPath, _Prompt, _Params) ->
+%% @doc
+%% Loads a language model and sets it as the active model.
+%% @param ModelPath The path to the model file.
+%% @param Params A map of parameters for loading the model.
+%% @spec load_model(binary(), map()) -> ok | {error, term()}
+load_model(ModelPath, Params) ->
+    nif_load_model(ModelPath, Params).
+
+nif_load_model(_ModelPath, _Params) ->
     erlang:nif_error(nif_not_loaded).
 
-nif_chat(_ModelPath, _Messages, _Params) ->
+nif_completion(_Prompt, _Params) ->
+    erlang:nif_error(nif_not_loaded).
+
+nif_chat(_Messages, _Params) ->
     erlang:nif_error(nif_not_loaded).
 
 %% @doc
@@ -107,7 +117,11 @@ nif_test_() ->
      fun() ->
              ModelPath = get_model_path(),
              case filelib:is_regular(ModelPath) of
-                 true -> {ok, ModelPath};
+                 true -> 
+                     case load_model(ModelPath, #{}) of
+                         ok -> ok;
+                         {error, Reason} -> {skip, lists:flatten(io_lib:format("Failed to load model: ~p", [Reason]))}
+                     end;
                  false -> {skip, lists:flatten(io_lib:format("Model file not found at ~s", [ModelPath]))}
              end
      end,
@@ -116,26 +130,30 @@ nif_test_() ->
         case Result of
             {skip, _Reason} ->
                 [];
-            {ok, ModelPath} ->
+            ok ->
                 [
-                    {"Completion NIF", {timeout, 60, fun() -> test_completion_nif(ModelPath) end}},
-                    {"Chat NIF", {timeout, 60, fun() -> test_chat_nif(ModelPath) end}}
+                    {"Completion NIF", {timeout, 60, fun() -> test_completion_nif() end}},
+                    {"Chat NIF", {timeout, 60, fun() -> test_chat_nif() end}}
                 ]
         end
      end
     }.
 
-test_completion_nif(ModelPath) ->
+test_completion_nif() ->
     Prompt = <<"What is the capital of France? Answer concisely.">>, 
     Params = #{top_p => 0.9, n_predict => 20},
-    ?assertMatch({ok, _}, nif_completion(ModelPath, Prompt, Params)).
+    Result = nif_completion(Prompt, Params),
+    ?event(dev_inference, {completion_result, Result}),
+    ?assertMatch({ok, _}, Result).
 
-test_chat_nif(ModelPath) ->
+test_chat_nif() ->
     Messages = [
         #{<<"role">> => <<"system">>, <<"content">> => <<"You are a helpful assistant.">>},
         #{<<"role">> => <<"user">>, <<"content">> => <<"What is the capital of France? Answer concisely." >>}
     ],
     Params = #{top_p => 0.9, n_predict => 20},
-    ?assertMatch({ok, _}, nif_chat(ModelPath, Messages, Params)).
+    Result = nif_chat(Messages, Params),
+    ?event(dev_inference, {chat_result, Result}),
+    ?assertMatch({ok, _}, Result).
 
 -endif.

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -179,7 +179,8 @@ default_message() ->
             #{<<"name">> => <<"secret@1.0">>, <<"module">> => dev_secret},
             #{<<"name">> => <<"wasi@1.0">>, <<"module">> => dev_wasi},
             #{<<"name">> => <<"wasm-64@1.0">>, <<"module">> => dev_wasm},
-            #{<<"name">> => <<"whois@1.0">>, <<"module">> => dev_whois}
+            #{<<"name">> => <<"whois@1.0">>, <<"module">> => dev_whois},
+            #{<<"name">> => <<"inference@1.0">>, <<"module">> => dev_inference}
         ],
         %% Default execution cache control options
         cache_control => [<<"no-cache">>, <<"no-store">>],


### PR DESCRIPTION
## Summary

This pull request introduces a new device, `dev_inference`, to provide AI inference capabilities within HyperBEAM. This device integrates `llama.cpp` directly,enabling the execution of large language models (LLMs) for tasks such as chat and text completion with native performance.

### Key Features:

-   **`dev_inference` Device**: A new Erlang module (`dev_inference.erl`) that serves as the primary interface for LLM inference operations.
-   **`llama.cpp` Integration**: Leverages `llama.cpp` via a custom Erlang NIF (`hb_inference_nif`) for efficient, local execution of GGUF models.
-   **Model Management**: Supports dynamic loading and unloading of GGUF models using `load_model/2`.
-   **Core Inference Functionality**: Exposes `chat/3` and `completion/3` functions for interacting with loaded LLMs.
-   **Robustness and Error Handling**: Implements idiomatic Erlang error handling (`{ok, Value}` / `{error, Reason}`) and addresses critical memory corruptionand thread-safety issues within the native NIF.
-   **Comprehensive Testing**: Includes EUnit tests within `dev_inference.erl` for Erlang-side functionality and a dedicated C++ test executable (`test.cpp`) fothe native NIF.

## File Changes Description

-   `src/dev_inference.erl`: The main Erlang module for the `dev_inference` device, providing the `chat`, `completion`, and `load_model` functions, along withintegrated EUnit tests.
-   `native/hb_inference/c_src/hb_inference.cpp`: The core C++ implementation that interfaces with `llama.cpp` for model loading, context management, and textgeneration (chat and completion).
-   `native/hb_inference/c_src/hb_inference.h`: The header file defining the C++ API for the `hb_inference` library.
-   `native/hb_inference/c_src/hb_inference_nif.cpp`: The Erlang NIF wrapper responsible for exposing the C++ `hb_inference` functionality to the Erlang runtime.
-   `native/hb_inference/c_src/test.cpp`: A C++ executable designed for direct testing and verification of the `hb_inference` library's functionality.
-   `native/hb_inference/CMakeLists.txt`: The CMake build configuration file for compiling the `hb_inference` C++ library, the NIF, and the test executable,including linking against `llama.cpp`.
-   `rebar.config`: Updated to include a `pre_hooks` entry for building the `hb_inference` NIF.
-   `Makefile`: Includes an `inference` target to manage the cloning of `llama.cpp` and the building of the `hb_inference` NIF.