### PR TITLE
impr: process cache-write performance

### DIFF
--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -454,7 +454,7 @@ store_result(ForceSnapshot, ProcID, Slot, Msg3, Msg2, Opts) ->
                         {snapshot, WithLastSnapshot}
                     }
                 ),
-                hb_cache:ensure_all_loaded(WithLastSnapshot, Opts)
+                WithLastSnapshot
         end,
     ?event(compute, {caching_result, {proc_id, ProcID}, {slot, Slot}}, Opts),
     Writer = 

--- a/src/dev_process_cache.erl
+++ b/src/dev_process_cache.erl
@@ -18,7 +18,7 @@ read(ProcID, SlotRef, Opts) ->
 %% @doc Write a process computation result to the cache.
 write(ProcID, Slot, Msg, Opts) ->
     % Write the item to the cache in the root of the store.
-    {ok, Root} = hb_cache:write(Msg, Opts),
+    {ok, Root} = hb_cache:write(hb_private:reset(Msg), Opts),
     % Link the item to the path in the store by slot number.
     SlotNumPath = path(ProcID, Slot, Opts),
     hb_cache:link(Root, SlotNumPath, Opts),


### PR DESCRIPTION
Do not force load every key before writing process state to cache.