### PR TITLE
fix: preserve `content-type` key in `httpsig@1.0` bundled messages

### DIFF
--- a/src/dev_codec_httpsig_conv.erl
+++ b/src/dev_codec_httpsig_conv.erl
@@ -254,10 +254,9 @@ from_body_part(InlinedKey, Part, Opts) ->
             RestHeaders =
                 hb_maps:without(
                     [
-                        <<"content-disposition">>, 
-                        <<"content-type">>, 
-                        <<"ao-body-key">>, 
-                        <<"content-digest">>
+                        <<"ao-body-key">>,
+                        <<"content-digest">>,
+                        <<"content-disposition">>
                     ],
                     Headers,
                     Opts


### PR DESCRIPTION
Fixes an error in which `content-type` was inappropriately removed from nested bundled messages in `~httpsig@1.0` form. `content-type` should only be removed from the root message and only if it starts `multipart/`.
