### PR TITLE
fix: explicitly overwrite dedup trie rather than set over keys

### DIFF
--- a/src/dev_dedup.erl
+++ b/src/dev_dedup.erl
@@ -99,27 +99,29 @@ handle(Key, M1, M2, Opts) ->
             case hb_ao:get(SubjectID, DedupTrie, Opts) of
                 not_found ->
                     ?event({not_seen, SubjectID}),
-                    NewDedupTrie =
-                        hb_ao:set(
+                    Slot =
+                        hb_maps:get(
+                            <<"slot">>,
+                            M2,
+                            true,
+                            Opts
+                        ),
+                    {ok, NewDedupTrie} =
+                        hb_ao:resolve(
                             DedupTrie,
-                            SubjectID,
-                            hb_maps:get(
-                                <<"slot">>,
-                                M2,
-                                true,
-                                Opts
-                            ),
+                            #{ <<"path">> => <<"set">>, SubjectID => Slot },
                             Opts
                         ),
                     ?event({dedup_updated, NewDedupTrie}),
-                    Result =
-                        hb_ao:set(
-                            M1,
-                            <<"dedup">>,
-                            NewDedupTrie,
-                            Opts
-                        ),
-                    {ok, Result};
+                    hb_ao:resolve(
+                        M1,
+                        #{ 
+                            <<"path">> => <<"set">>,
+                            <<"set-mode">> => <<"explicit">>,
+                            <<"dedup">> => NewDedupTrie
+                        },
+                        Opts
+                    );
                 Value ->
                     ?event(
                         {already_seen,

--- a/src/dev_trie.erl
+++ b/src/dev_trie.erl
@@ -90,8 +90,7 @@ insert(TrieNode, Key, Val, Opts, KeyPrefixSizeAcc) ->
     <<_KeyPrefix:KeyPrefixSizeAcc/bitstring, KeySuffix/bitstring>> = Key,
     EdgeLabels = edges(TrieNode, Opts),
     ChunkSize = round(math:log2(?RADIX)),
-    LongestPrefixMatch = longest_prefix_match(KeySuffix, EdgeLabels, ChunkSize),
-    case LongestPrefixMatch of
+    case longest_prefix_match(KeySuffix, EdgeLabels, ChunkSize) of
         % NO MATCH: This internal node has no traversible children, because its
         % edge labels do not match any portion of what remains to be matched of
         % our key. If we've matched the entire length of our key on our way here,

--- a/src/dev_trie.erl
+++ b/src/dev_trie.erl
@@ -90,7 +90,8 @@ insert(TrieNode, Key, Val, Opts, KeyPrefixSizeAcc) ->
     <<_KeyPrefix:KeyPrefixSizeAcc/bitstring, KeySuffix/bitstring>> = Key,
     EdgeLabels = edges(TrieNode, Opts),
     ChunkSize = round(math:log2(?RADIX)),
-    case longest_prefix_match(KeySuffix, EdgeLabels, ChunkSize) of
+    LongestPrefixMatch = longest_prefix_match(KeySuffix, EdgeLabels, ChunkSize),
+    case LongestPrefixMatch of
         % NO MATCH: This internal node has no traversible children, because its
         % edge labels do not match any portion of what remains to be matched of
         % our key. If we've matched the entire length of our key on our way here,


### PR DESCRIPTION
Explicitly set new dedup trie rather than deep merging to avoid node value collisions