### PR TITLE
fix(process-cache): remove snapshot before commitment normalization

### DIFF
--- a/src/dev_process_cache.erl
+++ b/src/dev_process_cache.erl
@@ -13,7 +13,16 @@ read(ProcID, Opts) ->
 read(ProcID, SlotRef, Opts) ->
     ?event({reading_computed_result, ProcID, SlotRef}),
     Path = path(ProcID, SlotRef, Opts),
-    hb_cache:read(Path, Opts).
+    % hb_cache:read(Path, Opts).
+    case hb_cache:read(Path, Opts#{ skip_normalize => true }) of
+        {ok, RawResult} ->
+            %% Remove snapshot before normalizing commitments to avoid
+            %% inconsistency between committed keys and actual message keys.
+            ResultWithoutSnapshot = hb_maps:remove(<<"snapshot">>, RawResult, Opts),
+            {ok, hb_message:normalize_commitments(ResultWithoutSnapshot, Opts)};
+        Other ->
+            Other
+    end.
 
 %% @doc Write a process computation result to the cache.
 write(ProcID, Slot, Msg, Opts) ->

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -399,7 +399,10 @@ read(Path, Opts) ->
         store_read(Path, hb_opts:get(store, no_viable_store, Opts), Opts),
     case StoreReadResult of 
         {ok, Res} ->
-            {ok, hb_message:normalize_commitments(Res, Opts)};
+            case hb_opts:get(skip_normalize, false, Opts) of
+                true -> {ok, Res};
+                false -> {ok, hb_message:normalize_commitments(Res, Opts)}
+            end;
         _ -> StoreReadResult
     end.
 do_read_commitment(Path, Opts) ->


### PR DESCRIPTION
When reading compute results from cache, the HMAC commitment was being calculated while `snapshot` was still in the message. The snapshot was then removed before returning, and thus committed keys list included `snapshot` but the actual message did not.

This caused paranoid mode verification to fail with `badmatch: false`.

Fix by reading with `skip_normalize`, removing snapshot, then normalizing.