### PR TITLE
feat: `~manifest@1.0` redirects and performance improvements

### DIFF
--- a/src/dev_manifest.erl
+++ b/src/dev_manifest.erl
@@ -1,7 +1,7 @@
 %%% @doc An Arweave path manifest resolution device. Follows the v1 schema:
 %%% https://specs.ar.io/?tx=lXLd0OPwo-dJLB_Amz5jgIeDhiOkjXuM3-r0H_aiNj0
 -module(dev_manifest).
--export([index/3, info/0, manifest/3]).
+-export([index/3, info/0]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -67,7 +67,8 @@ route(Key, M1, M2, Opts) ->
     ),
     {ok, Res}.
 
-%% @doc Find and deserialize a manifest from the given base.
+%% @doc Find and deserialize a manifest from the given base, returning a 
+%% message with the `~manifest@1.0' device.
 manifest(Base, _Req, Opts) ->
     JSON =
         hb_ao:get_first(
@@ -77,15 +78,11 @@ manifest(Base, _Req, Opts) ->
             ],
             Opts
         ),
-    ?event({manifest_json, JSON}),
     FlatManifest = #{ <<"paths">> := FlatPaths } = hb_json:decode(JSON),
-    ?event(debug_manifest, {manifest_dejsonified, {explicit, FlatManifest}}),
     {ok, DeepPaths} = dev_codec_flat:from(FlatPaths, #{}, Opts),
     LinkifiedPaths = linkify(DeepPaths, Opts),
-    ?event(debug_manifest, {manifest_linkified_paths, {explicit, LinkifiedPaths}}),
     Structured = FlatManifest#{ <<"paths">> => LinkifiedPaths },
-    ?event(debug_manifest, {manifest_structured, {explicit, Structured}}),
-    {ok, Structured}.
+    {ok, Structured#{ <<"device">> => <<"manifest@1.0">> }}.
 
 %% @doc Generate a nested message of links to content from a parsed (and
 %% structured) manifest.

--- a/src/dev_manifest.erl
+++ b/src/dev_manifest.erl
@@ -54,6 +54,9 @@ route(<<"index">>, M1, M2, Opts) ->
             ?event(manifest_not_parsed),
             {error, not_found}
     end;
+route(ID, _, _, Opts) when ?IS_ID(ID) ->
+    ?event({manifest_reading_id, ID}),
+    hb_cache:read(ID, Opts);
 route(Key, M1, M2, Opts) ->
     ?event({manifest_lookup, Key}),
     {ok, Manifest} = manifest(M1, M2, Opts),

--- a/src/dev_manifest.erl
+++ b/src/dev_manifest.erl
@@ -1,7 +1,7 @@
 %%% @doc An Arweave path manifest resolution device. Follows the v1 schema:
 %%% https://specs.ar.io/?tx=lXLd0OPwo-dJLB_Amz5jgIeDhiOkjXuM3-r0H_aiNj0
 -module(dev_manifest).
--export([index/3, info/0]).
+-export([index/3, info/0, manifest/3]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -58,14 +58,14 @@ route(ID, _, _, Opts) when ?IS_ID(ID) ->
     ?event({manifest_reading_id, ID}),
     hb_cache:read(ID, Opts);
 route(Key, M1, M2, Opts) ->
-    ?event({manifest_lookup, Key}),
+    ?event(debug_manifest, {manifest_lookup, Key}),
     {ok, Manifest} = manifest(M1, M2, Opts),
     Res = hb_ao:get(
         <<"paths/", Key/binary>>,
         {as, <<"message@1.0">>, Manifest},
         Opts
     ),
-    {ok, hb_cache:ensure_all_loaded(Res, Opts)}.
+    {ok, Res}.
 
 %% @doc Find and deserialize a manifest from the given base.
 manifest(Base, _Req, Opts) ->
@@ -78,15 +78,14 @@ manifest(Base, _Req, Opts) ->
             Opts
         ),
     ?event({manifest_json, JSON}),
-    Structured = 
-        hb_cache:ensure_all_loaded(
-            hb_message:convert(JSON, <<"structured@1.0">>, <<"json@1.0">>, Opts),
-            Opts
-        ),
-    ?event({manifest_structured, {explicit, Structured}}),
-    Linkified = linkify(Structured, Opts),
-    ?event({manifest_linkified, {explicit, Linkified}}),
-    {ok, Linkified}.
+    FlatManifest = #{ <<"paths">> := FlatPaths } = hb_json:decode(JSON),
+    ?event(debug_manifest, {manifest_dejsonified, {explicit, FlatManifest}}),
+    {ok, DeepPaths} = dev_codec_flat:from(FlatPaths, #{}, Opts),
+    LinkifiedPaths = linkify(DeepPaths, Opts),
+    ?event(debug_manifest, {manifest_linkified_paths, {explicit, LinkifiedPaths}}),
+    Structured = FlatManifest#{ <<"paths">> => LinkifiedPaths },
+    ?event(debug_manifest, {manifest_structured, {explicit, Structured}}),
+    {ok, Structured}.
 
 %% @doc Generate a nested message of links to content from a parsed (and
 %% structured) manifest.

--- a/src/dev_manifest.erl
+++ b/src/dev_manifest.erl
@@ -15,7 +15,7 @@ info() ->
 
 %% @doc Return the fallback index page when the manifest itself is requested.
 index(M1, M2, Opts) ->
-    ?event({manifest_index_request, M1, M2}),
+    ?event(debug_manifest, {index_request, {m1, M1}, {m2, M2}}),
     case route(<<"index">>, M1, M2, Opts) of
         {ok, Index} ->
             ?event({manifest_index_returned, Index}),
@@ -28,20 +28,24 @@ index(M1, M2, Opts) ->
 route(<<"index">>, M1, M2, Opts) ->
     ?event({manifest_index, M1, M2}),
     case manifest(M1, M2, Opts) of
-        {ok, JSONStruct} ->
-            ?event({manifest_json_struct, JSONStruct}),
+        {ok, Manifest} ->
             % Get the path to the index page from the manifest. We make
             % sure to use `hb_maps:get/4' to ensure that we do not recurse
             % on the `index' key with an `ao' resolve.
             Index =
                 hb_maps:get(
                     <<"index">>,
-                    JSONStruct,
+                    Manifest,
                     #{},
                     Opts
                 ),
-            ?event({manifest_index_found, Index}),
-            Path = hb_maps:get(<<"path">>, Index, Opts),
+            ?event(debug_manifest,
+                {manifest_index_found,
+                    {index, Index},
+                    {manifest, Manifest}
+                }
+            ),
+            Path = hb_maps:get(<<"path">>, Index, not_found, Opts),
             case Path of
                 not_found ->
                     ?event({manifest_path_not_found, <<"index/path">>}),
@@ -58,7 +62,7 @@ route(ID, _, _, Opts) when ?IS_ID(ID) ->
     ?event({manifest_reading_id, ID}),
     hb_cache:read(ID, Opts);
 route(Key, M1, M2, Opts) ->
-    ?event(debug_manifest, {manifest_lookup, Key}),
+    ?event(debug_manifest, {manifest_lookup, {key, Key}, {m1, M1}, {m2, M2}}),
     {ok, Manifest} = manifest(M1, M2, Opts),
     Res = hb_ao:get(
         <<"paths/", Key/binary>>,
@@ -124,7 +128,7 @@ resolve_test() ->
         },
         <<"index">> => #{ <<"path">> => <<"page1">> }
     },
-    JSON = hb_message:convert(Manifest, <<"json@1.0">>, <<"structured@1.0">>, Opts),
+    JSON = hb_json:encode(Manifest),
     ManifestMsg =
         #{
             <<"device">> => <<"manifest@1.0">>,

--- a/src/hb_ao.erl
+++ b/src/hb_ao.erl
@@ -876,6 +876,10 @@ maybe_force_message({Status, Res}, Opts) ->
 maybe_force_message(Res, Opts) ->
     maybe_force_message({ok, Res}, Opts).
 
+%% @doc Force a resolution result into a message, suitable for transmission
+%% via HTTP.
+force_message({Status, ResLink}, Opts) when ?IS_LINK(ResLink) ->
+    force_message({Status, hb_cache:ensure_loaded(ResLink, Opts)}, Opts);
 force_message({Status, Res}, Opts) when is_list(Res) ->
     force_message({Status, normalize_keys(Res, Opts)}, Opts);
 force_message({Status, Subres = {resolve, _}}, _Opts) ->

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -467,12 +467,12 @@ reply(Req, TABMReq, Message, Opts) ->
     reply(Req, TABMReq, Status, Message, Opts).
 reply(Req, TABMReq, BinStatus, RawMessage, Opts) when is_binary(BinStatus) ->
     reply(Req, TABMReq, binary_to_integer(BinStatus), RawMessage, Opts);
-reply(InitReq, TABMReq, Status, RawMessage, Opts) ->
+reply(InitReq, TABMReq, RawStatus, RawMessage, Opts) ->
     KeyNormMessage = hb_ao:normalize_keys(RawMessage, Opts),
     {ok, Req, Message} = reply_handle_cookies(InitReq, KeyNormMessage, Opts),
-    {ok, HeadersBeforeCors, EncodedBody} =
+    {Status, HeadersBeforeCors, EncodedBody} =
         encode_reply(
-            Status,
+            RawStatus,
             TABMReq,
             Message,
             Opts
@@ -618,7 +618,7 @@ encode_reply(Status, TABMReq, Message, Opts) ->
             ),
             {ok, ErrMsg} =
                 dev_hyperbuddy:return_error(Message, Opts),
-            {ok,
+            {Status,
                 maps:without([<<"body">>], ErrMsg),
                 maps:get(<<"body">>, ErrMsg, <<>>)
             };
@@ -628,7 +628,7 @@ encode_reply(Status, TABMReq, Message, Opts) ->
                     <<"hyperbuddy@1.0">>,
                     <<"404.html">>
                 ),
-            {ok,
+            {Status,
                 maps:without([<<"body">>], ErrMsg),
                 maps:get(<<"body">>, ErrMsg, <<>>)
             };
@@ -659,7 +659,7 @@ encode_reply(Status, TABMReq, Message, Opts) ->
                     Opts
                 ),
             {
-                ok,
+                Status,
                 hb_maps:without([<<"body">>], EncMessage, Opts),
                 hb_maps:get(<<"body">>, EncMessage, <<>>, Opts)
             };
@@ -667,7 +667,7 @@ encode_reply(Status, TABMReq, Message, Opts) ->
             % The `ans104@1.0' codec is a binary format, so we must serialize
             % the message to a binary before sending it.
             {
-                ok,
+                Status,
                 BaseHdrs,
                 ar_bundles:serialize(
                     hb_message:convert(
@@ -693,6 +693,20 @@ encode_reply(Status, TABMReq, Message, Opts) ->
                     )
                 )
             };
+        {_, <<"manifest@1.0">>, _} ->
+            {ok, CachedID} = hb_cache:write(Message, Opts),
+            {
+                307,
+                #{
+                    <<"location">> =>
+                        <<
+                            "/",
+                            CachedID/binary,
+                            "~manifest@1.0/index"
+                        >>
+                },
+                <<"Manifesting your data...">>
+            };
         _ ->
             % Other codecs are already in binary format, so we can just convert
             % the message to the codec. We also include all of the top-level 
@@ -715,7 +729,8 @@ encode_reply(Status, TABMReq, Message, Opts) ->
                     fun(_K, V) -> hb_util:bin(V) end,
                     ExtraHdrs
                 ),
-            {ok,
+            {
+                Status,
                 hb_maps:merge(EncodedExtraHdrs, BaseHdrs, Opts),
                 hb_message:convert(
                     Message,
@@ -741,7 +756,19 @@ accept_to_codec(OriginalReq, Opts) ->
     accept_to_codec(OriginalReq, undefined, Opts).
 accept_to_codec(#{ <<"require-codec">> := RequiredCodec }, _Reply, Opts) ->
     mime_to_codec(RequiredCodec, Opts);
-accept_to_codec(_OriginalReq, #{ <<"content-type">> := _ }, _Opts) ->
+accept_to_codec(OriginalReq, Reply = #{ <<"content-type">> := Link }, Opts) when ?IS_LINK(Link) ->
+    accept_to_codec(
+        OriginalReq,
+        Reply#{ <<"content-type">> => hb_cache:ensure_loaded(Link, Opts) },
+        Opts
+    );
+accept_to_codec(
+        _,
+        #{ <<"content-type">> := <<"application/x.arweave-manifest", _/binary>> },
+        _Opts
+    ) ->
+    <<"manifest@1.0">>;
+accept_to_codec(_OriginalReq, #{ <<"content-type">> := CT }, _Opts) ->
     <<"httpsig@1.0">>;
 accept_to_codec(OriginalReq, _, Opts) ->
     Accept = hb_maps:get(<<"accept">>, OriginalReq, <<"*/*">>, Opts),


### PR DESCRIPTION
Introduces handling of `application/x.arweave-manifest*` content-types to the HTTP subsystem of HyperBEAM. In the event that HB attempts to return a message with the manifest type, the result is now written to the cache and a redirect to the root of the manifest is returned. Consequently, attempting to access a manifest on `GET /ID` in a browser results in the multi-component page being rendered as expected on a gateway.

In addition:
- a small bug in `hb_ao:force_message` has been fixed, ensuring that linkified results are correctly handled.
- manifest loading has been made significantly more efficient by removing unnecessary resource loads during parsing.