### PR TITLE
fix: Manifest redirect ID

### DIFF
--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -694,14 +694,14 @@ encode_reply(Status, TABMReq, Message, Opts) ->
                 )
             };
         {_, <<"manifest@1.0">>, _} ->
-            {ok, CachedID} = hb_cache:write(Message, Opts),
+            MessageID = hb_message:id(Message, signed),
             {
                 307,
                 #{
                     <<"location">> =>
                         <<
                             "/",
-                            CachedID/binary,
+                            MessageID/binary,
                             "~manifest@1.0/index"
                         >>
                 },

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -694,7 +694,7 @@ encode_reply(Status, TABMReq, Message, Opts) ->
                 )
             };
         {_, <<"manifest@1.0">>, _} ->
-            MessageID = hb_message:id(Message, signed),
+            MessageID = hb_message:id(Message, signed, Opts),
             {
                 307,
                 #{


### PR DESCRIPTION
By accessing `http://localhost:8734/42jky7O3rzKkMOfHBXgK-304YjulzEYqHc9qyjT3efA`, this will redirect to
`http://localhost:8734/gmv8IAS0fiha99-1FowTDpgDt8khuxgZOI757Xs49hw~manifest@1.0/index` which only works because it was cached.
`gmv8IAS0fiha99-1FowTDpgDt8khuxgZOI757Xs49hw` is the message signature, but we can use the message ID to redirect to `http://localhost:8734/42jky7O3rzKkMOfHBXgK-304YjulzEYqHc9qyjT3efA~manifest@1.0/index`