### PR TITLE
fix: fall back to alg when type is missing in signature params

### DIFF
--- a/src/dev_codec_httpsig.erl
+++ b/src/dev_codec_httpsig.erl
@@ -520,7 +520,10 @@ signature_params_line(RawCommitment, Opts) ->
                                     <<"tag">>,
                                     <<"bundle">>
                                 ],
-                                Commitment#{ <<"alg">> => maps:get(<<"type">>, Commitment) }
+                                %% FIX: Fall back to alg when type is not present
+                                %% hbsig client sends alg,keyid but not type
+                                Commitment#{ <<"alg">> => maps:get(<<"type">>, Commitment,
+                                    maps:get(<<"alg">>, Commitment, <<"rsa-pss-sha512">>)) }
                             )
                         ))
                     )


### PR DESCRIPTION
## Problem                                                                                 
                                                                                           
`signature_params_line/2` in `dev_codec_httpsig.erl` (line 523) does:                      
                                                                                           
```erlang
Commitment#{ <<"alg">> => maps:get(<<"type">>, Commitment) }
```

This is a bare `maps:get/2` with no default, so it crashes with `{badkey, <<"type">>}` when
 the commitment map doesn't contain a `type` key.

### When this happens

The HTTP Signature spec (RFC 9421) uses `alg` as the parameter name for the signing algorit
hm. HyperBEAM internally uses `type` for the same purpose (e.g., `<<"rsa-pss-sha512">>`, `<
<"hmac-sha256">>`). The `commit/3` function in the same module always sets `type`, but exte
rnal clients using the hbsig format may send commitments with `alg` and `keyid` without a `
type` key, since `alg` is the standard field name.

### Call path

```
dev_codec_httpsig:verify/3
  -> verify_commitment/4 (line 443)
    -> signature_params_line/2 (line 483)
      -> maps:get(<<"type">>, Commitment)  ** crashes here **
```

## Fix

Use `maps:get/3` with a fallback chain: try `type` first, then `alg`, then default to `rsa-
pss-sha512`:

```erlang
Commitment#{ <<"alg">> => maps:get(<<"type">>, Commitment,
    maps:get(<<"alg">>, Commitment, <<"rsa-pss-sha512">>)) }
```

This is consistent with how the rest of the module treats `type` and `alg` as equivalent — 
`commit/3` already maps between them (lines 119-122).

## Test Plan

- [ ] Existing `dev_codec_httpsig` tests pass 
- [ ] Commitments with `alg` but no `type` verify correctly

`