### PR TITLE
fix: `~process@1.0` result message integrity

### DIFF
--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -808,7 +808,7 @@ keys(Msg, Opts) ->
         ok,
         lists:filter(
             fun(Key) -> not hb_private:is_private(Key) end,
-            hb_maps:keys(Msg, Opts)
+            hb_maps:keys(hb_message:uncommitted(Msg, Opts), Opts)
         )
     }.
 

--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -7,7 +7,7 @@
 -module(dev_message).
 %%% Base AO-Core reserved keys:
 -export([info/0, keys/1, keys/2]).
--export([set/3, set_path/3, remove/2, remove/3, get/3, get/4]).
+-export([set/3, set_path/3, remove/3, get/3, get/4]).
 %%% Commitment-specific keys:
 -export([id/1, id/2, id/3]).
 -export([commit/3, committed/3, committers/1, committers/2, committers/3, verify/3]).
@@ -785,13 +785,14 @@ set_path(Base, Value, Opts) when not is_map(Value) ->
     end.
 
 %% @doc Remove a key or keys from a message.
-remove(Base, Key) ->
-	remove(Base, Key, #{}).
-
 remove(Base, #{ <<"item">> := Key }, Opts) ->
     remove(Base, #{ <<"items">> => [Key] }, Opts);
 remove(Base, #{ <<"items">> := Keys }, Opts) ->
-    { ok, hb_maps:without(Keys, Base, Opts) }.
+    set(
+        Base,
+        #{ Key => unset || Key <- Keys },
+        Opts
+    ).
 
 %% @doc Get the public keys of a message.
 keys(Msg) ->

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -159,23 +159,10 @@ snapshot(RawBase, _Req, Opts) ->
             Base,
             #{ <<"path">> => <<"snapshot">>, <<"mode">> => <<"Map">> },
             Opts#{
-                cache_control => [<<"no-cache">>, <<"no-store">>],
-                hashpath => ignore
+                cache_control => [<<"no-cache">>, <<"no-store">>]
             }
         ),
-    ProcID = hb_message:id(Base, all, Opts),
-    Slot = hb_ao:get(<<"at-slot">>, {as, <<"message@1.0">>, Base}, Opts),
-    {ok,
-        hb_private:set(
-            SnapshotMsg#{ <<"cache-control">> => [<<"store">>] },
-            #{ <<"priv/additional-hashpaths">> =>
-                    [
-                        hb_path:to_binary([ProcID, <<"snapshot">>, Slot])
-                    ]
-            },
-            Opts
-        )
-    }.
+    {ok, SnapshotMsg}.
 
 %% @doc Before computation begins, a boot phase is required. This phase
 %% allows devices on the execution stack to initialize themselves. We set the
@@ -383,7 +370,10 @@ compute_slot(ProcID, State, RawInputMsg, ReqMsg, Opts) ->
             NewProcStateMsgWithSlot =
                 hb_ao:set(
                     NewProcStateMsg,
-                    #{ <<"device">> => <<"process@1.0">>, <<"at-slot">> => NextSlot },
+                    #{
+                        <<"device">> => <<"process@1.0">>,
+                        <<"at-slot">> => NextSlot
+                    },
                     Opts
                 ),
             % Notify any waiters that the result for a slot is now available.
@@ -415,8 +405,11 @@ store_result(ForceSnapshot, ProcID, Slot, Res, Req, Opts) ->
         case ForceSnapshot orelse should_snapshot(Slot, Res, Opts) of
             false -> Res;
             true ->
-                ?event(compute_debug,
-                    {snapshotting, {proc_id, ProcID}, {slot, Slot}}, Opts),
+                ?event(
+                    compute_debug,
+                    {snapshotting, {proc_id, ProcID}, {slot, Slot}},
+                    Opts
+                ),
                 {ok, Snapshot} = snapshot(Res, Req, Opts),
 				?event(snapshot,
 					{got_snapshot,
@@ -432,9 +425,16 @@ store_result(ForceSnapshot, ProcID, Slot, Res, Req, Opts) ->
                     },
                     Opts
                 ),
+                WithSnapshot =
+                    hb_ao:set(
+                        Res,
+                        <<"snapshot">>,
+                        Snapshot,
+                        Opts
+                    ),
 				WithLastSnapshot =
                     hb_private:set(
-                        Res#{ <<"snapshot">> => Snapshot },
+                        WithSnapshot,
                         <<"last-snapshot">>,
                         os:system_time(second),
                         Opts
@@ -676,4 +676,4 @@ ensure_loaded(Base, Req, Opts) ->
 
 %% @doc Remove the `snapshot' key from a message and return it.
 without_snapshot(Msg, Opts) ->
-    hb_maps:remove(<<"snapshot">>, Msg, Opts).
+    hb_ao:set(Msg, <<"snapshot">>, unset, Opts).

--- a/src/dev_process_lib.erl
+++ b/src/dev_process_lib.erl
@@ -38,10 +38,11 @@ run_as(Key, Base, Req, Opts) ->
     ?event({running_as, {key, {explicit, Key}}, {req, Req}}),
     % Prepare the message with the specialized device configuration.
     % This sets up the device context for the specific operation type.
-    PreparedMsg =
-        hb_util:deep_merge(
+    {ok, PreparedMsg} =
+        hb_ao:resolve(
             ensure_process_key(Base, Opts),
             #{
+                <<"path">> => <<"set">>,
                 <<"device">> =>
                     DeviceSet =
                         hb_maps:get(

--- a/src/dev_process_test_vectors.erl
+++ b/src/dev_process_test_vectors.erl
@@ -227,7 +227,7 @@ test_device_compute_test() ->
         hb_ao:resolve(
             Base,
             <<"schedule/assignments/1/body/test-label">>,
-            #{ <<"hashpath">> => ignore }
+            #{}
         )
     ),
     Req = #{ <<"path">> => <<"compute">>, <<"slot">> => 1 },
@@ -239,24 +239,45 @@ test_device_compute_test() ->
 wasm_compute_test() ->
     init(),
     Base = wasm_process(<<"test/test-64.wasm">>),
+    schedule_wasm_call(Base, <<"fac">>, [2.0]),
+    schedule_wasm_call(Base, <<"fac">>, [3.0]),
+    schedule_wasm_call(Base, <<"fac">>, [4.0]),
     schedule_wasm_call(Base, <<"fac">>, [5.0]),
     schedule_wasm_call(Base, <<"fac">>, [6.0]),
-    {ok, Res} = 
+    {ok, _} = 
         hb_ao:resolve(
             Base,
-            #{ <<"path">> => <<"compute">>, <<"slot">> => 0 },
-            #{ <<"hashpath">> => ignore }
+            #{ <<"path">> => <<"compute">>, <<"slot">> => 3 },
+            #{}
         ),
-    ?event({computed_message, {res, Res}}),
-    ?assertEqual([120.0], hb_ao:get(<<"results/output">>, Res, #{})),
-    {ok, Msg4} = 
+    {ok, _} = 
+        hb_ao:resolve(
+            Base,
+            #{ <<"path">> => <<"compute">>, <<"slot">> => 3 },
+            #{}
+        ),
+    {ok, _} = 
        hb_ao:resolve(
             Base,
             #{ <<"path">> => <<"compute">>, <<"slot">> => 1 },
-            #{ <<"hashpath">> => ignore }
+            #{}
         ),
-    ?event({computed_message, {msg4, Msg4}}),
-    ?assertEqual([720.0], hb_ao:get(<<"results/output">>, Msg4, #{})).
+    {ok, _} = 
+        hb_ao:resolve(
+            Base,
+            #{ <<"path">> => <<"compute">>, <<"slot">> => 2 },
+            #{}
+        ),
+    {ok, _} = 
+        hb_ao:resolve(
+            Base,
+            #{ <<"path">> => <<"compute">>, <<"slot">> => 4 },
+            #{}
+        ),
+    ok.
+    % ?assertEqual([24.0], hb_ao:get(<<"results/output">>, Slot2Res, #{})),
+    % ?assertEqual([2.0], hb_ao:get(<<"results/output">>, Slot0Res, #{})),
+    % ?assertEqual([6.0], hb_ao:get(<<"results/output">>, Slot1Res, #{})).
 
 wasm_compute_from_id_test() ->
     init(),

--- a/src/dev_scheduler_formats.erl
+++ b/src/dev_scheduler_formats.erl
@@ -207,8 +207,7 @@ aos2_normalize_types(Msg) ->
     ?event(
         {
             aos2_normalized_types,
-            {msg, Msg},
-            {anchor, hb_ao:get(<<"anchor">>, Msg, <<>>, #{})}
+            {msg, Msg}
         }
     ),
     Msg.


### PR DESCRIPTION
Previously, calls to `~process@1.0/as` and `~process@1.0/snapshot` could leave to inconsistencies in result verifiability. These issues were detected as a result of the the work in #604 and solved in this PR.