### PR TITLE
fix: Load routes via store

### DIFF
--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -338,8 +338,9 @@ apply_routes(Msg, R, Opts) ->
 apply_route(Msg, Route, Opts) ->
     % LoadedRoute = hb_cache:ensure_all_loaded(Route, Opts),
     RouteOpts = hb_maps:get(<<"opts">>, Route, #{}),
+    RouteOpts2 = hb_opts:mimic_default_types(RouteOpts, existing, Opts),
     {ok, #{
-        <<"opts">> => RouteOpts,
+        <<"opts">> => RouteOpts2,
         <<"uri">> =>
             hb_util:ok(
                 do_apply_route(

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -337,10 +337,10 @@ apply_routes(Msg, R, Opts) ->
 %% - `match' and `with': A regex to replace in the path.
 apply_route(Msg, Route, Opts) ->
     % LoadedRoute = hb_cache:ensure_all_loaded(Route, Opts),
-    RouteOpts = hb_maps:get(<<"opts">>, Route, #{}),
-    RouteOpts2 = hb_opts:mimic_default_types(RouteOpts, existing, Opts),
+    RouteOpts = hb_opts:mimic_default_types(
+        hb_maps:get(<<"opts">>, Route, #{}), existing, Opts),
     {ok, #{
-        <<"opts">> => RouteOpts2,
+        <<"opts">> => RouteOpts,
         <<"uri">> =>
             hb_util:ok(
                 do_apply_route(

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -1804,7 +1804,7 @@ redirect_from_graphql() ->
         #{ store =>
             [
                 #{ <<"store-module">> => hb_store_fs, <<"name">> => <<"cache-mainnet">> },
-                #{ <<"store-module">> => hb_store_gateway, <<"store">> => false }
+                #{ <<"store-module">> => hb_store_gateway, <<"store">> => [] }
             ]
         },
     {ok, Msg} = hb_cache:read(<<"0syT13r0s0tgPmIed95bJnuSqaD29HQNN8D3ElLSrsc">>, Opts),
@@ -1877,7 +1877,7 @@ http_init(Opts) ->
                 <<"store-module">> => hb_store_lmdb,
                 <<"name">> => <<"cache-mainnet/lmdb">>
             },
-			#{ <<"store-module">> => hb_store_gateway, <<"store">> => false }
+			#{ <<"store-module">> => hb_store_gateway, <<"store">> => [] }
 		]
 	},
     Node = hb_http_server:start_node(ExtendedOpts),

--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -215,13 +215,9 @@ cache_read_message_test() ->
 %% produce the same result, despite an empty 'only' route list, then we would
 %% know that the module is not respecting the route list.
 specific_route_test() ->
-    hb_http_server:start_node(#{}),
+    LocalNode = hb_http_server:start_node(#{}),
     %% Define the response we want
     ID = <<"BOogk_XAI3bvNWnxNxwxmvOfglZt17o4MOVAdPNZ_ew">>,
-    Data = <<"specific_route_testx">>,
-    DefaultResponse = {200, Data},
-    Endpoints = [{<<"/raw/", ID/binary>>, ok, DefaultResponse}],
-    {ok, MockServer, ServerHandle} = hb_mock_server:start(Endpoints),
     %% Define configuration, we use a valid gateway to obtain a valid response
     %% and then mock the raw endpoint to our mockserver.
     Opts = #{
@@ -244,8 +240,10 @@ specific_route_test() ->
                     #{
                         <<"template">> => <<"/raw">>,
                         <<"node">> =>
+                            %% This prefix allow us to set a custom message that is a little bit 
+                            %% different than the original one (data field isn't provided).
                             #{
-                                <<"prefix">> => MockServer,
+                                <<"prefix">> => <<LocalNode/binary, "~message@1.0/message?message=3#">>,
                                 <<"opts">> => #{
                                     <<"http_client">> => gun,
                                     <<"protocol">> => http2 
@@ -256,11 +254,10 @@ specific_route_test() ->
                 }
             ]
     },
-    try
-        ?assertMatch({ok, #{<<"data">> := Data}}, hb_cache:read(ID, Opts))
-    after 
-        hb_mock_server:stop(ServerHandle)
-    end.
+    {ok, Response} = hb_cache:read(ID, Opts),
+    %% If the result returns <<"1984">>, it is using the default route, 
+    %% not the custom one we defined
+    ?assert(maps:get(<<"data">>, Response, <<>>) /= <<"1984">>).
 
 %% @doc Test that the default node config allows for data to be accessed.
 external_http_access_test() ->

--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -216,11 +216,14 @@ cache_read_message_test() ->
 %% know that the module is not respecting the route list.
 specific_route_test() ->
     hb_http_server:start_node(#{}),
-    CustomID = <<"BOogk_XAI3bvNWnxNxwxmvOfglZt17o4MOVAdPNZ_ew">>,
-    DefaultResponse = {200, <<"specific_route_test">>},
-    Endpoints = [{<<"/raw/", CustomID/binary>>, ok, DefaultResponse}],
+    %% Define the response we want
+    ID = <<"BOogk_XAI3bvNWnxNxwxmvOfglZt17o4MOVAdPNZ_ew">>,
+    Data = <<"specific_route_testx">>,
+    DefaultResponse = {200, Data},
+    Endpoints = [{<<"/raw/", ID/binary>>, ok, DefaultResponse}],
     {ok, MockServer, _ServerHandle} = hb_mock_server:start(Endpoints),
-    PreloadedDevices = maps:get(preloaded_devices, hb_opts:default_message()),
+    %% Define configuration, we use a valid gateway to obtain a valid response
+    %% and then mock the raw endpoint to our mockserver.
     Opts = #{
         store =>
             [
@@ -232,7 +235,7 @@ specific_route_test() ->
                             #{
                                 <<"prefix">> => <<"https://arweave-search.goldsky.com">>,
                                 <<"opts">> => #{
-                                    <<"http_client">> => httpc, 
+                                    <<"http_client">> => httpc,
                                     <<"protocol">> => http2
                                 }
                             }
@@ -243,22 +246,17 @@ specific_route_test() ->
                         <<"node">> =>
                             #{
                                 <<"prefix">> => MockServer,
-                                <<"opts">> => #{ 
-                                    <<"http_client">> => httpc, 
+                                <<"opts">> => #{
+                                    <<"http_client">> => gun,
                                     <<"protocol">> => http2 
                                 }
                             }
                      }
-                   ],
-                   preloaded_devices => PreloadedDevices,
-                   <<"only">> => local
+                   ]
                 }
             ]
     },
-    ?assertMatch(
-       {ok, #{<<"data">> := <<"specific_route_test">>}},
-        hb_cache:read(CustomID, Opts)
-    ).
+    ?assertMatch({ok, #{<<"data">> := Data}}, hb_cache:read(ID, Opts)).
 
 %% @doc Test that the default node config allows for data to be accessed.
 external_http_access_test() ->

--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -72,7 +72,8 @@ read(BaseStoreOpts, Key) ->
 %% @doc Normalize the routes in the given `Opts`.
 opts(Opts) ->
     case hb_maps:find(<<"node">>, Opts) of
-        error -> Opts;
+        error ->
+            hb_opts:mimic_default_types(Opts, existing, Opts);
         {ok, Node} ->
             case hb_maps:get(<<"node-type">>, Opts, <<"arweave">>, Opts) of
                 <<"arweave">> ->
@@ -215,21 +216,48 @@ cache_read_message_test() ->
 %% know that the module is not respecting the route list.
 specific_route_test() ->
     hb_http_server:start_node(#{}),
+    CustomID = <<"BOogk_XAI3bvNWnxNxwxmvOfglZt17o4MOVAdPNZ_ew">>,
+    DefaultResponse = {200, <<"specific_route_test">>},
+    Endpoints = [{<<"/raw/", CustomID/binary>>, ok, DefaultResponse}],
+    {ok, MockServer, _ServerHandle} = hb_mock_server:start(Endpoints),
+    PreloadedDevices = maps:get(preloaded_devices, hb_opts:default_message()),
     Opts = #{
         store =>
             [
                 #{ <<"store-module">> => hb_store_gateway, 
-                   <<"routes">> => [],
+                   <<"routes">> => [
+                    #{
+                        <<"template">> => <<"/graphql">>,
+                        <<"nodes">> => [
+                            #{
+                                <<"prefix">> => <<"https://arweave-search.goldsky.com">>,
+                                <<"opts">> => #{
+                                    <<"http_client">> => httpc, 
+                                    <<"protocol">> => http2
+                                }
+                            }
+                        ]
+                    },
+                    #{
+                        <<"template">> => <<"/raw">>,
+                        <<"node">> =>
+                            #{
+                                <<"prefix">> => MockServer,
+                                <<"opts">> => #{ 
+                                    <<"http_client">> => httpc, 
+                                    <<"protocol">> => http2 
+                                }
+                            }
+                     }
+                   ],
+                   preloaded_devices => PreloadedDevices,
                    <<"only">> => local
                 }
             ]
     },
     ?assertMatch(
-        not_found,
-        hb_cache:read(
-            <<"BOogk_XAI3bvNWnxNxwxmvOfglZt17o4MOVAdPNZ_ew">>,
-            Opts
-        )
+       {ok, #{<<"data">> := <<"specific_route_test">>}},
+        hb_cache:read(CustomID, Opts)
     ).
 
 %% @doc Test that the default node config allows for data to be accessed.

--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -221,7 +221,7 @@ specific_route_test() ->
     Data = <<"specific_route_testx">>,
     DefaultResponse = {200, Data},
     Endpoints = [{<<"/raw/", ID/binary>>, ok, DefaultResponse}],
-    {ok, MockServer, _ServerHandle} = hb_mock_server:start(Endpoints),
+    {ok, MockServer, ServerHandle} = hb_mock_server:start(Endpoints),
     %% Define configuration, we use a valid gateway to obtain a valid response
     %% and then mock the raw endpoint to our mockserver.
     Opts = #{
@@ -256,7 +256,11 @@ specific_route_test() ->
                 }
             ]
     },
-    ?assertMatch({ok, #{<<"data">> := Data}}, hb_cache:read(ID, Opts)).
+    try
+        ?assertMatch({ok, #{<<"data">> := Data}}, hb_cache:read(ID, Opts))
+    after 
+        hb_mock_server:stop(ServerHandle)
+    end.
 
 %% @doc Test that the default node config allows for data to be accessed.
 external_http_access_test() ->

--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -243,7 +243,7 @@ specific_route_test() ->
                             %% This prefix allow us to set a custom message that is a little bit 
                             %% different than the original one (data field isn't provided).
                             #{
-                                <<"prefix">> => <<LocalNode/binary, "~message@1.0/message?message=3#">>,
+                                <<"prefix">> => <<LocalNode/binary, "~message@1.0/set&body=3#">>,
                                 <<"opts">> => #{
                                     <<"http_client">> => gun,
                                     <<"protocol">> => http2 
@@ -257,7 +257,7 @@ specific_route_test() ->
     {ok, Response} = hb_cache:read(ID, Opts),
     %% If the result returns <<"1984">>, it is using the default route, 
     %% not the custom one we defined
-    ?assert(maps:get(<<"data">>, Response, <<>>) /= <<"1984">>).
+    ?assertEqual(<<"3">>, maps:get(<<"data">>, Response)).
 
 %% @doc Test that the default node config allows for data to be accessed.
 external_http_access_test() ->


### PR DESCRIPTION
This fix enables the use of custom store routes by modifying `<<"routes">>` to `routes`, allowing it to be picked up by the configuration. https://github.com/permaweb/HyperBEAM/blob/edge/src/dev_router.erl#L289

There was already a test to check this functionality, but it was incomplete due to missing parameters in the configuration, causing a `not_found` to be returned, but not for the reason we wanted (to test the `routes`). I've changed this to use the mock server to provide the object data and the other information is provided by GraphQL (maybe I can mock this as well to not rely on external endpoints).


