### PR TITLE
feat: Fallback to manifest index on file not found in dev_manifest

### DIFF
--- a/src/dev_manifest.erl
+++ b/src/dev_manifest.erl
@@ -74,7 +74,7 @@ route(Key, M1, M2, Opts) ->
             %% Support materialized view in some JavaScript frameworks
             case hb_opts:get(manifest_404, fallback, Opts) of
                 error ->
-                    not_found;
+                    {error, not_found};
                 fallback ->
                     ?event({manifest_fallback, {key, Key}}),
                     route(<<"index">>, M1, M2, Opts)

--- a/src/dev_manifest.erl
+++ b/src/dev_manifest.erl
@@ -69,7 +69,19 @@ route(Key, M1, M2, Opts) ->
         {as, <<"message@1.0">>, Manifest},
         Opts
     ),
-    {ok, Res}.
+    case Res of
+        not_found ->
+            %% Support materialized view in some JavaScript frameworks
+            case hb_opts:get(manifest_404, fallback, Opts) of
+                error ->
+                    not_found;
+                fallback ->
+                    ?event({manifest_fallback, {key, Key}}),
+                    route(<<"index">>, M1, M2, Opts)
+            end;
+        _ ->
+            {ok, Res}
+    end.
 
 %% @doc Find and deserialize a manifest from the given base, returning a 
 %% message with the `~manifest@1.0' device.
@@ -145,3 +157,48 @@ resolve_test() ->
         {ok, #{ <<"body">> := <<"Page 2">>}}, 
         hb_http:get(Node, << ManifestID/binary, "/nested/page2" >>, Opts)),
     ok.
+
+manifest_default_fallback_test() ->
+    Opts = #{ store => hb_opts:get(store, no_viable_store, #{}) },
+    {ok, ManifestID} = create_generic_manifest(Opts),
+    ?event({manifest_id, ManifestID}),
+    Node = hb_http_server:start_node(Opts),
+    ?assertMatch(
+        {ok, #{ <<"body">> := <<"Page 1">> }},
+        hb_http:get(Node, << ManifestID/binary, "/invalid_path" >>, Opts)
+    ),
+    ok.
+
+manifest_404_error_test() ->
+    Opts = #{
+        store => hb_opts:get(store, no_viable_store, #{}),
+        manifest_404 => error
+    },
+    {ok, ManifestID} = create_generic_manifest(Opts),
+    ?event({manifest_id, ManifestID}),
+    Node = hb_http_server:start_node(Opts),
+    ?assertMatch(
+        {error, not_found},
+        hb_http:get(Node, << ManifestID/binary, "/invalid_path" >>, Opts)
+    ),
+    ok.
+
+create_generic_manifest(Opts) ->
+    IndexPage = #{
+        <<"content-type">> => <<"text/html">>,
+        <<"body">> => <<"Page 1">>
+    },
+    {ok, IndexID} = hb_cache:write(IndexPage, Opts),
+    Manifest = #{
+        <<"paths">> => #{
+            <<"page1">> => #{ <<"id">> => IndexID }
+        },
+        <<"index">> => #{ <<"path">> => <<"page1">> }
+    },
+    JSON = hb_json:encode(Manifest),
+    ManifestMsg =
+        #{
+            <<"device">> => <<"manifest@1.0">>,
+            <<"body">> => JSON
+        },
+    hb_cache:write(ManifestMsg, Opts).

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -377,8 +377,8 @@ default_message() ->
         % Define the behaviour when accessing a file inside a manifest that 
         % doesn't exists.
         % Options:
-        % - fallback (to the index page)
-        % - error: 404 Not Found
+        % - fallback: Fallback to the index page
+        % - error: Return 404 Not Found
         manifest_404 => fallback
     }.
 

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -367,13 +367,19 @@ default_message() ->
         genesis_wasm_import_authorities =>
             [
                 <<"WjnS-s03HWsDSdMnyTdzB1eHZB2QheUWP_FVRVYxkXk">>
-            ]
+            ],
         % Should the node track and expose prometheus metrics?
         % We do not set this explicitly, so that the hb_features:test() value
         % can be used to determine if we should expose metrics instead,
         % dynamically changing the configuration based on whether we are running
         % tests or not. To override this, set the `prometheus' option explicitly.
         % prometheus => false
+        % Define the behaviour when accessing a file inside a manifest that 
+        % doesn't exists.
+        % Options:
+        % - fallback (to the index page)
+        % - error: 404 Not Found
+        manifest_404 => fallback
     }.
 
 %% @doc Get an option from the global options, optionally overriding with a

--- a/src/hb_singleton.erl
+++ b/src/hb_singleton.erl
@@ -382,7 +382,8 @@ parse_part_mods(<<$=, InlinedMsgBin/binary>>, M = #{ <<"path">> := Path }, Opts)
     parse_part_mods(<< "&", Path/binary, "=", InlinedMsgBin/binary >>, M, Opts);
 parse_part_mods(<<$+, InlinedMsgBin/binary>>, M = #{ <<"path">> := Path }, Opts)
         when map_size(M) =:= 1, is_binary(InlinedMsgBin) ->
-    parse_part_mods(<< "&", Path/binary, "+", InlinedMsgBin/binary >>, M, Opts).
+    parse_part_mods(<< "&", Path/binary, "+", InlinedMsgBin/binary >>, M, Opts);
+parse_part_mods(_, Msg, _Opts) -> Msg.
 
 %% @doc Extrapolate the inlined key-value pair from a path segment. If the
 %% key has a value, it may provide a type (as with typical keys), but if a
@@ -867,3 +868,6 @@ path_parts_test() ->
         path_parts($/, <<"/a/(x/y/z)/c">>)
     ),
     ok.
+
+path_messages_space_edge_case_test() ->
+    path_messages(<<"42jky7O3rzKkMOfHBXgK-304YjulzEYqHc9qyjT3efA~manifest@1.0/[object Object]">>, #{}).


### PR DESCRIPTION
This PR helps keep compatibility with the arweave.net behaviour on transactions with manifest.
- Fixes 500 crash when using spaces in URL.
- Allow to fallback to the index defined in the manifest by default. This behaviour can be modified by changing `manifest_404` to `error`.