### PR TITLE
fix: terminate genesis_wasm_server gracefully

### DIFF
--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -2,7 +2,7 @@
 %%% processes, using HyperBEAM infrastructure. This allows existing `legacynet'
 %%% AO process definitions to be used in HyperBEAM.
 -module(dev_genesis_wasm).
--export([init/3, compute/3, normalize/3, snapshot/3, import/3]).
+-export([init/3, compute/3, normalize/3, snapshot/3, import/3, terminate/0]).
 -export([latest_checkpoint/2]).
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("include/hb.hrl").
@@ -480,11 +480,13 @@ collect_events(Port) ->
 collect_events(Port, Acc) ->
     receive
         {Port, {data, Data}} ->
+            persistent_term:put({?MODULE, port}, Port),
             collect_events(Port,
                 log_server_events(<<Acc/binary, Data/binary>>)
             );
         stop ->
             port_close(Port),
+            persistent_term:erase({?MODULE, port}),
             ?event(genesis_wasm_stopped, {pid, self()}),
             ok
     end.
@@ -497,6 +499,11 @@ log_server_events([Line | Rest]) ->
     ?event(genesis_wasm_server, {server_logged, {string, Line}}),
     log_server_events(Rest).
 
+terminate() ->
+    case persistent_term:get({?MODULE, port}, undefined) of
+        undefined -> ok;
+        Port -> port_close(Port)
+    end.
 %%% Tests
 -ifdef(ENABLE_GENESIS_WASM).
 

--- a/src/hb_app.erl
+++ b/src/hb_app.erl
@@ -7,7 +7,7 @@
 
 -behaviour(application).
 
--export([start/2, stop/1]).
+-export([start/2, prep_stop/1, stop/1]).
 
 -include("include/hb.hrl").
 
@@ -17,6 +17,10 @@ start(_StartType, _StartArgs) ->
     ok = dev_scheduler_registry:start(),
     _TimestampServer = ar_timestamp:start(),
     {ok, _} = hb_http_server:start().
+
+prep_stop(State) ->
+    dev_genesis_wasm:terminate(),
+    State.
 
 stop(_State) ->
     ok.


### PR DESCRIPTION
During redeployment there was a situation where the `genesis_wasm_server` was still on memory and was not replaced by the new version.
This PR introduces a graceful shutdown to address at least one of the reasons for it by terminating `genesis_wasm_server` when the HB service is stopped. 