### PR TITLE
fix: remove relay headers, pass m2 as headers without custom

### DIFF
--- a/src/dev_delegated_compute.erl
+++ b/src/dev_delegated_compute.erl
@@ -141,7 +141,6 @@ do_relay(Method, Path, Body, Headers, Opts) ->
             <<"relay-method">> => Method,
             <<"relay-body">> => Body,
             <<"relay-path">> => Path,
-            <<"relay-headers">> => Headers,
             <<"content-type">> => ContentType
         },
         Opts

--- a/src/dev_delegated_compute.erl
+++ b/src/dev_delegated_compute.erl
@@ -138,10 +138,14 @@ do_relay(Method, Path, Body, Headers, Opts) ->
         },
         Headers#{
             <<"path">> => <<"call">>,
-            <<"relay-method">> => Method,
-            <<"relay-body">> => Body,
-            <<"relay-path">> => Path,
-            <<"content-type">> => ContentType
+            <<"target">> => <<"payload">>,
+            <<"payload">> =>
+                Headers#{
+                    <<"path">> => Path,
+                    <<"method">> => Method,
+                    <<"body">> => Body,
+                    <<"content-type">> => ContentType
+                }
         },
         Opts
     ).

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -380,7 +380,7 @@ compute_slot(ProcID, State, RawInputMsg, ReqMsg, Opts) ->
             undefined -> RawInputMsg#{ <<"path">> => <<"compute">> };
             _ -> RawInputMsg
         end,
-    ?event(compute,{input_msg, InputMsg}),
+    ?event(compute, {input_msg, InputMsg}),
     ?event(compute, {executing, {proc_id, ProcID}, {slot, NextSlot}}, Opts),
     % Unset the previous results.
     UnsetResults = hb_ao:set(State, #{ <<"results">> => unset }, Opts),

--- a/src/dev_relay.erl
+++ b/src/dev_relay.erl
@@ -44,13 +44,9 @@ call(M1, RawM2, Opts) ->
             Opts
         ),
     RelayHeaders = 
-        hb_ao:get_first(
-            [
-                {M1, <<"relay-headers">>},
-                {{as, <<"message@1.0">>, BaseTarget}, <<"relay-headers">>},
-                {RawM2, <<"relay-headers">>}
-            ],
-            not_found,
+        hb_maps:without(
+            [<<"relay-method">>, <<"relay-body">>, <<"relay-path">>],
+            RawM2,
             Opts
         ),
     RelayDevice =

--- a/src/dev_relay.erl
+++ b/src/dev_relay.erl
@@ -120,7 +120,6 @@ call(M1, RawM2, Opts) ->
             not_found -> TargetMod3;
             _ -> 
                 hb_maps:merge(
-                    TargetMod3,
                     hb_maps:without(
                         [<<"commitments">>],
                         hb_util:ok(
@@ -128,6 +127,7 @@ call(M1, RawM2, Opts) ->
                         ),
                         Opts
                     ),
+                    TargetMod3,
                     Opts
                 )
         end,

--- a/src/dev_relay.erl
+++ b/src/dev_relay.erl
@@ -43,12 +43,6 @@ call(M1, RawM2, Opts) ->
             ],
             Opts
         ),
-    RelayHeaders = 
-        hb_maps:without(
-            [<<"relay-method">>, <<"relay-body">>, <<"relay-path">>],
-            RawM2,
-            Opts
-        ),
     RelayDevice =
         hb_ao:get_first(
             [
@@ -116,21 +110,11 @@ call(M1, RawM2, Opts) ->
             _ -> TargetMod2#{<<"device">> => RelayDevice}
         end,
     TargetMod4 = 
-        case RelayHeaders of
-            not_found -> TargetMod3;
-            _ -> 
-                hb_maps:merge(
-                    hb_maps:without(
-                        [<<"commitments">>],
-                        hb_util:ok(
-                            hb_message:with_only_committed(RelayHeaders, Opts)
-                        ),
-                        Opts
-                    ),
-                    TargetMod3,
-                    Opts
-                )
-        end,
+        hb_maps:without(
+            [<<"commitments">>],
+            TargetMod3,
+            Opts
+        ),
     TargetMod5 =
         case Commit of
             true ->


### PR DESCRIPTION
Simple fix to remove passing of relay headers and rather read m2 without custom values (`relay-method`, `relay-body`, `relay-path`)