### PR TITLE
[WIP] fix: make rsa_pss int_to_bit_size more efficient

### DIFF
--- a/src/rsa_pss.erl
+++ b/src/rsa_pss.erl
@@ -185,16 +185,9 @@ ep(B, #'RSAPublicKey'{modulus=N, publicExponent=E}) ->
     crypto:mod_pow(B, E, N).
 
 %% @private
-int_to_bit_size(I) ->
-    int_to_bit_size(I, 0).
+int_to_bit_size(I) -> 
+    bit_size(binary:encode_unsigned(I)).
 
-%% @private
-int_to_bit_size(0, B) ->
-    B;
-int_to_bit_size(I, B) ->
-    int_to_bit_size(I bsr 1, B + 1).
-
-%% @private
 int_to_byte_size(I) ->
     int_to_byte_size(I, 0).
 


### PR DESCRIPTION
When inspecting the eflame of computing the AO token, lots of time being taken in `dev_scheduler_formats:aos2_to_assignments`, specifically `rsa_pss:verify` and `rsa_pss:int_to_bit_size` (14% of computation time). When replacing `int_to_bit_size` with a more efficient implementation, drops to 2%. Eflames below:
Before:
<img width="1195" height="999" alt="Screenshot 2025-09-30 at 4 46 12 PM" src="https://github.com/user-attachments/assets/1a8f1141-0c87-4953-8b08-5d3234525ea1" />
After:
<img width="1198" height="988" alt="Screenshot 2025-09-30 at 4 46 35 PM" src="https://github.com/user-attachments/assets/6e5f8b46-be03-41e1-ba2a-3aa04e531848" />
