### PR TITLE
fix: strip commitments from nested maps in hb_link:normalize

### DIFF
--- a/src/hb_link.erl
+++ b/src/hb_link.erl
@@ -66,17 +66,34 @@ normalize(Msg, Mode, Opts) when is_map(Msg) ->
                         % its IDs by proxy.
                         NormChild = normalize(V, Mode, Opts),
                         NormKey = hb_util:bin(Key),
-                        % Generate the ID of the normalized child message.
-                        ID = hb_message:id(NormChild, all, Opts),
-                        % If we are in `offload' mode, we write the message to the
-                        % cache. If we are in `discard' mode, we simply drop the 
-                        % nested message.
+                        % Strip commitments from nested maps before computing
+                        % ID and writing. Nested content maps inherit stale
+                        % commitments from their parent context, which causes
+                        % with_only_committed to filter out new entries.
+                        ChildWithoutCommitments =
+                            case is_map(NormChild) of
+                                true -> maps:without([<<"commitments">>], NormChild);
+                                false -> NormChild
+                            end,
+                        % Generate the ID of the child message WITHOUT
+                        % commitments. Use 'none' committers and
+                        % 'linkify_mode => discard' to match how hb_cache:write
+                        % computes the storage ID. Using 'all' with a
+                        % commitments key (even empty) can produce a different
+                        % ID than 'none' without the key, causing body link
+                        % resolution failures.
+                        ID = hb_message:id(
+                            ChildWithoutCommitments,
+                            none,
+                            Opts#{ linkify_mode => discard }
+                        ),
+                        % If we are in `offload' mode, we write the message to
+                        % the cache. If we are in `discard' mode, we simply
+                        % drop the nested message.
                         case Mode of
                             discard -> do_nothing;
                             offload ->
-                                % Write the child to the store to ensure its
-                                % storage and availability.
-                                hb_cache:write(NormChild, Opts)
+                                hb_cache:write(ChildWithoutCommitments, Opts)
                         end,
                         ?event(debug_linkify, {generated_link, {key, Key}, {id, ID}}),
                         {<<NormKey/binary, "+link">>, ID};


### PR DESCRIPTION
## Problem                                                                                 
                                                                                           
`normalize/3` in `hb_link.erl` (line 28) converts nested submessages into `+link` reference
s by computing their ID and optionally offloading them to the cache. The submessage clause 
at line 60 (`{Key, V} when is_map(V) or is_list(V)`) previously computed the ID with commit
ments included, but `hb_cache:write` computes the storage ID without them — causing a misma
tch where the link points to an ID that doesn't exist in the cache.                        
                                                                                           
### When this happens                                                                      
                                                                                           
When a message contains nested maps (e.g., a process's state containing submessages), the c
hild maps can inherit stale `<<"commitments">>` entries from their parent context. This cau
ses two problems:                                                                          
                                                                                           
1. **`with_only_committed` filtering:** `hb_cache:write` calls `hb_message:with_only_commit
ted` (line 233 of `hb_cache.erl`), which filters out keys not covered by the message's comm
itments. Stale inherited commitments don't cover new entries in the child map, so those ent
ries get silently dropped.                                                                 
                                                                                           
2. **Link ID mismatch:** The old code computed the link ID as `hb_message:id(NormChild, all
, Opts)` — which includes the `<<"commitments">>` key in the hash. But `hb_cache:do_write_m
essage/3` (line 274 of `hb_cache.erl`) computes the storage ID as `hb_message:id(Msg, none,
 Opts#{ linkify_mode => discard })` — which excludes commitments. The link then points to a
n ID that doesn't exist in the store.                                                      
                                                                                           
### Call path                                                                              
                                                                                           
```                                                                                        
hb_link:normalize/3 (line 28)                                                              
  -> for each submessage ({Key, V} when is_map(V)):                                        
    -> normalize(V, Mode, Opts)              %% recursive normalization                    
    -> OLD: hb_message:id(NormChild, all, Opts)                                            
       Computes ID = hash(content + commitments)    -- "ID_A"                              
    -> hb_cache:write(NormChild, Opts)                                                     
       -> hb_cache:do_write_message (hb_cache.erl:274)                                     
          -> hb_message:id(Msg, none, Opts#{ linkify_mode => discard })                    
             Computes StorageID = hash(content only) -- "ID_B"         
    -> stores {<<Key/binary, "+link">>, ID_A}   %% link points to ID_A                     
    -> cache stores message at ID_B               %% but data lives at ID_B                
    -> ID_A ≠ ID_B → body link resolution fails on read                                    
```

## Fix

Strip commitments from nested maps before both ID computation and cache writing. Use `none`
 committers with `linkify_mode => discard` to match how `hb_cache:write` computes storage I
Ds:

```erlang
%% Before (hb_link.erl, submessage clause):
NormChild = normalize(V, Mode, Opts),
ID = hb_message:id(NormChild, all, Opts),
hb_cache:write(NormChild, Opts),
{<<NormKey/binary, "+link">>, ID}

%% After:
NormChild = normalize(V, Mode, Opts),
ChildWithoutCommitments =
    case is_map(NormChild) of
        true -> maps:without([<<"commitments">>], NormChild);
        false -> NormChild
    end,
ID = hb_message:id(
    ChildWithoutCommitments,
    none,
    Opts#{ linkify_mode => discard }
),
case Mode of
    discard -> do_nothing;
    offload -> hb_cache:write(ChildWithoutCommitments, Opts)
end,
{<<NormKey/binary, "+link">>, ID}
```

The key change is that both the link ID and the cache write now use the same commitment-fre
e message with `none` committers and `linkify_mode => discard`, matching the ID computation
 in `hb_cache:do_write_message/3` (line 274). 

### Impact

- **Before:** Processes with nested state maps (common in AO message handling) experience b
ody link resolution failures after state updates — the link points to a non-existent ID
- **After:** Link IDs and storage IDs are guaranteed to match, regardless of whether the ne
sted map inherited commitments

## Test Plan

- [ ] Existing link tests pass (`hb_link` test suite, including `offload_linked_message_tes
t`)
- [ ] Existing cache tests pass (`hb_cache` test suite)
- [ ] Processes with nested state maps correctly resolve body links after state updates
