### PR TITLE
fix: scheduler server uploads message as well as assignment explicitly

### DIFF
--- a/src/dev_scheduler_server.erl
+++ b/src/dev_scheduler_server.erl
@@ -227,6 +227,8 @@ do_assign(State, Message, ReplyPID) ->
                 State
             ),
             ?event(writes_complete),
+            ?event(uploading_message),
+            hb_client:upload(Message, Opts),
             ?event(uploading_assignment),
             hb_client:upload(Assignment, Opts),
             ?event(uploads_complete),


### PR DESCRIPTION
This PR adds a fix to explicitly upload messages to Arweave from dev_scheduler_server.