### PR TITLE
feat: Optionally route downstream messages to remote nodes in `~push@1.0`

### DIFF
--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -227,9 +227,15 @@ compute(Base, Req, Opts) ->
         ),
     case TargetSlot of
         not_found ->
-            % The slot is not set, so we need to serve the latest known state.
+            % The slot is not set, so we need to serve the latest known state
+            % unless the `init' key is set to a value aside from `now'.
             % We do this by setting the `process_now_from_cache' option to `true'.
-            now(Base, Req, Opts#{ process_now_from_cache => true });
+            case hb_maps:get(<<"init">>, Req, <<"now">>, Opts) of
+                <<"now">> ->
+                    now(Base, Req, Opts#{ process_now_from_cache => true });
+                _ ->
+                    {error, not_found}
+            end;
         RawSlot ->
             Slot = hb_util:int(RawSlot),
             case dev_process_cache:read(ProcID, Slot, Opts) of

--- a/src/dev_process_lib.erl
+++ b/src/dev_process_lib.erl
@@ -106,31 +106,11 @@ ensure_process_key(Base, Opts) ->
             % If the message has lost its signers, we need to re-read it from
             % the cache. This can happen if the message was 'cast' to a different
             % device, leading the signers to be unset.
-            ProcessMsg =
-                case hb_message:signers(Base, Opts) of
-                    [] ->
-                        ?event({process_key_not_found_no_signers, {base, Base}}),
-                        case hb_cache:read(hb_message:id(Base, all, Opts), Opts) of
-                            {ok, Proc} -> Proc;
-                            not_found ->
-                                % Fallback to the original message if we cannot
-                                % read it from the cache.
-                                Base
-                        end;
-                    Signers ->
-                        ?event(
-                            {process_key_not_found_but_signers_present,
-                                {signers, Signers},
-                                {base, Base}
-                            }
-                        ),
-                        Base
-                end,
-            {ok, Committed} = hb_message:with_only_committed(ProcessMsg, Opts),
+            {ok, Committed} = hb_message:with_only_committed(Base, Opts),
             ?event(
                 {process_key_before_set,
                     {base, Base},
-                    {process_msg, {explicit, ProcessMsg}},
+                    {process_msg, Base},
                     {committed, Committed}
                 }
             ),
@@ -143,7 +123,7 @@ ensure_process_key(Base, Opts) ->
             ?event(
                 {set_process_key_res,
                     {base, Base},
-                    {process_msg, ProcessMsg},
+                    {process_msg, Base},
                     {res, Res}
                 }
             ),

--- a/src/dev_process_lib.erl
+++ b/src/dev_process_lib.erl
@@ -11,7 +11,7 @@ process_id(Base, Req, Opts) ->
             process_id(ensure_process_key(Base, Opts), Req, Opts);
         Process ->
             Signers = hb_message:signers(Process, Opts),
-            case {hb_message:verify(Process, Opts), Signers} of
+            case {hb_message:verify(Process, all, Opts), Signers} of
                 {false, _} ->
                     ?event({process_not_verified, {process, Process}}),
                     throw({process_not_verified, Process});

--- a/src/dev_process_lib.erl
+++ b/src/dev_process_lib.erl
@@ -8,13 +8,23 @@
 process_id(Base, Req, Opts) ->
     case hb_ao:get(<<"process">>, Base, Opts#{ hashpath => ignore }) of
         not_found ->
-            process_id(dev_process_lib:ensure_process_key(Base, Opts), Req, Opts);
+            process_id(ensure_process_key(Base, Opts), Req, Opts);
         Process ->
-            hb_message:id(
-                Process,
-                hb_util:atom(maps:get(<<"commitments">>, Req, <<"all">>)),
-                Opts
-            )
+            Signers = hb_message:signers(Process, Opts),
+            case {hb_message:verify(Process, Opts), Signers} of
+                {false, _} ->
+                    ?event({process_not_verified, {process, Process}}),
+                    throw({process_not_verified, Process});
+                {true, []} ->
+                    ?event({process_has_no_signers, {process, Process}}),
+                    throw({process_has_no_signers, Process});
+                {true, _} ->
+                    hb_message:id(
+                        Process,
+                        hb_util:atom(maps:get(<<"commitments">>, Req, <<"signed">>)),
+                        Opts
+                    )
+            end
     end.
 
 %% @doc Run a message against Base, with the device being swapped out for

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -372,7 +372,7 @@ push_downstream_remote(TargetID, NextSlotOnProc, Origin, RawOpts) ->
 %% @doc Push a resulting message recursively, executing the action on this node.
 push_downstream_local(TargetID, NextSlotOnProc, Origin, Opts) ->
     {ok, TargetBase} = hb_cache:read(TargetID, Opts),
-    TargetAsProcess = dev_process:ensure_process_key(TargetBase, Opts),
+    TargetAsProcess = dev_process_lib:ensure_process_key(TargetBase, Opts),
     RecvdID = hb_message:id(TargetBase, all, Opts),
     ?event(push, {recvd_id, {id, RecvdID}, {msg, TargetAsProcess}}),
     % Push the message downstream. We decrease the result-depth.
@@ -1055,7 +1055,7 @@ remote_routed_push() ->
         },
     N2 = hb_http_server:start_node(N2Opts),
     % Create the second process on the second node.
-    Proc2 = dev_process:test_aos_process(N2Opts),
+    Proc2 = dev_process_test_vectors:aos_process(N2Opts),
     LoadedProc2 = hb_cache:ensure_all_loaded(Proc2, N2Opts),
     Proc2ID = hb_message:id(Proc2, signed, N2Opts),
     % Next, create the first node and process.
@@ -1082,7 +1082,7 @@ remote_routed_push() ->
         )
     ),
     % Create the first process on the first node.
-    Proc1 = dev_process:test_aos_process(N1Opts),
+    Proc1 = dev_process_test_vectors:aos_process(N1Opts),
     LoadedProc1 = hb_cache:ensure_all_loaded(Proc1, N1Opts),
     Proc1ID = hb_message:id(LoadedProc1, all, N1Opts),
     % Write both processes to each of the nodes' caches, such that both are
@@ -1112,9 +1112,9 @@ remote_routed_push() ->
             "ao.isAssignable = function(m) return true end"
         >>,
     {ok, SetAuthProc1} =
-        dev_process:schedule_aos_call(LoadedProc1, SetAuthoritiesCommand, N1Opts),
+        dev_process_test_vectors:schedule_aos_call(LoadedProc1, SetAuthoritiesCommand, N1Opts),
     {ok, SetAuthProc2} =
-        dev_process:schedule_aos_call(LoadedProc2, SetAuthoritiesCommand, N2Opts),
+        dev_process_test_vectors:schedule_aos_call(LoadedProc2, SetAuthoritiesCommand, N2Opts),
     ?event(debug_test,
         {set_authorities, 
             {command, {string, SetAuthoritiesCommand}},
@@ -1126,13 +1126,13 @@ remote_routed_push() ->
     % reply script, and the first process has reply script with a trigger to
     % send a message to the second process.
     {ok, P2ScriptLoadRes} =
-        dev_process:schedule_aos_call(
+        dev_process_test_vectors:schedule_aos_call(
             LoadedProc2,
             reply_script(),
             N2Opts
         ),
     {ok, P1ScriptLoadRes} =
-        dev_process:schedule_aos_call(
+        dev_process_test_vectors:schedule_aos_call(
             LoadedProc1,
             reply_script(Proc2ID),
             N1Opts

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -1041,7 +1041,7 @@ remote_routed_push() ->
     % pushed from user to process 1, to process 2, then back to process 1.
     % 
     % We start by generating the isolated wallets and stores for each node.
-    N1Wallet = hb:wallet(),
+    N1Wallet = ar_wallet:new(),
     N1Store = [hb_test_utils:test_store()],
     N2Wallet = ar_wallet:new(),
     N2Store = [hb_test_utils:test_store()],
@@ -1096,7 +1096,9 @@ remote_routed_push() ->
             {proc1ID, Proc1ID},
             {proc2ID, Proc2ID},
             {n1, N1},
-            {n2, N2}
+            {n2, N2},
+            {wallet1, ar_wallet:to_address(N1Wallet)},
+            {wallet2, ar_wallet:to_address(N2Wallet)}
         }
     ),
     % Set the authorities of the processes to include both wallets.
@@ -1105,7 +1107,9 @@ remote_routed_push() ->
             "ao.authorities = { ",
                 "\"", (hb_util:human_id(N1Wallet))/binary, "\",",
                 "\"", (hb_util:human_id(N2Wallet))/binary, "\"",
-            " }"
+            " }; ",
+            "ao.addAssignable('foobar', function (msg) return true end); "
+            "ao.isAssignable = function(m) return true end"
         >>,
     {ok, SetAuthProc1} =
         dev_process:schedule_aos_call(LoadedProc1, SetAuthoritiesCommand, N1Opts),
@@ -1113,7 +1117,7 @@ remote_routed_push() ->
         dev_process:schedule_aos_call(LoadedProc2, SetAuthoritiesCommand, N2Opts),
     ?event(debug_test,
         {set_authorities, 
-            {command, SetAuthoritiesCommand},
+            {command, {string, SetAuthoritiesCommand}},
             {proc1_result, SetAuthProc1},
             {proc2_result, SetAuthProc2}
         }
@@ -1141,14 +1145,21 @@ remote_routed_push() ->
     ),
     % Get the slot of the message to push on process 1.
     SlotP1 = hb_ao:get(<<"slot">>, P1ScriptLoadRes, N1Opts),
+    ?event(debug_test, {slot_p1, SlotP1}),
     PushRes =
         hb_http:post(
             N1,
-            <<Proc1ID/binary, "/push">>,
-            #{ <<"slot">> => SlotP1 },
+            #{ 
+                <<"path">> => <<Proc1ID/binary, "/push">>,
+                <<"slot">> => SlotP1
+            },
             N1Opts
         ),
-    ?event({push_res, PushRes}),
+    ?event(debug_test, {push_res, PushRes}),
+    {ok, SchedResP1} = hb_ao:resolve(LoadedProc1, <<"schedule">>, N1Opts),
+    ?event(debug_test, {sched_res_p1, SchedResP1}),
+    {ok, SchedResP2} = hb_ao:resolve(LoadedProc2, <<"schedule">>, N2Opts),
+    ?event(debug_test, {sched_res_p2, SchedResP2}),
     ?assertEqual(
         {ok, 0},
         hb_ao:resolve(LoadedProc2, <<"now/at-slot">>, N2Opts)

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -403,13 +403,16 @@ push_downstream_remote(TargetID, NextSlotOnProc, Origin, RawOpts) ->
 
 %% @doc Push a resulting message recursively, executing the action on this node.
 push_downstream_local(TargetID, NextSlotOnProc, Origin, Opts) ->
-    {ok, TargetBase} = hb_cache:read(TargetID, Opts),
-    TargetAsProcess = dev_process_lib:ensure_process_key(TargetBase, Opts),
-    RecvdID = hb_message:id(TargetBase, all, Opts),
-    ?event(push, {recvd_id, {id, RecvdID}, {msg, TargetAsProcess}}),
+    ?event(push,
+        {push_downstream_local,
+            {target, TargetID},
+            {slot, NextSlotOnProc},
+            {origin, Origin}
+        }
+    ),
     % Push the message downstream. We decrease the result-depth.
     hb_ao:resolve(
-        {as, <<"process@1.0">>, TargetAsProcess},
+        {as, <<"process@1.0">>, TargetID},
         #{
             <<"path">> => <<"push">>,
             <<"slot">> => NextSlotOnProc,

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -270,28 +270,7 @@ push_result_message(TargetProcess, MsgToPush, Origin, Opts) ->
                             {slot, NextSlotOnProc}
                         }
                     ),
-                    {ok, TargetBase} = hb_cache:read(TargetID, Opts),
-                    TargetAsProcess = dev_process_lib:ensure_process_key(TargetBase, Opts),
-                    RecvdID = hb_message:id(TargetBase, all, Opts),
-                    ?event(push, {recvd_id, {id, RecvdID}, {msg, TargetAsProcess}}),
-                    % Push the message downstream. We decrease the result-depth.
-                    Recurse =
-                        hb_ao:resolve(
-                            {as, <<"process@1.0">>, TargetAsProcess},
-                            #{
-                                <<"path">> => <<"push">>,
-                                <<"slot">> => NextSlotOnProc,
-                                <<"result-depth">> =>
-                                    hb_ao:get(
-                                        <<"result-depth">>,
-                                        Origin,
-                                        1,
-                                        Opts
-                                    ) - 1
-                            },
-                            Opts#{ cache_control => <<"always">> }
-                        ),
-                    case Recurse of
+                    case push_downstream(TargetID, NextSlotOnProc, Origin, Opts) of
                         {ok, Downstream} ->
                             #{
                                 <<"id">> => PushedMsgID,
@@ -316,6 +295,87 @@ push_result_message(TargetProcess, MsgToPush, Origin, Opts) ->
                     }
             end
     end.
+
+%% @doc Push a downstream resultant message that has already been scheduled.
+%% We determine whether to push the message locally or remotely based on the
+%% `push_route_downstream' option.
+push_downstream(TargetID, NextSlotOnProc, Origin, Opts) ->
+    case hb_opts:get(push_route_downstream, false, Opts) of
+        true -> push_downstream_remote(TargetID, NextSlotOnProc, Origin, Opts);
+        false -> push_downstream_local(TargetID, NextSlotOnProc, Origin, Opts)
+    end.
+
+%% @doc Push a downstream message on a remote node if a route can be found to
+%% perform the action. If no route is found, we execute the action locally.
+push_downstream_remote(TargetID, NextSlotOnProc, Origin, RawOpts) ->
+    Path = <<TargetID/binary, "/push&slot=", (hb_util:bin(NextSlotOnProc))/binary>>,
+    RouteReq =
+        #{
+            <<"path">> => <<"match">>,
+            <<"route-path">> => Path
+        },
+    Opts =
+        case dev_whois:ensure_host(RawOpts) of
+            {ok, NewOpts} -> NewOpts;
+            _ -> RawOpts
+        end,
+    Self = hb_opts:get(host, host_not_specified, Opts),
+    case hb_ao:resolve(#{ <<"device">> => <<"router@1.0">> }, RouteReq, Opts) of
+        {error, no_matching_route} ->
+            ?event(push,
+                {no_push_route_found,
+                    {target, TargetID},
+                    {slot, NextSlotOnProc},
+                    {continuing, locally}
+                },
+                Opts
+            ),
+            push_downstream_local(TargetID, NextSlotOnProc, Origin, Opts);
+        {ok, Self} ->
+            % If we matched ourselves as the route, we can just push locally.
+            ?event(push,
+                {routing_matched_self,
+                    {target, TargetID},
+                    {slot, NextSlotOnProc},
+                    {continuing, locally}
+                },
+                Opts
+            ),
+            push_downstream_local(TargetID, NextSlotOnProc, Origin, Opts);
+        {ok, Node} ->
+            ?event(push,
+                {routing_matched_remote,
+                    {target, TargetID},
+                    {slot, NextSlotOnProc},
+                    {node, Node}
+                },
+                Opts
+            ),
+            hb_http:post(Node, Path, Opts)
+    end.
+
+%% @doc Push a resulting message recursively, executing the action on this node.
+push_downstream_local(TargetID, NextSlotOnProc, Origin, Opts) ->
+    {ok, TargetBase} = hb_cache:read(TargetID, Opts),
+    TargetAsProcess = dev_process:ensure_process_key(TargetBase, Opts),
+    RecvdID = hb_message:id(TargetBase, all, Opts),
+    ?event(push, {recvd_id, {id, RecvdID}, {msg, TargetAsProcess}}),
+    % Push the message downstream. We decrease the result-depth.
+    hb_ao:resolve(
+        {as, <<"process@1.0">>, TargetAsProcess},
+        #{
+            <<"path">> => <<"push">>,
+            <<"slot">> => NextSlotOnProc,
+            <<"result-depth">> =>
+                hb_ao:get(
+                    <<"result-depth">>,
+                    Origin,
+                    1,
+                    Opts
+                ) - 1
+        },
+        Opts#{ cache_control => <<"always">> }
+    ).
 
 %% @doc Augment the message with from-* keys, if it doesn't already have them.
 normalize_message(MsgToPush, Opts) ->

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -317,7 +317,7 @@ push_downstream_remote(TargetID, NextSlotOnProc, Origin, RawOpts) ->
     Path = <<TargetID/binary, "/push&slot=", (hb_util:bin(NextSlotOnProc))/binary>>,
     RouteReq =
         #{
-            <<"path">> => <<"match">>,
+            <<"path">> => <<"route">>,
             <<"route-path">> => Path
         },
     Opts =
@@ -326,8 +326,17 @@ push_downstream_remote(TargetID, NextSlotOnProc, Origin, RawOpts) ->
             _ -> RawOpts
         end,
     Self = hb_opts:get(host, host_not_specified, Opts),
+    ?event(remote_push,
+        {push_downstream_remote,
+            {target, TargetID},
+            {slot, NextSlotOnProc},
+            {origin, Origin},
+            {opts, Opts}
+        }
+    ),
     case hb_ao:resolve(#{ <<"device">> => <<"router@1.0">> }, RouteReq, Opts) of
-        {error, no_matching_route} ->
+        {error, no_matches} ->
+            throw({no_matching_route, {target, TargetID}, {slot, NextSlotOnProc}}),
             ?event(push,
                 {no_push_route_found,
                     {target, TargetID},
@@ -337,7 +346,7 @@ push_downstream_remote(TargetID, NextSlotOnProc, Origin, RawOpts) ->
                 Opts
             ),
             push_downstream_local(TargetID, NextSlotOnProc, Origin, Opts);
-        {ok, #{ <<"node">> := Self }} ->
+        {ok, Self} ->
             % If we matched ourselves as the route, we can just push locally.
             ?event(push,
                 {routing_matched_self,
@@ -348,7 +357,7 @@ push_downstream_remote(TargetID, NextSlotOnProc, Origin, RawOpts) ->
                 Opts
             ),
             push_downstream_local(TargetID, NextSlotOnProc, Origin, Opts);
-        {ok, #{ <<"node">> := Node }} ->
+        {ok, Node} ->
             ?event(push,
                 {routing_matched_remote,
                     {target, TargetID},
@@ -1010,84 +1019,143 @@ push_prompts_encoding_change() ->
 remote_routed_push_test_() ->
     {timeout, 60, fun remote_routed_push/0}.
 remote_routed_push() ->
-    W = hb:wallet(),
-    DefaultStores = hb_opts:get(store),
-    BaseOpts =
+    % Creates a network of nodes and processes with the following structure:
+    % Node 1:
+    %   - Schedules for process 1.
+    %   - Routes requests for process 2 to Node 2.
+    % Node 2:
+    %   - Schedules for process 2.
+    %
+    % Process 1:
+    %   - Has an `owner` of Node 1's wallet.
+    %   - Has both node 1 and node 2 as authorities.
+    %   - Pushes a `pong` message to process 2 on recipient of an `action: ping`
+    %     message.
+    % 
+    % Process 2:
+    %   - Has an `owner` of Node 2's wallet.
+    %   - Has both node 1 and node 2 as authorities.
+    %   - Pushes a `pong` message to process 1 on recipient of a message.
+    % 
+    % After establishing the network, we ensure that a message can be correctly
+    % pushed from user to process 1, to process 2, then back to process 1.
+    % 
+    % We start by generating the isolated wallets and stores for each node.
+    N1Wallet = hb:wallet(),
+    N1Store = [hb_test_utils:test_store()],
+    N2Wallet = ar_wallet:new(),
+    N2Store = [hb_test_utils:test_store()],
+    % Next, create the second node and process. We do this before node 1 such 
+    % that the routes of node 1 and the target of process 1's message are known
+    % when we create them.
+    N2Opts =
         #{
-            store => [hb_test_utils:test_store() | DefaultStores],
-            priv_wallet => W
+            store => N2Store,
+            priv_wallet => N2Wallet
         },
-    P1Base = dev_process:test_aos_process(BaseOpts),
-    P1 = hb_cache:ensure_all_loaded(P1Base, BaseOpts),
-    ProcID1 = hb_message:id(P1, all, BaseOpts),
-    P2 = hb_cache:ensure_all_loaded(dev_process:test_aos_process(BaseOpts), BaseOpts),
-    OptsN2 = BaseOpts,
-    N2 = hb_http_server:start_node(OptsN2),
-    RoutesP1 =
-        [
-            #{
-                <<"template">> => <<ProcID1/binary, "/.*">>,
-                <<"node">> => N2
-            }
-        ],
-    OptsN1 = BaseOpts#{ routes => RoutesP1 },
-    N1 = hb_http_server:start_node(OptsN1),
-    hb_cache:write(P1, OptsN1),
-    hb_cache:write(P2, OptsN1),
-    hb_cache:write(P1, OptsN2),
-    hb_cache:write(P2, OptsN2),
-    RouteOpts =
-        OptsN1#{
-            routes => RoutesP1,
-            push_route_downstream => true,
-            host => N1
+    N2 = hb_http_server:start_node(N2Opts),
+    % Create the second process on the second node.
+    Proc2 = dev_process:test_aos_process(N2Opts),
+    LoadedProc2 = hb_cache:ensure_all_loaded(Proc2, N2Opts),
+    Proc2ID = hb_message:id(Proc2, signed, N2Opts),
+    % Next, create the first node and process.
+    N1Opts =
+        #{
+            store => N1Store,
+            priv_wallet => N1Wallet,
+            routes =>
+                [
+                    #{
+                        <<"template">> => <<Proc2ID/binary, ".*">>,
+                        <<"node">> => N2
+                    }
+                ]
         },
-    % Sanity check that routing resolves the P1 path to N2.
-    RouteRes =
-        hb_ao:resolve(
-            #{ <<"device">> => <<"router@1.0">>, routes => RoutesP1 },
-            #{
-                <<"path">> => <<"match">>,
-                <<"route-path">> => <<ProcID1/binary, "/push&slot=1">>
-            },
-            RouteOpts
-        ),
+    N1 = hb_http_server:start_node(N1Opts),
+    % Sanity check that routing resolves the Proc2ID path to N2 on the first node.
     ?assertMatch(
-        {ok, #{ <<"node">> := N2 }},
-        RouteRes
+        {ok, N2},
+        hb_http:get(
+            N1,
+            <<"/~router@1.0/route?route-path=", Proc2ID/binary, "/push&slot=1">>,
+            N1Opts
+        )
     ),
-    Script = ping_pong_script(0),
-    {ok, ReqP1N1} = dev_process:schedule_aos_call(P1, Script, OptsN1),
-    SlotP1N1 = hb_ao:get(<<"slot">>, ReqP1N1, OptsN1),
-    {ok, _} =
-        hb_ao:resolve(
-            P1,
-            #{ <<"path">> => <<"push">>, <<"slot">> => SlotP1N1 },
-            RouteOpts
-        ),
-    P2Script =
+    % Create the first process on the first node.
+    Proc1 = dev_process:test_aos_process(N1Opts),
+    LoadedProc1 = hb_cache:ensure_all_loaded(Proc1, N1Opts),
+    Proc1ID = hb_message:id(LoadedProc1, all, N1Opts),
+    % Write both processes to each of the nodes' caches, such that both are
+    % 'globally' available to each other.
+    hb_cache:write(LoadedProc1, N1Opts),
+    hb_cache:write(LoadedProc1, N2Opts),
+    hb_cache:write(LoadedProc2, N1Opts),
+    hb_cache:write(LoadedProc2, N2Opts),
+    ?event(debug_test,
+        {network_setup, 
+            {proc1ID, Proc1ID},
+            {proc2ID, Proc2ID},
+            {n1, N1},
+            {n2, N2}
+        }
+    ),
+    % Set the authorities of the processes to include both wallets.
+    SetAuthoritiesCommand =
         <<
-            Script/binary,
-            "Send({ Target = \"", ProcID1/binary, "\", Action = \"Ping\", Count = 1 })\n"
+            "ao.authorities = { ",
+                "\"", (hb_util:human_id(N1Wallet))/binary, "\",",
+                "\"", (hb_util:human_id(N2Wallet))/binary, "\"",
+            " }"
         >>,
-    {ok, ReqP2} = dev_process:schedule_aos_call(P2, P2Script, OptsN1),
-    SlotP2 = hb_ao:get(<<"slot">>, ReqP2, OptsN1),
-    hb_cache:write(ReqP2, OptsN1),
-    hb_cache:write(ReqP2, OptsN2),
-    {ok, ResP2N2M1} =
-        hb_ao:resolve(
-            P2,
-            #{ <<"path">> => <<"push">>, <<"slot">> => SlotP2 },
-            RouteOpts
+    {ok, SetAuthProc1} =
+        dev_process:schedule_aos_call(LoadedProc1, SetAuthoritiesCommand, N1Opts),
+    {ok, SetAuthProc2} =
+        dev_process:schedule_aos_call(LoadedProc2, SetAuthoritiesCommand, N2Opts),
+    ?event(debug_test,
+        {set_authorities, 
+            {command, SetAuthoritiesCommand},
+            {proc1_result, SetAuthProc1},
+            {proc2_result, SetAuthProc2}
+        }
+    ),
+    % Load the scripts into each process. The second process has the base
+    % reply script, and the first process has reply script with a trigger to
+    % send a message to the second process.
+    {ok, P2ScriptLoadRes} =
+        dev_process:schedule_aos_call(
+            LoadedProc2,
+            reply_script(),
+            N2Opts
         ),
-    ?event({res_p2_n2_m1, ResP2N2M1}),
+    {ok, P1ScriptLoadRes} =
+        dev_process:schedule_aos_call(
+            LoadedProc1,
+            reply_script(Proc2ID),
+            N1Opts
+        ),
+    ?event(debug_test,
+        {script_load, 
+            {proc2_result, P2ScriptLoadRes},
+            {proc1_result, P1ScriptLoadRes}
+        }
+    ),
+    % Get the slot of the message to push on process 1.
+    SlotP1 = hb_ao:get(<<"slot">>, P1ScriptLoadRes, N1Opts),
+    PushRes =
+        hb_http:post(
+            N1,
+            <<Proc1ID/binary, "/push">>,
+            #{ <<"slot">> => SlotP1 },
+            N1Opts
+        ),
+    ?event({push_res, PushRes}),
     ?assertEqual(
         {ok, 0},
-        hb_ao:resolve(P1, <<"now/at-slot">>, OptsN2)
+        hb_ao:resolve(LoadedProc2, <<"now/at-slot">>, N2Opts)
     ),
     ?assertMatch(
         {ok, Slot} when Slot > 0,
-        hb_ao:resolve(P1, <<"now/at-slot">>, OptsN1)
+        hb_ao:resolve(LoadedProc1, <<"now/at-slot">>, N1Opts)
     ).
 
 oracle_push_test_() -> {timeout, 30, fun oracle_push/0}.
@@ -1207,6 +1275,11 @@ reply_script() ->
            end
         )
         """
+    >>.
+reply_script(OtherProcessID) ->
+    <<
+        (reply_script())/binary, "\n",
+        "Send({ Target = \"", (OtherProcessID)/binary, "\", Action = \"Ping\" })\n"
     >>.
 
 message_to_legacynet_scheduler_script() ->

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -86,16 +86,48 @@ do_push(PrimaryProcess, Assignment, Opts) ->
         {push_computing_outbox,
             {process_id, ID},
             {base_id, BaseID},
+            {process_uncommitted_id, UncommittedID},
             {slot, Slot}
         }
     ),
     ?event(push, {push_computing_outbox, {process_id, ID}, {slot, Slot}}),
     {Status, Result} =
-        hb_ao:resolve(
-            {as, <<"process@1.0">>, PrimaryProcess},
-            #{ <<"path">> => <<"compute/results">>, <<"slot">> => Slot },
-            Opts#{ hashpath => ignore }
-        ),
+        try
+            hb_ao:resolve(
+                {as, <<"process@1.0">>, PrimaryProcess},
+                    #{ <<"path">> => <<"compute/results">>, <<"slot">> => Slot },
+                    Opts#{ hashpath => ignore }
+                )
+        catch
+            Class:Reason:Trace ->
+                ?event(
+                    push,
+                    {push_compute_failed,
+                        {process, PrimaryProcess},
+                        {slot, Slot},
+                        {class, Class},
+                        {reason, Reason},
+                        {stack, {trace, Trace}}
+                    },
+                    Opts
+                ),
+                {error,
+                    #{
+                        <<"body">> =>
+                                <<
+                                    "Pushing slot ",
+                                    (hb_util:bin(Slot))/binary,
+                                    " failed on process `",
+                                    (hb_util:bin(ID))/binary,
+                                    "` with error: ",
+                                    (hb_util:bin(hb_format:term(Reason, Opts, 0)))
+                                        /binary
+                                >>,
+                        <<"class">> => Class,
+                        <<"reason">> => Reason
+                    }
+                }
+        end,
     % Determine if we should include the full compute result in our response.
     IncludeDepth = hb_ao:get(<<"result-depth">>, Assignment, 1, Opts),
     AdditionalRes =

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -1195,12 +1195,18 @@ remote_routed_push() ->
     {ok, SchedResP2} = hb_ao:resolve(LoadedProc2, <<"schedule">>, N2Opts),
     ?event(debug_test, {sched_res_p2, SchedResP2}),
     ?assertEqual(
-        {ok, 0},
-        hb_ao:resolve(LoadedProc2, <<"now/at-slot">>, N2Opts)
+        {error, not_found},
+        hb_ao:resolve_many(
+            [
+                LoadedProc2,
+                #{ <<"path">> => <<"compute">>, <<"init">> => <<"stop">> }
+            ],
+            N1Opts
+        )
     ),
     ?assertMatch(
         {ok, Slot} when Slot > 0,
-        hb_ao:resolve(LoadedProc1, <<"now/at-slot">>, N1Opts)
+        hb_ao:resolve(LoadedProc2, <<"now/at-slot">>, N2Opts)
     ).
 
 oracle_push_test_() -> {timeout, 30, fun oracle_push/0}.

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -338,7 +338,7 @@ push_result_message(TargetProcess, MsgToPush, Origin, Opts) ->
 %% We determine whether to push the message locally or remotely based on the
 %% `push_route_downstream' option.
 push_downstream(TargetID, NextSlotOnProc, Origin, Opts) ->
-    case hb_opts:get(push_route_downstream, false, Opts) of
+    case hb_opts:get(push_route_downstream, true, Opts) of
         true -> push_downstream_remote(TargetID, NextSlotOnProc, Origin, Opts);
         false -> push_downstream_local(TargetID, NextSlotOnProc, Origin, Opts)
     end.
@@ -368,7 +368,6 @@ push_downstream_remote(TargetID, NextSlotOnProc, Origin, RawOpts) ->
     ),
     case hb_ao:resolve(#{ <<"device">> => <<"router@1.0">> }, RouteReq, Opts) of
         {error, no_matches} ->
-            throw({no_matching_route, {target, TargetID}, {slot, NextSlotOnProc}}),
             ?event(push,
                 {no_push_route_found,
                     {target, TargetID},

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -104,7 +104,13 @@ do_push(PrimaryProcess, Assignment, Opts) ->
             _ -> #{}
         end,
     ?event(push_depth, {depth, IncludeDepth, {assignment, Assignment}}),
-    ?event(push, {push_computed, {process, ID}, {slot, Slot}}),
+    ?event(push,
+        {push_compute_result,
+            {process, ID},
+            {slot, Slot},
+            {status, Status}
+        }
+    ),
     ?event(debug,
         {push_computed,
             {status, Status},
@@ -331,7 +337,7 @@ push_downstream_remote(TargetID, NextSlotOnProc, Origin, RawOpts) ->
                 Opts
             ),
             push_downstream_local(TargetID, NextSlotOnProc, Origin, Opts);
-        {ok, Self} ->
+        {ok, #{ <<"node">> := Self }} ->
             % If we matched ourselves as the route, we can just push locally.
             ?event(push,
                 {routing_matched_self,
@@ -342,7 +348,7 @@ push_downstream_remote(TargetID, NextSlotOnProc, Origin, RawOpts) ->
                 Opts
             ),
             push_downstream_local(TargetID, NextSlotOnProc, Origin, Opts);
-        {ok, Node} ->
+        {ok, #{ <<"node">> := Node }} ->
             ?event(push,
                 {routing_matched_remote,
                     {target, TargetID},
@@ -1000,6 +1006,89 @@ push_prompts_encoding_change() ->
             Opts
         ),
     ?assertMatch({error, #{ <<"status">> := 422 }}, Res).
+
+remote_routed_push_test_() ->
+    {timeout, 60, fun remote_routed_push/0}.
+remote_routed_push() ->
+    W = hb:wallet(),
+    DefaultStores = hb_opts:get(store),
+    BaseOpts =
+        #{
+            store => [hb_test_utils:test_store() | DefaultStores],
+            priv_wallet => W
+        },
+    P1Base = dev_process:test_aos_process(BaseOpts),
+    P1 = hb_cache:ensure_all_loaded(P1Base, BaseOpts),
+    ProcID1 = hb_message:id(P1, all, BaseOpts),
+    P2 = hb_cache:ensure_all_loaded(dev_process:test_aos_process(BaseOpts), BaseOpts),
+    OptsN2 = BaseOpts,
+    N2 = hb_http_server:start_node(OptsN2),
+    RoutesP1 =
+        [
+            #{
+                <<"template">> => <<ProcID1/binary, "/.*">>,
+                <<"node">> => N2
+            }
+        ],
+    OptsN1 = BaseOpts#{ routes => RoutesP1 },
+    N1 = hb_http_server:start_node(OptsN1),
+    hb_cache:write(P1, OptsN1),
+    hb_cache:write(P2, OptsN1),
+    hb_cache:write(P1, OptsN2),
+    hb_cache:write(P2, OptsN2),
+    RouteOpts =
+        OptsN1#{
+            routes => RoutesP1,
+            push_route_downstream => true,
+            host => N1
+        },
+    % Sanity check that routing resolves the P1 path to N2.
+    RouteRes =
+        hb_ao:resolve(
+            #{ <<"device">> => <<"router@1.0">>, routes => RoutesP1 },
+            #{
+                <<"path">> => <<"match">>,
+                <<"route-path">> => <<ProcID1/binary, "/push&slot=1">>
+            },
+            RouteOpts
+        ),
+    ?assertMatch(
+        {ok, #{ <<"node">> := N2 }},
+        RouteRes
+    ),
+    Script = ping_pong_script(0),
+    {ok, ReqP1N1} = dev_process:schedule_aos_call(P1, Script, OptsN1),
+    SlotP1N1 = hb_ao:get(<<"slot">>, ReqP1N1, OptsN1),
+    {ok, _} =
+        hb_ao:resolve(
+            P1,
+            #{ <<"path">> => <<"push">>, <<"slot">> => SlotP1N1 },
+            RouteOpts
+        ),
+    P2Script =
+        <<
+            Script/binary,
+            "Send({ Target = \"", ProcID1/binary, "\", Action = \"Ping\", Count = 1 })\n"
+        >>,
+    {ok, ReqP2} = dev_process:schedule_aos_call(P2, P2Script, OptsN1),
+    SlotP2 = hb_ao:get(<<"slot">>, ReqP2, OptsN1),
+    hb_cache:write(ReqP2, OptsN1),
+    hb_cache:write(ReqP2, OptsN2),
+    {ok, ResP2N2M1} =
+        hb_ao:resolve(
+            P2,
+            #{ <<"path">> => <<"push">>, <<"slot">> => SlotP2 },
+            RouteOpts
+        ),
+    ?event({res_p2_n2_m1, ResP2N2M1}),
+    ?assertEqual(
+        {ok, 0},
+        hb_ao:resolve(P1, <<"now/at-slot">>, OptsN2)
+    ),
+    ?assertMatch(
+        {ok, Slot} when Slot > 0,
+        hb_ao:resolve(P1, <<"now/at-slot">>, OptsN1)
+    ).
 
 oracle_push_test_() -> {timeout, 30, fun oracle_push/0}.
 oracle_push() ->

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -410,6 +410,13 @@ match_routes(ToMatch, Routes, Opts) ->
         Keys,
         Opts
     ).
+match_routes(Req = #{ <<"route-path">> := Path }, Routes, Keys, Opts) ->
+    match_routes(
+        (maps:without([<<"route-path">>], Req))#{ <<"path">> => Path },
+        Routes,
+        Keys,
+        Opts
+    );
 match_routes(#{ <<"path">> := Explicit = <<"http://", _/binary>> }, _, _, _) ->
     % If the route is an explicit HTTP URL, we can match it directly.
     #{ <<"node">> => Explicit, <<"reference">> => <<"explicit">> };

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -591,15 +591,7 @@ do_post_schedule(Base, Req, ToSched, Opts) ->
     % Find the ProcessID of the target message:
     % - If it is a Process, use the ID of the message.
     % - If not, use the target as the ProcessID.
-    ProcID =
-        case hb_ao:get(<<"type">>, ToSched, not_found, Opts) of
-            <<"Process">> -> hb_message:id(ToSched, all, Opts);
-            _ ->
-                case hb_ao:get(<<"target">>, ToSched, not_found, Opts) of
-                    not_found -> find_target_id(Base, Req, Opts);
-                    Target -> hb_util:human_id(Target)
-                end
-        end,
+    ProcID = find_target_id(Base, Req, ToSched, Opts),
     ?event({proc_id, ProcID}),
     % Filter all unsigned keys from the source message.
     case hb_message:with_only_committed(ToSched, Opts) of
@@ -1511,12 +1503,23 @@ post_legacy_schedule(ProcID, OnlyCommitted, Node, Opts) ->
 
 %% @doc Find the schedule ID from a given request. The precidence order for 
 %% search is as follows:
-%% [1. `ToSched/id' -- in the case of `POST schedule', handled locally]
+%% 1. `ToSched/id' when `ToSched' has `type: Process'
+%% 2. `ToSched/target' when `ToSched' has a `target' key
 %% 2. `Req/target'
 %% 3. `Req/id' when `Req' has `type: Process'
 %% 4. `Base/process/id'
 %% 5. `Base/id' when `Base' has `type: Process'
 %% 6. `Req/id'
+find_target_id(Base, Req, ToSched, Opts) ->
+    case hb_ao:get(<<"type">>, ToSched, not_found, Opts) of
+        <<"Process">> ->
+            dev_process_lib:process_id(ToSched, #{}, Opts);
+        _ ->
+            case hb_ao:get(<<"target">>, ToSched, not_found, Opts) of
+                not_found -> find_target_id(Base, Req, Opts);
+                Target -> hb_util:human_id(Target)
+            end
+    end.
 find_target_id(Base, Req, Opts) ->
     TempOpts = Opts#{ hashpath => ignore },
     Res = case hb_ao:resolve(Req, <<"target">>, TempOpts) of
@@ -1527,23 +1530,20 @@ find_target_id(Base, Req, Opts) ->
             case hb_ao:resolve(Req, <<"type">>, TempOpts) of
                 {ok, <<"Process">>} ->
                     % Req is a Process, so the ID is at Req/id
-                    hb_message:id(Req, all, Opts);
+                    dev_process_lib:process_id(Req, #{}, Opts);
                 _ ->
                     case hb_ao:resolve(Base, <<"process">>, TempOpts) of
-                        {ok, Process} ->
-                            LoadedProcess = hb_cache:read_all_commitments(Process, Opts),
-                            ?event(lookup, {loaded_process, LoadedProcess}),
-                            % ID found at Base/process/id
-                            hb_message:id(LoadedProcess, all, Opts);
+                        {ok, _Process} ->
+                            dev_process_lib:process_id(Base, #{}, Opts);
                         _ ->
-                            % Does the message have a type of Process?
+                            % Does the message have a type of process?
                             case hb_ao:get(<<"type">>, Base, TempOpts) of
                                 <<"Process">> ->
-                                    % Yes, so try Base/id
-                                    hb_message:id(Base, all, Opts);
+                                    % Yes: Base is the process.
+                                    dev_process_lib:process_id(Base, #{}, Opts);
                                 _ ->
-                                    % No, so the ID is at Req/id
-                                    hb_message:id(Req, all, Opts)
+                                    % No: Req is the target process.
+                                    dev_process_lib:process_id(Req, #{}, Opts)
                             end
                 end
             end
@@ -1753,7 +1753,7 @@ register_location_on_boot_test() ->
 
 schedule_message_and_get_slot_test() ->
     start(),
-    Base = test_process(),
+    Base = hb_message:commit(test_process(), #{ priv_wallet => hb:wallet() }),
     Req = #{
         <<"path">> => <<"schedule">>,
         <<"method">> => <<"POST">>,
@@ -1768,7 +1768,7 @@ schedule_message_and_get_slot_test() ->
     Res = #{
         <<"path">> => <<"slot">>,
         <<"method">> => <<"GET">>,
-        <<"process">> => hb_util:id(Base)
+        <<"process">> => dev_process_lib:process_id(Base, #{}, #{})
     },
     ?event({pg, dev_scheduler_registry:get_processes()}),
     ?event({getting_schedule, {msg, Res}}),
@@ -1780,7 +1780,11 @@ redirect_to_hint_test() ->
     start(),
     RandAddr = hb_util:human_id(crypto:strong_rand_bytes(32)),
     TestLoc = <<"http://test.computer">>,
-    Base = test_process(<< RandAddr/binary, "?hint=", TestLoc/binary>>),
+    Base =
+        hb_message:commit(
+            test_process(<< RandAddr/binary, "?hint=", TestLoc/binary>>),
+            #{ priv_wallet => hb:wallet() }
+        ),
     Req = #{
         <<"path">> => <<"schedule">>,
         <<"method">> => <<"POST">>,
@@ -1835,7 +1839,7 @@ redirect_from_graphql() ->
 
 get_local_schedule_test() ->
     start(),
-    Base = test_process(),
+    Base = hb_message:commit(test_process(), #{ priv_wallet => hb:wallet() }),
     Req = #{
         <<"path">> => <<"schedule">>,
         <<"method">> => <<"POST">>,

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -1531,8 +1531,10 @@ find_target_id(Base, Req, Opts) ->
                 _ ->
                     case hb_ao:resolve(Base, <<"process">>, TempOpts) of
                         {ok, Process} ->
+                            LoadedProcess = hb_cache:read_all_commitments(Process, Opts),
+                            ?event(lookup, {loaded_process, LoadedProcess}),
                             % ID found at Base/process/id
-                            hb_message:id(Process, all, Opts);
+                            hb_message:id(LoadedProcess, all, Opts);
                         _ ->
                             % Does the message have a type of Process?
                             case hb_ao:get(<<"type">>, Base, TempOpts) of

--- a/src/hb_ao_test_vectors.erl
+++ b/src/hb_ao_test_vectors.erl
@@ -39,6 +39,8 @@ test_suite() ->
             fun as_path_test/1},
         {continue_as, "continue as",
             fun continue_as_test/1},
+        {as_commitments, "as commitment normalization",
+            fun as_commitments_test/1},
         {multiple_as_subresolutions, "multiple as subresolutions",
             fun multiple_as_subresolutions_test/1},
         {resolve_key_twice, "resolve key twice",
@@ -186,6 +188,7 @@ test_opts() ->
                 device_excludes,
                 deep_set_with_device,
                 as,
+                as_commitments,
                 step_hook
             ]
         }
@@ -822,6 +825,37 @@ continue_as_test(Opts) ->
                 #{ <<"path">> => <<"test_key">> }
             ],
             Opts
+        )
+    ).
+
+as_commitments_test(RawOpts) ->
+    % Test that attempting to cast a message as a device which it already is
+    % does not lose its commitments.
+    OptsWithWallet = RawOpts#{ priv_wallet => hb:wallet() },
+    Msg =
+        hb_message:commit(
+            #{
+                <<"device">> => <<"test-device@1.0">>,
+                <<"test-key">> => <<"test-value">>
+            },
+            OptsWithWallet
+        ),
+    InitialComms = hb_ao:get(<<"commitments">>, Msg, OptsWithWallet),
+    {ok, ResolvedMsg} =
+        hb_ao:resolve(
+            {as, <<"test-device@1.0">>, Msg},
+            <<"commitments">>,
+            OptsWithWallet
+        ),
+    ?assertEqual(InitialComms, ResolvedMsg),
+    ?assertEqual(
+        {ok, []},
+        hb_ao:resolve_many(
+            [
+                {as, <<"message@1.0">>, Msg},
+                <<"committers">>
+            ],
+            OptsWithWallet
         )
     ).
 


### PR DESCRIPTION
This PR modifies `~push@1.0` to attempt to route push requests to remote nodes using `~router@1.0` during the recursive step of message distribution. This allows node operators to easily configure clusters of HyperBEAM nodes that efficiently distribute message pushing work between them.