### PR TITLE
impr: small hook resolution improvements

### DIFF
--- a/src/dev_hook.erl
+++ b/src/dev_hook.erl
@@ -164,12 +164,12 @@ execute_handler(HookName, Handler, Req, Opts) ->
         % committed before execution.
         BaseReq =
             Req#{
-                <<"path">> => hb_ao:get(<<"path">>, Handler, HookName, Opts),
-                <<"method">> => hb_ao:get(<<"method">>, Handler, <<"GET">>, Opts)
+                <<"path">> => hb_maps:get(<<"path">>, Handler, HookName, Opts),
+                <<"method">> => hb_maps:get(<<"method">>, Handler, <<"GET">>, Opts)
             },
         CommitReqBin = 
             hb_util:bin(
-                hb_ao:get(<<"hook/commit-request">>, Handler, <<"false">>, Opts)
+                hb_maps:get(<<"hook/commit-request">>, Handler, <<"false">>, Opts)
             ),
         {PreparedBase, PreparedReq} =
             case CommitReqBin of
@@ -204,7 +204,7 @@ execute_handler(HookName, Handler, Req, Opts) ->
                 {res, Res}
             }
         ),
-        case {Status, hb_ao:get(<<"hook/result">>, Handler, <<"return">>, Opts)} of
+        case {Status, hb_util:deep_get(<<"hook/result">>, Handler, <<"return">>, Opts)} of
             {ok, <<"ignore">>} -> {Status, Req};
             {ok, <<"return">>} -> {Status, Res};
             {ok, <<"error">>} -> {error, Res};

--- a/src/dev_hook.erl
+++ b/src/dev_hook.erl
@@ -94,8 +94,15 @@ find(_Base, Req, Opts) ->
     HookName = maps:get(maps:get(<<"target">>, Req, <<"body">>), Req),
     case maps:get(HookName, hb_opts:get(on, #{}, Opts), []) of
         Handler when is_map(Handler) -> 
-            % If a single handler is found, wrap it in a list.
-            [Handler];
+            case hb_util:is_ordered_list(Handler, Opts) of
+                true ->
+                    % If the term is an ordered list message (containing only
+                    % numbered map keys sequentially), convert it to a list.
+                    hb_util:message_to_ordered_list(Handler, Opts);
+                false ->
+                    % If a single handler is found, wrap it in a list.
+                    [Handler]
+            end;
         Handlers when is_list(Handlers) -> 
             % If multiple handlers are found, return them as is
             Handlers;

--- a/src/hb_util.erl
+++ b/src/hb_util.erl
@@ -340,10 +340,14 @@ list_to_numbered_message(List) ->
 is_ordered_list(Msg, _Opts) when is_list(Msg) -> true;
 is_ordered_list(Msg, Opts) ->
     is_ordered_list(1, hb_ao:normalize_keys(Msg, Opts), Opts).
-is_ordered_list(_, Msg, _Opts) when map_size(Msg) == 0 -> true;
 is_ordered_list(N, Msg, _Opts) ->
     case maps:get(NormKey = hb_ao:normalize_key(N), Msg, not_found) of
-        not_found -> false;
+        not_found ->
+            WithoutPriv = hb_private:reset(Msg),
+            case maps:without([<<"commitments">>, <<"ao-types">>], WithoutPriv) of
+                EmptyMsg when map_size(EmptyMsg) == 0 -> true;
+                _ -> false
+            end;
         _ ->
             is_ordered_list(
                 N + 1,


### PR DESCRIPTION
- Determine if the handlers for a hook are a sequence more accurately.
- Avoid using `hb_ao:get` in hook parameter gathering. Use `hb_maps:get` instead.

Still much more to do here -- particularly in regularization of the handler invocation mechanism. Ideally needs to be uniform across all devices with a similar pattern.