### PR TITLE
impr: Use loaded configuration when fetching for global config

### DIFF
--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -36,6 +36,8 @@ start() ->
             hb_opts:default_message_with_env(),
             Loaded
         ),
+    %% Store config to be reused later
+    persistent_term:put(server_startup_config, MergedConfig),
     %% Apply store defaults before starting store
     StoreOpts = hb_opts:get(store, no_store, MergedConfig),
     StoreDefaults = hb_opts:get(store_defaults, #{}, MergedConfig),

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -480,7 +480,10 @@ normalize_default(Default) -> Default.
 %% @doc An abstraction for looking up configuration variables. In the future,
 %% this is the function that we will want to change to support a more dynamic
 %% configuration system.
-config_lookup(Key, Default, _Opts) -> maps:get(Key, default_message(), Default).
+config_lookup(Key, Default, _Opts) ->
+    DefaultConfig = persistent_term:get(server_startup_config, default_message()),
+    DefaultConfig2 = maps:merge(default_message(), DefaultConfig),
+    maps:get(Key, DefaultConfig2, Default).
 
 %% @doc Parse a `flat@1.0' encoded file into a map, matching the types of the 
 %% keys to those in the default message.


### PR DESCRIPTION
When we modify the default configuration using the `HB_CONFIG` environment variable, it will not be available when fetching `hb_opts:get`. This will call `global_get` and `config_lookup` that will fetch the `default_message` instead of the current configuration.

The behaviour that triggered this issue was that setting new routes via `HB_CONFIG` wouldn't be used when [`load_routes`](https://github.com/permaweb/HyperBEAM/blob/edge/src/dev_router.erl#L286) was called. 

The `hb_opts:get(routes, [], Opts);` call would return the `hb_opts:default_message/0` instead of the loaded from `HB_CONFIG`.

# Side quest
Looking into the code, `routes` can't be fetched from the `Opts` (in this case, `Opts` is the Store Options) when we set up via HB_CONFIG. The key is always a string, and the requested key is an `atom`. Maybe this logic could be revised in the future.