### PR TITLE
fix: Link signed ID to `~scheduler@1.0` assignment pseudo-path.

### DIFF
--- a/src/dev_scheduler_cache.erl
+++ b/src/dev_scheduler_cache.erl
@@ -37,12 +37,12 @@ write(RawAssignment, RawOpts) ->
         }
     ),
     case hb_cache:write(Assignment, Opts) of
-        {ok, RootPath} ->
+        {ok, _UnsignedID} ->
             % Create symlinks from the message on the process and the 
             % slot on the process to the underlying data.
             hb_store:make_link(
                 Store,
-                RootPath,
+                hb_message:id(Assignment, signed, Opts),
                 hb_store:path(
                     Store,
                     [


### PR DESCRIPTION
Prior to this commit, assignments in `~scheduler@1.0`'s cache were linked to the unsigned ID, leading to their signed commitment being missing in subsequent loads.