### PR TITLE
impr: use default commitment spec opt on uploads of downstream pushed messages

### DIFF
--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -492,7 +492,17 @@ calculate_base_id(GivenProcess, Opts) ->
 %% If the remote scheduler does not support the given codec, it will be
 %% downgraded and re-signed.
 schedule_result(TargetProcess, MsgToPush, Origin, Opts) ->
-    schedule_result(TargetProcess, MsgToPush, <<"httpsig@1.0">>, Origin, Opts).
+    schedule_result(
+        TargetProcess,
+        MsgToPush,
+        hb_opts:get(
+            scheduler_default_commitment_spec,
+            <<"httpsig@1.0">>,
+            Opts
+        ),
+        Origin,
+        Opts
+    ).
 schedule_result(TargetProcess, MsgToPush, Codec, Origin, Opts) ->
     Target = hb_ao:get(<<"target">>, MsgToPush, Opts),
     ?event(push,

--- a/src/dev_scheduler_server.erl
+++ b/src/dev_scheduler_server.erl
@@ -244,7 +244,6 @@ do_assign(State, Message, ReplyPID) ->
             ?event(writes_complete),
             ?event(uploading_message),
             hb_client:upload(Message, Opts),
-            ?event(uploading_assignment),
             hb_client:upload(Assignment, Opts),
             ?event(uploads_complete),
             maybe_inform_recipient(


### PR DESCRIPTION
Previously on uploads of downstream pushed messages, the default commitment spec was set to `httpsig@1.0`. This PR updates `dev_push` to check for the default commitment spec set in `Opts`.