### PR TITLE
impr: httpsig duplicate component handling on commit/verify 

### DIFF
--- a/src/dev_codec_httpsig.erl
+++ b/src/dev_codec_httpsig.erl
@@ -125,6 +125,7 @@ commit(MsgToSign, Req = #{ <<"type">> := <<"rsa-pss-sha512">> }, RawOpts) ->
         {generating_rsa_pss_sha512_commitment, {msg, MsgToSign}, {req, Req}}
     ),
     Opts = opts(RawOpts),
+    ensure_unique_committed_req(Req),
     Wallet = hb_opts:get(priv_wallet, no_viable_wallet, Opts),
     if Wallet =:= no_viable_wallet ->
         throw({cannot_commit, no_viable_wallet, MsgToSign});
@@ -189,6 +190,7 @@ commit(MsgToSign, Req = #{ <<"type">> := <<"rsa-pss-sha512">> }, RawOpts) ->
 commit(BaseMsg, Req = #{ <<"type">> := <<"hmac-sha256">> }, RawOpts) ->
     % Extract the key material from the request.
     Opts = opts(RawOpts),
+    ensure_unique_committed_req(Req),
     ?event({req_to_key_material, {req, Req}}),
     {ok, Scheme, Key, KeyID} = dev_codec_httpsig_keyid:req_to_key_material(Req, Opts),
     Committer = dev_codec_httpsig_keyid:keyid_to_committer(Scheme, KeyID),
@@ -451,7 +453,7 @@ signature_base(EncodedMsg, Commitment, Opts) ->
 
 %% @doc Given a list of Component Identifiers and a Request/Response Message
 %% context, create the "signature-base-line" portion of the signature base
-%% TODO: catch duplicate identifier:
+%% catch duplicate identifier:
 %% https://datatracker.ietf.org/doc/html/rfc9421#section-2.5-7.2.2.5.2.1
 %%
 %% See https://datatracker.ietf.org/doc/html/rfc9421#section-2.5-7.2.1
@@ -476,6 +478,21 @@ signature_components_line(Req, Commitment, _Opts) ->
             maps:get(<<"committed">>, Commitment)
         ),
 	iolist_to_binary(lists:join(<<"\n">>, ComponentsLines)).
+
+ensure_unique_components(Components) ->
+    case length(Components) =:= length(lists:usort(Components)) of
+        true -> ok;
+        false -> throw({duplicate_signature_component, Components})
+    end.
+
+ensure_unique_committed_req(Req) ->
+    case maps:get(<<"committed">>, Req, undefined) of
+        undefined -> ok;
+        Explicit ->
+            ensure_unique_components(
+                hb_util:message_to_ordered_list(Explicit, #{})
+            )
+    end.
 
 %% @doc construct the "signature-params-line" part of the signature base.
 %%
@@ -650,3 +667,22 @@ sign_and_verify_link_test() ->
     Signed = hb_message:commit(NormMsg, Opts),
     ?event({signed_msg, Signed}),
     ?assert(hb_message:verify(Signed, Opts)).
+
+%% @doc Ensure duplicate committed components error in httpsig commit.
+duplicate_signature_component_test() ->
+    Msg = #{
+        <<"normal">> => <<"typical-value">>,
+        <<"untyped">> => #{ <<"inner-untyped">> => <<"inner-value">> },
+        <<"typed">> => #{ <<"inner-typed">> => 123 }
+    },
+    Opts = #{ priv_wallet => hb:wallet() },
+    Res =
+        catch dev_codec_httpsig:commit(
+            Msg,
+            #{
+                <<"type">> => <<"rsa-pss-sha512">>,
+                <<"committed">> => [<<"normal">>, <<"normal">>]
+            },
+            Opts
+        ),
+    ?assertMatch({duplicate_signature_component, _}, Res).

--- a/src/dev_codec_httpsig.erl
+++ b/src/dev_codec_httpsig.erl
@@ -125,7 +125,6 @@ commit(MsgToSign, Req = #{ <<"type">> := <<"rsa-pss-sha512">> }, RawOpts) ->
         {generating_rsa_pss_sha512_commitment, {msg, MsgToSign}, {req, Req}}
     ),
     Opts = opts(RawOpts),
-    ensure_unique_committed_req(Req),
     Wallet = hb_opts:get(priv_wallet, no_viable_wallet, Opts),
     if Wallet =:= no_viable_wallet ->
         throw({cannot_commit, no_viable_wallet, MsgToSign});
@@ -190,7 +189,6 @@ commit(MsgToSign, Req = #{ <<"type">> := <<"rsa-pss-sha512">> }, RawOpts) ->
 commit(BaseMsg, Req = #{ <<"type">> := <<"hmac-sha256">> }, RawOpts) ->
     % Extract the key material from the request.
     Opts = opts(RawOpts),
-    ensure_unique_committed_req(Req),
     ?event({req_to_key_material, {req, Req}}),
     {ok, Scheme, Key, KeyID} = dev_codec_httpsig_keyid:req_to_key_material(Req, Opts),
     Committer = dev_codec_httpsig_keyid:keyid_to_committer(Scheme, KeyID),
@@ -324,6 +322,7 @@ normalize_for_encoding(Msg, Commitment, Opts) ->
             maps:get(<<"committed">>, Commitment, []),
             Opts
         ),
+    ensure_unique_components(RawInputs),
     % Normalize the keys to their maybe-linked form, adding `+link` if necessary.
     Inputs =
         lists:map(
@@ -483,15 +482,6 @@ ensure_unique_components(Components) ->
     case length(Components) =:= length(lists:usort(Components)) of
         true -> ok;
         false -> throw({duplicate_signature_component, Components})
-    end.
-
-ensure_unique_committed_req(Req) ->
-    case maps:get(<<"committed">>, Req, undefined) of
-        undefined -> ok;
-        Explicit ->
-            ensure_unique_components(
-                hb_util:message_to_ordered_list(Explicit, #{})
-            )
     end.
 
 %% @doc construct the "signature-params-line" part of the signature base.
@@ -684,5 +674,20 @@ duplicate_signature_component_test() ->
                 <<"committed">> => [<<"normal">>, <<"normal">>]
             },
             Opts
+        ),
+    ?assertMatch({duplicate_signature_component, _}, Res).
+
+%% @doc Ensure duplicate committed components error during verify path.
+duplicate_signature_component_verify_test() ->
+    Base = #{ <<"normal">> => <<"typical-value">> },
+    Res =
+        catch dev_codec_httpsig:verify(
+            Base,
+            #{
+                <<"type">> => <<"rsa-pss-sha512">>,
+                <<"signature">> => <<"dummy">>,
+                <<"committed">> => [<<"normal">>, <<"normal">>]
+            },
+            #{}
         ),
     ?assertMatch({duplicate_signature_component, _}, Res).


### PR DESCRIPTION
## About
addressing the hanging TODO comment in the `src/dev_codec_httpsig.erl` module regarding RFC 9421 [section 2.5](https://datatracker.ietf.org/doc/html/rfc9421#section-2.5-7.2.2.1) wrt enforcing a MUST:

> If the component identifier (including its parameters) has already been added to the signature base, produce an error.

the change rejects duplicate entries in committed during signature base creation in `normalize_for_encoding/3` (used by both sign + verify) using a non-perf affecting check (ulist then strict equal size check).

i added the `duplicate_signature_component_test()` and `duplicate_signature_component_verify_test()` tests, all mod eunit tests pass:

```bash
======================== EUnit ========================
module 'dev_codec_httpsig'
  dev_codec_httpsig: validate_large_message_from_http_test...[5.718 s] ok
  dev_codec_httpsig: committed_id_test...[0.024 s] ok
  dev_codec_httpsig: commit_secret_key_test...[0.001 s] ok
  dev_codec_httpsig: multicommitted_id_test...[3.623 s] ok
  dev_codec_httpsig: sign_and_verify_link_test...[0.015 s] ok
  dev_codec_httpsig: duplicate_signature_component_test...ok
  dev_codec_httpsig: duplicate_signature_component_verify_test...ok
  [done in 9.402 s]
=======================================================
  All 7 tests passed.
  ```

my git commits are signed