### PR TITLE
impr: replicate legacynet handling of `data` field in `~json-iface@1.0`

### DIFF
--- a/src/dev_delegated_compute.erl
+++ b/src/dev_delegated_compute.erl
@@ -59,14 +59,16 @@ compute(Msg1, Msg2, Opts) ->
     Type = hb_ao:get(<<"type">>, Msg2, not_found, Opts),
     ?event({doing_delegated_compute, {msg2, Msg2}, {type, Type}}),
     % Execute the compute via external CU
-    case Type of
-        <<"Assignment">> ->
-            Slot = hb_ao:get(<<"slot">>, Msg2, Opts),
-            Res = do_compute(ProcessID, Msg2, Opts);
-        _ ->
-            Slot = dryrun,
-            Res = do_dryrun(ProcessID, Msg2, Opts)
-    end,
+    {Slot, Res} =
+        case Type of
+            <<"Assignment">> ->
+                {
+                    hb_ao:get(<<"slot">>, Msg2, Opts),
+                    do_compute(ProcessID, Msg2, Opts)
+                };
+            _ ->
+                {dryrun, do_dryrun(ProcessID, Msg2, Opts)}
+        end,
     handle_relay_response(Msg1, Msg2, Opts, Res, OutputPrefix, ProcessID, Slot).
 
 %% @doc Execute computation on a remote machine via relay and the JSON-Iface.

--- a/src/dev_json_iface.erl
+++ b/src/dev_json_iface.erl
@@ -146,13 +146,18 @@ message_to_json_struct(RawMsg, Features, Opts) ->
             <<>>,
             Opts
         ),
-    Data =
+    DataBytes =
         hb_ao:get(
             <<"data">>,
             {as, <<"message@1.0">>, MsgWithoutCommitments},
             <<>>,
             Opts
         ),
+    Data =
+        case hb_util:is_printable_string(DataBytes) of
+            true -> DataBytes;
+            false -> null 
+        end,
     Target =
         hb_ao:get(
             <<"target">>,

--- a/src/hb_format.erl
+++ b/src/hb_format.erl
@@ -442,7 +442,7 @@ binary(Bin) ->
                     end
                 ),
             PrintSegment =
-                case is_human_binary(Printable) of
+                case hb_util:is_printable_string(Printable) of
                     true -> Printable;
                     false -> hb_util:encode(Printable)
                 end,
@@ -880,13 +880,6 @@ short_id(<< "/", SingleElemHashpath/binary >>) ->
     end;
 short_id(Key) when byte_size(Key) < 43 -> Key;
 short_id(_) -> undefined.
-
-%% @doc Determine whether a binary is human-readable.
-is_human_binary(Bin) when is_binary(Bin) ->
-    case unicode:characters_to_binary(Bin) of
-        {error, _, _} -> false;
-        _ -> true
-    end.
 
 %% Determine the maximum number of keys to print for messages, given a node
 %% `Opts`.

--- a/src/hb_util.erl
+++ b/src/hb_util.erl
@@ -5,6 +5,7 @@
 -export([id/1, id/2, native_id/1, human_id/1, human_int/1, to_hex/1]).
 -export([key_to_atom/1, key_to_atom/2, binary_to_strings/1]).
 -export([encode/1, decode/1, safe_encode/1, safe_decode/1]).
+-export([is_printable_string/1]).
 -export([find_value/2, find_value/3]).
 -export([deep_merge/3, deep_set/4, deep_get/3, deep_get/4]).
 -export([number/1, list_to_numbered_message/1]).
@@ -230,6 +231,13 @@ safe_decode(E) ->
         {ok, D}
     catch
         _:_ -> {error, invalid}
+    end.
+
+%% @doc Determine whether a binary contains only unicode printable characters.
+is_printable_string(Bin) when is_binary(Bin) ->
+    case unicode:characters_to_binary(Bin) of
+        {error, _, _} -> false;
+        _ -> true
     end.
 
 %% @doc Convert a binary to a hex string. Do not use this for anything other than


### PR DESCRIPTION
This PR replicates the legacynet scheduler's behavior with regard to messages with non-JSON encodable binaries in their `data` field: Test for unicode encodability; return data as `null` if it not possible.