### PR TITLE
impr: Proper default timeout values

### DIFF
--- a/src/hb_http_client.erl
+++ b/src/hb_http_client.erl
@@ -14,6 +14,8 @@
 
 -define(DEFAULT_RETRIES, 0).
 -define(DEFAULT_RETRY_TIME, 1000).
+-define(DEFAULT_KEEPALIVE_TIMEOUT, 60_000).
+-define(DEFAULT_CONNECT_TIMEOUT, 60_000).
 
 %%% ==================================================================
 %%% Public interface.
@@ -518,7 +520,7 @@ open_connection(#{ peer := Peer }, Opts) ->
                     keepalive =>
                         hb_opts:get(
                             http_keepalive,
-                            no_keepalive_timeout,
+                            ?DEFAULT_KEEPALIVE_TIMEOUT,
                             Opts
                         )
                 },
@@ -526,7 +528,7 @@ open_connection(#{ peer := Peer }, Opts) ->
             connect_timeout =>
                 hb_opts:get(
                     http_connect_timeout,
-                    no_connect_timeout,
+                    ?DEFAULT_CONNECT_TIMEOUT,
                     Opts
                 )
         },


### PR DESCRIPTION
When using `only => local` in the store definition, all the default values from `hb_opts:default_message` will not be available. 

The default values in the code for `http_keepalive` and `http_connect_timeout` should be working ones; if not, it is mandatory to define them in the config file, wasting time to understand this was the culprit of the unexpected behaviour.