### PR TITLE
fix: load all commitments in prepare_links, not just Target

### DIFF
--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -522,50 +522,66 @@ prepare_links(Target, RootPath, Subpaths, Store, Opts) ->
         maps:from_list(lists:filtermap(
             fun(<<"ao-types">>) -> false;
                 (<<"commitments">>) ->
-                    % List the commitments for this message, and load them into
-                    % memory. If there no commitments at the path, we exclude
+                    % List ALL commitments for this message, and load them into
+                    % memory. If there are no commitments at the path, we exclude
                     % commitments from the list of links.
-                    CommPath =
+                    % FIX: Previously only loaded Target commitment, missing others
+                    % like HMAC commitments with different IDs.
+                    CommBasePath =
                         hb_store:resolve(
                             Store,
                             hb_store:path(
                                 Store,
-                                [
-                                    RootPath,
-                                    <<"commitments">>,
-                                    Target
-                                ]
+                                [RootPath, <<"commitments">>]
                             )
                         ),
                     ?event(read_commitment,
-                        {reading_commitment,
+                        {reading_all_commitments,
                             {target, Target},
                             {root_path, RootPath},
-                            {commitments_path, CommPath}
+                            {commitments_base_path, CommBasePath}
                         }
                     ),
-                    case do_read_commitment(CommPath, Opts) of
-                        {ok, Commitment} ->
-                            LoadedCommitment = 
-                                ensure_all_loaded(
-                                    Commitment,
-                                    Opts#{ commitment => true }
-                                ),
-                            ?event(read_commitment,
-                                {found_target_commitment,
-                                    {path, CommPath},
-                                    {commitment, LoadedCommitment}
-                                }
+                    case hb_store:list(Store, CommBasePath) of
+                        {ok, CommitmentIDs} ->
+                            LoadedCommitments = lists:filtermap(
+                                fun(CommID) ->
+                                    CommPath = hb_store:path(
+                                        Store,
+                                        [CommBasePath, CommID]
+                                    ),
+                                    case do_read_commitment(CommPath, Opts) of
+                                        {ok, Commitment} ->
+                                            LoadedCommitment =
+                                                ensure_all_loaded(
+                                                    Commitment,
+                                                    Opts#{ commitment => true }
+                                                ),
+                                            ?event(read_commitment,
+                                                {found_commitment,
+                                                    {id, CommID},
+                                                    {path, CommPath},
+                                                    {commitment, LoadedCommitment}
+                                                }
+                                            ),
+                                            {true, {CommID, LoadedCommitment}};
+                                        _ ->
+                                            false
+                                    end
+                                end,
+                                CommitmentIDs
                             ),
-                            % We have commitments, so we read each commitment
-                            % into memory, and return it as part of the message.
-                            {
-                                true,
-                                {
-                                    <<"commitments">>,
-                                    #{ Target => LoadedCommitment }
-                                }
-                            };
+                            case LoadedCommitments of
+                                [] -> false;
+                                _ ->
+                                    {
+                                        true,
+                                        {
+                                            <<"commitments">>,
+                                            maps:from_list(LoadedCommitments)
+                                        }
+                                    }
+                            end;
                         _ ->
                             false
                     end;


### PR DESCRIPTION
## Problem                                                                                 
                                                                                           
`prepare_links/5` in `hb_cache.erl` (line 519) is the primary code path for reading message
s from cache. When it encounters the `<<"commitments">>` subpath (line 524), it previously 
only loaded the single commitment matching `Target` — the ID used to look up the message. A
ny other commitments stored under different IDs were silently dropped.                     
                                                                                           
### When this happens                                                                      
                                                                                           
Messages in HyperBEAM can have multiple commitment types. A typical signed message has:    
- An **RSA commitment** (from the signer's wallet), stored at `[RootPath, "commitments", Si
gnerCommitmentID]`                                                                         
- Potentially an **HMAC commitment** (unsigned/self-attested), stored under a different com
mitment ID                                                                                 
                                                                                           
The `write_key/6` function (line 302) correctly writes each commitment under its own ID ins
ide `[RootPath, "commitments", CommitmentID]`. But when reading back, the old `prepare_link
s` only loaded `[RootPath, "commitments", Target]`, so if you looked up a message by its un
signed ID, you'd get only that commitment and miss the RSA one (and vice versa).           
                                                                                           
Note: `read_all_commitments/2` (line 411) already implements the correct pattern — it lists
 all IDs under the commitments path and loads each. But `prepare_links` — which is the read
 path used by `store_read/4` (line 465) and therefore `read/2` (line 398) — was still using
 the old single-target pattern.                                                            
                                                                                           
### Call path                                                                              
                                                                                           
```                                                                                        
hb_cache:read/2 (line 398)                                                                 
  -> store_read/4 (line 465)                                                               
    -> hb_store:list returns subpaths including <<"commitments">>                          
    -> prepare_links/5 (line 519)                                                          
      -> <<"commitments">> clause (line 524)                                               
        -> OLD: only loaded [RootPath, "commitments", Target]                              
        -> missing all other commitment IDs                                                
```                                                                                        
                                                                                           
## Fix                                                                                     
 List all commitment IDs under `[RootPath, "commitments"]` via `hb_store:list` and load each
 one, matching the pattern already used in `read_all_commitments/2`:                       

```erlang
%% Before: only loads the Target commitment
CommPath = hb_store:path(Store, [RootPath, <<"commitments">>, Target]),
case do_read_commitment(CommPath, Opts) of
    {ok, Commitment} -> {true, {<<"commitments">>, #{Target => Commitment}}};
    _ -> false
end

%% After: lists and loads all commitments
CommBasePath = hb_store:resolve(Store,
    hb_store:path(Store, [RootPath, <<"commitments">>])),
case hb_store:list(Store, CommBasePath) of
    {ok, CommitmentIDs} ->
        LoadedCommitments = lists:filtermap(fun(CommID) ->
            CommPath = hb_store:path(Store, [CommBasePath, CommID]),
            case do_read_commitment(CommPath, Opts) of
                {ok, Commitment} ->
                    {true, {CommID, ensure_all_loaded(Commitment,
                        Opts#{ commitment => true })}};
                _ -> false
            end
        end, CommitmentIDs),
        case LoadedCommitments of
            [] -> false;
            _ -> {true, {<<"commitments">>, maps:from_list(LoadedCommitments)}}
        end;
    _ -> false
end
```

### Impact

- **Before:** Messages with multiple commitment types lose all but one commitment on read-back, causing subsequent verification of the missing commitment type to fail
- **After:** All stored commitments are loaded regardless of which ID was used to look up the message

## Test Plan

- [ ] Existing cache tests pass (`hb_cache` test suite)
- [ ] Messages with multiple commitment types load all commitments correctly on read-back