### PR TITLE
impr: add environment flag to change Erlang node short name on boot

### DIFF
--- a/config/vm.args.src
+++ b/config/vm.args.src
@@ -1,0 +1,1 @@
+-sname ${HB_ERL_SNAME:-"hb"}


### PR DESCRIPTION
Erlang node short name can now be controlled with the `HB_ERL_SNAME` environment variable. It defaults to `hb` as previously.