### PR TITLE
fix: handle graphql parsing in dev_scheduler_formats

### DIFF
--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -901,14 +901,7 @@ find_remote_scheduler(ProcID, Scheduler, Opts) ->
             % We have a hint. Construct a redirect message.
             generate_redirect(ProcID, Hint, Opts);
         not_found ->
-            NormalizedScheduler =
-                case Scheduler of
-                    [S] when is_binary(S) ->
-                        string:trim(S);
-                    S when is_binary(S) ->
-                        string:trim(S)
-                end,
-            case dev_scheduler_cache:read_location(NormalizedScheduler, Opts) of
+            case dev_scheduler_cache:read_location(Scheduler, Opts) of
                 {ok, SchedMsg} ->
                     % We have a cached scheduler location. Use it to construct a
                     % redirect message.
@@ -916,7 +909,7 @@ find_remote_scheduler(ProcID, Scheduler, Opts) ->
                 not_found ->
                     % We have not yet cached the location for this address.
                     % Find it via the gateway.
-                    case hb_gateway_client:scheduler_location(NormalizedScheduler, Opts) of
+                    case hb_gateway_client:scheduler_location(Scheduler, Opts) of
                         {ok, SchedMsg} ->
                             % We have found the location. Cache it and use it to
                             % construct a redirect message.

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -890,8 +890,8 @@ find_remote_scheduler(ProcID, [Scheduler | Rest], Opts) ->
     case find_remote_scheduler(ProcID, Rest, Opts) of
         {error, not_found} ->
             find_remote_scheduler(ProcID, Scheduler, Opts);
-        {ok, Redirect} ->
-            {ok, Redirect}
+        {redirect, Redirect} ->
+            {redirect, Redirect}
     end;
 find_remote_scheduler(ProcID, Scheduler, Opts) ->
     % Parse the scheduler location to see if it has a hint. If there is a hint,
@@ -901,7 +901,14 @@ find_remote_scheduler(ProcID, Scheduler, Opts) ->
             % We have a hint. Construct a redirect message.
             generate_redirect(ProcID, Hint, Opts);
         not_found ->
-            case dev_scheduler_cache:read_location(Scheduler, Opts) of
+            NormalizedScheduler =
+                case Scheduler of
+                    [S] when is_binary(S) ->
+                        string:trim(S);
+                    S when is_binary(S) ->
+                        string:trim(S)
+                end,
+            case dev_scheduler_cache:read_location(NormalizedScheduler, Opts) of
                 {ok, SchedMsg} ->
                     % We have a cached scheduler location. Use it to construct a
                     % redirect message.
@@ -909,7 +916,7 @@ find_remote_scheduler(ProcID, Scheduler, Opts) ->
                 not_found ->
                     % We have not yet cached the location for this address.
                     % Find it via the gateway.
-                    case hb_gateway_client:scheduler_location(Scheduler, Opts) of
+                    case hb_gateway_client:scheduler_location(NormalizedScheduler, Opts) of
                         {ok, SchedMsg} ->
                             % We have found the location. Cache it and use it to
                             % construct a redirect message.
@@ -1484,6 +1491,7 @@ post_legacy_schedule(ProcID, OnlyCommitted, Node, Opts) ->
                                 hb_json:decode(
                                     hb_ao:get(<<"body">>, AssignmentRes, Opts)
                                 ),
+                            ?event({assignment_json, AssignmentJSON}),
                             Assignment =
                                 dev_scheduler_formats:aos2_to_assignment(
                                     AssignmentJSON,

--- a/src/dev_scheduler_formats.erl
+++ b/src/dev_scheduler_formats.erl
@@ -134,14 +134,24 @@ aos2_to_assignments(ProcID, Body, RawOpts) ->
 %% NOTE: This method is destructive to the verifiability of the assignment.
 aos2_to_assignment(A, RawOpts) ->
     Opts = format_opts(RawOpts),
-    % Unwrap the node if it is provided
-    Node = hb_maps:get(<<"node">>, A, A, Opts),
+    % Unwrap the node if it is provided. Handle GraphQL-style responses with edges.
+    Node = case hb_maps:get(<<"edges">>, A, undefined, Opts) of
+        [FirstEdge | _] when is_map(FirstEdge) ->
+            hb_maps:get(<<"node">>, FirstEdge, A, Opts);
+        undefined ->
+            hb_maps:get(<<"node">>, A, A, Opts);
+        _ ->
+            A
+    end,
     ?event({node, Node}),
+    AssignmentData = hb_maps:get(<<"assignment">>, Node, undefined, Opts),
+    ?event({assignment_data, AssignmentData}),
     {ok, Assignment} =
         hb_gateway_client:result_to_message(
-            aos2_normalize_data(hb_maps:get(<<"assignment">>, Node, undefined, Opts)),
+            aos2_normalize_data(AssignmentData),
             Opts
         ),
+        ?event({result_assignment, Assignment}),
     NormalizedAssignment = aos2_normalize_types(Assignment),
     {ok, Message} =
         case hb_maps:get(<<"message">>, Node, undefined, Opts) of

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -302,10 +302,6 @@ default_message() ->
             [
                 ?DEFAULT_PRIMARY_STORE,
                 #{
-                    <<"store-module">> => hb_store_remote_node,
-                    <<"name">> => <<"https://scheduler.forward.computer">>
-                },
-                #{
                     <<"store-module">> => hb_store_fs,
                     <<"name">> => <<"cache-mainnet">>
                 },

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -302,6 +302,10 @@ default_message() ->
             [
                 ?DEFAULT_PRIMARY_STORE,
                 #{
+                    <<"store-module">> => hb_store_remote_node,
+                    <<"name">> => <<"https://scheduler.forward.computer">>
+                },
+                #{
                     <<"store-module">> => hb_store_fs,
                     <<"name">> => <<"cache-mainnet">>
                 },


### PR DESCRIPTION
- Fixed function_clause errors when processing scheduler addresses with leading/trailing whitespace
- Added support for GraphQL-style responses with edges structure in scheduler formats
- Fixed case clause handling for redirect tuples in scheduler lookup