### PR TITLE
fix: encode & in eflame generation

### DIFF
--- a/src/dev_profile.erl
+++ b/src/dev_profile.erl
@@ -181,8 +181,10 @@ eflame_profile(Fun, Req, Opts) ->
             undefined ->
                 hb_escape:encode(hb_util:bin(io_lib:format("~p", [Fun])));
             Path ->
-                hb_escape:encode_quotes(
-                    hb_maps:get(Path, Req, Path, Opts)
+                hb_escape:encode_ampersand(
+                    hb_escape:encode_quotes(
+                        hb_maps:get(Path, Req, Path, Opts)
+                    )
                 )
         end,
     StackToFlameScript = hb_util:bin(filename:join(EflameDir, "flamegraph.pl")),

--- a/src/hb_escape.erl
+++ b/src/hb_escape.erl
@@ -10,6 +10,7 @@
 -module(hb_escape).
 -export([encode/1, decode/1, encode_keys/2, decode_keys/2]).
 -export([encode_quotes/1, decode_quotes/1]).
+-export([encode_ampersand/1]).
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
 
@@ -35,6 +36,13 @@ decode_quotes([]) -> [];
 decode_quotes([$\\, $\" | Rest]) -> [$\" | decode_quotes(Rest)];
 decode_quotes([$\" | Rest]) -> decode_quotes(Rest);
 decode_quotes([C | Rest]) -> [C | decode_quotes(Rest)].
+
+%% @doc Encode ampersands as &amp; for XML output.
+encode_ampersand(String) when is_binary(String) ->
+    list_to_binary(encode_ampersand(binary_to_list(String)));
+encode_ampersand([]) -> [];
+encode_ampersand([$& | Rest]) -> [$&, $a, $m, $p, $; | encode_ampersand(Rest)];
+encode_ampersand([C | Rest]) -> [C | encode_ampersand(Rest)].
 
 %% @doc Return a message with all of its keys decoded.
 decode_keys(Msg, Opts) when is_map(Msg) ->


### PR DESCRIPTION
When generating eflame graphs, eval path having `&` (ex: `http://localhost:8734/~profile@1.0/eval=%220syT13r0s0tgPmIed95bJnuSqaD29HQNN8D3ElLSrsc~process@1.0/compute&slot=3%22&engine=eflame`) causes the renderer to break. This escapes the `&` and fixes the renderer