### PR TITLE
Disable document formatting in erlang_ls.config

### DIFF
--- a/erlang_ls.config
+++ b/erlang_ls.config
@@ -18,3 +18,5 @@ lenses:
 providers:
   enabled:
     - signature-help
+  disabled:
+    - document-formatting


### PR DESCRIPTION
Since we don't use ErlangLS formatting, we can disable it.