### PR TITLE
fix: Double read on hb_store_gateway

### DIFF
--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -46,7 +46,7 @@ read(BaseStoreOpts, Key) ->
     StoreOpts = opts(BaseStoreOpts),
     case hb_path:term_to_path_parts(Key, StoreOpts) of
         [ID|Rest] when ?IS_ID(ID) ->
-            case hb_store_remote_node:maybe_read(StoreOpts, ID) of
+            case hb_store_remote_node:read_local_cache(StoreOpts, ID) of
                 not_found ->
                     ?event({gateway_read, {opts, StoreOpts}, {id, ID}, {subpath, Rest}}),
                     case hb_gateway_client:read(ID, StoreOpts) of

--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -233,7 +233,8 @@ avoid_double_read_test() ->
             [
                 #{ <<"store-module">> => hb_store_gateway,
                     <<"local-store">> => [Local],
-                    <<"routes">> => custom_raw_routes(MockServer)
+                    %% To be replaced with `<<"routes">>` after PR 563
+                    routes => custom_raw_routes(MockServer)
                 }
             ]
     },

--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -46,23 +46,28 @@ read(BaseStoreOpts, Key) ->
     StoreOpts = opts(BaseStoreOpts),
     case hb_path:term_to_path_parts(Key, StoreOpts) of
         [ID|Rest] when ?IS_ID(ID) ->
-            ?event({gateway_read, {opts, StoreOpts}, {id, ID}, {subpath, Rest}}),
-            case hb_gateway_client:read(ID, StoreOpts) of
-                {error, _} ->
-                    ?event({read_not_found, {key, ID}}),
-                    not_found;
-                {ok, Message} ->
-                    ?event({read_found, {key, ID}}),
-                    try hb_store_remote_node:maybe_cache(StoreOpts, Message)
-                    catch _:_ -> ignored end,
-                    case Rest of
-                        [] -> {ok, Message};
-                        _ ->
-                            case hb_util:deep_get(Rest, Message, StoreOpts) of
-                                not_found -> not_found;
-                                Value -> {ok, Value}
-                            end
-                    end
+            case hb_store_remote_node:maybe_read(StoreOpts, ID) of
+                not_found ->
+                    ?event({gateway_read, {opts, StoreOpts}, {id, ID}, {subpath, Rest}}),
+                    case hb_gateway_client:read(ID, StoreOpts) of
+                        {error, _} ->
+                            ?event({read_not_found, {key, ID}}),
+                            not_found;
+                        {ok, Message} ->
+                            ?event({read_found, {key, ID}}),
+                            try hb_store_remote_node:maybe_cache(StoreOpts, Message)
+                            catch _:_ -> ignored end,
+                            case Rest of
+                                [] -> {ok, Message};
+                                _ ->
+                                    case hb_util:deep_get(Rest, Message, StoreOpts) of
+                                        not_found -> not_found;
+                                        Value -> {ok, Value}
+                                    end
+                             end
+                    end;
+                {ok, Value} ->
+                    {ok, Value}
             end;
         _ ->
             ?event({ignoring_non_id, Key}),
@@ -207,6 +212,68 @@ cache_read_message_test() ->
             #{ store => [Local] }
         ),
     ?assert(hb_message:match(Read, Written)).
+
+avoid_double_read_test() ->
+    hb_http_server:start_node(#{}),
+    %% Setup local node
+    ID = <<"BOogk_XAI3bvNWnxNxwxmvOfglZt17o4MOVAdPNZ_ew">>,
+    Data = <<"123">>,
+    DefaultResponse = {200, Data},
+    Endpoints = [{<<"/raw/", ID/binary>>, raw, DefaultResponse}],
+    %% Start MockServer
+    {ok, MockServer, ServerHandle} = hb_mock_server:start(Endpoints),
+    %% Setup local store
+    Local = #{
+        <<"store-module">> => hb_store_fs,
+        <<"name">> => <<"cache-TEST/avoid_double_read_test">>
+    },
+    hb_store:reset(Local),
+    WriteOpts = #{
+        store =>
+            [
+                #{ <<"store-module">> => hb_store_gateway,
+                    <<"local-store">> => [Local],
+                    <<"routes">> => custom_raw_routes(MockServer)
+                }
+            ]
+    },
+    {ok, Written} = hb_cache:read(ID, WriteOpts),
+    {ok, Read} = hb_cache:read(ID, #{ store => [Local] }),
+    try
+        ?assert(hb_message:match(Read, Written)),
+        %% Check number of requests make to raw
+        TXs = hb_mock_server:get_requests(raw, 1, ServerHandle),
+        ?assert(length(TXs) == 1)
+    after
+        hb_mock_server:stop(ServerHandle)
+    end.
+
+custom_raw_routes(MockServer) ->
+    [
+        #{
+            <<"template">> => <<"/graphql">>,
+            <<"nodes">> => [
+                #{
+                    <<"prefix">> => <<"https://arweave-search.goldsky.com">>,
+                    <<"opts">> => #{
+                        <<"http_client">> => httpc,
+                        <<"protocol">> => http2
+                    }
+                }
+            ]
+        },
+        #{
+            <<"template">> => <<"/raw">>,
+            <<"node">> =>
+                #{
+                    <<"prefix">> => MockServer,
+                    <<"opts">> => #{
+                        <<"http_client">> => gun,
+                        <<"protocol">> => http2
+                    }
+                }
+        }
+    ].
 
 %% @doc Routes can be specified in the options, overriding the default routes.
 %% We test this by inversion: If the above cache read test works, then we know 

--- a/src/hb_store_remote_node.erl
+++ b/src/hb_store_remote_node.erl
@@ -6,7 +6,7 @@
 -module(hb_store_remote_node).
 -export([scope/1, type/2, read/2, write/3, make_link/3, resolve/2]).
 %%% Public utilities.
--export([maybe_cache/2, maybe_cache/3, maybe_read/2]).
+-export([maybe_cache/2, maybe_cache/3, read_local_cache/2]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -117,8 +117,8 @@ maybe_cache(StoreOpts, Data, Links) ->
     end.
 
 %% @doc Read local store cached value.
-maybe_read(StoreOpts, ID) ->
-    ?event({maybe_read, StoreOpts, ID}),
+read_local_cache(StoreOpts, ID) ->
+    ?event({read_local_cache, StoreOpts, ID}),
     case hb_maps:get(<<"local-store">>, StoreOpts, false, StoreOpts) of
         false ->
             not_found;

--- a/src/hb_store_remote_node.erl
+++ b/src/hb_store_remote_node.erl
@@ -6,7 +6,7 @@
 -module(hb_store_remote_node).
 -export([scope/1, type/2, read/2, write/3, make_link/3, resolve/2]).
 %%% Public utilities.
--export([maybe_cache/2, maybe_cache/3]).
+-export([maybe_cache/2, maybe_cache/3, maybe_read/2]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -114,6 +114,16 @@ maybe_cache(StoreOpts, Data, Links) ->
                     ?event(warning, {error_caching_remote_node_data, Err}),
                     {error, Err}
             end
+    end.
+
+%% @doc Read local store cached value.
+maybe_read(StoreOpts, ID) ->
+    ?event({maybe_read, StoreOpts, ID}),
+    case hb_maps:get(<<"local-store">>, StoreOpts, false, StoreOpts) of
+        false ->
+            not_found;
+        Store ->
+            hb_cache:read(ID, #{store => Store})
     end.
 
 %% @doc Write a key to the remote node.


### PR DESCRIPTION
Fix double read when calling `type` (that internally calls `read`) followed by `read`.
`read` caches the value in the defined `<<"local-store">>`, but it doesn't check if it was already cached.