### PR TITLE
feat: Add ed25519 support

### DIFF
--- a/src/ar_bundles.erl
+++ b/src/ar_bundles.erl
@@ -129,7 +129,7 @@ enforce_valid_tx(TX) ->
         {invalid_field, anchor, TX#tx.anchor}
     ),
     hb_util:ok_or_throw(TX,
-        hb_util:check_size(TX#tx.owner, [0, byte_size(?DEFAULT_OWNER)]),
+        hb_util:check_size(TX#tx.owner, [0, 32,  byte_size(?DEFAULT_OWNER)]),
         {invalid_field, owner, TX#tx.owner}
     ),
     hb_util:ok_or_throw(TX,
@@ -137,7 +137,7 @@ enforce_valid_tx(TX) ->
         {invalid_field, target, TX#tx.target}
     ),
     hb_util:ok_or_throw(TX,
-        hb_util:check_size(TX#tx.signature, [0, 65, byte_size(?DEFAULT_SIG)]),
+        hb_util:check_size(TX#tx.signature, [0, 64, 65, byte_size(?DEFAULT_SIG)]),
         {invalid_field, signature, TX#tx.signature}
     ),
     hb_util:ok_or_throw(TX,
@@ -184,14 +184,16 @@ data_item_signature_data(RawItem) ->
     ar_deep_hash:hash([
         utf8_encoded("dataitem"),
         utf8_encoded("1"),
-        %% Only SignatureType 1 is supported for now (RSA 4096)
-        utf8_encoded("1"),
+        utf8_encoded(get_signature_type(Item#tx.signature_type)),
         <<(Item#tx.owner)/binary>>,
         <<(Item#tx.target)/binary>>,
         <<(Item#tx.anchor)/binary>>,
         encode_tags(Item#tx.tags),
         <<(Item#tx.data)/binary>>
     ]).
+
+get_signature_type({rsa, 65537}) -> "1";
+get_signature_type({eddsa, ed25519}) -> "2".
 
 %% @doc Verify the data item's ID matches the signature.
 verify_data_item_id(DataItem) ->
@@ -316,6 +318,8 @@ to_serialized_pair(Item, false, Signed) ->
 %% little-endian format which is why we encode to `<<1, 0>>'.
 encode_signature_type({rsa, 65537}) ->
     <<1, 0>>;
+encode_signature_type({eddsa, ed25519}) ->
+    <<2, 0>>;
 encode_signature_type(_) ->
     unsupported_tx_format.
 
@@ -498,6 +502,8 @@ decode_bundle_header(Count, <<Size:256/little-integer, ID:32/binary, Rest/binary
 %% little-endian format which is why we match on `<<1, 0>>'.
 decode_signature(<<1, 0, Signature:512/binary, Owner:512/binary, Rest/binary>>) ->
     {{rsa, 65537}, Signature, Owner, Rest};
+decode_signature(<<2, 0, Signature:64/binary, Owner:32/binary, Rest/binary>>) ->
+    {{eddsa, ed25519}, Signature, Owner, Rest};
 decode_signature(Other) ->
     ?event({error_decoding_signature,
         {sig_type, {explicit, binary:part(Other, 0, 2)}},
@@ -749,6 +755,32 @@ bundle_map_test() ->
     ?assertEqual(Item1#tx.data, (maps:get(<<"key1">>, BundleItem#tx.data))#tx.data),
     ?assert(verify_item(BundleItem)).
 
+eddsa_cases_test() ->
+    Key = ar_wallet:new(?EDDSA_KEY_TYPE),
+    %% Owner and SignatureType defined during signing process.
+    Item1 = sign_item(#tx{
+        format = ans104,
+        target = crypto:strong_rand_bytes(32),
+        anchor = crypto:strong_rand_bytes(32),
+        tags = [{<<"tag1">>, <<"value1">>}, {<<"tag2">>, <<"value2">>}],
+        data = <<"item1_data">>
+    }, Key),
+    Bundle = serialize(dev_arweave_common:normalize(Item1)),
+    BundleItem = deserialize(Bundle),
+    %% Sign a valid transaction and verify it
+    ?assert(verify_item(BundleItem)),
+    %% Missing Anchor should fail
+    ?assertNot(verify_item(BundleItem#tx{anchor = <<>>})),
+    %% Missing Tags should fail
+    ?assertNot(verify_item(BundleItem#tx{tags = []})),
+    %% Missing Owner should fail
+    ?assertNot(verify_item(BundleItem#tx{owner = crypto:strong_rand_bytes(32)})),
+    %% Missing Target should fail
+    ?assertNot(verify_item(BundleItem#tx{target = <<>>})),
+    %% Missing Data should fail
+    ?assertNot(verify_item(BundleItem#tx{data = <<>>})),
+    ok.
+
 extremely_large_bundle_test() ->
     W = ar_wallet:new(),
     Data = crypto:strong_rand_bytes(100_000_000),
@@ -992,3 +1024,13 @@ generate_and_write_map_bundle_test_disabled() ->
     ?assert(verify_item(Deserialized)),
     ok = file:write_file(
         <<"test/arbundles.js/ans104-map-bundle-erlang.bundle">>, Serialized).
+
+deserialize_ed25519_transaction_test() ->
+    % ans104-item-ed25519.bin is dataitem 1rTy7gQuK9lJydlKqCEhtGLp2WWG-GOrVo5JdiCmaxs
+    {ok, Serialized} = file:read_file(<<"test/arbundles.js/ans104-item-ed25519.bin">>),
+    Deserialized = deserialize(Serialized),
+    ?assertEqual([{<<"Content-Type">>,<<"image/png">>}], Deserialized#tx.tags),
+    ?assertEqual(<<"ZbExyvGrJKOJTJcHMtKzoOZVCQBkjZ+5">>, Deserialized#tx.anchor),
+    ?assertEqual(<<"ejhYD9Cw9VCsVik6yGLoclo3CLRvAITHTZamLY_6ro4">>,
+        hb_util:human_id(ar_wallet:to_address(Deserialized#tx.owner, Deserialized#tx.signature_type))),
+    ?assert(verify_item(Deserialized)).

--- a/src/ar_bundles.erl
+++ b/src/ar_bundles.erl
@@ -87,7 +87,12 @@ new_item(Target, Anchor, Tags, Data) ->
 %% @doc Sign a data item.
 sign_item(_, undefined) -> throw(wallet_not_found);
 sign_item(RawItem, {PrivKey, {KeyType, Owner}}) ->
-    Item = (dev_arweave_common:normalize(RawItem))#tx{format = ans104, owner = Owner, signature_type = KeyType},
+    Item =
+        (dev_arweave_common:normalize(RawItem))#tx{
+            format = ans104,
+            owner = Owner,
+            signature_type = KeyType
+        },
     % Generate the signature from the data item's data segment in 'signed'-ready mode.
     Sig = ar_wallet:sign(PrivKey, data_item_signature_data(Item)),
     dev_arweave_common:reset_ids(Item#tx{signature = Sig}).

--- a/src/ar_wallet.erl
+++ b/src/ar_wallet.erl
@@ -16,7 +16,7 @@
 
 new() ->
     new({rsa, 65537}).
-new(KeyType = {rsa, 65537}) ->
+new(KeyType) when KeyType =:= {rsa, 65537} orelse KeyType =:= {eddsa, ed25519} ->
     case request_pooled_wallet(KeyType) of
         {ok, Wallet} -> Wallet;
         timeout -> generate_wallet(KeyType)
@@ -25,6 +25,9 @@ new(KeyType = {rsa, 65537}) ->
 generate_wallet(KeyType = {KeyAlg, PublicExpnt}) when KeyType =:= {rsa, 65537} ->
     {[_, Pub], [_, Pub, Priv|_]} = {[_, Pub], [_, Pub, Priv|_]}
         = crypto:generate_key(KeyAlg, {4096, PublicExpnt}),
+    {{KeyType, Priv, Pub}, {KeyType, Pub}};
+generate_wallet(KeyType = {KeyAlg, Curve}) when KeyType =:= {?EDDSA_SIGN_ALG, ed25519} ->
+    {Pub, Priv} = crypto:generate_key(KeyAlg, Curve),
     {{KeyType, Priv, Pub}, {KeyType, Pub}}.
 
 request_pooled_wallet(KeyType) ->
@@ -83,7 +86,6 @@ maybe_spawn_wallet_workers(KeyType, Wallets, Waiters, InFlight) ->
     ),
     {Wallets, InFlight + Needed}.
 
-
 %% @doc Sign some data with a private key.
 sign(Key, Data) ->
     sign(Key, Data, sha256).
@@ -100,6 +102,8 @@ sign({{rsa, PublicExpnt}, Priv, Pub}, Data, DigestType) when PublicExpnt =:= 655
             privateExponent = binary:decode_unsigned(Priv)
         }
     );
+sign({KeyType = {KeyAlg, Curve}, Priv, _Pub}, Data, _DigestType) when KeyType =:= {?EDDSA_SIGN_ALG, ed25519} ->
+    crypto:sign(KeyAlg, none, Data, [Priv, Curve]);
 sign({{KeyType, Priv, Pub}, {KeyType, Pub}}, Data, DigestType) ->
     sign({KeyType, Priv, Pub}, Data, DigestType).
 
@@ -121,7 +125,11 @@ verify({{rsa, PublicExpnt}, Pub}, Data, Sig, DigestType) when PublicExpnt =:= 65
             publicExponent = PublicExpnt,
             modulus = binary:decode_unsigned(Pub)
         }
-    ).
+    );
+verify({{eddsa, Curve}, Pub}, Data, Sig, _DigestType) when
+      byte_size(Pub) == 32 andalso byte_size(Sig) == 64 andalso Curve =:= ed25519 ->
+    crypto:verify(eddsa, none, Data, Sig, [Pub, Curve]).
+
 
 %% @doc Find a public key from a wallet.
 to_pubkey(Pubkey) ->
@@ -145,7 +153,9 @@ to_address({{_, _, PubKey}, {_, PubKey}}, _) ->
 to_address(PubKey, {rsa, 65537}) ->
     to_rsa_address(PubKey);
 to_address(PubKey, {ecdsa, 256}) ->
-	to_ecdsa_address(PubKey).
+    to_ecdsa_address(PubKey);
+to_address(PubKey, {eddsa, ed25519}) ->
+    to_eddsa_address(PubKey).
 
 %% @doc Generate a new wallet public and private key, with a corresponding keyfile.
 %% The provided key is used as part of the file name.
@@ -293,6 +303,9 @@ hash_address(PubKey) ->
 
 to_ecdsa_address(PubKey) ->
 	hb_keccak:key_to_ethereum_address(PubKey).
+
+to_eddsa_address(PubKey) ->
+    hash_address(PubKey).
 
 %%%===================================================================
 %%% Private functions.

--- a/src/dev_codec_ans104.erl
+++ b/src/dev_codec_ans104.erl
@@ -36,16 +36,15 @@ commit(Msg, Req = #{ <<"type">> := Type }, Opts) when Type =:= <<"rsa-pss-sha256
     % Convert the given message to an ANS-104 TX record, sign it, and convert
     % it back to a structured message.
     {ok, TX} = to(hb_private:reset(Msg), Req, Opts),
-    Wallet = hb_opts:get(priv_wallet, no_viable_wallet, Opts),
-    Signed = ar_bundles:sign_item(TX, Wallet),
-    SignedStructured =
-        hb_message:convert(
-            Signed,
-            <<"structured@1.0">>,
-            <<"ans104@1.0">>,
-            Opts
-        ),
-    {ok, SignedStructured};
+    case {hb_opts:get(priv_wallet, no_viable_wallet, Opts), Type} of
+        {{{?RSA_KEY_TYPE, _Priv, _Pub}, _} = Wallet, <<"rsa-pss-sha256">>} ->
+            sign_tx(TX, Wallet, Opts);
+        {{{?EDDSA_KEY_TYPE, _Priv, _Pub}, _} = Wallet, <<"ed25519-sha512">>} ->
+            sign_tx(TX, Wallet, Opts);
+        {{{WalletType, _, _}, _}, _Type} ->
+            ?event(warning, {wrong_wallet_to_sign, {request_type, Type}, {wallet_type, WalletType}}),
+            throw(wrong_wallet_to_sign)
+    end;
 commit(Msg, #{ <<"type">> := <<"unsigned-sha256">> }, Opts) ->
     % Remove the commitments from the message, convert it to ANS-104, then back.
     % This forces the message to be normalized and the unsigned ID to be
@@ -59,6 +58,17 @@ commit(Msg, #{ <<"type">> := <<"unsigned-sha256">> }, Opts) ->
             Opts
         )
     }.
+
+sign_tx(TX, Wallet, Opts) ->
+    Signed = ar_bundles:sign_item(TX, Wallet),
+    SignedStructured =
+        hb_message:convert(
+            Signed,
+            <<"structured@1.0">>,
+            <<"ans104@1.0">>,
+            Opts
+        ),
+    {ok, SignedStructured}.
 
 %% @doc Verify an ANS-104 commitment.
 verify(Msg, Req, Opts) ->

--- a/src/dev_codec_ans104.erl
+++ b/src/dev_codec_ans104.erl
@@ -32,7 +32,7 @@ commit(Msg, Req = #{ <<"type">> := <<"unsigned">> }, Opts) ->
     commit(Msg, Req#{ <<"type">> => <<"unsigned-sha256">> }, Opts);
 commit(Msg, Req = #{ <<"type">> := <<"signed">> }, Opts) ->
     commit(Msg, Req#{ <<"type">> => <<"rsa-pss-sha256">> }, Opts);
-commit(Msg, Req = #{ <<"type">> := <<"rsa-pss-sha256">> }, Opts) ->
+commit(Msg, Req = #{ <<"type">> := Type }, Opts) when Type =:= <<"rsa-pss-sha256">> orelse Type =:= <<"ed25519-sha512">> ->
     % Convert the given message to an ANS-104 TX record, sign it, and convert
     % it back to a structured message.
     {ok, TX} = to(hb_private:reset(Msg), Req, Opts),

--- a/src/dev_codec_ans104_from.erl
+++ b/src/dev_codec_ans104_from.erl
@@ -203,13 +203,17 @@ with_unsigned_commitment(
 with_signed_commitment(
         Item, Device, FieldCommitments, Tags, 
         UncommittedMessage, CommittedKeys, Opts) ->
-    Address = hb_util:human_id(ar_wallet:to_address(Item#tx.owner)),
+    Address = hb_util:human_id(ar_wallet:to_address(Item#tx.owner, Item#tx.signature_type)),
     ID = hb_util:human_id(Item#tx.id),
     ExtraCommitments = hb_maps:merge(
         FieldCommitments,
         hb_maps:with(?BUNDLE_KEYS, Tags),
         Opts
     ),
+    Type = case Item#tx.signature_type of
+        ?RSA_KEY_TYPE -> <<"rsa-pss-sha256">>;
+        ?EDDSA_KEY_TYPE -> <<"ed25519">>
+    end,
     Commitment =
         filter_unset(
             hb_maps:merge(
@@ -221,7 +225,7 @@ with_signed_commitment(
                     <<"signature">> => hb_util:encode(Item#tx.signature),
                     <<"keyid">> =>
                         <<"publickey:", (hb_util:encode(Item#tx.owner))/binary>>,
-                    <<"type">> => <<"rsa-pss-sha256">>,
+                    <<"type">> => Type,
                     <<"bundle">> => bundle_commitment_key(Tags, Opts),
                     <<"original-tags">> => original_tags(Item, Opts)
                 },

--- a/src/dev_codec_ans104_from.erl
+++ b/src/dev_codec_ans104_from.erl
@@ -212,7 +212,7 @@ with_signed_commitment(
     ),
     Type = case Item#tx.signature_type of
         ?RSA_KEY_TYPE -> <<"rsa-pss-sha256">>;
-        ?EDDSA_KEY_TYPE -> <<"ed25519">>
+        ?EDDSA_KEY_TYPE -> <<"ed25519-sha512">>
     end,
     Commitment =
         filter_unset(

--- a/src/dev_codec_ans104_to.erl
+++ b/src/dev_codec_ans104_to.erl
@@ -105,6 +105,7 @@ commitment_to_tx(Commitment, FieldsFun, Opts) ->
         case maps:get(<<"type">>, Commitment) of
             <<"rsa-pss-sha256">> -> {rsa, 65537};
             <<"ed25519-sha512">> -> {eddsa, ed25519};
+            <<"unsigned-sha256">> -> {rsa, 65537};
             Type ->
                 ?event(error, {signature_type, {type, Type}}),
                 throw({invalid_signature_type, Type})

--- a/src/dev_codec_ans104_to.erl
+++ b/src/dev_codec_ans104_to.erl
@@ -101,6 +101,14 @@ commitment_to_tx(Commitment, FieldsFun, Opts) ->
                 );
             error -> ?DEFAULT_OWNER
         end,
+    SignatureType =
+        case maps:get(<<"type">>, Commitment) of
+            <<"rsa-pss-sha256">> -> {rsa, 65537};
+            <<"ed25519-sha512">> -> {eddsa, ed25519};
+            Type ->
+                ?event(error, {signature_type, {type, Type}}),
+                throw({invalid_signature_type, Type})
+        end,
     Tags =
         case hb_maps:find(<<"original-tags">>, Commitment, Opts) of
             {ok, OriginalTags} -> original_tags_to_tags(OriginalTags);
@@ -108,10 +116,12 @@ commitment_to_tx(Commitment, FieldsFun, Opts) ->
         end,
     ?event({commitment_owner, Owner}),
     ?event({commitment_signature, Signature}),
+    ?event({commitment_type, SignatureType}),
     ?event({commitment_tags, Tags}),
     TX = #tx{
         owner = Owner,
         signature = Signature,
+        signature_type = SignatureType,
         tags = Tags
     },
     FieldsFun(TX, ?FIELD_PREFIX, Commitment, Opts).

--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -949,9 +949,16 @@ set_ignore_undefined_test() ->
 	?assertEqual(#{ <<"test-key">> => <<"Value1">> },
 		hb_private:reset(hb_util:ok(set(Base, Req, #{ hashpath => ignore })))).
 
-verify_test() ->
+verify_test_() ->
+	{foreach, fun () -> ok end, fun (_) -> ok end, [
+		{"RSA", fun () -> test_verify(?RSA_KEY_TYPE) end},
+		{"EDSSA", fun () -> test_verify(?EDDSA_KEY_TYPE) end}
+	]}.
+
+test_verify(KeyType) ->
     Unsigned = #{ <<"a">> => <<"b">> },
-    Signed = hb_message:commit(Unsigned, #{ priv_wallet => hb:wallet() }),
+    Wallet = ar_wallet:new(KeyType),
+    Signed = hb_message:commit(Unsigned, #{ priv_wallet => Wallet }),
     ?event({signed, Signed}),
     BadSigned = Signed#{ <<"a">> => <<"c">> },
     ?event({bad_signed, BadSigned}),

--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -257,6 +257,7 @@ result_to_message(ExpectedID, Item, Opts) ->
         ),
 	SignatureType =
         case byte_size(Signature) of
+            64 -> {eddsa, ed25519};
             65 -> {ecdsa, 256};
             512 -> {rsa, 65537};
             _ -> unsupported_tx_signature_type
@@ -424,10 +425,43 @@ l1_transaction_test() ->
 %% @doc Test l2 message from graphql
 l2_dataitem_test() ->
     _Node = hb_http_server:start_node(#{}),
-    {ok, Res} = read(<<"oyo3_hCczcU7uYhfByFZ3h0ELfeMMzNacT-KpRoJK6g">>, #{}),
+    {ok, Res} = read(ID = <<"oyo3_hCczcU7uYhfByFZ3h0ELfeMMzNacT-KpRoJK6g">>, #{}),
     ?event(gateway, {l2_dataitem, Res}),
+    Opts = #{},
+    CommitmentType = hb_util:deep_get(
+        [<<"commitments">>, ID, <<"type">>],
+        Res,
+        not_found,
+        Opts
+    ),
+    ?assertEqual(<<"rsa-pss-sha256">>, CommitmentType),
     Data = maps:get(<<"data">>, Res),
     ?assertEqual(<<"Hello World">>, Data).
+
+%% @doc ed25519 L2 Transaction test
+l2_dataitem_ed25519_test() ->
+    _Node = hb_http_server:start_node(#{}),
+    ID = <<"AwrAs-HaBlc8xeI8sw6Wpbi7A0weQWeXYwW20CpX5oM">>,
+    {ok, Res} = read(ID, #{}),
+    ?event(gateway, {l2_dataitem, Res}),
+    Opts = #{},
+    CommitmentType = hb_util:deep_get(
+        [<<"commitments">>, ID, <<"type">>],
+        Res,
+        not_found,
+        Opts
+    ),
+    ?assertEqual(<<"ed25519">>, CommitmentType),
+    CommitmentCommitter = hb_util:deep_get(
+        [<<"commitments">>, ID, <<"committer">>],
+        Res,
+        not_found,
+        Opts
+    ),
+    ?assertEqual(<<"ejhYD9Cw9VCsVik6yGLoclo3CLRvAITHTZamLY_6ro4">>, CommitmentCommitter),
+    %% Check Data
+    Data = maps:get(<<"data">>, Res),
+    ?assertEqual(<<"{\"displayName\":\"Test Hub\",\"description\":\"This is a test hub created in the test suite\",\"externalurl\":\"\",\"image\":\"\"}">>, Data).
 
 %% @doc Test optimistic index
 ao_dataitem_test() ->

--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -451,7 +451,7 @@ l2_dataitem_ed25519_test() ->
         not_found,
         Opts
     ),
-    ?assertEqual(<<"ed25519">>, CommitmentType),
+    ?assertEqual(<<"ed25519-sha512">>, CommitmentType),
     CommitmentCommitter = hb_util:deep_get(
         [<<"commitments">>, ID, <<"committer">>],
         Res,

--- a/src/hb_message_test_vectors.erl
+++ b/src/hb_message_test_vectors.erl
@@ -23,7 +23,11 @@ test_codecs() ->
         #{ <<"device">> => <<"httpsig@1.0">>, <<"bundle">> => true },
         <<"flat@1.0">>,
         <<"ans104@1.0">>,
-        #{<<"device">> => <<"ans104@1.0">>, <<"type">> => <<"ed25519-sha512">>},
+        #{
+            <<"device">> => <<"ans104@1.0">>,
+            <<"type">> => <<"ed25519-sha512">>,
+            <<"with-opts">> => [ed25519]
+        },
         #{ <<"device">> => <<"ans104@1.0">>, <<"bundle">> => true },
         <<"json@1.0">>,
         #{ <<"device">> => <<"json@1.0">>, <<"bundle">> => true },
@@ -41,6 +45,11 @@ suite_test_opts() ->
             parallel => true,
             desc => <<"Default opts">>,
             opts => test_opts(normal)
+        },
+        #{
+            name => ed25519,
+            desc => <<"ED25519 opts">>,
+            opts => test_opts(ed25519)
         }
     ].
 suite_test_opts(OptsName) ->
@@ -50,6 +59,11 @@ test_opts(normal) ->
     #{
         store => hb_test_utils:test_store(),
         priv_wallet => hb:wallet()
+    };
+test_opts(ed25519) ->
+    #{
+        store => hb_test_utils:test_store(),
+        priv_wallet => ar_wallet:new({eddsa, ed25519})
     }.
  
 test_suite() ->
@@ -184,19 +198,31 @@ suite_test_() ->
 %% are completely isolated from each other.
 codec_test_suite(Codecs, OptsType) ->
     lists:flatmap(
-        fun(CodecName) ->
-            lists:map(fun({Desc, Test}) ->
-                TestName =
-                    binary_to_list(
-                        << (suite_name(CodecName))/binary, ": ", Desc/binary >>
-                    ),
-                TestSpecificOpts = test_opts(OptsType),
-                {
-                    Desc,
-                    TestName,
-                    fun(_SuiteOpts) -> Test(CodecName, TestSpecificOpts) end
-                }
-            end, test_suite())
+        fun(CodecSpec) ->
+            lists:filtermap(
+                fun({Desc, Test}) ->
+                    TestName =
+                        binary_to_list(
+                            << (suite_name(CodecSpec))/binary, ": ", Desc/binary >>
+                        ),
+                    TestSpecificOpts = test_opts(OptsType),
+                    case is_relevant_opts(CodecSpec, OptsType) of
+                        false -> false;
+                        true ->
+                            {
+                                true,
+                                {
+                                    Desc,
+                                    TestName,
+                                    fun(_SuiteOpts) ->
+                                        Test(CodecSpec, TestSpecificOpts)
+                                    end
+                                }
+                            }
+                    end
+                end,
+                test_suite()
+            )
         end,
         Codecs
     ).
@@ -210,6 +236,14 @@ suite_name(CodecSpec) when is_map(CodecSpec) ->
         true -> << CodecName/binary, " (bundle)">>
     end.
 
+%% @doc Determine if the given codec setup is relevant, given the `OptsType'
+%% specified.
+is_relevant_opts(#{ <<"with-opts">> := RelevantOpts }, OptsType) ->
+    lists:member(OptsType, RelevantOpts);
+is_relevant_opts(_Codec, _OptsType) -> true.
+
+%% @doc Determine if a CodecSpec (either binary, map, or list thereof) matches
+%% a given codec device name binary.
 is_device_codec(Devices, Codec) when is_list(Devices) ->
     lists:any(fun(Device) -> is_device_codec(Device, Codec) end, Devices);
 is_device_codec(Device, Codec) when Device == Codec ->

--- a/src/hb_message_test_vectors.erl
+++ b/src/hb_message_test_vectors.erl
@@ -23,6 +23,7 @@ test_codecs() ->
         #{ <<"device">> => <<"httpsig@1.0">>, <<"bundle">> => true },
         <<"flat@1.0">>,
         <<"ans104@1.0">>,
+        #{<<"device">> => <<"ans104@1.0">>, <<"type">> => <<"ed25519-sha512">>},
         #{ <<"device">> => <<"ans104@1.0">>, <<"bundle">> => true },
         <<"json@1.0">>,
         #{ <<"device">> => <<"json@1.0">>, <<"bundle">> => true },

--- a/src/hb_message_test_vectors.erl
+++ b/src/hb_message_test_vectors.erl
@@ -1684,3 +1684,25 @@ bundled_ordering_test(Codec = #{ <<"bundle">> := true }, Opts) ->
     ?assert(hb_message:verify(Decoded, all, Opts));
 bundled_ordering_test(_Codec, _Opts) ->
     skip.
+
+rsa_wallet_not_match_message_ed25519_type_test() ->
+    Opts = #{priv_wallet => ar_wallet:new(?RSA_KEY_TYPE)},
+    SignatureType = <<"ed25519-sha512">>,
+    Msg = #{<<"a">> => <<"b">>},
+    ?assertThrow(wrong_wallet_to_sign,
+        hb_message:commit(
+            Msg,
+            Opts,
+            #{<<"commitment-device">> => <<"ans104@1.0">>, <<"type">> => SignatureType}
+        )).
+
+ed25519_wallet_not_match_message_rsa_type_test() ->
+    Opts = #{priv_wallet => ar_wallet:new(?EDDSA_KEY_TYPE)},
+    SignatureType = <<"rsa-pss-sha256">>,
+    Msg = #{<<"a">> => <<"b">>},
+    ?assertThrow(wrong_wallet_to_sign,
+        hb_message:commit(
+            Msg,
+            Opts,
+            #{<<"commitment-device">> => <<"ans104@1.0">>, <<"type">> => SignatureType}
+        )).

--- a/src/include/ar.hrl
+++ b/src/include/ar.hrl
@@ -97,10 +97,11 @@
 
 -define(ECDSA_SIGN_ALG, ecdsa).
 -define(ECDSA_TYPE_BYTE, <<2>>).
+-define(ECDSA_KEY_TYPE, {?ECDSA_SIGN_ALG, secp256k1}).
 
 -define(EDDSA_SIGN_ALG, eddsa).
 -define(EDDSA_TYPE_BYTE, <<3>>).
--define(ECDSA_KEY_TYPE, {?ECDSA_SIGN_ALG, secp256k1}).
+-define(EDDSA_KEY_TYPE, {?EDDSA_SIGN_ALG, ed25519}).
 
 %% The default key type used by transactions that do not specify a signature type.
 -define(DEFAULT_KEY_TYPE, ?RSA_KEY_TYPE).


### PR DESCRIPTION
Add support for ed25519 signing algorithm on:
- `ar_wallet` (create, sign, and verify).
- `ar_bundles` (L2 transactions).

## Notes
Some transactions that use `ed25519` might not be verified, because the GraphQL endpoint doesn't provide the anchor information required for validation. Eg: `1rTy7gQuK9lJydlKqCEhtGLp2WWG-GOrVo5JdiCmaxs`