### PR TITLE
impr: Avoid confusion of 32 bytes URL with 32 bytes hash

### DIFF
--- a/src/hb_format.erl
+++ b/src/hb_format.erl
@@ -856,6 +856,10 @@ message(Item, Opts, Indent) ->
 %%% Utility functions.
 
 %% @doc Return a short ID for the different types of IDs used in AO-Core.
+short_id(<<"http://", _/binary>> = Bin) ->
+    Bin;
+short_id(<<"https://", _/binary>> = Bin) ->
+    Bin;
 short_id(Bin) when is_binary(Bin) andalso byte_size(Bin) == 32 ->
     short_id(hb_util:human_id(Bin));
 short_id(Bin) when is_binary(Bin) andalso byte_size(Bin) == 43 ->


### PR DESCRIPTION
When a URL's size matches the 32-byte binary hash, we don't want it converted to an ID and shortened.