### PR TITLE
feat: Add multi-filter support to dev_copycat

### DIFF
--- a/src/dev_copycat_graphql.erl
+++ b/src/dev_copycat_graphql.erl
@@ -127,6 +127,8 @@ index_graphql(Total, Query, Vars, Node, OpName, Opts) ->
                 {ok, NewTotal}
         end
     else
+        {error, _} when Total > 0 ->
+            {ok, Total};
         {error, Reason} ->
             {error, Reason}
     end.

--- a/src/dev_copycat_graphql.erl
+++ b/src/dev_copycat_graphql.erl
@@ -245,7 +245,7 @@ build_tags_part(TagsMap) when is_map(TagsMap) ->
             "\", values: ", 
             (build_graphql_array(Value))/binary, 
         "}">>
-        || {Key, Value} <- maps:to_list(TagsMap)
+        || {Key, Value} <- hb_maps:to_list(hb_message:uncommitted(TagsMap))
     ],
     [<<"tags: [", (iolist_to_binary(lists:join(<<", ">>, TagStrings)))/binary, "]">>].
 

--- a/src/dev_copycat_graphql.erl
+++ b/src/dev_copycat_graphql.erl
@@ -430,11 +430,16 @@ combined_filters_test() ->
 %% @doc Real world test with actual indexing
 fetch_scheduler_location_test() ->
     {Node, _Opts} = run_test_node(),
-    {ok, Res} =
+    Res =
         hb_http:get(
             Node,
             #{
-                <<"path">> => <<"~copycat@1.0/graphql?tags+map=Type=Scheduler-Location">>
+                <<"path">> =>
+                    <<
+                        "~copycat@1.0/graphql?",
+                        "owners=6F7pOU5Gh5GAqFIRYEInp7gbHmbupdZDZimj46Rje3U&",
+                        "tags+map=Type=Scheduler-Location"
+                    >>
             },
             #{}
         ),


### PR DESCRIPTION
Rebases, updates, and fixes small issues with @Lucifer0x17's #470 work.

The description @Lucifer0x17 wrote in the prior PR still stands:

Extends `dev_copycat` module to support multiple filters in GraphQL queries:
- Introduces support for combining tags, owners, recipients, and IDs filters.
- Unifies the query generation logic for different filter types.
- Includes new tests to validate the updated functionality.
- Fixes issues related to owner and recipient queries to align with the GQL schema.

Examples:
- `~copycat@1.0/graphql?tags+map="Type=Scheduler-Location"&owners+list=NoZH3pueH0Cih6zjSNu_KRAcmg4ZJV1aGHKi0Pi5_Hc`
- `~copycat@1.0/graphql?tags+map="Type=Assignment,Process=CW6tynwMQffgBeNE_g-a5hWZ_jUK3DF9sRcQS6k26Wk"`
- `~copycat@1.0/graphql?tags+map="Type=Scheduler-Location"`