### PR TITLE
Fix ans104_wasm_test

### DIFF
--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -1162,16 +1162,16 @@ cors_get_test() ->
     ).
 
 ans104_wasm_test() ->
-    TestStore = [hb_test_utils:test_store()],
-    TestOpts =
+    ServerStore = [hb_test_utils:test_store()],
+    ServerOpts =
         #{
             force_signed => true,
-            store => TestStore,
+            store => ServerStore,
             priv_wallet => ar_wallet:new()
         },
     ClientStore = [hb_test_utils:test_store()],
     ClientOpts = #{ store => ClientStore, priv_wallet => hb:wallet() },
-    URL = hb_http_server:start_node(TestOpts),
+    URL = hb_http_server:start_node(ServerOpts),
     {ok, Bin} = file:read_file(<<"test/test-64.wasm">>),
     Msg =
         hb_message:commit(
@@ -1188,14 +1188,21 @@ ans104_wasm_test() ->
         ),
     ?assert(hb_message:verify(Msg, all, ClientOpts)),
     ?event({msg, Msg}),
+    %% TODO: We could resolve before return, but I don't think that 
+    %% is the desired behaviour.
     {ok, Res} =
         post(
             URL,
             Msg#{ <<"path">> => <<"/init/compute/results">> },
             ClientOpts
         ),
-    ?event({res, Res}),
-    ?assertEqual(6.0, hb_ao:get(<<"output/1">>, Res, ClientOpts)).
+    %% TODO: Is there a better way to do this?
+    {link, LinkID, _ } = maps:get(<<"output">>, Res),
+    %% We need to resolve agaisnt the server cache
+    {ok, #{<<"body">> := Body}} = post(URL, Msg#{<<"path">> => <<"/", LinkID/binary, "/1">>}, ClientOpts),
+    ?assertEqual(<<"6.00000000000000000000e+00">>, Body).
+    %% This is a simple alternative, but I would avoid call internal functions.
+    %%?assertEqual(6.0, hb_ao:get(<<"output/1">>, Res, ServerOpts)).
 
 send_large_signed_request_test() ->
     % Note: If the signature scheme ever changes, we will need to run the 

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -1188,21 +1188,16 @@ ans104_wasm_test() ->
         ),
     ?assert(hb_message:verify(Msg, all, ClientOpts)),
     ?event({msg, Msg}),
-    %% TODO: We could resolve before return, but I don't think that 
-    %% is the desired behaviour.
     {ok, Res} =
         post(
             URL,
             Msg#{ <<"path">> => <<"/init/compute/results">> },
             ClientOpts
         ),
-    %% TODO: Is there a better way to do this?
     {link, LinkID, _ } = maps:get(<<"output">>, Res),
     %% We need to resolve agaisnt the server cache
     {ok, #{<<"body">> := Body}} = post(URL, Msg#{<<"path">> => <<"/", LinkID/binary, "/1">>}, ClientOpts),
     ?assertEqual(<<"6.00000000000000000000e+00">>, Body).
-    %% This is a simple alternative, but I would avoid call internal functions.
-    %%?assertEqual(6.0, hb_ao:get(<<"output/1">>, Res, ServerOpts)).
 
 send_large_signed_request_test() ->
     % Note: If the signature scheme ever changes, we will need to run the 


### PR DESCRIPTION
The test was checking the local cache to resolve the output link. It needs to resolve the link using the server cache.