### PR TITLE
fix: prevent 404 when data size is ~"0"

### DIFF
--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -241,8 +241,8 @@ result_to_message(ExpectedID, Item, Opts) ->
     % We have the headers, so we can get the data.
     Data =
         case hb_maps:get(<<"data">>, Item, not_found, GQLOpts) of
+            #{ <<"size">> := Zero } when Zero =:= <<"0">> orelse Zero =:= 0 -> <<>>;
             BinData when is_binary(BinData) -> BinData;
-            #{ <<"size">> := 0 } -> <<>>;
             _ ->
                 {ok, Bytes} = data(ExpectedID, Opts),
                 Bytes


### PR DESCRIPTION
## What

Compares the data size also to binary 0 to prevent requesting the raw transaction.

## Why

The last node/assignment of process `qNvAoz0TgcH7DMg8BCVn8jF32QH5L6T29VjHxhHqqGE` has size = <<"0">>. 

## Issue example 

Call `dev_copycat:graphql(#{}, #{<<"query">> => Query}, #{}).` for this `Query`:
```
query { 
  transactions(  tags: [
    {name:"Process", values:["qNvAoz0TgcH7DMg8BCVn8jF32QH5L6T29VjHxhHqqGE"]}, {name:"Type", values:["Assignment"]}]) { 
    edges {     
      node {
          id
          anchor
          signature
          recipient
          owner { key address }
          fee { winston }
          quantity { winston }
          tags { name value }
          data { size }
      }
    }
  } 
}
``` 