### PR TITLE
fix: make lua ledger tests efficient

### DIFF
--- a/src/dev_lua_test_ledgers.erl
+++ b/src/dev_lua_test_ledgers.erl
@@ -463,7 +463,6 @@ transfer_unauthorized() ->
     %    being transferred.
     transfer(Proc, Alice, Bob, 101, Opts),
     ?event({unauthorized_transfer, {result, Result}}),
-    receive after 1000 -> ok end,
     ?event({env, map([Proc], #{ Alice => alice, Bob => bob }, Opts)}),
     ?assertEqual(100, balance(Proc, Alice, Opts)),
     ?assertEqual(0, balance(Proc, Bob, Opts)),

--- a/src/dev_lua_test_ledgers.erl
+++ b/src/dev_lua_test_ledgers.erl
@@ -103,7 +103,7 @@ subledger(Root, Extra, Opts) ->
     BareRoot =
         maps:without(
             [<<"token">>, <<"balance">>],
-            hb_message:uncommitted(Root)
+            hb_message:uncommitted(Root, Opts)
         ),
     Proc = 
         hb_message:commit(
@@ -113,7 +113,7 @@ subledger(Root, Extra, Opts) ->
                 },
                 Extra
             ),
-            hb_opts:get(priv_wallet, hb:wallet(), Opts)
+            Opts#{ priv_wallet => hb_opts:get(priv_wallet, hb:wallet(), Opts) }
         ),
     hb_cache:write(Proc, Opts),
     Proc.
@@ -142,10 +142,10 @@ transfer(ProcMsg, Sender, Recipient, Quantity, Route, Opts) ->
                         <<"recipient">> => hb_util:human_id(Recipient),
                         <<"quantity">> => Quantity
                     },
-                    Sender
+                    Opts#{ priv_wallet => Sender }
                 )
             },
-            Sender
+            Opts#{ priv_wallet => Sender }
         ),
     hb_ao:resolve(
         ProcMsg,
@@ -209,7 +209,8 @@ balances(Prefix, ProcMsg, Opts) ->
     Balances = hb_ao:get(<<Prefix/binary, "/balance">>, ProcMsg, #{}, Opts),
     hb_private:reset(
         hb_message:uncommitted(
-            hb_cache:ensure_all_loaded(Balances, Opts)
+            hb_cache:ensure_all_loaded(Balances, Opts),
+            Opts
         )
     ).
 
@@ -412,7 +413,7 @@ normalize_without_root(RootProc, Procs) ->
 %% recipients via remote stores. This improves test performance.
 test_opts() ->
     hb:init(),
-    #{}.
+    #{ store => [hb_test_utils:test_store()]}.
 
 %%% Test cases.
 
@@ -689,7 +690,7 @@ subledger_to_subledger() ->
 %% compute correctness guarantees.
 unregistered_peer_transfer_test_() -> {timeout, 30, fun unregistered_peer_transfer/0}.
 unregistered_peer_transfer() ->
-    Opts = #{},
+    Opts = test_opts() ,
     Alice = ar_wallet:new(),
     Bob = ar_wallet:new(),
     RootLedger =

--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -645,7 +645,7 @@ set(Base, NewValuesMsg, Opts) ->
             KeysToSet
         )
     ),
-    % Caclulate if the keys to be set conflict with any committed keys.
+    % Calculate if the keys to be set conflict with any committed keys.
     {ok, CommittedKeys} =
         committed(
             Base,


### PR DESCRIPTION
Lua test ledger tests were slow - this was due to the test store not being set, causing default store to be used, which includes graphql store. Caused a gql query to be made on cache misses. This PR sets the default store.

Additionally, tests began to fail after this. This was because `hb_message:match` was not being called correctly in `dev_message:set`, causing the default opts to be used rather than the passed opts.