### PR TITLE
impr: `~cron@1.0` quality of life improvements

### DIFF
--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -24,7 +24,10 @@
 -define(DEFAULT_PRINT_OPTS, [error, http_error]).
 -else.
 -define(DEFAULT_PRINT_OPTS,
-    [error, http_error, http_short, compute_short, push_short, copycat_short]
+    [
+        error, http_error, cron_error,
+        http_short, compute_short, push_short, copycat_short
+    ]
 ).
 -endif.
 


### PR DESCRIPTION
Introduces three quality of life improvements for `~cron@1.0`:
1. Callers can now invoke using the default key syntax of `hb_singleton`. For example: `GET /~cron@1.0/once="/procID/now"`.
2. Keys now default as `every` intervals, such that paths as follows are possible: `GET /~cron@1.0/10-seconds="/procID/now"`.
3. The`cron_error` event group is printed by default, in the same way as `error` and `http_error` are.