### PR TITLE
fix: Do not crash on unsuported signature types

### DIFF
--- a/src/dev_arweave_common.erl
+++ b/src/dev_arweave_common.erl
@@ -211,5 +211,4 @@ do_not_crash_with_unsupported_signature_type_test() ->
             data_size = 3,
             data = <<0, 1, 2>>
            },
-    R = reset_ids(TX),
-    erlang:display({r, R}).
+    ?assert(is_record(reset_ids(TX), tx)).

--- a/src/dev_arweave_common.erl
+++ b/src/dev_arweave_common.erl
@@ -82,8 +82,11 @@ generate_id(TX, unsigned) ->
 
 generate_signature_data_segment(TX = #tx{ format = ans104 }) ->
     try ar_bundles:data_item_signature_data(TX) catch 
-        _:_ ->
-            ?DEFAULT_ID
+        Class:Error:Stack ->
+            ?event(error, {invalid_tx, {class, Class},
+                           {error, Error},
+                           {stack, Stack}}),
+            <<>>
     end;
 generate_signature_data_segment(TX) ->
     ar_tx:generate_signature_data_segment(TX).
@@ -196,3 +199,17 @@ normalize_data_root(Item = #tx{data = Bin, format = 2})
     Item#tx{data_root = ar_tx:data_root(Bin)};
 normalize_data_root(Item) -> Item.
 
+%% Tests
+
+do_not_crash_with_unsupported_signature_type_test() ->
+    SignatureType = unsupported_tx_signature_type,
+    TX = #tx{
+            format = ans104,
+            signature = <<0:256>>,
+            signature_type = SignatureType,
+            owner = <<0:256>>,
+            data_size = 3,
+            data = <<0, 1, 2>>
+           },
+    R = reset_ids(TX),
+    erlang:display({r, R}).

--- a/src/dev_arweave_common.erl
+++ b/src/dev_arweave_common.erl
@@ -81,7 +81,10 @@ generate_id(TX, unsigned) ->
         generate_signature_data_segment(TX#tx{ owner = ?DEFAULT_OWNER })).
 
 generate_signature_data_segment(TX = #tx{ format = ans104 }) ->
-    ar_bundles:data_item_signature_data(TX);
+    try ar_bundles:data_item_signature_data(TX) catch 
+        _:_ ->
+            ?DEFAULT_ID
+    end;
 generate_signature_data_segment(TX) ->
     ar_tx:generate_signature_data_segment(TX).
 
@@ -192,5 +195,4 @@ normalize_data_root(Item = #tx{data = Bin, format = 2})
         when is_binary(Bin) andalso Bin =/= ?DEFAULT_DATA ->
     Item#tx{data_root = ar_tx:data_root(Bin)};
 normalize_data_root(Item) -> Item.
-
 


### PR DESCRIPTION
When normalizing a transaction by requesting `dev_arweave_common:reset_ids`, if the signature type is unsupported (the owner/public key size isn't supported and/or signature size), it will continue the processing of the transaction/data item, but it will be unable to verify it.

An example case is the `1rTy7gQuK9lJydlKqCEhtGLp2WWG-GOrVo5JdiCmaxs`, which is signed using `ed25519`, a signature type not supported by HyperBEAM.