### PR TITLE
fix: do not override path key in `ans104` and `tx` `POST` operations

### DIFF
--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -5,7 +5,7 @@
 %%% `/arweave` route in the node's configuration message.
 -module(dev_arweave).
 -export([tx/3, chunk/3, block/3, current/3, status/3, price/3, tx_anchor/3]).
--export([post_binary_ans104/2]).
+-export([post_tx/3, post_tx/4, post_binary_ans104/2]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 

--- a/src/hb_client.erl
+++ b/src/hb_client.erl
@@ -107,19 +107,22 @@ upload(Msg, Opts, <<"httpsig@1.0">>) ->
             ?event({uploading_item, Msg}),
             hb_http:post(Bundler, <<"/tx">>, Msg, Opts)
     end;
-upload(Msg, Opts, <<"ans104@1.0">>) when is_map(Msg) ->
-    hb_ao:resolve(
-        #{ <<"device">> => <<"arweave@2.9-pre">> },
-        Msg#{ <<"path">> => <<"/tx">>, <<"method">> => <<"POST">> },
-        Opts
-    );
 upload(Msg, Opts, <<"ans104@1.0">>) when is_binary(Msg) ->
     dev_arweave:post_binary_ans104(Msg, Opts);
-upload(Msg, Opts, <<"tx@1.0">>) when is_map(Msg) ->
-    hb_ao:resolve(
+upload(Msg, Opts, <<"ans104@1.0">>) when is_map(Msg) ->
+    ?event({uploading_item, Msg}),
+    dev_arweave:post_tx(
         #{ <<"device">> => <<"arweave@2.9-pre">> },
-        Msg#{ <<"path">> => <<"/tx">>, <<"method">> => <<"POST">> },
-        Opts
+        Msg,
+        Opts,
+        <<"ans104@1.0">>
+    );
+upload(Msg, Opts, <<"tx@1.0">>) when is_map(Msg) ->
+    dev_arweave:post_tx(
+        #{ <<"device">> => <<"arweave@2.9-pre">> },
+        Msg,
+        Opts,
+        <<"tx@1.0">>
     ).
 
 %%% Tests


### PR DESCRIPTION
As the name implies. This issue caused failures of the scheduler to upload to Arweave, introduced in #535.