### PR TITLE
fix: send error reply on scheduling failure instead of silent timeout

### DIFF
--- a/src/dev_scheduler_server.erl
+++ b/src/dev_scheduler_server.erl
@@ -124,7 +124,10 @@ schedule(ErlangProcID, Message) ->
     ErlangProcID ! {schedule, Message, self(), AbortTime},
     receive
         {scheduled, Message, Assignment} ->
-            Assignment
+            Assignment;
+        {scheduling_error, Message, {error, Reason}} ->
+            % Handle error from assign/3 instead of timing out
+            throw({scheduling_failed, {proc_id, ErlangProcID}, {reason, Reason}})
     after ?DEFAULT_TIMEOUT ->
         throw({scheduler_timeout, {proc_id, ErlangProcID}, {message, Message}})
     end.
@@ -174,7 +177,11 @@ assign(State, Message, ReplyPID) ->
         do_assign(State, Message, ReplyPID)
     catch
         _Class:Reason:Stack ->
-            ?event({error_scheduling, {reason, Reason}, {trace, Stack}}),
+            ?event(error, {error_scheduling, {reason, Reason}, {trace, Stack}}),
+            % CRITICAL: Send error reply to prevent client timeout.
+            % Previously this returned State without replying, causing a 10-second
+            % timeout on the client side (scheduler_timeout error).
+            ReplyPID ! {scheduling_error, Message, {error, Reason}},
             State
     end.
 


### PR DESCRIPTION
`
## Problem                                                                                 
                                                                                           
In `dev_scheduler_server.erl`, when `assign/3` (line 172) throws an exception, the catch bl
ock at line 176 logs the error and returns `State` — but never sends a reply to the caller.
                                                                                           
The caller in `schedule/2` (line 115) is blocked in a `receive` waiting for `{scheduled, Me
ssage, Assignment}`. Since no reply ever arrives, it waits the full `?DEFAULT_TIMEOUT` (10 
seconds, defined at line 15) before throwing `{scheduler_timeout, ...}`.                   
                                                                                           
This means every scheduling failure takes 10 seconds to surface, and the actual error reaso
n is lost — the caller only sees `scheduler_timeout`.                                      
                                                                                           
### Call path                                                                              
                                                                                           
```                                                                                        
schedule/2 (line 115)                                                                      
  -> sends {schedule, Message, self(), AbortTime} to gen_server                            
  -> receive                                                                               
       {scheduled, ...} -> ok         %% happy path                                        
       %% no clause for errors!                                                            
     after 10000 ->                                                                        
       throw(scheduler_timeout)        %% misleading error                                 
     end                                                                                   

server loop -> assign/3 (line 172)
  -> do_assign/3 throws
  -> catch block (line 176):
       ?event(error_scheduling),
       State                           %% returns state, never replies!
```

## Fix

Two changes:

1. **`assign/3` catch block:** Send `{scheduling_error, Message, {error, Reason}}` to `Repl
yPID` before returning `State`
2. **`schedule/2` receive:** Add a clause for `{scheduling_error, ...}` that immediately th
rows with the real reason

```erlang
%% schedule/2: new receive clause
{scheduling_error, Message, {error, Reason}} ->
    throw({scheduling_failed, {proc_id, ErlangProcID}, {reason, Reason}})

%% assign/3: reply in catch block
catch
    _Class:Reason:Stack ->
        ?event(error, {error_scheduling, {reason, Reason}, {trace, Stack}}),
        ReplyPID ! {scheduling_error, Message, {error, Reason}},
        State
```

### Impact

- **Before:** Every scheduling failure = 10-second hang + misleading `scheduler_timeout`
- **After:** Failures propagate immediately with the actual reason (e.g., `{scheduling_fail
ed, {reason, badarg}}`)

## Test Plan

- [ ] Existing scheduler tests pass
- [ ] Trigger a scheduling error and confirm immediate propagation (no 10s wait)

`