### PR TITLE
Fix multiple cache loading message

### DIFF
--- a/src/dev_codec_httpsig_conv.erl
+++ b/src/dev_codec_httpsig_conv.erl
@@ -900,7 +900,7 @@ group_maps_flat_compatible_test() ->
     ?assertEqual(dev_codec_flat:from(Lifted, #{}, #{}), {ok, Map}),
     ok.
 
-encode_message_with_links_test() ->
+encode_message_with_cache_values_test() ->
     Msg = #{
         <<"immediate-key">> => <<"immediate-value">>,
         <<"typed-key">> => 4
@@ -908,7 +908,7 @@ encode_message_with_links_test() ->
     {ok, Path} = hb_cache:write(Msg, #{}),
     {ok, Read} = hb_cache:read(Path, #{}),
     % Ensure that the message now has a lazy link
-    ?assertMatch({link, _, _}, maps:get(<<"typed-key">>, Read, #{})),
+    ?assertNotMatch({link, _, _}, maps:get(<<"typed-key">>, Read, #{})),
     % Encode and decode the message as `httpsig@1.0`
     Enc = hb_message:convert(Msg, <<"httpsig@1.0">>, #{}),
     ?event({encoded, Enc}),

--- a/src/dev_codec_httpsig_conv.erl
+++ b/src/dev_codec_httpsig_conv.erl
@@ -908,7 +908,7 @@ encode_message_with_cache_values_test() ->
     {ok, Path} = hb_cache:write(Msg, #{}),
     {ok, Read} = hb_cache:read(Path, #{}),
     % Ensure that the message now has a lazy link
-    ?assertNotMatch({link, _, _}, maps:get(<<"typed-key">>, Read, #{})),
+    ?assertEqual(4, maps:get(<<"typed-key">>, Read, #{})),
     % Encode and decode the message as `httpsig@1.0`
     Enc = hb_message:convert(Msg, <<"httpsig@1.0">>, #{}),
     ?event({encoded, Enc}),

--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -272,6 +272,7 @@ commit(Self, Req, Opts) ->
         ),
     % Encode to a TABM
     Loaded =
+        %% This is where the message is first loaded from cache
         ensure_commitments_loaded(
             hb_message:convert(Base, tabm, CommitOpts),
             Opts

--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -272,7 +272,6 @@ commit(Self, Req, Opts) ->
         ),
     % Encode to a TABM
     Loaded =
-        %% This is where the message is first loaded from cache
         ensure_commitments_loaded(
             hb_message:convert(Base, tabm, CommitOpts),
             Opts

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -238,7 +238,7 @@ do_normalize_commitments(Msg, Opts, passive) ->
     }),
     case {UnsignedCommitments, SignedCommitments} of
         {[], _} ->
-            {ok, #{ <<"commitments">> := NewCommitments }} =
+            {ok, #{ <<"commitments">> := NewCommitments } = LoadedMsg} =
                 dev_message:commit(
                     uncommitted(Msg),
                     #{ 
@@ -251,7 +251,7 @@ do_normalize_commitments(Msg, Opts, passive) ->
                 hb_maps:from_list(SignedCommitments),
                 Opts
             ),
-            Msg#{ <<"commitments">> => MergedCommitments };
+            LoadedMsg#{ <<"commitments">> => MergedCommitments };
         _ -> Msg
     end;
 do_normalize_commitments(Msg, Opts, verify) ->
@@ -262,7 +262,7 @@ do_normalize_commitments(Msg, Opts, verify) ->
                 {ID, #{ <<"committed">> => Committed }};
             _ -> {undefined, #{}}
         end,
-    {ok, #{ <<"commitments">> := NormCommitments }} =
+    {ok, #{ <<"commitments">> := NormCommitments } = LoadedMsg} =
         dev_message:commit(
             uncommitted(Msg),
             MaybeCommittedSpec#{ 
@@ -278,7 +278,7 @@ do_normalize_commitments(Msg, Opts, verify) ->
         {undefined, _NewID} ->
             % We did not have an unsigned ID to begin with, so we need to add it.
             attach_phash2(
-                Msg#{
+                LoadedMsg#{
                     <<"commitments">> =>
                         hb_maps:merge(
                             NormCommitments,
@@ -290,14 +290,14 @@ do_normalize_commitments(Msg, Opts, verify) ->
         {_OldID, _NewID} ->
             {ok, #{ <<"commitments">> := NewCommitments }} = 
                 dev_message:commit(
-                    uncommitted(Msg),
+                    uncommitted(LoadedMsg),
                     #{ <<"type">> => <<"unsigned">> },
                     Opts
                 ),
             % We had an unsigned ID to begin with and the new one is different.
             % This means that the committed keys have changed, so we drop any
             % other commitments and return only the new unsigned one.
-            attach_phash2(Msg#{ <<"commitments">> => NewCommitments }, Opts)
+            attach_phash2(LoadedMsg#{ <<"commitments">> => NewCommitments }, Opts)
     end;
 do_normalize_commitments(Msg, Opts, fast) when is_map(Msg) ->
     ExpectedHash = erlang:phash2(hb_private:reset(Msg)),

--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -66,6 +66,7 @@
 -export([with_only_committed/2, without_unless_signed/3]).
 -export([with_commitments/3, without_commitments/3, remove_all_commitments/2]).
 -export([diff/3, match/2, match/3, match/4, find_target/3]).
+-export([contains_links/1]).
 %%% Helpers:
 -export([default_tx_list/0, filter_default_keys/1]).
 %%% Debugging tools:
@@ -251,8 +252,19 @@ do_normalize_commitments(Msg, Opts, passive) ->
                 hb_maps:from_list(SignedCommitments),
                 Opts
             ),
-            LoadedMsg#{ <<"commitments">> => MergedCommitments };
-        _ -> Msg
+            %% We don't always want the LoadedMsg. If the Msg isn't linkfied, 
+            %% we will use that instead. Only when Msg is linkfied, we use 
+            %% the LoadedMsg.
+            IsMsgLinked = contains_links(Msg),
+            IsLoadedMsgLinked = contains_links(LoadedMsg),
+            case {IsMsgLinked, IsLoadedMsgLinked} of 
+                {true, false} -> 
+                    LoadedMsg#{ <<"commitments">> => MergedCommitments };
+                _ ->
+                    Msg#{ <<"commitments">> => MergedCommitments }
+            end;
+        _ -> 
+            Msg
     end;
 do_normalize_commitments(Msg, Opts, verify) ->
     UnsignedCommitment = commitment(#{ <<"type">> => <<"unsigned">> }, Msg, Opts),
@@ -262,7 +274,7 @@ do_normalize_commitments(Msg, Opts, verify) ->
                 {ID, #{ <<"committed">> => Committed }};
             _ -> {undefined, #{}}
         end,
-    {ok, #{ <<"commitments">> := NormCommitments } = LoadedMsg} =
+    {ok, #{ <<"commitments">> := NormCommitments }} =
         dev_message:commit(
             uncommitted(Msg),
             MaybeCommittedSpec#{ 
@@ -278,7 +290,7 @@ do_normalize_commitments(Msg, Opts, verify) ->
         {undefined, _NewID} ->
             % We did not have an unsigned ID to begin with, so we need to add it.
             attach_phash2(
-                LoadedMsg#{
+                Msg#{
                     <<"commitments">> =>
                         hb_maps:merge(
                             NormCommitments,
@@ -290,14 +302,14 @@ do_normalize_commitments(Msg, Opts, verify) ->
         {_OldID, _NewID} ->
             {ok, #{ <<"commitments">> := NewCommitments }} = 
                 dev_message:commit(
-                    uncommitted(LoadedMsg),
+                    uncommitted(Msg),
                     #{ <<"type">> => <<"unsigned">> },
                     Opts
                 ),
             % We had an unsigned ID to begin with and the new one is different.
             % This means that the committed keys have changed, so we drop any
             % other commitments and return only the new unsigned one.
-            attach_phash2(LoadedMsg#{ <<"commitments">> => NewCommitments }, Opts)
+            attach_phash2(Msg#{ <<"commitments">> => NewCommitments }, Opts)
     end;
 do_normalize_commitments(Msg, Opts, fast) when is_map(Msg) ->
     ExpectedHash = erlang:phash2(hb_private:reset(Msg)),
@@ -990,3 +1002,6 @@ default_tx_message() ->
 default_tx_list() ->
     Keys = lists:map(fun hb_ao:normalize_key/1, record_info(fields, tx)),
     lists:zip(Keys, tl(tuple_to_list(#tx{}))).
+
+contains_links(Msg) when is_map(Msg) ->
+    maps:filter(fun (_Key, Value) -> ?IS_LINK(Value) end, Msg) /= #{}.


### PR DESCRIPTION
We discovered an issue where the message was fetching data from cache 3 times during a call to a transaction ID.

Example: `curl http://localhost:8734/ICC8rNh2ziKUDQHK7wnoaxtO0KNKYuW1dCwZc8B9e4g` was accessed 2 more times than usual to the cache in `hb_http:reply` function because the message handed from `dev_meta` to `hb_http:reply` didn't contain the results fetched from cache.

Message was first loaded inside `do_normalize_message` call by `dev_message:commit`, which calls `hb_message:convert` and then [`hb_link:normalize`](https://github.com/permaweb/HyperBEAM/blob/4d657e4ca956e8116e0324d78731d8601cfa3d25/src/hb_link.erl#L83-L87), which loads the information in the cache.

In some cases, loading can be avoided by providing the header `bundle: false`, but this wasn't a solution here.

This is a list of the time spent in some function while processing the request.

```
sent, status: 200, duration: 23955, method: GET, path: /ICC8rNh2ziKUDQHK7wnoaxtO0KNKYuW1dCwZc8B9e4g, body_size: 570206867
-- store_read, path: ICC8r..B9e4g, duration: 595
-- store_read, path: ICC8r..B9e4g/data, duration: 6101
-- http_reply: duration: 15599
---- reply_handle_cookies: duration: 6710
------ store_read, path: ICC8r..B9e4g/data, duration: 6677
---- encode_reply: duration: 8883
------ store_read, path: ICC8r..B9e4g/data, duration: 5490
```

**Improvement**
`http_reply: duration: 2703` (now) vs `http_reply: duration: 15207` (previously).