### PR TITLE
Feat: Handling invalid messages in hb_store_gateway

### DIFF
--- a/src/hb_ao.erl
+++ b/src/hb_ao.erl
@@ -166,7 +166,35 @@ resolve_many([ID], Opts) when ?IS_ID(ID) ->
     %    to use in looking up a cached result.
     ?event(ao_core, {stage, na, resolve_directly_to_id, ID, {opts, Opts}}, Opts),
     try {ok, ensure_message_loaded(ID, Opts)}
-    catch _:_:_ -> {error, not_found}
+    catch
+        _:{necessary_message_not_found, _, _}:_StackTrace ->
+            {error, not_found};
+        Class:Reason:Stacktrace ->
+            ?event(error,
+                {store_call_failed_retrying,
+                    {class, Class},
+                    {reason, Reason},
+                    {stacktrace, {trace, Stacktrace}}
+                }
+            ),
+            FailMode = hb_opts:get(debug_print_fail_mode, quiet, Opts),
+            Body = case FailMode of
+                quiet ->
+                    #{
+                        <<"type">> => Class,
+                        <<"details">> => <<"Cannot process the message">>
+                    };
+                long ->
+                    ClassBin = iolist_to_binary(io_lib:format("~p", [Class])),
+                    ReasonBin = iolist_to_binary(io_lib:format("~p", [Reason])),
+                    StacktraceBin = iolist_to_binary(io_lib:format("~p", [Stacktrace])),
+                    #{
+                        <<"type">> => ClassBin,
+                        <<"details">> => ReasonBin,
+                        <<"stacktrace">> => StacktraceBin
+                    }
+            end,
+            {failure, Body#{<<"status">> => 500}}
     end;
 resolve_many(ListMsg, Opts) when is_map(ListMsg) ->
     % We have been given a message rather than a list of messages, so we should

--- a/src/hb_ao.erl
+++ b/src/hb_ao.erl
@@ -166,35 +166,7 @@ resolve_many([ID], Opts) when ?IS_ID(ID) ->
     %    to use in looking up a cached result.
     ?event(ao_core, {stage, na, resolve_directly_to_id, ID, {opts, Opts}}, Opts),
     try {ok, ensure_message_loaded(ID, Opts)}
-    catch
-        _:{necessary_message_not_found, _, _}:_StackTrace ->
-            {error, not_found};
-        Class:Reason:Stacktrace ->
-            ?event(error,
-                {store_call_failed_retrying,
-                    {class, Class},
-                    {reason, Reason},
-                    {stacktrace, {trace, Stacktrace}}
-                }
-            ),
-            FailMode = hb_opts:get(debug_print_fail_mode, quiet, Opts),
-            Body = case FailMode of
-                quiet ->
-                    #{
-                        <<"type">> => Class,
-                        <<"details">> => <<"Cannot process the message">>
-                    };
-                long ->
-                    ClassBin = iolist_to_binary(io_lib:format("~p", [Class])),
-                    ReasonBin = iolist_to_binary(io_lib:format("~p", [Reason])),
-                    StacktraceBin = iolist_to_binary(io_lib:format("~p", [Stacktrace])),
-                    #{
-                        <<"type">> => ClassBin,
-                        <<"details">> => ReasonBin,
-                        <<"stacktrace">> => StacktraceBin
-                    }
-            end,
-            {failure, Body#{<<"status">> => 500}}
+    catch _:_:_ -> {error, not_found}
     end;
 resolve_many(ListMsg, Opts) when is_map(ListMsg) ->
     % We have been given a message rather than a list of messages, so we should
@@ -874,6 +846,8 @@ ensure_message_loaded(MsgID, Opts) when ?IS_ID(MsgID) ->
     case hb_cache:read(MsgID, Opts) of
         {ok, LoadedMsg} ->
             LoadedMsg;
+        failure ->
+            failure;
         not_found ->
             throw({necessary_message_not_found, <<"/">>, MsgID})
     end;

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -470,12 +470,14 @@ store_read(Target, Path, Store, Opts) ->
         {store, Store}
     }),
     case hb_store:type(Store, ResolvedFullPath) of
+        failure -> failure;
         not_found -> not_found;
         simple ->
             ?event({reading_data, ResolvedFullPath}),
             case hb_store:read(Store, ResolvedFullPath) of
                 {ok, Bin} -> {ok, Bin};
-                not_found -> not_found
+                not_found -> not_found;
+                failure -> failure
             end;
         composite ->
             ?event({reading_composite, ResolvedFullPath}),

--- a/src/hb_store.erl
+++ b/src/hb_store.erl
@@ -362,12 +362,11 @@ do_call_function([Store = #{<<"access">> := Access} | Rest], Function, Args) ->
     end;
 do_call_function([Store = #{<<"store-module">> := Mod} | Rest], Function, Args) ->
     % Attempt to apply the function. If it fails, try the next store.
-    try apply_store_function(Mod, Store, Function, Args) of
+    case apply_store_function(Mod, Store, Function, Args) of
         not_found ->
             do_call_function(Rest, Function, Args);
         Result ->
             Result
-    catch _:_:_ -> do_call_function(Rest, Function, Args)
     end.
 
 %% @doc Apply a store function, checking if the store returns a retry request or
@@ -380,21 +379,9 @@ apply_store_function(_Mod, _Store, _Function, _Args, 0) ->
     % Too many attempts have already failed. Bail.
     not_found;
 apply_store_function(Mod, Store, Function, Args, AttemptsRemaining) ->
-    try apply(Mod, Function, [Store | Args]) of
+    case apply(Mod, Function, [Store | Args]) of
         retry -> retry(Mod, Store, Function, Args, AttemptsRemaining);
         Other -> Other
-    catch Class:Reason:Stacktrace ->
-        ?event(store_error,
-            {store_call_failed_retrying,
-                {store, Store},
-                {function, Function},
-                {args, Args},
-                {class, Class},
-                {reason, Reason},
-                {stacktrace, {trace, Stacktrace}}
-            }
-        ),
-        retry(Mod, Store, Function, Args, AttemptsRemaining)
     end.
 
 %% @doc Stop and start the store, then retry.

--- a/src/hb_store.erl
+++ b/src/hb_store.erl
@@ -381,7 +381,6 @@ apply_store_function(_Mod, _Store, _Function, _Args, 0) ->
     not_found;
 apply_store_function(Mod, Store, Function, Args, AttemptsRemaining) ->
     try apply(Mod, Function, [Store | Args]) of
-        failure -> failure;
         retry -> retry(Mod, Store, Function, Args, AttemptsRemaining);
         Other -> Other
     catch Class:Reason:Stacktrace ->

--- a/src/hb_store.erl
+++ b/src/hb_store.erl
@@ -362,11 +362,12 @@ do_call_function([Store = #{<<"access">> := Access} | Rest], Function, Args) ->
     end;
 do_call_function([Store = #{<<"store-module">> := Mod} | Rest], Function, Args) ->
     % Attempt to apply the function. If it fails, try the next store.
-    case apply_store_function(Mod, Store, Function, Args) of
+    try apply_store_function(Mod, Store, Function, Args) of
         not_found ->
             do_call_function(Rest, Function, Args);
         Result ->
             Result
+    catch _:_:_ -> do_call_function(Rest, Function, Args)
     end.
 
 %% @doc Apply a store function, checking if the store returns a retry request or
@@ -379,9 +380,22 @@ apply_store_function(_Mod, _Store, _Function, _Args, 0) ->
     % Too many attempts have already failed. Bail.
     not_found;
 apply_store_function(Mod, Store, Function, Args, AttemptsRemaining) ->
-    case apply(Mod, Function, [Store | Args]) of
+    try apply(Mod, Function, [Store | Args]) of
+        failure -> failure;
         retry -> retry(Mod, Store, Function, Args, AttemptsRemaining);
         Other -> Other
+    catch Class:Reason:Stacktrace ->
+        ?event(store_error,
+            {store_call_failed_retrying,
+                {store, Store},
+                {function, Function},
+                {args, Args},
+                {class, Class},
+                {reason, Reason},
+                {stacktrace, {trace, Stacktrace}}
+            }
+        ),
+        retry(Mod, Store, Function, Args, AttemptsRemaining)
     end.
 
 %% @doc Stop and start the store, then retry.

--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -475,10 +475,10 @@ verifiability_test() ->
     ?event({verifying, {structured, Structured}, {original, Message}}),
     ?assert(hb_message:verify(Structured)).
 
-%% @doc Reading an unsupported transaction should fail
+%% @doc Reading an unsupported signature type transaction should fail
 failure_to_process_message_test() ->
     hb_http_server:start_node(#{}),
-    failure =
+    ?assertEqual(failure,
         hb_cache:read(
             <<"j0_mJMXG2YO4oRcOtjYsNoUJbN2TaKLo4nTtbhKqnEU">>,
             #{
@@ -489,7 +489,8 @@ failure_to_process_message_test() ->
                         }
                     ]
             }
-        ).
+        )
+    ).
 
 %% @doc Test that another HyperBEAM node offering the `~query@1.0' device can
 %% be used as a store.

--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -60,14 +60,24 @@ read(BaseStoreOpts, Key) ->
             case hb_store_remote_node:read_local_cache(StoreOpts, ID) of
                 not_found ->
                     ?event({gateway_read, {opts, StoreOpts}, {id, ID}, {subpath, Rest}}),
-                    case hb_gateway_client:read(ID, StoreOpts) of
-                        {error, _} ->
+                    try hb_gateway_client:read(ID, StoreOpts) of
+                        {error, no} ->
                             ?event({read_not_found, {key, ID}}),
                             not_found;
                         {ok, Message} ->
                             ?event({read_found, {key, ID}}),
                             hb_store_remote_node:maybe_cache(StoreOpts, Message),
                             extract_path_value(Message, Rest, StoreOpts)
+                    catch Class:Reason:Stacktrace ->
+                        ?event(
+                            gateway,
+                            {read_failed,
+                                {class, Class},
+                                {reason, Reason},
+                                {stacktrace, {trace, Stacktrace}}
+                            }
+                        ),
+                        failure
                     end;
                 {ok, CachedMessage} ->
                     extract_path_value(CachedMessage, Rest, StoreOpts)

--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -13,6 +13,7 @@ list(StoreOpts, Key) ->
     ?event(store_gateway, executing_list),
     case read(StoreOpts, Key) of
         not_found -> not_found;
+        failure -> failure;
         {ok, Message} -> {ok, hb_maps:keys(Message, StoreOpts)}
     end.
 
@@ -23,6 +24,7 @@ type(StoreOpts, Key) ->
     ?event(store_gateway, executing_type),
     case read(StoreOpts, Key) of
         not_found -> not_found;
+        failure -> failure;
         {ok, Data} ->
             ?event({type, hb_private:reset(hb_message:uncommitted(Data, StoreOpts))}),
             IsFlat = lists:all(
@@ -61,7 +63,7 @@ read(BaseStoreOpts, Key) ->
                 not_found ->
                     ?event({gateway_read, {opts, StoreOpts}, {id, ID}, {subpath, Rest}}),
                     try hb_gateway_client:read(ID, StoreOpts) of
-                        {error, no} ->
+                        {error, _} ->
                             ?event({read_not_found, {key, ID}}),
                             not_found;
                         {ok, Message} ->
@@ -472,6 +474,22 @@ verifiability_test() ->
         ),
     ?event({verifying, {structured, Structured}, {original, Message}}),
     ?assert(hb_message:verify(Structured)).
+
+%% @doc Reading an unsupported transaction should fail
+failure_to_process_message_test() ->
+    hb_http_server:start_node(#{}),
+    failure =
+        hb_cache:read(
+            <<"j0_mJMXG2YO4oRcOtjYsNoUJbN2TaKLo4nTtbhKqnEU">>,
+            #{
+                store =>
+                    [
+                        #{
+                            <<"store-module">> => hb_store_gateway
+                        }
+                    ]
+            }
+        ).
 
 %% @doc Test that another HyperBEAM node offering the `~query@1.0' device can
 %% be used as a store.


### PR DESCRIPTION
Some messages aren't supported in HyperBeam. Example:
- `j0_mJMXG2YO4oRcOtjYsNoUJbN2TaKLo4nTtbhKqnEU` (invalid avro serialization)
- `E5oYGXwWLEb7ZHQodmpGfWrqsE3EfiV2TX5i3p61usw` (solana signature)

Instead of returning a 404 Not Found error, we want to explicitly state that we can't process them (500 Internal Server Error).