### PR TITLE
fix: only normalize fields to ints on assignment

### DIFF
--- a/src/dev_scheduler_formats.erl
+++ b/src/dev_scheduler_formats.erl
@@ -163,9 +163,8 @@ aos2_to_assignment(A, RawOpts) ->
                     Opts
                 )
         end,
-    NormalizedMessage = aos2_normalize_types(Message),
     ?event({message, Message}),
-    NormalizedAssignment#{ <<"body">> => NormalizedMessage }.
+    NormalizedAssignment#{ <<"body">> => Message }.
 
 %% @doc The `hb_gateway_client' module expects all JSON structures to at least
 %% have a `data' field. This function ensures that.


### PR DESCRIPTION
Previously, `dev_scheduler_formats` normalized types for `timestamp`, `nonce`, `slot`, and `block-hash` on both the message and assignment of the node response from the SU. However, the message has tags on it, which are user input and are possibly not able to be normalized. It is only necessary to normalize these fields on the assignment.
Steps to reproduce error on edge:
1. Spawn a process
2. Send a message to it with tag Nonce = 123
3. Hydrate on HB. Works as expected.
4. Send a message to it with tag Nonce = '123-str'
 5. Compute on HB fails with the following error:
 ```
erlang:list_to_integer/["123-456"] [No details]
dev_scheduler_formats:aos2_normalize_types/1 [/root/hb-node/src/dev_scheduler_formats.erl:188]
```