### PR TITLE
Convert commit value to atom using hb_util:atom

### DIFF
--- a/src/dev_relay.erl
+++ b/src/dev_relay.erl
@@ -83,19 +83,6 @@ call(M1, RawM2, Opts) ->
             ],
             Opts
         ),
-    CommitRaw =
-        hb_ao:get_first(
-            [
-                {{as, <<"message@1.0">>, BaseTarget}, <<"commit-request">>},
-                {RawM2, <<"relay-commit-request">>},
-                {M1, <<"relay-commit-request">>},
-                {RawM2, <<"commit-request">>},
-                {M1, <<"commit-request">>}
-            ],
-            false,
-            Opts
-        ),
-    Commit = hb_util:atom(CommitRaw),
     TargetMod1 =
         if RelayBody == not_found -> BaseTarget;
         true -> BaseTarget#{<<"body">> => RelayBody}
@@ -116,8 +103,20 @@ call(M1, RawM2, Opts) ->
             TargetMod3,
             Opts
         ),
+    Commit =
+        hb_ao:get_first(
+            [
+                {{as, <<"message@1.0">>, BaseTarget}, <<"commit-request">>},
+                {RawM2, <<"relay-commit-request">>},
+                {M1, <<"relay-commit-request">>},
+                {RawM2, <<"commit-request">>},
+                {M1, <<"commit-request">>}
+            ],
+            false,
+            Opts
+        ),
     TargetMod5 =
-        case Commit of
+        case hb_util:atom(Commit) of
             true ->
                 case hb_opts:get(relay_allow_commit_request, false, Opts) of
                     true ->
@@ -134,7 +133,6 @@ call(M1, RawM2, Opts) ->
     ?event(debug_relay, {relay_call, {without_http_params, TargetMod4}}),
     ?event(debug_relay, {relay_call, {with_http_params, TargetMod5}}),
     true = hb_message:verify(TargetMod5),
-
     ?event(debug_relay, {relay_call, {verified, true}}),
     Client =
         case hb_maps:get(<<"http-client">>, BaseTarget, not_found, Opts) of

--- a/src/dev_relay.erl
+++ b/src/dev_relay.erl
@@ -83,7 +83,7 @@ call(M1, RawM2, Opts) ->
             ],
             Opts
         ),
-    Commit =
+    CommitRaw =
         hb_ao:get_first(
             [
                 {{as, <<"message@1.0">>, BaseTarget}, <<"commit-request">>},
@@ -95,6 +95,7 @@ call(M1, RawM2, Opts) ->
             false,
             Opts
         ),
+    Commit = hb_util:atom(CommitRaw),
     TargetMod1 =
         if RelayBody == not_found -> BaseTarget;
         true -> BaseTarget#{<<"body">> => RelayBody}


### PR DESCRIPTION
## Fix `case_clause` error in `dev_relay.erl`

**Problem:** The `dev_relay:call/3` function was crashing with `{case_clause,<<"true">>}` when the `commit-request` parameter was provided as a binary string instead of an atom.

**Root Cause:** The case statement at line 119 expected `Commit` to be an atom (`true` or `false`), but `hb_ao:get_first/3` can return binary strings (`<<"true">>` or `<<"false">>`) when values are extracted from message maps.

**Solution:** Added normalization logic to convert binary string values to their corresponding atoms before the case statement. The normalization handles:

* `<<"true">>` → `true`
* `<<"false">>` → `false`
* Existing atoms pass through unchanged
* Unknown values default to `false`

**Impact:** Prevents crashes when `commit-request` is passed as a binary string in HTTP requests or message maps.