### PR TITLE
fix: remove recursive forced key load from key normalization util

### DIFF
--- a/src/dev_json_iface.erl
+++ b/src/dev_json_iface.erl
@@ -420,9 +420,7 @@ preprocess_results(Msg, Opts) ->
 
 %% @doc Convert a message with tags into a map of their key-value pairs.
 tags_to_map(Msg, Opts) ->
-    NormMsg = hb_util:lower_case_key_map(
-        hb_ao:normalize_keys(Msg, Opts), 
-    Opts),
+    NormMsg = hb_util:lower_case_keys(hb_ao:normalize_keys(Msg, Opts), Opts),
     RawTags = hb_maps:get(<<"tags">>, NormMsg, [], Opts),
     TagList =
         [

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -185,7 +185,7 @@ do_push(PrimaryProcess, Assignment, Opts) ->
                                 <<"message">> => Msg
                             }
                     end,
-                    hb_util:lower_case_key_map(
+                    hb_util:lower_case_keys(
                         hb_ao:normalize_keys(hb_private:reset(Outbox)),
                         Opts
                     ),
@@ -239,7 +239,7 @@ maybe_evaluate_message(Message, Opts) ->
 %% the slot number from which it was sent, and the outbox key of the message,
 %% and the depth to which downstream results should be included in the message.
 push_result_message(TargetProcess, MsgToPush, Origin, Opts) ->
-    NormMsgToPush = hb_util:lower_case_key_map(MsgToPush, Opts),
+    NormMsgToPush = hb_ao:normalize_keys(MsgToPush, Opts),
     case hb_ao:get(<<"target">>, NormMsgToPush, undefined, Opts) of
         undefined ->
             ?event(push,

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -513,17 +513,25 @@ match(Map1, Map2, Mode, Opts) ->
 unsafe_match(Map1, Map2, Mode, Path, Opts) ->
     Keys1 =
         hb_maps:keys(
-            NormMap1 = hb_util:lower_case_key_map(minimize(
-                normalize(hb_ao:normalize_keys(Map1, Opts), Opts),
-                [<<"content-type">>, <<"ao-body-key">>]
-            ), Opts)
+            NormMap1 =
+                minimize(
+                    normalize(
+                        hb_ao:normalize_keys(Map1, Opts),
+                        Opts
+                    ),
+                    [<<"content-type">>, <<"ao-body-key">>]
+                )
         ),
     Keys2 =
         hb_maps:keys(
-            NormMap2 = hb_util:lower_case_key_map(minimize(
-                normalize(hb_ao:normalize_keys(Map2, Opts), Opts),
-                [<<"content-type">>, <<"ao-body-key">>]
-            ), Opts)
+            NormMap2 =
+                minimize(
+                    normalize(
+                        hb_ao:normalize_keys(Map2, Opts),
+                        Opts
+                    ),
+                    [<<"content-type">>, <<"ao-body-key">>]
+                )
         ),
     PrimaryKeysPresent =
         (Mode == primary) andalso


### PR DESCRIPTION
Removes unnecessary expensive force load of messages.