### PR TITLE
Fix: send 404 on nonexistent balance (trie search bug)

### DIFF
--- a/src/dev_trie.erl
+++ b/src/dev_trie.erl
@@ -35,21 +35,36 @@ info() ->
 %% as it recurses.
 get(Key, Trie, Req, Opts) ->
     get(Trie, Req#{ <<"key">> => Key }, Opts).
-get(Trie, Req, Opts) ->
+get(Link, Req, Opts) when ?IS_LINK(Link) ->
+    get(hb_cache:ensure_loaded(Link, Opts), Req, Opts);
+get(Node, Req, Opts) ->
     case hb_maps:find(<<"key">>, Req, Opts) of
         error -> {error, <<"`key' parameter is required for trie lookup.">>};
-        {ok, <<>>} -> {ok, Trie};
+        {ok, <<>>} ->
+            % We have reached the end of the key characters. Return the current
+            % node.
+            {ok, Node};
+        {ok, RemainingKey} when not is_map(Node) ->
+            % We have more characters to resolve, but the current node is not a
+            % message, so we cannot continue.
+            ?event(debug_trie,
+                {not_found,
+                    {node, Node},
+                    {remaining_key, RemainingKey}
+                }
+            ),
+            {error, not_found};
         {ok, Key} ->
             % If we have a key to search for, find the longest prefix match
             % amongst the keys in the trie and recurse, until there are no more
             % bytes of the key to match on.
-            case longest_match(Key, Trie, Opts) of
+            case longest_match(Key, Node, Opts) of
                 <<>> -> {error, not_found};
                 Prefix ->
                     % Find the child node and the remaining key.
                     get(
                         remove_prefix(Prefix, Key),
-                        hb_maps:get(Prefix, Trie, #{}, Opts),
+                        hb_maps:get(Prefix, Node, #{}, Opts),
                         #{},
                         Opts
                     )
@@ -257,6 +272,31 @@ set_multiple_test() ->
                 #{}
             ),
             primary
+        )
+    ).
+
+not_found_test() ->
+    hb:init(),
+    ?assertEqual(
+        not_found,
+        hb_ao:get(
+            <<"ac">>,
+            #{
+                <<"device">> => <<"trie@1.0">>,
+                <<"a">> => #{ <<"b">> => <<"layer-2">> }
+            },
+            #{}
+        )
+    ),
+    ?assertEqual(
+        not_found,
+        hb_ao:get(
+            <<"abcde">>,
+            #{
+                <<"device">> => <<"trie@1.0">>,
+                <<"a">> => #{ <<"b">> => <<"layer-2">> }
+            },
+            #{}
         )
     ).
 

--- a/src/dev_trie.erl
+++ b/src/dev_trie.erl
@@ -49,7 +49,7 @@ get(Trie, Req, Opts) ->
                     % Find the child node and the remaining key.
                     get(
                         remove_prefix(Prefix, Key),
-                        hb_maps:get(Prefix, Trie, Opts),
+                        hb_maps:get(Prefix, Trie, #{}, Opts),
                         #{},
                         Opts
                     )


### PR DESCRIPTION
My findings: the logic in `dev_trie:get()` malfunctioned in cases where there was a partial prefix match on a nonexistent key, as we would call `hb_maps:get()` on line 52 but accidentally pass in the `Opts` map instead of a default values map.  The result is that `hb_maps:get()` would find nothing in the `Trie` structure, and would thus populate the data structure in the following recursion with the atoms from the `hb_opts` defaults.  And so, instead of reaching the base case and terminating the recursion with a `not_found`, we instead passed bad and mis-typed arguments into the prefix matching function and attempted to continue, throwing an error.

Notable:  before this PR, I observed different results for two different flavors of bad keys.  If you attempted a request with a well-formed but nonexistent key, you'd receive a 500.  This has been fixed, and now you'll receive a 404.  

But if you attempted a request with a malformed key -- for example, a key that's too short -- you'd receive a 403.  We no longer receive a 403, and now malformed keys just take you to some node information page.  I _think_ this is the correct behavior, because of the way the trie device behaves if you search for a key which exists but does not possess a terminal value -- i.e., a valid internal node.  But LMK if this is not the case and I can take another look...