### PR TITLE
feat: Device Inheritance

### DIFF
--- a/src/dev_test.erl
+++ b/src/dev_test.erl
@@ -61,7 +61,7 @@ load(Base, _, _Opts) ->
     {ok, Base#{ <<"device">> => <<"test-device@1.0">> }}.
 
 test_func(_) ->
-	{ok, <<"GOOD_FUNCTION">>}.
+	{ok, <<"GOOD FUNCTION">>}.
 
 %% @doc Example implementation of a `compute' handler. Makes a running list of
 %% the slots that have been computed in the state message and places the new
@@ -195,7 +195,7 @@ device_with_function_key_module_test() ->
 			<<"device">> => <<"test-device@1.0">>
 		},
 	?assertEqual(
-		{ok, <<"GOOD_FUNCTION">>},
+		{ok, <<"GOOD FUNCTION">>},
 		hb_ao:resolve(Msg, test_func, #{})
 	).
 

--- a/src/hb_ao.erl
+++ b/src/hb_ao.erl
@@ -469,10 +469,11 @@ resolve_stage(5, Base, Req, ExecName, Opts) ->
                     {opts, Opts}
                 }
             ),
-			{Status, _Mod, Func} = hb_ao_device:message_to_fun(Base, Key, UserOpts),
+			{Status, Device, Func} = hb_ao_device:message_to_fun(Base, Key, UserOpts),
 			?event(
 				{found_func_for_exec,
                     {key, Key},
+                    {device, Device},
 					{func, Func},
 					{base, Base},
 					{req, Req},

--- a/src/hb_ao_device.erl
+++ b/src/hb_ao_device.erl
@@ -34,13 +34,19 @@ truncate_args(Fun, Args) ->
 %% 1. The message does not specify a device, so we use the default device.
 %% 2. The device has a `handler' key in its `Dev:info()' map, which is a
 %% function that takes a key and returns a function to handle that key. We pass
-%% the key as an additional argument to this function.
+%% the key as an additional argument to this function:
+%%     `Mod:Handler(Key, Base, Req, Opts) -> {Status, Fun}'
 %% 3. The device has a function of the name `Key', which should be called
 %% directly.
-%% 4. The device does not implement the key, but does have a default handler
-%% for us to call. We pass it the key as an additional argument.
-%% 5. The device does not implement the key, and has no default handler. We use
-%% the default device to handle the key.
+%% 4. The device does not implement the key, but does have a default function
+%% for us to call. We pass it the key as an additional argument, as with (2).
+%% `default' differs from `handler' in that it only matches for keys where the
+%% module exports no function of the given name.
+%% 5. The device has a `default' key with a device or module name as its value.
+%% We use this device to handle the key, restarting the process of resolving the
+%% key to a function.
+%% 6. The device does not implement the key and states no defaults. We use the
+%% global default device to handle the key.
 %% Error: If the device is specified, but not loadable, we raise an error.
 %%
 %% Returns {ok | add_key, Fun} where Fun is the function to call, and add_key
@@ -83,15 +89,18 @@ message_to_fun(Msg, Key, Opts) ->
 							% Case 4: The device has a default handler.
                             ?event({found_default_handler, {func, DefaultFunc}}),
 							{add_key, Dev, DefaultFunc};
-                        {{ok, DefaultMod}, true} when is_atom(DefaultMod) ->
+                        {{ok, DefaultMod}, true} when is_binary(DefaultMod)
+                                orelse is_atom(DefaultMod) ->
+                            % Case 5: The device gives a specific further device
+                            % to default to.
 							?event({found_default_handler, {mod, DefaultMod}}),
-                            {Status, Func} =
-                                message_to_fun(
-                                    Msg#{ <<"device">> => DefaultMod }, Key, Opts
-                                ),
-                            {Status, Dev, Func};
+                            message_to_fun(
+                                Msg#{ <<"device">> => DefaultMod },
+                                Key,
+                                Opts
+                            );
 						_ ->
-							% Case 5: The device has no default handler.
+							% Case 6: The device has no default handler.
 							% We use the default device to handle the key.
 							case default() of
 								Dev ->

--- a/src/hb_ao_test_vectors.erl
+++ b/src/hb_ao_test_vectors.erl
@@ -84,6 +84,8 @@ test_suite() ->
             fun device_exports_test/1},
         {device_excludes, "device excludes",
             fun device_excludes_test/1},
+        {device_inheritance, "device inheritance",
+            fun device_inheritance_test/1},
         {denormalized_device_name, "denormalized device name",
             fun denormalized_device_name_test/1},
         {list_transform, "list transform",
@@ -189,6 +191,7 @@ test_opts() ->
                 set_with_device,
                 device_exports,
                 device_excludes,
+                device_inheritance,
                 deep_set_with_device,
                 as,
                 as_commitments,
@@ -733,6 +736,28 @@ device_excludes_test(Opts) ->
     ?assertMatch(#{ <<"test-key2">> := <<"2">> },
         hb_ao:set(Msg, <<"test-key2">>, <<"2">>, Opts)).
 
+device_inheritance_test(Opts) ->
+    % Create a device that inherits from another device and ensure that the
+    % precedence order of matching keys is correct:
+    %     The local device > the inherited device > the global default device*
+    % Note that we only fallback to the global device in this case because the
+    % inherited device does not specify a further `default' key in its `info'.
+    Dev = #{
+        info =>
+            fun() ->
+                #{
+                    default => <<"test-device@1.0">>
+                }
+            end,
+        device_key =>
+            fun(_, _, _) ->
+                {ok, <<"DEVICE VALUE">>}
+            end
+    },
+    Msg = #{ <<"device">> => Dev, <<"message-key">> => <<"MESSAGE VALUE">> },
+    ?assertEqual(<<"DEVICE VALUE">>, hb_ao:get(<<"device-key">>, Msg, Opts)),
+    ?assertEqual(<<"GOOD FUNCTION">>, hb_ao:get(<<"test-func">>, Msg, Opts)),
+    ?assertEqual(<<"MESSAGE VALUE">>, hb_ao:get(<<"message-key">>, Msg, Opts)).
 
 denormalized_device_name_test(Opts) ->
     Msg = #{ <<"device">> => dev_test },
@@ -782,7 +807,7 @@ list_transform_test(Opts) ->
 
 start_as_test(Opts) ->
     ?assertEqual(
-        {ok, <<"GOOD_FUNCTION">>},
+        {ok, <<"GOOD FUNCTION">>},
         hb_ao:resolve_many(
             [
                 {as, <<"test-device@1.0">>, #{ <<"path">> => <<>> }},
@@ -798,7 +823,7 @@ start_as_with_parameters_test(Opts) ->
         <<"test_func">> => #{ <<"test_key">> => <<"MESSAGE">> }
     },
     ?assertEqual(
-        {ok, <<"GOOD_FUNCTION">>},
+        {ok, <<"GOOD FUNCTION">>},
         hb_ao:resolve_many(
             [
                 {as, <<"message@1.0">>, Msg},
@@ -829,12 +854,12 @@ load_as_test(Opts) ->
 
 as_path_test(Opts) ->
     % Create a message with the test device, which implements the test_func
-    % function. It normally returns `GOOD_FUNCTION'.
+    % function. It normally returns `GOOD FUNCTION'.
     Msg = #{
         <<"device">> => <<"test-device@1.0">>,
         <<"test_func">> => #{ <<"test_key">> => <<"MESSAGE">> }
     },
-    ?assertEqual(<<"GOOD_FUNCTION">>, hb_ao:get(<<"test_func">>, Msg, Opts)),
+    ?assertEqual(<<"GOOD FUNCTION">>, hb_ao:get(<<"test_func">>, Msg, Opts)),
     % Now use the `as' keyword to subresolve a key with the message device.
     ?assertMatch(
         {ok, #{ <<"test_key">> := <<"MESSAGE">> }},


### PR DESCRIPTION
This PR allows the use of inheritance of key resolvers recursively between devices.

A device may now specify the `info/default` key in the form of another device's name or a module atom, which the AO-Core engine will then use to resolve keys that do not match in the primary device. AO-Core already performed a similar operation when defaulting from a given device to `message@1.0` if a key did not match. This commit opens up that system to allow for standard OOP-style inheritance structures.
