### PR TITLE
Fix sub-path handling in gateway store local cache reads

### DIFF
--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -66,8 +66,15 @@ read(BaseStoreOpts, Key) ->
                                     end
                              end
                     end;
-                {ok, Value} ->
-                    {ok, Value}
+                {ok, CachedMessage} ->
+                    case Rest of
+                        [] -> {ok, CachedMessage};
+                        _ ->
+                            case hb_util:deep_get(Rest, CachedMessage, StoreOpts) of
+                                not_found -> not_found;
+                                Value -> {ok, Value}
+                            end
+                    end
             end;
         _ ->
             ?event({ignoring_non_id, Key}),

--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -40,6 +40,17 @@ type(StoreOpts, Key) ->
             end
     end.
 
+%% @doc Extract a value from a message, handling sub-paths.
+extract_path_value(Message, Rest, StoreOpts) ->
+    case Rest of
+        [] -> {ok, Message};
+        _ ->
+            case hb_util:deep_get(Rest, Message, StoreOpts) of
+                not_found -> not_found;
+                Value -> {ok, Value}
+            end
+    end.
+
 %% @doc Read the data at the given key from the GraphQL route. Will only attempt
 %% to read the data if the key is an ID.
 read(BaseStoreOpts, Key) ->
@@ -55,26 +66,11 @@ read(BaseStoreOpts, Key) ->
                             not_found;
                         {ok, Message} ->
                             ?event({read_found, {key, ID}}),
-                            try hb_store_remote_node:maybe_cache(StoreOpts, Message)
-                            catch _:_ -> ignored end,
-                            case Rest of
-                                [] -> {ok, Message};
-                                _ ->
-                                    case hb_util:deep_get(Rest, Message, StoreOpts) of
-                                        not_found -> not_found;
-                                        Value -> {ok, Value}
-                                    end
-                             end
+                            hb_store_remote_node:maybe_cache(StoreOpts, Message),
+                            extract_path_value(Message, Rest, StoreOpts)
                     end;
                 {ok, CachedMessage} ->
-                    case Rest of
-                        [] -> {ok, CachedMessage};
-                        _ ->
-                            case hb_util:deep_get(Rest, CachedMessage, StoreOpts) of
-                                not_found -> not_found;
-                                Value -> {ok, Value}
-                            end
-                    end
+                    extract_path_value(CachedMessage, Rest, StoreOpts)
             end;
         _ ->
             ?event({ignoring_non_id, Key}),

--- a/src/hb_store_remote_node.erl
+++ b/src/hb_store_remote_node.erl
@@ -79,41 +79,45 @@ maybe_cache(StoreOpts, Data) ->
     maybe_cache(StoreOpts, Data, []).
 maybe_cache(StoreOpts, Data, Links) ->
     ?event({maybe_cache, StoreOpts, Data}),
-    % Check if the local store is in our store options.
-    case hb_maps:get(<<"local-store">>, StoreOpts, false, StoreOpts) of
-        false ->
-            skipped;
-        Store ->
-            case hb_cache:write(Data, #{ store => Store }) of
-                {ok, RootPath} ->
-                    % Remove the base path from the links.
-                    LinksWithoutRootPath =
-                        lists:filter(
-                            fun(Link) -> Link /= RootPath end,
-                            Links
+    try
+        % Check if the local store is in our store options.
+        case hb_maps:get(<<"local-store">>, StoreOpts, false, StoreOpts) of
+            false ->
+                skipped;
+            Store ->
+                case hb_cache:write(Data, #{ store => Store }) of
+                    {ok, RootPath} ->
+                        % Remove the base path from the links.
+                        LinksWithoutRootPath =
+                            lists:filter(
+                                fun(Link) -> Link /= RootPath end,
+                                Links
+                            ),
+                        ?event(store_remote_node, cached_received),
+                        LinkResults =
+                            lists:filter(
+                                fun(Link) ->
+                                    hb_store:make_link(Store, RootPath, Link) == false
+                                end,
+                                LinksWithoutRootPath
+                            ),
+                        ?event(store_remote_node,
+                            {linked_cached,
+                                {failed_links, LinkResults}
+                            }
                         ),
-                    ?event(store_remote_node, cached_received),
-                    LinkResults =
-                        lists:filter(
-                            fun(Link) ->
-                                hb_store:make_link(Store, RootPath, Link) == false
-                            end,
-                            LinksWithoutRootPath
-                        ),
-                    ?event(store_remote_node,
-                        {linked_cached,
-                            {failed_links, LinkResults}
-                        }
-                    ),
-                    case LinkResults of
-                        [] -> ok;
-                        _ -> {failed_links, LinkResults}
-                    end;
-                {error, Err} ->
-                    ?event(store_remote_node, error_on_local_cache_write),
-                    ?event(warning, {error_caching_remote_node_data, Err}),
-                    {error, Err}
-            end
+                        case LinkResults of
+                            [] -> ok;
+                            _ -> {failed_links, LinkResults}
+                        end;
+                    {error, Err} ->
+                        ?event(store_remote_node, error_on_local_cache_write),
+                        ?event(warning, {error_caching_remote_node_data, Err}),
+                        {error, Err}
+                end
+        end
+    catch _:_ ->
+        ignored
     end.
 
 %% @doc Read local store cached value.


### PR DESCRIPTION
## Problem

When reading from the local cache in `hb_store_gateway`, the code was returning cached values directly without handling sub-paths. This caused issues when:

1. A full message was cached
2. A sub-path was requested (e.g., `ID/commitments`)
3. The full message was returned instead of the sub-path value
4. This partial value could then cause errors when writing back to the cache

The error manifested as a `{badkey,<<"committed">>}` error when trying to normalize commitments, because the code expected a specific structure but received a full message instead.

## Solution

Updated the `read/2` function in `hb_store_gateway.erl` to properly handle sub-paths when reading from the local cache, using `deep_get` to extract the requested sub-path value. This makes cached reads consistent with gateway reads.

## Changes

- Modified `hb_store_gateway:read/2` to handle `Rest` path when reading from local cache
- Ensures cached reads with sub-paths return the correct sub-path value, not the full message
