### PR TITLE
impr: call `~dedup@1.0` in `~genesis-wasm@1.0` default stack

### DIFF
--- a/src/dev_dedup.erl
+++ b/src/dev_dedup.erl
@@ -67,8 +67,14 @@ handle(Key, M1, M2, Opts) ->
         end,
     % Is this the first pass, if we are executing in a stack?
     FirstPass = hb_ao:get(<<"pass">>, {as, <<"message@1.0">>, M1}, 1, Opts) == 1,
-    % Get the list of already seen subjects.
-    DedupList = hb_ao:get(<<"dedup">>, {as, <<"message@1.0">>, M1}, [], Opts),
+    % Get the trie of already seen subjects.
+    DedupTrie =
+        hb_ao:get(
+            <<"dedup">>,
+            {as, <<"message@1.0">>, M1},
+            #{ <<"device">> => <<"trie@1.0">> },
+            Opts
+        ),
     ?event({dedup_handle,
         {key, Key},
         {base, M1},
@@ -89,21 +95,39 @@ handle(Key, M1, M2, Opts) ->
             % If this is the first pass, we need to check if the subject has
             % already been seen.
             SubjectID = hb_message:id(Subject, signed, Opts),
-            ?event({dedup_checking, {existing, DedupList}}),
-            case lists:member(SubjectID, DedupList) of
-                true ->
-                    ?event({already_seen, SubjectID}),
-                    {skip, M1};
-                false ->
+            ?event({dedup_checking, DedupTrie}),
+            case hb_ao:get(SubjectID, DedupTrie, Opts) of
+                not_found ->
                     ?event({not_seen, SubjectID}),
-                    M3 =
+                    NewDedupTrie =
                         hb_ao:set(
-                            M1,
-                            #{ <<"dedup">> => [SubjectID|DedupList] },
+                            DedupTrie,
+                            SubjectID,
+                            hb_maps:get(
+                                <<"slot">>,
+                                M2,
+                                true,
+                                Opts
+                            ),
                             Opts
                         ),
-                    ?event({dedup_updated, M3}),
-                    {ok, M3}
+                    ?event({dedup_updated, NewDedupTrie}),
+                    Result =
+                        hb_ao:set(
+                            M1,
+                            <<"dedup">>,
+                            NewDedupTrie,
+                            Opts
+                        ),
+                    {ok, Result};
+                Value ->
+                    ?event(
+                        {already_seen,
+                            {subject, SubjectID},
+                            {dedup_value, Value}
+                        }
+                    ),
+                    {skip, M1}
             end
     end.
 

--- a/src/dev_dedup.erl
+++ b/src/dev_dedup.erl
@@ -88,7 +88,7 @@ handle(Key, M1, M2, Opts) ->
         {true, _} ->
             % If this is the first pass, we need to check if the subject has
             % already been seen.
-            SubjectID = hb_message:id(Subject, all),
+            SubjectID = hb_message:id(Subject, signed, Opts),
             ?event({dedup_checking, {existing, DedupList}}),
             case lists:member(SubjectID, DedupList) of
                 true ->

--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -72,32 +72,39 @@ delegate_request(Msg, Req, Opts) ->
 
 
 %% @doc Handle normal compute execution with state persistence (GET method).
-do_compute(Msg, Req, Opts) ->
-    % Resolve the `delegated-compute@1.0' device.
-    case hb_ao:resolve(Msg, {as, <<"delegated-compute@1.0">>, Req}, Opts) of
-        {ok, Res} ->
-            PatchResult = 
-                hb_ao:resolve(
-                    Res,
-                    {
-                        as,
-                        <<"patch@1.0">>,
-                        Req#{ <<"patch-from">> => <<"/results/outbox">> }
-                    },
-                    Opts
-                ),
-            % Resolve the `patch@1.0' device.
-            case PatchResult of 
-                {ok, Msg4} ->
-                    % Return the patched message.
-                    {ok, Msg4};
-                {error, Error} ->
-                    % Return the error.
-                    {error, Error}
-            end;
+do_compute(State, Req, Opts) ->
+    maybe
+        {ok, State2} ?=
+            hb_ao:resolve(
+                State,
+                {as, <<"dedup@1.0">>, Req},
+                Opts
+            ),
+        {ok, State3} ?=
+            hb_ao:resolve(
+                State2,
+                {as, <<"delegated-compute@1.0">>, Req},
+                Opts
+            ),
+        {ok, State4} ?=
+            hb_ao:resolve(
+                State3,
+                {
+                    as,
+                    <<"patch@1.0">>,
+                    Req#{ <<"patch-from">> => <<"/results/outbox">> }
+                },
+                Opts
+            ),
+        {ok, State4}
+    else
         {error, Error} ->
-            % Return the error.
-            {error, Error}
+            % Issue an event and return the error.
+            ?event({genesis_wasm_compute_error, Error}),
+            {error, Error};
+        {skip, ExitState} ->
+            ?event({genesis_wasm_skipping_duplicate, Req}),
+            {skip, ExitState}
     end.
 
 %% @doc Ensure the local `genesis-wasm@1.0' is live. If it not, start it.

--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -129,11 +129,22 @@ do_compute(State, Req, Opts) ->
             {error, State};
         {skip, ExitState} ->
             Req2 =
-                #{
-                    <<"path">> => hb_maps:get(<<"path">>, Req, <<"compute">>, Opts),
-                    <<"slot">> => hb_maps:get(<<"slot">>, Req, -1, Opts),
-                    <<"skip">> => true
-                },
+                hb_message:commit(
+                    (hb_message:remove_all_commitments(Req, Opts))
+                    #{
+                        <<"path">> => 
+                            hb_maps:get(<<"path">>, Req, <<"compute">>, Opts),
+                        <<"slot">> =>
+                            hb_maps:get(<<"slot">>, Req, -1, Opts),
+                        <<"skip">> => true,
+                        <<"body">> => 
+                            hb_message:commit(#{
+                                <<"data">> => <<"Dedup no op">>,
+                                <<"timestamp">> => os:system_time(millisecond)
+                            },
+                            Opts
+                        )
+                }, Opts),
             ?event(dedup_short,
                 {skip,
                     {cause, dedup},
@@ -763,7 +774,7 @@ dedup_test() ->
             Opts
         ),
     schedule_aos_call(Base, <<"Number = 1">>),
-    % Manually double schedule the same message base
+    % Manually triple schedule the same message base
     MsgBase = 
         hb_message:commit(
             #{
@@ -791,7 +802,8 @@ dedup_test() ->
             },
             Opts
         ),
-    % Schedule the message twice
+    % Schedule the message thrice
+    {ok, _} = hb_ao:resolve(Base, Req, Opts),
     {ok, _} = hb_ao:resolve(Base, Req, Opts),
     {ok, _} = hb_ao:resolve(Base, Req, Opts),
     % Ensure the message is scheduled twice
@@ -814,13 +826,22 @@ dedup_test() ->
             hb_ao:get(<<"assignments/3/body/commitments">>, SchedulerRes)
         )
     ),
+    ?assertEqual(
+        hb_private:reset(
+            hb_ao:get(<<"assignments/3/body/commitments">>, SchedulerRes)
+        ),
+        hb_private:reset(
+            hb_ao:get(<<"assignments/4/body/commitments">>, SchedulerRes)
+        )
+    ),
+    % Schedule twice to avoid nonce warning
+    schedule_aos_call(Base, <<"return Number">>),
     schedule_aos_call(Base, <<"return Number">>),
     % Compute with dedup - initialize number to 1, then two increments,
     % but the second increment should be skipped for dedup - expected result is 2
     {ok, Result} = hb_ao:resolve(Base, #{ <<"path">> => <<"now">> }, Opts),
-    Results = hb_ao:get(<<"results">>, Result),
-    ?event(debug_test, {results, Results}),
-    ok.
+    Data = hb_ao:get(<<"results/data">>, Result),
+    ?assertEqual(<<"2">>, Data).
 spawn_and_execute_slot_test_() ->
     { timeout, 900, fun spawn_and_execute_slot/0 }.
 spawn_and_execute_slot() ->

--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -814,10 +814,7 @@ dedup_test() ->
     {ok, SchedulerRes} =
         hb_ao:resolve(
             Base, 
-            #{
-                <<"method">> => <<"GET">>,
-                <<"path">> => <<"schedule">>
-            },
+            <<"schedule">>,
             Opts
         ),
     ?event(debug_test, {dedup_test, {scheduler_res, SchedulerRes}}),
@@ -843,7 +840,7 @@ dedup_test() ->
     schedule_aos_call(Base, <<"return Number">>),
     % Compute with dedup - initialize number to 1, then two increments,
     % but the second increment should be skipped for dedup - expected result is 2
-    {ok, Result} = hb_ao:resolve(Base, #{ <<"path">> => <<"now">> }, Opts),
+    {ok, Result} = hb_ao:resolve(Base, <<"now">>, Opts),
     Data = hb_ao:get(<<"results/data">>, Result),
     ?assertEqual(<<"2">>, Data).
 spawn_and_execute_slot_test_() ->

--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -128,23 +128,27 @@ do_compute(State, Req, Opts) ->
             ),
             {error, State};
         {skip, ExitState} ->
+            ReqWithoutCommitments =
+                hb_message:remove_all_commitments(Req, Opts),
             Req2 =
                 hb_message:commit(
-                    (hb_message:remove_all_commitments(Req, Opts))
-                    #{
+                    ReqWithoutCommitments#{
                         <<"path">> => 
                             hb_maps:get(<<"path">>, Req, <<"compute">>, Opts),
                         <<"slot">> =>
                             hb_maps:get(<<"slot">>, Req, -1, Opts),
                         <<"skip">> => true,
                         <<"body">> => 
-                            hb_message:commit(#{
-                                <<"data">> => <<"Dedup no op">>,
-                                <<"timestamp">> => os:system_time(millisecond)
-                            },
-                            Opts
-                        )
-                }, Opts),
+                            hb_message:commit(
+                                #{
+                                    <<"timestamp">> => 
+                                        os:system_time(millisecond)
+                                },
+                                Opts
+                            )
+                    },
+                    Opts
+                ),
             ?event(dedup_short,
                 {skip,
                     {cause, dedup},

--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -42,8 +42,12 @@ compute(Msg, Req, Opts) ->
                     },
                     Opts
                 ),
+            ?event({genesis_wasm_patched_message, Msg4}),
             % Return the patched message.
             {ok, Msg4};
+        {skip, Res} ->
+            ?event({genesis_wasm_skipping_duplicate, {req, Req}, {res, Res}, {msg, Msg}}),
+            {ok, Msg};
         {error, Error} ->
             % Return the error.
             {error, Error}
@@ -73,6 +77,7 @@ delegate_request(Msg, Req, Opts) ->
 
 %% @doc Handle normal compute execution with state persistence (GET method).
 do_compute(State, Req, Opts) ->
+    ?event(debug_test, {do_compute, {state, State}, {req, Req}}),
     maybe
         {ok, State2} ?=
             hb_ao:resolve(
@@ -80,6 +85,7 @@ do_compute(State, Req, Opts) ->
                 {as, <<"dedup@1.0">>, Req},
                 Opts
             ),
+        ?event(debug_test, {do_compute, dedup_passed}),
         {ok, State3} ?=
             hb_ao:resolve(
                 State2,
@@ -96,6 +102,7 @@ do_compute(State, Req, Opts) ->
                 },
                 Opts
             ),
+        ?event(debug_test, {do_compute, patched_message}),
         {ok, State4}
     else
         {error, Error} ->
@@ -103,7 +110,7 @@ do_compute(State, Req, Opts) ->
             ?event({genesis_wasm_compute_error, Error}),
             {error, Error};
         {skip, ExitState} ->
-            ?event({genesis_wasm_skipping_duplicate, Req}),
+            ?event(debug_test, {genesis_wasm_skipping_duplicate, Req}),
             {skip, ExitState}
     end.
 
@@ -703,6 +710,85 @@ schedule_aos_call(Base, Code, Action, Opts) ->
         ),
     schedule_test_message(Base, <<"TEST MSG">>, Req).
 
+dedup_test() ->
+    application:ensure_all_started(hb),
+    Opts = #{
+        priv_wallet => hb:wallet(),
+        cache_control => <<"always">>,
+        store => hb_opts:get(store)
+    },
+    Base = test_genesis_wasm_process(),
+    hb_cache:write(Base, Opts),
+    ProcID = hb_message:id(Base, all),
+    {ok, _SchedInit} =
+        hb_ao:resolve(
+            Base,
+            #{
+                <<"method">> => <<"POST">>,
+                <<"path">> => <<"schedule">>,
+                <<"body">> => Base
+            },
+            Opts
+        ),
+    schedule_aos_call(Base, <<"Number = 1">>),
+    % Manually double schedule the same message base
+    MsgBase = 
+        hb_message:commit(
+            #{
+                <<"action">> => <<"Eval">>,
+                <<"data">> => <<"Number = Number + 1; return Number">>,
+                <<"target">> => ProcID,
+                <<"timestamp">> => os:system_time(millisecond)
+            },
+            Opts
+        ),
+    UncommittedBase = hb_message:uncommitted(MsgBase),
+    Req =
+        hb_message:commit(
+            #{
+                <<"path">> => <<"schedule">>,
+                <<"method">> => <<"POST">>,
+                <<"body">> =>
+                    hb_message:commit(
+                        UncommittedBase#{
+                            <<"type">> => <<"Message">>,
+                            <<"test-label">> => <<"TEST MSG">>
+                        },
+                        Opts
+                    )
+            },
+            Opts
+        ),
+    % Schedule the message twice
+    {ok, _} = hb_ao:resolve(Base, Req, Opts),
+    {ok, _} = hb_ao:resolve(Base, Req, Opts),
+    % Ensure the message is scheduled twice
+    {ok, SchedulerRes} =
+        hb_ao:resolve(
+            Base, 
+            #{
+                <<"method">> => <<"GET">>,
+                <<"path">> => <<"schedule">>
+            },
+            Opts
+        ),
+    ?event(debug_test, {dedup_test, {scheduler_res, SchedulerRes}}),
+    % Assert successful double schedule
+    ?assertEqual(
+        hb_private:reset(
+            hb_ao:get(<<"assignments/2/body/commitments">>, SchedulerRes)
+        ),
+        hb_private:reset(
+            hb_ao:get(<<"assignments/3/body/commitments">>, SchedulerRes)
+        )
+    ),
+    schedule_aos_call(Base, <<"return Number">>),
+    % Compute with dedup - initialize number to 1, then two increments,
+    % but the second increment should be skipped for dedup - expected result is 2
+    {ok, Result} = hb_ao:resolve(Base, #{ <<"path">> => <<"now">> }, Opts),
+    Results = hb_ao:get(<<"results">>, Result),
+    ?event(debug_test, {results, Results}),
+    ok.
 spawn_and_execute_slot_test_() ->
     { timeout, 900, fun spawn_and_execute_slot/0 }.
 spawn_and_execute_slot() ->
@@ -827,13 +913,13 @@ send_message_between_genesis_wasm_processes() ->
     {ok, _SchedInitReceiver} =
         hb_ao:resolve(
             MsgReceiver,
-        #{
-            <<"method">> => <<"POST">>,
-            <<"path">> => <<"schedule">>,
-            <<"body">> => MsgReceiver
-        },
-        Opts
-    ),
+            #{
+                <<"method">> => <<"POST">>,
+                <<"path">> => <<"schedule">>,
+                <<"body">> => MsgReceiver
+            },
+            Opts
+        ),
     schedule_aos_call(MsgReceiver, <<"Number = 10">>),
     schedule_aos_call(MsgReceiver, <<"
     Handlers.add('foo', function(msg)

--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -85,7 +85,14 @@ do_compute(State, Req, Opts) ->
                 {as, <<"dedup@1.0">>, Req},
                 Opts
             ),
-        ?event(debug_test, {do_compute, dedup_passed}),
+        ?event(dedup_short,
+            {continue,
+                {path, hb_maps:get(<<"path">>, Req, no_path, Opts)},
+                {assignment_slot, hb_maps:get(<<"slot">>, Req, no_slot, Opts)},
+                {state_slot, hb_maps:get(<<"at-slot">>, State, no_slot, Opts)},
+                {input, hb_ao:get(<<"body/data">>, Req, no_input, Opts)}
+            }
+        ),
         {ok, State3} ?=
             hb_ao:resolve(
                 State2,
@@ -102,6 +109,9 @@ do_compute(State, Req, Opts) ->
                 },
                 Opts
             ),
+        ?event(dedup_short,
+            {result, hb_ao:get(<<"results/data">>, State4, no_data, Opts)}
+        ),
         ?event(debug_test, {do_compute, patched_message}),
         {ok, State4}
     else
@@ -109,9 +119,31 @@ do_compute(State, Req, Opts) ->
             % Issue an event and return the error.
             ?event({genesis_wasm_compute_error, Error}),
             {error, Error};
+        {skip, DoubleSkip = #{ <<"skip">> := true }} ->
+            ?event(dedup_short,
+                {dedup_error,
+                    {cause, double_skip},
+                    {skip_request, DoubleSkip}
+                }
+            ),
+            {error, State};
         {skip, ExitState} ->
-            ?event(debug_test, {genesis_wasm_skipping_duplicate, Req}),
-            {skip, ExitState}
+            Req2 =
+                #{
+                    <<"path">> => hb_maps:get(<<"path">>, Req, <<"compute">>, Opts),
+                    <<"slot">> => hb_maps:get(<<"slot">>, Req, -1, Opts),
+                    <<"skip">> => true
+                },
+            ?event(dedup_short,
+                {skip,
+                    {cause, dedup},
+                    {action, run_no_op},
+                    {path, hb_maps:get(<<"path">>, Req, no_path, Opts)},
+                    {assignment_slot, hb_maps:get(<<"slot">>, Req, no_slot, Opts)},
+                    {state_slot, hb_maps:get(<<"at-slot">>, State, no_slot, Opts)}
+                }
+            ),
+            do_compute(ExitState, Req2, Opts)
     end.
 
 %% @doc Ensure the local `genesis-wasm@1.0' is live. If it not, start it.


### PR DESCRIPTION
As the name implies: The `dedup@1.0` device is now executed before `delegated-compute@1.0` in the `genesis-wasm@1.0` device. Additionally, we switch to using the `signed` specifier as the dedup ID source, rather than `all`.