### PR TITLE
fix: safely parse HTTP status to avoid crash on non-numeric values

### DIFF
--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -466,7 +466,13 @@ reply(Req, TABMReq, Message, Opts) ->
         end,
     reply(Req, TABMReq, Status, Message, Opts).
 reply(Req, TABMReq, BinStatus, RawMessage, Opts) when is_binary(BinStatus) ->
-    reply(Req, TABMReq, binary_to_integer(BinStatus), RawMessage, Opts);
+    %% Safely parse the status as an integer. If it's not a valid number
+    %% (e.g., "pending" from a nested object's status field), default to 200.
+    IntStatus = case hb_util:safe_int(BinStatus) of
+        {ok, N} when N >= 100, N =< 599 -> N;
+        _ -> 200
+    end,
+    reply(Req, TABMReq, IntStatus, RawMessage, Opts);
 reply(InitReq, TABMReq, RawStatus, RawMessage, Opts) ->
     KeyNormMessage = hb_ao:normalize_keys(RawMessage, Opts),
     {ok, Req, Message} = reply_handle_cookies(InitReq, KeyNormMessage, Opts),


### PR DESCRIPTION
## Problem                                                                                 
                                                                                           
`reply/5` in `hb_http.erl` (line 468) does:                                                
                                                                                           
```erlang                                                                                  
reply(Req, TABMReq, BinStatus, RawMessage, Opts) when is_binary(BinStatus) ->              
    reply(Req, TABMReq, binary_to_integer(BinStatus), RawMessage, Opts);                   
```                                                                                        
                                                                                           
`binary_to_integer/1` crashes with `badarg` when the binary is not a valid integer string.

### When this happens

The status is resolved by `hb_ao:get(<<"status">>, Message, Opts)` at line 463. This traver
ses the message map using AO-Core key resolution, which can follow links and resolve nested
 structures. In some cases — particularly with JSON-encoded messages that have nested objec
ts with their own `status` fields — this can resolve to a non-numeric binary like `<<"pendi
ng">>` or `<<"active">>` instead of an HTTP status code.

### Call path

```
hb_http:reply/4 (line 461)
  -> hb_ao:get(<<"status">>, Message)    %% may return <<"pending">>
  -> reply/5 with BinStatus guard        %% matches is_binary
    -> binary_to_integer(<<"pending">>)   %% ** crashes with badarg **
```

## Fix

Use the existing `hb_util:safe_int/1` (exported at line 4 of `hb_util.erl`) with HTTP statu
s range validation:

```erlang
IntStatus = case hb_util:safe_int(BinStatus) of
    {ok, N} when N >= 100, N =< 599 -> N;
    _ -> 200
end,
reply(Req, TABMReq, IntStatus, RawMessage, Opts);
```

Defaults to 200 for non-numeric or out-of-range values rather than crashing the entire requ
est handler. The 100-599 range matches the HTTP status code spec.

## Test Plan

- [ ] Existing HTTP tests pass
- [ ] Messages with non-numeric or out-of-range status fields return 200 instead of crashin
g
