### PR TITLE
Fix paranoid when fetching a TX id

### DIFF
--- a/src/hb_message.erl
+++ b/src/hb_message.erl
@@ -533,7 +533,7 @@ do_paranoid_verify(Topic, Msg, Opts) ->
         ?event(debug_paranoia, {paranoid_verify_complete, ok}, Opts),
         true
     catch
-        throw:{verification_failure, RawPath, FailedMsg, Details, Stack} ->
+        throw:{verification_failure, _Topic, RawPath, FailedMsg, Details, Stack} ->
             Path = hb_path:to_binary(RawPath),
             ?event(error,
                 {paranoid_verification_failure,

--- a/src/hb_util.erl
+++ b/src/hb_util.erl
@@ -67,7 +67,9 @@ atom(Str) when is_binary(Str) ->
 atom(Str) when is_list(Str) ->
     list_to_existing_atom(Str);
 atom(Atom) when is_atom(Atom) ->
-    Atom.
+    Atom;
+atom(#{<<"ao-result">> := Key} = Result) ->
+    atom(maps:get(Key, Result)).
 
 %% @doc Coerce a value to a binary.
 bin(Value) when is_atom(Value) ->


### PR DESCRIPTION
While fetching a transaction ID, I've found a bug when `HB_PARANOID` was set to `true`.

`curl -v localhost:8734/BOogk_XAI3bvNWnxNxwxmvOfglZt17o4MOVAdPNZ_ew`