### PR TITLE
fix: keep routes ordered when matching

### DIFF
--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -397,10 +397,18 @@ match(Base, Req, Opts) ->
     end.
 
 match_routes(ToMatch, Routes, Opts) ->
+    Keys =
+        case hb_util:is_ordered_list(Routes, Opts) of
+            true ->
+                lists:seq(1, length(Routes));
+            false ->
+                NormalizedRoutes = hb_ao:normalize_keys(Routes, Opts),
+                hb_ao:keys(NormalizedRoutes)
+        end,
     match_routes(
         hb_cache:ensure_all_loaded(ToMatch, Opts),
         hb_cache:ensure_all_loaded(Routes, Opts),
-        hb_ao:keys(hb_ao:normalize_keys(Routes, Opts)),
+        Keys,
         Opts
     ).
 match_routes(#{ <<"path">> := Explicit = <<"http://", _/binary>> }, _, _, _) ->

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -400,10 +400,9 @@ match_routes(ToMatch, Routes, Opts) ->
     Keys =
         case hb_util:is_ordered_list(Routes, Opts) of
             true ->
-                lists:seq(1, length(Routes));
+                lists:seq(1, length(hb_util:message_to_ordered_list(Routes, Opts)));
             false ->
-                NormalizedRoutes = hb_ao:normalize_keys(Routes, Opts),
-                hb_ao:keys(NormalizedRoutes)
+                hb_ao:keys(hb_ao:normalize_keys(Routes, Opts))
         end,
     match_routes(
         hb_cache:ensure_all_loaded(ToMatch, Opts),


### PR DESCRIPTION
Currently, when matching routes, the routes list is normalized and then the keys are pulled. This results in an unordered list of 1...N, where N is the number of routes. Instead, simply use lists:seq to create the ordered list 1...N.