### PR TITLE
fix: unquote values in `hb_singleton` query strings

### DIFF
--- a/src/hb_singleton.erl
+++ b/src/hb_singleton.erl
@@ -180,7 +180,7 @@ from_path(RelativeRef) ->
     {
         ok,
         path_parts($/, Path),
-        hb_maps:from_list(QKVList)
+        maps:map(fun(_, Val) -> unquote(Val) end, hb_maps:from_list(QKVList))
     }.
 
 %% @doc Step 2: Decode, split and sanitize the path. Split by `/' but avoid


### PR DESCRIPTION
Normalizes the parsing of `?a="b"` query string parameters, following the standard set by `&a="b"` inline path params.