### PR TITLE
impr: Show invalid signature error

### DIFF
--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -257,9 +257,13 @@ result_to_message(ExpectedID, Item, Opts) ->
         ),
 	SignatureType =
         case byte_size(Signature) of
-            65 -> {ecdsa, 256};
-            512 -> {rsa, 65537};
-            _ -> unsupported_tx_signature_type
+            65 ->
+                {ecdsa, 256};
+            512 ->
+                {rsa, 65537};
+            SignatureByteSize ->
+                ?event(error, {unsupported_tx_signature_type, {byte_size, SignatureByteSize}}),
+                unsupported_tx_signature_type
         end,
     TX =
         dev_arweave_common:reset_ids(#tx {


### PR DESCRIPTION
When fetching an item with an invalid signature, there is no information regarding an error validating the transaction. Unless we know specifically which file we need to add to the `HB_PRINT` (in this case, `hb_store`), we don't get any feedback regarding the 404 being returned in the logs.

Two have better visibility we have two options:
- Log when a signature isn't valid (this PR).
- Modify [hb_store:387](https://github.com/permaweb/HyperBEAM/blob/edge/src/hb_store.erl#L387) to be `?event(error` instead of `?event(store_error`, so it can be visible in the logs.

If you think either option isn't valid, feel free to suggest a new one or close this PR.