### PR TITLE
impr: ID normalization in headers

### DIFF
--- a/src/dev_codec_flat.erl
+++ b/src/dev_codec_flat.erl
@@ -44,6 +44,12 @@ from(Map, Req, Opts) when is_map(Map) ->
 
 %% @doc Convert a TABM to a flat map.
 to(Bin, _, _Opts) when is_binary(Bin) -> {ok, Bin};
+to(List, Req, Opts) when is_list(List) ->
+    to(
+        hb_util:list_to_numbered_message(List),
+        Req,
+        Opts
+    );
 to(Map, Req, Opts) when is_map(Map) ->
     Res = 
         maps:fold(

--- a/src/dev_codec_httpsig.erl
+++ b/src/dev_codec_httpsig.erl
@@ -469,7 +469,7 @@ signature_components_line(Req, Commitment, _Opts) ->
                             }
                         );
                     Value ->
-                        << <<"\"">>/binary, Name/binary, <<"\"">>/binary, <<": ">>/binary, Value/binary>>
+                        <<"\"", Name/binary, "\": ", Value/binary>>
                 end
             end,
             maps:get(<<"committed">>, Commitment)

--- a/src/dev_codec_httpsig_conv.erl
+++ b/src/dev_codec_httpsig_conv.erl
@@ -50,10 +50,8 @@ from(HTTP, _Req, Opts) ->
     {OrderedBodyKeys, BodyTABM} = body_to_tabm(HTTP, Opts),
     % Merge the body keys with the headers.
     WithBodyKeys = maps:merge(Headers, BodyTABM),
-    % Decode the `ao-ids' key into a map. `ao-ids' is an encoding of literal
-    % binaries whose keys (given that they are IDs) cannot be distributed as
-    % HTTP headers.
-    WithIDs = ungroup_ids(WithBodyKeys, Opts),
+    % Decode percent-encoded headers.
+    WithIDs = decode_ids(WithBodyKeys, Opts),
     % Remove the signature-related headers, such that they can be reconstructed
     % from the commitments.
     MsgWithoutSigs = hb_maps:without(
@@ -367,7 +365,8 @@ to(TABM, Req = #{ <<"index">> := true }, _FormatOpts, Opts) ->
             % Return the encoded HTTPSig message without modification.
             {ok, EncOriginal}
     end;
-to(TABM, Req, FormatOpts, Opts) when is_map(TABM) ->
+to(RawTABM, Req, FormatOpts, Opts) when is_map(RawTABM) ->
+    TABM = encode_ids(RawTABM),
     % Ensure that the material for the message is loaded, if the request is
     % asking for a bundle.
     Msg =
@@ -402,12 +401,10 @@ to(TABM, Req, FormatOpts, Opts) when is_map(TABM) ->
             Msg,
             Opts
         ),
-    WithGroupedIDs = group_ids(Stripped),
-    ?event({grouped, WithGroupedIDs}),
-    {InlineFieldHdrs, InlineKey} = inline_key(WithGroupedIDs),
+    {InlineFieldHdrs, InlineKey} = inline_key(Stripped),
     Intermediate =
         do_to(
-            WithGroupedIDs,
+            Stripped,
             FormatOpts ++ [{inline, InlineFieldHdrs, InlineKey}],
             Opts
         ),
@@ -563,50 +560,26 @@ do_to(TABM, FormatOpts, Opts) when is_map(TABM) ->
     ?event({final_body_map, {msg, Enc2}}),
     Enc2.
 
-%% @doc Group all elements with:
-%% 1. A key that ?IS_ID returns true for, and
-%% 2. A value that is immediate
-%% into a combined SF dict-_like_ structure. If not encoded, these keys would 
-%% be sent as headers and lower-cased, losing their comparability against the
-%% original keys. The structure follows all SF dict rules, except that it allows
-%% for keys to contain capitals. The HyperBEAM SF parser will accept these keys,
-%% but standard RFC 8741 parsers will not. Subsequently, the resulting `ao-cased'
-%% key is not added to the `ao-types' map.
-group_ids(Map) ->
+%% @doc Transform all ID fields into their percent-encoded form.
+encode_ids(Msg) ->
     % Find all keys that are IDs.
-    IDDict = maps:filter(fun(K, V) -> ?IS_ID(K) andalso is_binary(V) end, Map),
-    % Convert the dictionary into a list of key-value pairs
-    IDDictStruct =
+    maps:from_list(
         lists:map(
-            fun({K, V}) ->
-                {K, {item, {string, V}, []}}
+            fun({K, V}) when ?IS_ID(K) -> {hb_escape:encode(K), V};
+                ({K, V}) -> {K, V}
             end,
-            maps:to_list(IDDict)
-        ),
-    % Convert the list of key-value pairs into a binary
-    IDBin = iolist_to_binary(hb_structured_fields:dictionary(IDDictStruct)),
-    % Remove the encoded keys from the map
-    Stripped = maps:without(maps:keys(IDDict), Map),
-    % Add the ID binary to the map if it is not empty
-    case map_size(IDDict) of
-        0 -> Stripped;
-        _ -> Stripped#{ <<"ao-ids">> => IDBin }
-    end.
+            maps:to_list(Msg)
+        )
+    ).
 
-%% @doc Decode the `ao-ids' key into a map.
-ungroup_ids(Msg = #{ <<"ao-ids">> := IDBin }, Opts) ->
-    % Extract the ID binary from the Map
-    EncodedIDsMap = hb_structured_fields:parse_dictionary(IDBin),
-    % Convert the value back into a raw binary
-    IDsMap =
+% @doc Decode all ID fields from their percent-encoded form.
+decode_ids(Msg, _Opts) ->
+    maps:from_list(
         lists:map(
-            fun({K, {item, {string, Bin}, _}}) -> {K, Bin} end,
-            EncodedIDsMap
-        ),
-    % Add the decoded IDs to the Map and remove the `ao-ids' key
-    hb_maps:merge(hb_maps:without([<<"ao-ids">>], Msg, Opts), hb_maps:from_list(IDsMap), Opts);
-
-ungroup_ids(Msg, _Opts) -> Msg.
+            fun({K, V}) -> {hb_escape:decode(K), V} end,
+            maps:to_list(Msg)
+        )
+    ).
 
 %% @doc Merge maps at the same level, if possible.
 group_maps(Map) ->

--- a/src/dev_codec_httpsig_conv.erl
+++ b/src/dev_codec_httpsig_conv.erl
@@ -365,26 +365,27 @@ to(TABM, Req = #{ <<"index">> := true }, _FormatOpts, Opts) ->
             % Return the encoded HTTPSig message without modification.
             {ok, EncOriginal}
     end;
-to(RawTABM, Req, FormatOpts, Opts) when is_map(RawTABM) ->
-    TABM = encode_ids(RawTABM),
+to(TABM, Req, FormatOpts, Opts) when is_map(TABM) ->
     % Ensure that the material for the message is loaded, if the request is
     % asking for a bundle.
     Msg =
         case hb_util:atom(hb_maps:get(<<"bundle">>, Req, false, Opts)) of
-            false -> TABM;
+            false -> encode_ids(TABM);
             true ->
                 % Convert back to the fully loaded structured@1.0 message, then
                 % convert to TABM with bundling enabled.
                 Structured = hb_message:convert(TABM, <<"structured@1.0">>, Opts),
                 Loaded = hb_cache:ensure_all_loaded(Structured, Opts),
-                hb_message:convert(
-                    Loaded,
-                    tabm,
-                    #{
-                        <<"device">> => <<"structured@1.0">>,
-                        <<"bundle">> => true
-                    },
-                    Opts
+                encode_ids(
+                    hb_message:convert(
+                        Loaded,
+                        tabm,
+                        #{
+                            <<"device">> => <<"structured@1.0">>,
+                            <<"bundle">> => true
+                        },
+                        Opts
+                    )
                 )
         end,
     % Group the IDs into a dictionary, so that they can be distributed as

--- a/src/dev_codec_httpsig_conv.erl
+++ b/src/dev_codec_httpsig_conv.erl
@@ -54,11 +54,12 @@ from(HTTP, _Req, Opts) ->
     WithIDs = decode_ids(WithBodyKeys, Opts),
     % Remove the signature-related headers, such that they can be reconstructed
     % from the commitments.
-    MsgWithoutSigs = hb_maps:without(
-        [<<"signature">>, <<"signature-input">>, <<"commitments">>],
-        WithIDs,
-        Opts
-    ),
+    MsgWithoutSigs =
+        hb_maps:without(
+            [<<"signature">>, <<"signature-input">>, <<"commitments">>],
+            WithIDs,
+            Opts
+        ),
     % Finally, we need to add the signatures to the TABM.
     Commitments =
         dev_codec_httpsig_siginfo:siginfo_to_commitments(
@@ -411,25 +412,27 @@ to(TABM, Req, FormatOpts, Opts) when is_map(TABM) ->
         ),
     % Finally, add the signatures to the encoded HTTP message with the
     % commitments from the original message.
-    CommitmentsMap = case maps:get(<<"commitments">>, Msg, undefined) of
-        undefined ->
-            case maps:get(<<"signature">>, Msg, undefined) of
-                undefined -> #{};
-                Signature ->
-                    MaybeBundleTag = maps:with([<<"bundle">>], Msg),
-                    #{
-                        Signature => MaybeBundleTag#{
-                            <<"signature">> => Signature,
-                            <<"committed">> => maps:get(<<"committed">>, Msg, #{}),
-                            <<"keyid">> => maps:get(<<"keyid">>, Msg, <<>>),
-                            <<"commitment-device">> => <<"httpsig@1.0">>,
-                            <<"type">> => maps:get(<<"type">>, Msg, <<>>)
+    CommitmentsMap =
+        case maps:get(<<"commitments">>, Msg, undefined) of
+            undefined ->
+                case maps:get(<<"signature">>, Msg, undefined) of
+                    undefined -> #{};
+                    Signature ->
+                        MaybeBundleTag = maps:with([<<"bundle">>], Msg),
+                        #{
+                            Signature => MaybeBundleTag#{
+                                <<"signature">> => Signature,
+                                <<"keyid">> => maps:get(<<"keyid">>, Msg, <<>>),
+                                <<"commitment-device">> => <<"httpsig@1.0">>,
+                                <<"type">> => maps:get(<<"type">>, Msg, <<>>),
+                                <<"committed">> =>
+                                    maps:get(<<"committed">>, Msg, #{})
+                            }
                         }
-                    }
-            end;
-        Commitments ->
-            Commitments
-    end,
+                end;
+            Commitments ->
+                Commitments
+        end,
     ?event({converting_commitments_to_siginfo, Msg}),
     {ok,
         maps:merge(

--- a/src/dev_codec_httpsig_siginfo.erl
+++ b/src/dev_codec_httpsig_siginfo.erl
@@ -367,15 +367,16 @@ from_siginfo_keys(HTTPEncMsg, BodyKeys, SigInfoCommitted) ->
             _ ->
                 ListWithoutBodyKey
         end,
-    Final =
+    Normalized =
         hb_ao:normalize_keys(
             lists:map(
                 fun hb_link:remove_link_specifier/1,
                 ListWithoutContentType
             )
         ),
-    ?event({from_siginfo_keys, {list, Final}}),
-    Final.
+    List = hb_util:message_to_ordered_list(Normalized),
+    ?event({from_siginfo_keys, {list, List}}),
+    List.
 
 %% @doc Convert committed keys to their siginfo format. This involves removing
 %% the `body' key from the committed keys, if present, and replacing it with

--- a/src/dev_codec_httpsig_siginfo.erl
+++ b/src/dev_codec_httpsig_siginfo.erl
@@ -540,7 +540,6 @@ escaped_value_test() ->
         <<"signature">> => hb_util:encode(Signature),
         <<"type">> => <<"rsa-pss-sha256">>
     },
-
     SigInfo = commitments_to_siginfo(#{}, #{ ID => Commitment }, #{}),
     Commitments = siginfo_to_commitments(SigInfo, #{}, #{}),
     ?event(debug_test, {siginfo, {explicit, SigInfo}}),

--- a/src/dev_codec_httpsig_siginfo.erl
+++ b/src/dev_codec_httpsig_siginfo.erl
@@ -523,7 +523,7 @@ escaped_value_test() ->
     Signature = crypto:strong_rand_bytes(512),
     ID = hb_util:human_id(crypto:hash(sha256, Signature)),
     Commitment = #{
-        <<"committed">> => #{},
+        <<"committed">> => [],
         <<"committer">> => Committer,
         <<"commitment-device">> => <<"tx@1.0">>,
         <<"keyid">> => <<"publickey:", (hb_util:encode(KeyID))/binary>>,

--- a/src/hb_ao.erl
+++ b/src/hb_ao.erl
@@ -1155,7 +1155,6 @@ normalize_keys(Base, Opts) when is_list(Base) ->
         ),
 		Opts
 	);
-
 normalize_keys(Map, Opts) when is_map(Map) ->
     hb_maps:from_list(
         lists:map(

--- a/src/hb_message_test_vectors.erl
+++ b/src/hb_message_test_vectors.erl
@@ -10,7 +10,7 @@
 run_test() ->
     hb:init(),
     encode_small_balance_table_test(
-        #{ <<"device">> => <<"httpsig@1.0">> },
+        #{ <<"device">> => <<"httpsig@1.0">>, <<"bundle">> => true },
         test_opts(normal)
     ).
 

--- a/src/hb_message_test_vectors.erl
+++ b/src/hb_message_test_vectors.erl
@@ -9,8 +9,8 @@
 %% Disable/enable as needed.
 run_test() ->
     hb:init(),
-    nested_structured_fields_test(
-        #{ <<"device">> => <<"json@1.0">>, <<"bundle">> => true },
+    encode_small_balance_table_test(
+        #{ <<"device">> => <<"httpsig@1.0">> },
         test_opts(normal)
     ).
 
@@ -1365,21 +1365,23 @@ priv_survives_conversion_test(Codec, Opts) ->
 
 encode_balance_table(Size, Codec, Opts) ->
     Msg =
-        #{
-            hb_util:encode(crypto:strong_rand_bytes(32)) =>
-                rand:uniform(1_000_000_000_000_000)
-        ||
-            _ <- lists:seq(1, Size)
-        },
-    Encoded = hb_message:convert(Msg, Codec, <<"structured@1.0">>, Opts),
-    ?event({encoded, {explicit, Encoded}}),
-    Decoded =
-        hb_message:uncommitted(
-            hb_message:convert(Encoded, <<"structured@1.0">>, Codec, Opts),
-            Opts
+        hb_message:commit(
+            #{
+                hb_util:encode(crypto:strong_rand_bytes(32)) =>
+                    rand:uniform(1_000_000_000_000_000)
+            ||
+                _ <- lists:seq(1, Size)
+            },
+            Opts,
+            Codec
         ),
-    ?event({decoded, {explicit, Decoded}}),
-    ?assert(hb_message:match(Msg, Decoded, if_present, Opts)).
+    Encoded = hb_message:convert(Msg, Codec, <<"structured@1.0">>, Opts),
+    ?event({encoded, Encoded}),
+    Decoded = hb_message:convert(Encoded, <<"structured@1.0">>, Codec, Opts),
+    ?event({decoded, Decoded}),
+    {ok, OnlyCommitted} = hb_message:with_only_committed(Decoded, Opts),
+    ?event({only_committed, OnlyCommitted}),
+    ?assert(hb_message:match(Msg, OnlyCommitted, if_present, Opts)).
 
 encode_small_balance_table_test(Codec, Opts) ->
     encode_balance_table(5, Codec, Opts).

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -226,7 +226,7 @@ default_message() ->
         debug_trace_type => ?DEFAULT_TRACE_TYPE,
         short_trace_len => 20,
         debug_metadata => true,
-        debug_ids => true,
+        debug_ids => false,
         debug_committers => true,
         debug_show_priv => if_present,
         debug_resolve_links => true,


### PR DESCRIPTION
This PR removes the `ao-ids` header in favor of a URL-encoding approach to handling IDs with upper-case characters in headers. Callers may now wish to url-decode the headers in HyperBEAM responses, such that all keys have been returned to their normal form -- including mixed case IDs.