### PR TITLE
fix: Allow exporting device keys with `-`.

### DIFF
--- a/src/dev_hook.erl
+++ b/src/dev_hook.erl
@@ -250,7 +250,7 @@ single_handler_test() ->
     % Create a message with a mock handler that adds a key to the request.
     Handler = #{
         <<"device">> => #{
-            <<"test-hook">> =>
+            test_hook =>
                 fun(_, Req, _) ->
                     {ok, Req#{ <<"handler_executed">> => true }}
                 end
@@ -266,7 +266,7 @@ multiple_handlers_test() ->
     % Create mock handlers that modify the request in sequence
     Handler1 = #{
         <<"device">> => #{
-            <<"test-hook">> =>
+            test_hook =>
                 fun(_, Req, _) ->
                     {ok, Req#{ <<"handler1">> => true }}
                 end
@@ -274,7 +274,7 @@ multiple_handlers_test() ->
     },
     Handler2 = #{
         <<"device">> => #{
-            <<"test-hook">> =>
+            test_hook =>
                 fun(_, Req, _) ->
                     {ok, Req#{ <<"handler2">> => true }}
                 end
@@ -291,7 +291,7 @@ halt_on_error_test() ->
     % Create handlers where the second one returns an error
     Handler1 = #{
         <<"device">> => #{
-            <<"test-hook">> =>
+            test_hook =>
                 fun(_, Req, _) ->
                     {ok, Req#{ <<"handler1">> => true }}
                 end
@@ -299,7 +299,7 @@ halt_on_error_test() ->
     },
     Handler2 = #{
         <<"device">> => #{
-            <<"test-hook">> =>
+            test_hook =>
                 fun(_, _, _) ->
                     {error, <<"Error in handler2">>}
                 end
@@ -307,7 +307,7 @@ halt_on_error_test() ->
     },
     Handler3 = #{
         <<"device">> => #{
-            <<"test-hook">> =>
+            test_hook =>
                 fun(_, Req, _) ->
                     {ok, Req#{ <<"handler3">> => true }}
                 end

--- a/src/hb_ao_device.erl
+++ b/src/hb_ao_device.erl
@@ -164,6 +164,11 @@ info_handler_to_fun(HandlerMap, Msg, Key, Opts) ->
 %% If the device is a map, we look for a key in the map. First we try to find
 %% the key using its literal value. If that fails, we cast the key to an atom
 %% and try again.
+find_exported_function(Msg, Mod, Key, Arity, Opts) when not is_atom(Key) ->
+	try hb_util:key_to_atom(Key, false) of
+		KeyAtom -> find_exported_function(Msg, Mod, KeyAtom, Arity, Opts)
+	catch _:_ -> not_found
+	end;
 find_exported_function(Msg, Dev, Key, MaxArity, Opts) when is_map(Dev) ->
     NormKey = hb_ao:normalize_key(Key),
     NormDev = hb_ao:normalize_keys(Dev, Opts),
@@ -181,11 +186,6 @@ find_exported_function(Msg, Dev, Key, MaxArity, Opts) when is_map(Dev) ->
 	end;
 find_exported_function(_Msg, _Mod, _Key, Arity, _Opts) when Arity < 0 ->
     not_found;
-find_exported_function(Msg, Mod, Key, Arity, Opts) when not is_atom(Key) ->
-	try hb_util:key_to_atom(Key, false) of
-		KeyAtom -> find_exported_function(Msg, Mod, KeyAtom, Arity, Opts)
-	catch _:_ -> not_found
-	end;
 find_exported_function(Msg, Mod, Key, Arity, Opts) ->
 	case erlang:function_exported(Mod, Key, Arity) of
 		true ->
@@ -211,17 +211,29 @@ is_exported(Msg, Dev, Key, Opts) ->
 	is_exported(info(Dev, Msg, Opts), Key, Opts).
 is_exported(_, info, _Opts) -> true;
 is_exported(Info = #{ excludes := Excludes }, Key, Opts) ->
-    NormKey = hb_ao:normalize_key(Key),
-    case lists:member(NormKey, lists:map(fun hb_ao:normalize_key/1, Excludes)) of
+    NormKey = maybe_normalize_device_key(Key, existing),
+    case lists:member(NormKey, lists:map(fun maybe_normalize_device_key/1, Excludes)) of
         true -> false;
         false -> is_exported(hb_maps:remove(excludes, Info, Opts), Key, Opts)
     end;
 is_exported(#{ exports := Exports }, Key, _Opts) ->
     lists:member(
-        hb_ao:normalize_key(Key),
-        lists:map(fun hb_ao:normalize_key/1, Exports)
+        maybe_normalize_device_key(Key, existing),
+        lists:map(fun maybe_normalize_device_key/1, Exports)
     );
 is_exported(_Info, _Key, _Opts) -> true.
+
+%% @doc Normalize an exported key to its canonical atomized form. By default
+%% new atoms are created if necessary. In practice this is used for keys that
+%% orinate from a device's `info' response, but _not_ for keys that could be
+%% chosen by non-author users. This imparts a requirement that device developers
+%% should not generate too many different exports/excludes -- just as they should
+%% not generate too many atoms.
+maybe_normalize_device_key(Key) -> maybe_normalize_device_key(Key, new_atoms).
+maybe_normalize_device_key(Key, Mode) ->
+    try hb_util:key_to_atom(hb_ao:normalize_key(Key), Mode)
+    catch _:_ -> Key
+    end.
 
 %% @doc Load a device module from its name or a message ID.
 %% Returns {ok, Executable} where Executable is the device module. On error,

--- a/src/hb_ao_test_vectors.erl
+++ b/src/hb_ao_test_vectors.erl
@@ -62,6 +62,8 @@ test_suite() ->
             fun device_with_default_handler_function_test/1},
         {basic_get, "basic get",
             fun basic_get_test/1},
+        {get_with_denormalized_key, "get with denormalized key",
+            fun denormalized_key_test/1},
         {recursive_get, "recursive get",
             fun recursive_get_test/1},
         {deep_recursive_get, "deep recursive get",
@@ -82,8 +84,8 @@ test_suite() ->
             fun device_exports_test/1},
         {device_excludes, "device excludes",
             fun device_excludes_test/1},
-        {denormalized_device_key, "denormalized device key",
-            fun denormalized_device_key_test/1},
+        {denormalized_device_name, "denormalized device name",
+            fun denormalized_device_name_test/1},
         {list_transform, "list transform",
             fun list_transform_test/1},
         {step_hook, "step hook",
@@ -149,7 +151,7 @@ test_opts() ->
                 }
             },
             skip => [
-                denormalized_device_key,
+                denormalized_device_name,
                 deep_set_with_device,
                 load_as
             ],
@@ -175,12 +177,13 @@ test_opts() ->
                 as_path,
                 multiple_as_subresolutions,
                 key_from_id_device_with_args,
+                get_with_denormalized_key,
                 set_new_messages,
                 resolve_from_multiple_keys,
                 resolve_path_element,
                 device_with_default_handler_function,
                 device_with_handler_function,
-                denormalized_device_key,
+                denormalized_device_name,
                 get_with_device,
                 get_as_with_device,
                 set_with_device,
@@ -685,7 +688,7 @@ device_exports_test(Opts) ->
         info =>
             fun() ->
                 #{
-                    exports => [test1, <<"test2">>],
+                    exports => [test1, test2],
                     handler =>
                         fun() ->
                             {ok, <<"Handler-Value">>}
@@ -693,7 +696,12 @@ device_exports_test(Opts) ->
                 }
             end
     },
-    Res = #{ <<"device">> => Dev2, <<"test1">> => <<"BAD1">>, <<"test3">> => <<"GOOD3">> },
+    Res =
+        #{
+            <<"device">> => Dev2,
+            <<"test1">> => <<"BAD1">>,
+            <<"test3">> => <<"GOOD3">>
+        },
     ?assertEqual(<<"Handler-Value">>, hb_ao:get(<<"test1">>, Res, Opts)),
     ?assertEqual(<<"Handler-Value">>, hb_ao:get(<<"test2">>, Res, Opts)),
     ?assertEqual(<<"GOOD3">>, hb_ao:get(<<"test3">>, Res, Opts)),
@@ -725,15 +733,43 @@ device_excludes_test(Opts) ->
     ?assertMatch(#{ <<"test-key2">> := <<"2">> },
         hb_ao:set(Msg, <<"test-key2">>, <<"2">>, Opts)).
 
-denormalized_device_key_test(Opts) ->
-	Msg = #{ <<"device">> => dev_test },
-	?assertEqual(dev_test, hb_ao:get(device, Msg, Opts)),
-	?assertEqual(dev_test, hb_ao:get(<<"device">>, Msg, Opts)),
-	?assertEqual({module, dev_test},
-		erlang:fun_info(
+
+denormalized_device_name_test(Opts) ->
+    Msg = #{ <<"device">> => dev_test },
+    ?assertEqual(dev_test, hb_ao:get(device, Msg, Opts)),
+    ?assertEqual(dev_test, hb_ao:get(<<"device">>, Msg, Opts)),
+    ?assertEqual(
+        {module, dev_test},
+        erlang:fun_info(
             element(3, hb_ao_device:message_to_fun(Msg, test_func, Opts)),
             module
         )
+    ).
+
+denormalized_key_test(Opts) ->
+    Msg =
+        #{
+            device =>
+                #{
+                    info =>
+                        fun() ->
+                            #{
+                                exports => [<<"test-key">>]
+                            }
+                        end,
+                    test_key =>
+                        fun(_) ->
+                            {ok, <<"TEST VALUE">>}
+                        end
+                }
+        },
+    ?assertEqual(
+        {ok, <<"TEST VALUE">>},
+        hb_ao:resolve(Msg, <<"test_key">>, Opts)
+    ),
+    ?assertEqual(
+        {ok, <<"TEST VALUE">>},
+        hb_ao:resolve(Msg, <<"test-key">>, Opts)
     ).
 
 list_transform_test(Opts) ->
@@ -953,9 +989,7 @@ benchmark_multistep_test(Opts) ->
                 hb_ao:resolve(
                     #{
                         <<"iteration">> => I,
-                        <<"a">> => #{
-                            <<"b">> => #{ <<"return">> => I }
-                        }
+                        <<"a">> => #{ <<"b">> => #{ <<"return">> => I } }
                     },
                     <<"a/b/return">>,
                     Opts


### PR DESCRIPTION
A small fix that corrects handling of `key_to_atom` in AO-Core's device key matching. This allows us to export device keys using HTTP `Title-Case` form, avoiding the need to use inconsistently formed endpoints (e.g `set_weight`).
