### PR TITLE
fix: remove `commitment-ids` from recursive ID verification calls

### DIFF
--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -316,7 +316,12 @@ verify(Self, Req, Opts) ->
     % additional keys to the commitment device.
     ReqBase =
         maps:without(
-            [<<"path">>, <<"committers">>, <<"commitments">>],
+            [
+                <<"path">>,
+                <<"committers">>,
+                <<"commitments">>,
+                <<"commitment-ids">>
+            ],
             Req
         ),
     % Verify the commitments. Stop execution if any fail.


### PR DESCRIPTION
Fixes an issue where a call for individual ID verification while a call for verification of all IDs would succeed.