### PR TITLE
impr: `~message@1.0` request parameter naming

### DIFF
--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -443,7 +443,7 @@ committed(Self, Req, Opts) ->
 %% @doc Return a message with only the relevant commitments for a given request.
 %% See `commitment_ids_from_request/3' for more information on the request format.
 with_relevant_commitments(Base, Req, Opts) ->
-    Commitments = maps:get(<<"commitments">>, Base, #{}),
+    Commitments = maps:get(<<"commitment-ids">>, Base, #{}),
     CommitmentIDs = commitment_ids_from_request(Base, Req, Opts),
     Base#{ <<"commitments">> => maps:with(CommitmentIDs, Commitments) }.
 
@@ -460,7 +460,7 @@ commitment_ids_from_request(Base, Req, Opts) ->
             X when is_list(X) -> X;
             CommitterDescriptor -> hb_ao:normalize_key(CommitterDescriptor)
         end,
-    RawReqCommitments = maps:get(<<"commitments">>, Req, <<"none">>),
+    RawReqCommitments = maps:get(<<"commitment-ids">>, Req, <<"none">>),
     ReqCommitments =
         case RawReqCommitments of
             X2 when is_list(X2) -> X2;

--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -218,14 +218,11 @@ id_device(_, _) ->
 committers(Base) -> committers(Base, #{}).
 committers(Base, Req) -> committers(Base, Req, #{}).
 committers(#{ <<"commitments">> := Commitments }, _, NodeOpts) ->
-    ?event(debug_commitments, {calculating_committers, {commitments, Commitments}}),
     {ok,
         hb_maps:values(
             hb_maps:filtermap(
                 fun(_ID, Commitment) ->
-                    Committer = maps:get(<<"committer">>, Commitment, undefined),
-                    ?event(debug_commitments, {committers, {committer, Committer}}),
-                    case Committer of
+                    case maps:get(<<"committer">>, Commitment, undefined) of
                         undefined -> false;
                         Committer -> {true, Committer}
                     end
@@ -487,7 +484,6 @@ commitment_ids_from_request(Base, Req, Opts) ->
                 ?event(no_commitment_ids_for_committers),
                 [];
             <<"all">> ->
-                ?event(debug_commitments, {getting_commitment_ids_for_all_committers}),
                 {ok, Committers} = committers(Base, Req, Opts),
                 ?event(debug_commitments, {commitment_ids_from_committers, Committers}),
                 commitment_ids_from_committers(Committers, Commitments, Opts);

--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -443,7 +443,7 @@ committed(Self, Req, Opts) ->
 %% @doc Return a message with only the relevant commitments for a given request.
 %% See `commitment_ids_from_request/3' for more information on the request format.
 with_relevant_commitments(Base, Req, Opts) ->
-    Commitments = maps:get(<<"commitment-ids">>, Base, #{}),
+    Commitments = maps:get(<<"commitments">>, Base, #{}),
     CommitmentIDs = commitment_ids_from_request(Base, Req, Opts),
     Base#{ <<"commitments">> => maps:with(CommitmentIDs, Commitments) }.
 

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -243,7 +243,7 @@ with_only_committed(Msg, Opts) when is_map(Msg) ->
                 CommittedKeys =
                     hb_message:committed(
                         Msg,
-                        #{ <<"commitments">> => <<"all">> },
+                        #{ <<"commitment-ids">> => <<"all">> },
                         Opts
                     ),
                 % Add the ao-body-key to the committed list if it is not

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -366,7 +366,7 @@ committed(Msg, all, Opts) ->
 committed(Msg, none, Opts) ->
     committed(Msg, #{ <<"committers">> => <<"none">> }, Opts);
 committed(Msg, List, Opts) when is_list(List) ->
-    committed(Msg, #{ <<"commitments">> => List }, Opts);
+    committed(Msg, #{ <<"commitment-ids">> => List }, Opts);
 committed(Msg, CommittersMsg, Opts) ->
     ?event(
         {committed,


### PR DESCRIPTION
This PR removes the `commitments` key in request parameters to the `~message@1.0` device, in favor of `commitment-ids`. This ensures that there is a clean differentiation between `commitments` sub-messages and the lists of the commitments IDs that should be considered when executing the various functionalities of the device.