### PR TITLE
impr: Allow executing a subset of message integrity checks

### DIFF
--- a/src/hb_ao.erl
+++ b/src/hb_ao.erl
@@ -388,6 +388,7 @@ resolve_stage(3, Base, Req, Opts) ->
     % Validation checks: If `paranoid_message_verification' is enabled, we should
     % verify the base and request messages prior to execution.
     hb_message:paranoid_verify(
+        pre_resolve,
         #{
             <<"reason">> => <<"AO-Core Pre-Execution Validation">>,
             <<"base">> => Base,
@@ -585,6 +586,7 @@ resolve_stage(6, Func, Base, Req, ExecName, Opts) ->
                 )
         end,
     hb_message:paranoid_verify(
+        post_resolve,
         #{
             <<"reason">> => <<"AO-Core Post-Execution Validation">>,
             <<"base">> => Base,

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -229,6 +229,7 @@ generate_binary_path(Bin, Opts) ->
 %% the commitments of the inner messages. We do not, however, store the IDs from
 %% commitments on signed _inner_ messages. We may wish to revisit this.
 write(RawMsg, Opts) when is_map(RawMsg) ->
+    hb_message:paranoid_verify(cache_write, RawMsg, Opts),
     {ok, Msg} = hb_message:with_only_committed(RawMsg, Opts),
     TABM = hb_message:convert(Msg, tabm, <<"structured@1.0">>, Opts),
     ?event(debug_cache, {writing_full_message, {msg, TABM}}),
@@ -399,6 +400,7 @@ read(Path, Opts) ->
         store_read(Path, hb_opts:get(store, no_viable_store, Opts), Opts),
     case StoreReadResult of 
         {ok, Res} ->
+            hb_message:paranoid_verify(cache_read, Res, Opts),
             {ok, hb_message:normalize_commitments(Res, Opts)};
         _ -> StoreReadResult
     end.

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -59,7 +59,7 @@
 -export([id/1, id/2, id/3]).
 -export([convert/3, convert/4, uncommitted/1, uncommitted/2, committed/3]).
 -export([with_only_committers/2, with_only_committers/3, commitment_devices/2]).
--export([verify/1, verify/2, verify/3, paranoid_verify/2]).
+-export([verify/1, verify/2, verify/3, paranoid_verify/2, paranoid_verify/3]).
 -export([commit/2, commit/3, signers/2, type/1, minimize/1]).
 -export([normalize_commitments/2, normalize_commitments/3, is_signed_key/3]).
 -export([commitment/2, commitment/3, commitments/3]).
@@ -515,46 +515,55 @@ verify(Msg, Spec, Opts) ->
 
 %% @doc Verify a message recursively, including all nested messages.
 paranoid_verify(Msg, Opts) ->
+    paranoid_verify(default, Msg, Opts).
+paranoid_verify(Topic, Msg, Opts) ->
     ?event(debug_paranoia, {paranoid_verify_called, Msg}, Opts),
     case hb_opts:get(paranoid_verify, false, Opts) of
-        false -> true;
-        true ->
-            try
-                do_paranoid_verify([], Msg, Opts),
-                ?event(debug_paranoia, {paranoid_verify_complete, ok}, Opts),
-                true
-            catch
-                throw:{verification_failure, RawPath, FailedMsg, Details, Stack} ->
-                    Path = hb_path:to_binary(RawPath),
-                    ?event(error,
-                        {paranoid_verification_failure,
-                            {at_path, Path},
-                            {failed_message, FailedMsg},
-                            {while_verifying, Msg},
-                            {details, Details},
-                            {stack, {trace, Stack}}
-                        },
-                        Opts#{
-                            paranoid_verify => false
-                        }
-                    ),
-                    throw({paranoid_verification_failure, Path, Msg, FailedMsg})
+        true -> do_paranoid_verify(Topic, Msg, Opts);
+        Topics ->
+            case lists:member(Topic, Topics) of
+                false -> true;
+                true -> do_paranoid_verify(Topic, Msg, Opts)
             end
     end.
-do_paranoid_verify(Path, {_Status, Msg}, Opts) ->
-    do_paranoid_verify(Path, Msg, Opts);
-do_paranoid_verify(Path, Link, Opts) when ?IS_LINK(Link) ->
+
+do_paranoid_verify(Topic, Msg, Opts) ->
+    try
+        do_paranoid_verify(Topic, [], Msg, Opts),
+        ?event(debug_paranoia, {paranoid_verify_complete, ok}, Opts),
+        true
+    catch
+        throw:{verification_failure, RawPath, FailedMsg, Details, Stack} ->
+            Path = hb_path:to_binary(RawPath),
+            ?event(error,
+                {paranoid_verification_failure,
+                    {triggered_by, Topic},
+                    {at_path, Path},
+                    {failed_message, FailedMsg},
+                    {while_verifying, Msg},
+                    {details, Details},
+                    {stack, {trace, Stack}}
+                },
+                Opts#{
+                    paranoid_verify => false
+                }
+            ),
+            throw({paranoid_verification_failure, Topic, Path, Msg, FailedMsg})
+    end.
+do_paranoid_verify(Topic, Path, {_Status, Msg}, Opts) ->
+    do_paranoid_verify(Topic, Path, Msg, Opts);
+do_paranoid_verify(Topic, Path, Link, Opts) when ?IS_LINK(Link) ->
     case hb_opts:get(paranoid_verify_links, true, Opts) of
         false -> true;
         true ->
-            do_paranoid_verify(Path, hb_cache:ensure_loaded(Link, Opts), Opts)
+            do_paranoid_verify(Topic, Path, hb_cache:ensure_loaded(Link, Opts), Opts)
     end;
-do_paranoid_verify(Path, ListMsg, Opts) when is_list(ListMsg) ->
-    do_paranoid_verify(Path, hb_util:list_to_numbered_message(ListMsg), Opts);
-do_paranoid_verify(Path, Msg, Opts) when is_map(Msg) ->
+do_paranoid_verify(Topic, Path, ListMsg, Opts) when is_list(ListMsg) ->
+    do_paranoid_verify(Topic, Path, hb_util:list_to_numbered_message(ListMsg), Opts);
+do_paranoid_verify(Topic, Path, Msg, Opts) when is_map(Msg) ->
     hb_maps:map(
         fun(Key, Value) ->
-            do_paranoid_verify(Path ++ [Key], Value, Opts)
+            do_paranoid_verify(Topic, Path ++ [Key], Value, Opts)
         end,
         uncommitted(hb_private:reset(Msg), Opts),
         Opts
@@ -562,9 +571,9 @@ do_paranoid_verify(Path, Msg, Opts) when is_map(Msg) ->
     try true = verify(Msg, #{ <<"commitment-ids">> => <<"all">> }, Opts)
     catch
         _:Details:St ->
-            throw({verification_failure, Path, Msg, Details, St})
+            throw({verification_failure, Topic, Path, Msg, Details, St})
     end;
-do_paranoid_verify(_Path, _Msg, _Opts) ->
+do_paranoid_verify(_Topic, _Path, _Msg, _Opts) ->
     true.
 
 %% @doc Return the unsigned version of a message in AO-Core format.
@@ -865,7 +874,8 @@ commitment(#{ <<"type">> := <<"unsigned">> }, Msg, Opts) ->
             {ok, CommID, hb_util:ok(hb_maps:find(CommID, UnsignedCommitments, Opts))};
         true ->
             ?event(commitment, {multiple_matches, {matches, UnsignedCommitments}}),
-            multiple_matches    end;
+            multiple_matches
+    end;
 commitment(Spec, Msg, Opts) ->
     Matches = commitments(Spec, Msg, Opts),
     ?event(debug_commitment, {commitment, {spec, Spec}, {matches, Matches}}),
@@ -877,10 +887,7 @@ commitment(Spec, Msg, Opts) ->
         true ->
             ?event(commitment, {multiple_matches, {matches, Matches}}),
             multiple_matches
-    end;
-commitment(_Spec, _Msg, _Opts) ->
-    % The message has no commitments, so the spec can never match.
-    not_found.
+    end.
 
 %% @doc Return a list of all commitments that match the spec.
 commitments(ID, Link, Opts) when ?IS_LINK(Link) ->

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -47,19 +47,12 @@
         hb_config_location => {"HB_CONFIG", "config.flat"},
         port => {"HB_PORT", fun erlang:list_to_integer/1, "8734"},
         mode => {"HB_MODE", fun list_to_existing_atom/1},
-        paranoid_verify => {"HB_PARANOID", fun list_to_existing_atom/1, "false"},
+        paranoid_verify =>
+            {"HB_PARANOID", fun topic_list_to_atoms/1, "false"},
         debug_print =>
-            {"HB_PRINT",
-                fun
-                    ({preparsed, Parsed}) -> Parsed;
-                    (Str) when Str == "1" -> true;
-                    (Str) when Str == "true" -> true;
-                    (Str) ->
-                        lists:map(
-                            fun(Topic) -> list_to_atom(Topic) end,
-                            string:tokens(Str, ",")
-                        )
-                end,
+            {
+                "HB_PRINT",
+                fun topic_list_to_atoms/1,
                 {preparsed, ?DEFAULT_PRINT_OPTS}
             },
         lua_scripts => {"LUA_SCRIPTS", "scripts"},
@@ -88,6 +81,17 @@
             }
     }
 ).
+
+%% @doc Convert a comma-separated list of topics, as occassionally used by `HB_*`
+%% environment variables, to a list of atoms. Additionally, will return `true' if
+%% the string is `true', `1', or `all'.
+topic_list_to_atoms({preparsed, Parsed}) -> Parsed;
+topic_list_to_atoms("false") -> [];
+topic_list_to_atoms("1") -> true;
+topic_list_to_atoms("true") -> true;
+topic_list_to_atoms("all") -> true;
+topic_list_to_atoms(Str) ->
+    lists:map(fun(Topic) -> list_to_atom(Topic) end, string:tokens(Str, ",")).
 
 %% @doc Return the default message with all environment variables set.
 default_message_with_env() ->


### PR DESCRIPTION
Introduces `topic`s, akin to `hb_event`, for each `hb_message:paranoid_verify` check. Additionally, `hb_cache` read and write integrity checks have been introduced.

The list of additional message integrity checks to execute can be controlled with `HB_PARANOID=1|true|cache_read,cache_write[,other topics]`. The overhead for `HB_PARANOID=cache_read,cache_write` is approximately 99% lower than for `HB_PARANOID=1`.