### PR TITLE
feat: Tooling for message corruption identification

### DIFF
--- a/src/dev_test.erl
+++ b/src/dev_test.erl
@@ -1,7 +1,7 @@
 -module(dev_test).
 -export([info/3]).
 -export([info/1, test_func/1, compute/3, init/3, restore/3, snapshot/3, mul/2]).
--export([update_state/3, increment_counter/3, delay/3]).
+-export([mangle/3, update_state/3, increment_counter/3, delay/3]).
 -export([index/3, postprocess/3, load/3]).
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
@@ -185,6 +185,29 @@ delay(Base, Req, Opts) ->
         end,
     ?event(delay, {returning, Return}),
     {ok, Return}.
+
+%% @doc Mangle the message by setting the first committed key to a random value.
+%% We do not update the message's commitments to reflect the new value, such that
+%% the message will be invalid after execution.
+%% 
+%% Caution: This function is not safe to use in production, as it may cause
+%% state inconsistencies.
+mangle(Base, _Req, Opts) ->
+    case hb_opts:get(mode, prod, Opts) of
+        prod -> {error, <<"`mangle' unavailable in `prod` mode.">>};
+        debug ->
+            ?no_prod("`mangle' is not safe to use in production."),
+            case hb_message:committed(Base, #{ <<"commitment-ids">> => <<"all">> }, Opts) of
+                [] ->
+                    {error, <<"No committed keys to mangle found on base message.">>};
+                [FirstKey|_] ->
+                    MangleReference = hb_util:human_id(crypto:strong_rand_bytes(32)),
+                    {
+                        ok,
+                        Base#{ FirstKey => <<"mangled-", MangleReference/binary>> }
+                    }
+            end
+    end.
 
 %%% Tests
 

--- a/src/hb_ao.erl
+++ b/src/hb_ao.erl
@@ -192,7 +192,7 @@ resolve_many([{resolve, Subres}], Opts) ->
 resolve_many(MsgList, Opts) ->
     ?event(ao_core, {resolve_many, MsgList}, Opts),
     Res = do_resolve_many(MsgList, Opts),
-    ?event(ao_core, {resolve_many_complete, {res, Res}, {req, MsgList}}, Opts),
+    ?event(ao_core, {resolve_many_complete, {res, Res}, {reqs, MsgList}}, Opts),
     Res.
 do_resolve_many([], _Opts) ->
     {failure, <<"Attempted to resolve an empty message sequence.">>};
@@ -385,8 +385,16 @@ resolve_stage(3, Base, Req, Opts) when not is_map(Base) or not is_map(Req) ->
     {error, not_found};
 resolve_stage(3, Base, Req, Opts) ->
     ?event(ao_core, {stage, 3, validation_check}, Opts),
-    % Validation checks: Enable as necessary. We do not presently perform any
-    % validity checks mid-execution, however we may wish to do so in the future.
+    % Validation checks: If `paranoid_message_verification' is enabled, we should
+    % verify the base and request messages prior to execution.
+    hb_message:paranoid_verify(
+        #{
+            <<"reason">> => <<"AO-Core Pre-Execution Validation">>,
+            <<"base">> => Base,
+            <<"request">> => Req
+        },
+        Opts
+    ),
     resolve_stage(4, Base, Req, Opts);
 resolve_stage(4, Base, Req, Opts) ->
     ?event(ao_core, {stage, 4, persistent_resolver_lookup}, Opts),
@@ -576,6 +584,15 @@ resolve_stage(6, Func, Base, Req, ExecName, Opts) ->
                     Opts
                 )
         end,
+    hb_message:paranoid_verify(
+        #{
+            <<"reason">> => <<"AO-Core Post-Execution Validation">>,
+            <<"base">> => Base,
+            <<"request">> => Req,
+            <<"result">> => Res
+        },
+        Opts
+    ),
     resolve_stage(7, Base, Req, Res, ExecName, Opts);
 resolve_stage(7, Base, Req, {St, Res}, ExecName, Opts = #{ on := On = #{ <<"step">> := _ }}) ->
     ?event(ao_core, {stage, 7, ExecName, executing_step_hook, {on, On}}, Opts),

--- a/src/hb_ao_test_vectors.erl
+++ b/src/hb_ao_test_vectors.erl
@@ -91,7 +91,13 @@ test_suite() ->
         {list_transform, "list transform",
             fun list_transform_test/1},
         {step_hook, "step hook",
-            fun step_hook_test/1}
+            fun step_hook_test/1},
+        {paranoid_message_verification, "paranoid message verification",
+            fun paranoid_message_verification_test/1},
+        {paranoid_input_verification, "paranoid input verification",
+            fun paranoid_input_verification_test/1},
+        {paranoid_result_verification, "paranoid result verification",
+            fun paranoid_result_verification_test/1}
     ].
 
 benchmark_suite() ->
@@ -195,7 +201,10 @@ test_opts() ->
                 deep_set_with_device,
                 as,
                 as_commitments,
-                step_hook
+                step_hook,
+                paranoid_message_verification,
+                paranoid_input_verification,
+                paranoid_result_verification
             ]
         }
     ].
@@ -993,6 +1002,51 @@ step_hook_test(InitOpts) ->
     ),
     % Test that the step hook was called.
     ?assert(receive {step, Ref} -> true after 100 -> false end).
+
+%% @doc Return the options for paranoid-mode verification tests. Adds the
+%% `paranoid_verify' flag and removes the `error' print option such that the 
+%% error messages are not printed.
+paranoid_opts(RawOpts) ->
+    PrintOpts =
+        case hb_opts:get(debug_print, false, RawOpts) of
+            List when is_list(List) ->
+                List -- [error];
+            Other ->
+                Other
+        end,
+    RawOpts#{
+        paranoid_verify => true,
+        debug_print => PrintOpts
+    }.
+
+paranoid_message_verification_test(RawOpts) ->
+    % Test that the `hb_message:paranoid_verify' infrastructure works correctly.
+    Opts = paranoid_opts(RawOpts),
+    Base = hb_message:normalize_commitments(#{ <<"a">> => 1 }, Opts),
+    ?assert(hb_message:paranoid_verify(Base, Opts)),
+    ?assertThrow(_, hb_message:paranoid_verify(Base#{ <<"a">> => 2 }, Opts)).
+
+paranoid_input_verification_test(RawOpts) ->
+    Opts = paranoid_opts(RawOpts),
+    % Test that the input and base messages are verified prior to execution.
+    Base = hb_message:normalize_commitments(#{ <<"a">> => 1 }, Opts),
+    Request =
+        hb_message:normalize_commitments(
+            #{ <<"path">> => <<"keys">>, <<"a">> => 1 },
+            Opts
+        ),
+    ?assertThrow(_, hb_ao:resolve(Base#{ <<"a">> => 2 }, Request, Opts)),
+    ?assertThrow(_, hb_ao:resolve(Base, Request#{ <<"a">> => 2 }, Opts)).
+
+paranoid_result_verification_test(RawOpts) ->
+    % Test that the result message is verified after execution.
+    Opts = paranoid_opts(RawOpts),
+    Base =
+        hb_message:normalize_commitments(
+            #{ <<"device">> => <<"test-device@1.0">>, <<"a">> => 1 },
+            Opts
+        ),
+    ?assertThrow(_, hb_ao:resolve(Base, <<"mangle">>, Opts)).
 
 %%% Benchmark tests
 benchmark_simple_test(Opts) ->

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -59,7 +59,8 @@
 -export([id/1, id/2, id/3]).
 -export([convert/3, convert/4, uncommitted/1, uncommitted/2, committed/3]).
 -export([with_only_committers/2, with_only_committers/3, commitment_devices/2]).
--export([verify/1, verify/2, verify/3, commit/2, commit/3, signers/2, type/1, minimize/1]).
+-export([verify/1, verify/2, verify/3, paranoid_verify/2]).
+-export([commit/2, commit/3, signers/2, type/1, minimize/1]).
 -export([normalize_commitments/2, normalize_commitments/3, is_signed_key/3]).
 -export([commitment/2, commitment/3, commitments/3]).
 -export([with_only_committed/2, without_unless_signed/3]).
@@ -511,6 +512,60 @@ verify(Msg, Spec, Opts) ->
             Opts
         ),
     Res.
+
+%% @doc Verify a message recursively, including all nested messages.
+paranoid_verify(Msg, Opts) ->
+    ?event(debug_paranoia, {paranoid_verify_called, Msg}, Opts),
+    case hb_opts:get(paranoid_verify, false, Opts) of
+        false -> true;
+        true ->
+            try
+                do_paranoid_verify([], Msg, Opts),
+                ?event(debug_paranoia, {paranoid_verify_complete, ok}, Opts),
+                true
+            catch
+                throw:{verification_failure, RawPath, FailedMsg, Details, Stack} ->
+                    Path = hb_path:to_binary(RawPath),
+                    ?event(error,
+                        {paranoid_verification_failure,
+                            {at_path, Path},
+                            {failed_message, FailedMsg},
+                            {while_verifying, Msg},
+                            {details, Details},
+                            {stack, {trace, Stack}}
+                        },
+                        Opts#{
+                            paranoid_verify => false
+                        }
+                    ),
+                    throw({paranoid_verification_failure, Path, Msg, FailedMsg})
+            end
+    end.
+do_paranoid_verify(Path, {_Status, Msg}, Opts) ->
+    do_paranoid_verify(Path, Msg, Opts);
+do_paranoid_verify(Path, Link, Opts) when ?IS_LINK(Link) ->
+    case hb_opts:get(paranoid_verify_links, true, Opts) of
+        false -> true;
+        true ->
+            do_paranoid_verify(Path, hb_cache:ensure_loaded(Link, Opts), Opts)
+    end;
+do_paranoid_verify(Path, ListMsg, Opts) when is_list(ListMsg) ->
+    do_paranoid_verify(Path, hb_util:list_to_numbered_message(ListMsg), Opts);
+do_paranoid_verify(Path, Msg, Opts) when is_map(Msg) ->
+    hb_maps:map(
+        fun(Key, Value) ->
+            do_paranoid_verify(Path ++ [Key], Value, Opts)
+        end,
+        uncommitted(hb_private:reset(Msg), Opts),
+        Opts
+    ),
+    try true = verify(Msg, #{ <<"commitment-ids">> => <<"all">> }, Opts)
+    catch
+        _:Details:St ->
+            throw({verification_failure, Path, Msg, Details, St})
+    end;
+do_paranoid_verify(_Path, _Msg, _Opts) ->
+    true.
 
 %% @doc Return the unsigned version of a message in AO-Core format.
 uncommitted(Msg) -> uncommitted(Msg, #{}).

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -47,6 +47,7 @@
         hb_config_location => {"HB_CONFIG", "config.flat"},
         port => {"HB_PORT", fun erlang:list_to_integer/1, "8734"},
         mode => {"HB_MODE", fun list_to_existing_atom/1},
+        paranoid_verify => {"HB_PARANOID", fun list_to_existing_atom/1, "false"},
         debug_print =>
             {"HB_PRINT",
                 fun


### PR DESCRIPTION
This patch adds tooling to AO-Core to aid developers in the identification of code paths which emit invalid messages. Verification of all messages before and after AO-Core execution (the `Base`, `Request`, and `Result`) may now be enabled by supplying the `paranoid_verify` node message key or adding `HB_PARANOID=true` as an environment flag before starting HyperBEAM.
