### PR TITLE
impr: Always normalize messages before and after `~lua@5.3a` execution

### DIFF
--- a/scripts/hyper-token.lua
+++ b/scripts/hyper-token.lua
@@ -866,18 +866,25 @@ end
 --- Index function, called by the `~process@1.0` device for scheduled messages.
 --- We route any `action' to the appropriate function based on the request path.
 function compute(base, assignment)
-    ao.event({ "compute called",
-        { balance = base.balance, ledgers = base.ledgers } })
-
-    assignment.body.action = string.lower(assignment.body.action or "")
+    local action = string.lower(assignment.body.action or "")
+    ao.event(
+        {
+            "compute called",
+            {
+                balance = base.balance,
+                ledgers = base.ledgers,
+                action = action
+            }
+        }
+    )
     
-    if assignment.body.action == "credit-notice" then
+    if action == "credit-notice" then
         return _G["credit-notice"](base, assignment)
-    elseif assignment.body.action == "transfer" then
+    elseif action == "transfer" then
         return transfer(base, assignment)
-    elseif assignment.body.action == "register" then
+    elseif action == "register" then
         return register(base, assignment)
-    elseif assignment.body.action == "register-remote" then
+    elseif action == "register-remote" then
         return _G["register-remote"](base, assignment)
     else
         -- Handle unknown `action' values.

--- a/scripts/hyper-token.lua
+++ b/scripts/hyper-token.lua
@@ -55,8 +55,8 @@
 --- 3. `credit-notice' messages that do not originate from a sub-ledger's
 ---    `token' are evaluated for parity of source code with the receiving
 ---     ledger. This is achieved by comparing the `from-base' field of the
----     credit-notice message with `process/id&commitments=none' on the receiving
----     ledger.
+---     credit-notice message with `process/id&committers=none' on the
+---     receiving ledger.
 
 --- Utility functions:
 
@@ -318,7 +318,7 @@ local function validate_new_peer_ledger(base, request)
     status, expected =
         ao.resolve(
             proc,
-            { path = "id", commitments = "none" }
+            { path = "id", committers = "none" }
         )
     ao.event({ "Expected `from-base`", { status = status, expected = expected } })
     -- Check if the `from-base' field is present in the assignment.

--- a/src/dev_lua.erl
+++ b/src/dev_lua.erl
@@ -488,7 +488,7 @@ post_invocation_message_validation_test() ->
     ?event({res_id, ResID}),
     {ok, ReadMsg} = hb_cache:read(UnsignedID, Opts),
     ?assertEqual(<<"test-value-1">>, hb_ao:get(<<"test-key">>, ReadMsg, Opts)),
-    ?assert(length(hb_message:signers(ReadMsg, Opts)) == 0),
+    ?assert(length(hb_message:signers(NormRes, Opts)) == 0),
     ?assert(hb_message:verify(NormRes, all, Opts)).
 
 load_modules_by_id_test_() ->

--- a/src/dev_lua_test_ledgers.erl
+++ b/src/dev_lua_test_ledgers.erl
@@ -207,7 +207,11 @@ balances(Mode, ProcMsg, Opts) when is_atom(Mode) ->
     balances(hb_util:bin(Mode), ProcMsg, Opts);
 balances(Prefix, ProcMsg, Opts) ->
     Balances = hb_ao:get(<<Prefix/binary, "/balance">>, ProcMsg, #{}, Opts),
-    hb_private:reset(hb_cache:ensure_all_loaded(Balances, Opts)).
+    hb_private:reset(
+        hb_message:uncommitted(
+            hb_cache:ensure_all_loaded(Balances, Opts)
+        )
+    ).
 
 %% @doc Get the supply of a ledger, either `now` or `initial`.
 supply(ProcMsg, Opts) ->

--- a/src/dev_lua_test_ledgers.erl
+++ b/src/dev_lua_test_ledgers.erl
@@ -595,7 +595,8 @@ subledger_registration_test_disabled() ->
     % Alice can send tokens to Bob on SubLedger2.
     verify_net(RootLedger, [SubLedger1, SubLedger2], Opts).
 
-single_subledger_to_subledger_test_() -> {timeout, 30, fun single_subledger_to_subledger/0}.
+single_subledger_to_subledger_test_() ->
+    {timeout, 30, fun single_subledger_to_subledger/0}.
 single_subledger_to_subledger() ->
     Opts = test_opts(),
     Alice = ar_wallet:new(),
@@ -622,16 +623,17 @@ single_subledger_to_subledger() ->
     ?event({root_ledger, RootLedger}),
     ?event({sl1, SubLedger1}),
     ?event({sl2, SubLedger2}),
+    % 1. At start, Alice has 100 tokens on the root ledger.
     ?assertEqual(100, balance(RootLedger, Alice, Opts)),
     % 2. Alice sends 90 tokens to herself on SubLedger1.
-    ?event({transfer_1}),
     transfer(RootLedger, Alice, Alice, 90, SubLedger1, Opts),
+    ?event({state2, map([RootLedger, SubLedger1, SubLedger2], Names, Opts)}),
     ?assertEqual(10, balance(RootLedger, Alice, Opts)),
     ?assertEqual(90, balance(SubLedger1, Alice, Opts)),
-    ?event({transfer_2}),
+    % 3. Alice sends 80 tokens to herself on SubLedger2.
     PushRes = transfer(SubLedger1, Alice, Alice, 80, SubLedger2, Opts),
     ?event({push_res, PushRes}),
-    ?event({map, map([RootLedger, SubLedger1, SubLedger2], Opts)}),
+    ?event({state3, map([RootLedger, SubLedger1, SubLedger2], Names, Opts)}),
     ?assertEqual(80, balance(SubLedger2, Alice, Opts)),
     ?assertEqual(10, balance(SubLedger1, Alice, Opts)).
 

--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -257,8 +257,19 @@ commit(Self, Req, Opts) ->
             _ ->
                 Opts#{ linkify_mode => offload }
         end,
-    AttMod = hb_ao:message_to_device(#{ <<"device">> => AttDev }, CommitOpts),
-    {ok, AttFun} = hb_ao:find_exported_function(Base, AttMod, commit, 3, CommitOpts),
+    AttMod =
+        hb_ao_device:message_to_device(
+            #{ <<"device">> => AttDev },
+            CommitOpts
+        ),
+    {ok, AttFun} =
+        hb_ao_device:find_exported_function(
+            Base,
+            AttMod,
+            commit,
+            3,
+            CommitOpts
+        ),
     % Encode to a TABM
     Loaded =
         ensure_commitments_loaded(

--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -257,8 +257,8 @@ commit(Self, Req, Opts) ->
             _ ->
                 Opts#{ linkify_mode => offload }
         end,
-    AttMod = hb_ao_device:message_to_device(#{ <<"device">> => AttDev }, CommitOpts),
-    {ok, AttFun} = hb_ao_device:find_exported_function(Base, AttMod, commit, 3, CommitOpts),
+    AttMod = hb_ao:message_to_device(#{ <<"device">> => AttDev }, CommitOpts),
+    {ok, AttFun} = hb_ao:find_exported_function(Base, AttMod, commit, 3, CommitOpts),
     % Encode to a TABM
     Loaded =
         ensure_commitments_loaded(

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -358,13 +358,19 @@ calculate_base_id(GivenProcess, Opts) ->
             not_found -> GivenProcess;
             Proc -> Proc
         end,
-    BaseProcess = maps:without([<<"authority">>, <<"scheduler">>], Process),
-    {ok, BaseID} = hb_ao:resolve(
-        BaseProcess,
-        #{ <<"path">> => <<"id">> },
-        Opts
-    ),
-    ?event({push_generated_base, {id, BaseID}, {base, BaseProcess}}),
+    BaseProcess =
+        hb_ao:set(
+            Process,
+            #{ <<"authority">> => unset, <<"scheduler">> => unset },
+            Opts#{ hashpath => ignore }
+        ),
+    {ok, BaseID} =
+        hb_ao:resolve(
+            BaseProcess,
+            #{ <<"path">> => <<"id">>, <<"committers">> => <<"none">> },
+            Opts
+        ),
+    ?event(debug_base, {push_generated_base, {id, BaseID}, {base, BaseProcess}}),
     BaseID.
 
 %% @doc Add the necessary keys to the message to be scheduled, then schedule it.

--- a/src/dev_scheduler_server.erl
+++ b/src/dev_scheduler_server.erl
@@ -193,7 +193,7 @@ do_assign(State, Message, ReplyPID) ->
                         <<"path">> =>
                             case hb_path:from_message(request, Message, Opts) of
                                 undefined -> <<"compute">>;
-                                Path -> Path
+                                Path -> hb_path:to_binary(Path)
                             end,
                         <<"data-protocol">> => <<"ao">>,
                         <<"variant">> => <<"ao.N.1">>,

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -201,7 +201,7 @@ id(Msg, RawCommitters, Opts) ->
 %% unsigned ID present. By forcing this work to occur in strategically positioned
 %% places, we avoid the need to recalculate the IDs for every `hb_message:id`
 %% call.
-normalize_commitments(Msg, Opts) when is_map(Msg) ->
+normalize_commitments(Msg, Opts) ->
     normalize_commitments(Msg, Opts, passive).
 normalize_commitments(Msg, Opts, Mode) when is_map(Msg) ->
     NormMsg = 

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -233,6 +233,8 @@ do_normalize_commitments(Msg, Opts, passive) ->
             Msg#{ <<"commitments">> => Commitments };
         _ -> Msg
     end;
+do_normalize_commitments(Msg, _Opts, verify) when ?IS_EMPTY_MESSAGE(Msg) ->
+    Msg;
 do_normalize_commitments(Msg, Opts, verify) ->
     {ok, #{ <<"commitments">> := NormCommitments }} =
         dev_message:commit(

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -204,6 +204,7 @@ id(Msg, RawCommitters, Opts) ->
 normalize_commitments(Msg, Opts) ->
     normalize_commitments(Msg, Opts, passive).
 normalize_commitments(Msg, Opts, Mode) when is_map(Msg) ->
+    ?event(debug_normalize_commitments, {normalize_commitments, {msg, Msg}}),
     NormMsg = 
         maps:map(
             fun(Key, Val) when Key == <<"commitments">> orelse Key == <<"priv">> ->
@@ -214,11 +215,13 @@ normalize_commitments(Msg, Opts, Mode) when is_map(Msg) ->
         ),
     do_normalize_commitments(NormMsg, Opts, Mode);
 normalize_commitments(Msg, Opts, Mode) when is_list(Msg) ->
+    ?event(debug_normalize_commitments, {normalize_commitments, {list, Msg}}),
     lists:map(fun(X) -> normalize_commitments(X, Opts, Mode) end, Msg);
 normalize_commitments(Msg, _Opts, _Mode) ->
     Msg.
 
 do_normalize_commitments(Msg, Opts, passive) ->
+    ?event(debug_normalize_commitments, {passive, {msg, Msg}}),
     case hb_maps:get(<<"commitments">>, Msg, not_found, Opts) of
         not_found ->
             {ok, #{ <<"commitments">> := Commitments }} =

--- a/src/hb_message_test_vectors.erl
+++ b/src/hb_message_test_vectors.erl
@@ -10,7 +10,7 @@
 run_test() ->
     hb:init(),
     encode_small_balance_table_test(
-        #{ <<"device">> => <<"httpsig@1.0">>, <<"bundle">> => true },
+        #{ <<"device">> => <<"httpsig@1.0">> },
         test_opts(normal)
     ).
 

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -38,8 +38,8 @@
 -endif.
 
 -define(DEFAULT_PRIMARY_STORE, #{
-    <<"name">> => <<"cache-mainnet/fs">>,
-    <<"store-module">> => hb_store_fs
+    <<"name">> => <<"cache-mainnet/lmdb">>,
+    <<"store-module">> => hb_store_lmdb
 }).
 -define(ENV_KEYS,
     #{

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -38,8 +38,8 @@
 -endif.
 
 -define(DEFAULT_PRIMARY_STORE, #{
-    <<"name">> => <<"cache-mainnet/lmdb">>,
-    <<"store-module">> => hb_store_lmdb
+    <<"name">> => <<"cache-mainnet/fs">>,
+    <<"store-module">> => hb_store_fs
 }).
 -define(ENV_KEYS,
     #{
@@ -229,7 +229,7 @@ default_message() ->
         debug_ids => false,
         debug_committers => true,
         debug_show_priv => if_present,
-        debug_resolve_links => true,
+        debug_resolve_links => false,
         debug_print_fail_mode => long,
 		trusted => #{},
         snp_enforced_keys => [

--- a/test/test.lua
+++ b/test/test.lua
@@ -13,6 +13,11 @@ function assoctable()
     }
 end
 
+function mutate_test_key(state)
+    state["test-key"] = "test-value-2"
+    return state
+end
+
 function error_response()
     return "error", "Very bad, but Lua caught it."
 end


### PR DESCRIPTION
This PR introduces normalization of message commitments before and after a `~lua@5.3a` execution call is made. This is necessary because the Lua device manually changes keys in the result message based on the user's request, without calling `hb_ao:set`.