### PR TITLE
Chore: store decoded JSON instead of raw JSON string

### DIFF
--- a/src/dev_delegated_compute.erl
+++ b/src/dev_delegated_compute.erl
@@ -187,16 +187,13 @@ handle_relay_response(Base, Req, Opts, Response, OutputPrefix, ProcessID, Slot) 
                 }
             ),
             {ok, Msg} = dev_json_iface:json_to_message(JSONRes, Opts),
+            Raw = hb_json:decode(JSONRes, Opts),
             {ok,
                 hb_ao:set(
                     Base,
                     #{
                         <<OutputPrefix/binary, "/results">> => Msg,
-                        <<OutputPrefix/binary, "/results/json">> =>
-                            #{
-                                <<"content-type">> => <<"application/json">>,
-                                <<"body">> => JSONRes
-                            }
+                        <<OutputPrefix/binary, "/results/raw">> => Raw
                     },
                     Opts
                 )


### PR DESCRIPTION
Simplify response structure in `dev_delegated_compute.erl`

**Change:** Removed the `/results/json` field from the response structure, keeping only `/results` and `/results/raw`.

**Details:**

* Removed `/results/json` which previously contained:

  * `content-type`: `application/json`
  * `body`: The raw JSON response string
* `/results/raw` continues to contain the decoded JSON structure
* `/results` continues to contain the message decoded via JSON-Iface

**Impact:** Simplifies the response structure by removing redundant metadata. Consumers can still access the decoded JSON via `/results/raw` and the structured message via `/results`.
