### PR TITLE
feat: Generalize `scheduler-location` records to `~location@1.0` device

### DIFF
--- a/src/dev_location.erl
+++ b/src/dev_location.erl
@@ -192,16 +192,23 @@ node(Base, RawReq, RawOpts) ->
     end.
 
 %% @doc Generate the default location record URL from the node's configuration.
+%% If a custom URL is provided in the `location_url' option, we will use that,
+%% otherwise we will construct the URL from the node's configuration (host, port,
+%% and protocol).
 default_url(Opts) ->
-    Port = hb_util:bin(hb_opts:get(port, 8734, Opts)),
-    Host = hb_opts:get(host, <<"localhost">>, Opts),
-    Protocol = hb_opts:get(protocol, http1, Opts),
-    ProtoStr =
-        case Protocol of
-            http1 -> <<"http">>;
-            _ -> <<"https">>
-        end,
-    <<ProtoStr/binary, "://", Host/binary, ":", Port/binary>>.
+    case hb_opts:get(location_url, not_found, Opts) of
+        not_found ->
+            Port = hb_util:bin(hb_opts:get(port, 8734, Opts)),
+            Host = hb_opts:get(host, <<"localhost">>, Opts),
+            Protocol = hb_opts:get(protocol, http1, Opts),
+            ProtoStr =
+                case Protocol of
+                    http1 -> <<"http">>;
+                    _ -> <<"https">>
+                end,
+            <<ProtoStr/binary, "://", Host/binary, ":", Port/binary>>;
+        GivenURL -> GivenURL
+    end.
 
 %% @doc We have been asked to generate a new location record, given the nonce,
 %% TTL, and codec. We will generate the record, sign it, store it in the cache,

--- a/src/dev_location.erl
+++ b/src/dev_location.erl
@@ -1,0 +1,373 @@
+%%% @doc Location registration records for nodes executing AO-Core computations.
+%%% This device allows nodes to specify the physical location (resolved through
+%%% DNS and IP addresses) that their cryptographic addresses will be found at
+%%% for a period of time.
+-module(dev_location).
+-export([info/0, read/2, node/3, known/3, all/3]).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(DEFAULT_TTL, 28 * 24 * 60 * 60). % 28 days.
+-define(DEFAULT_CODEC, <<"httpsig@1.0">>).
+
+%% @doc Handle all requests aside `known` with the `location/4' resolver.
+info() ->
+    #{
+        excludes => [<<"keys">>, <<"set">>, <<"set-path">>, <<"remove">>],
+        default_handler => fun read/4
+    }.
+
+%% @doc Route either `POST' or `GET' requests to the correct handler for known
+%% location records.
+known(Base, Req, Opts) ->
+    case hb_ao:get(<<"method">>, Req, <<"GET">>, Opts) of
+        <<"POST">> -> write_foreign(Base, Req, Opts);
+        <<"GET">> -> all(Base, Req, Opts)
+    end.
+
+%% @doc List all known location records.
+all(_Base, _Req, Opts) ->
+    dev_location_cache:list(Opts).
+
+%% @doc Search for the location of the scheduler in the scheduler-location
+%% cache. If an address is provided, we search for the location of that
+%% specific scheduler. Otherwise, we return the location record for the current
+%% node's scheduler, if it has been established.
+read(Address, _Base, _Req, Opts) ->
+    read(Address, Opts).
+read(Address, Opts) ->
+    % Search for the location of the scheduler in the scheduler-location cache.
+    case dev_location_cache:read(Address, Opts) of
+        {ok, Location} -> {ok, Location};
+        _ ->
+            case hb_gateway_client:location(Address, Opts) of
+                {ok, Location} ->
+                    % Cache the location record locally, now that we have found it.
+                    dev_location_cache:write(Location, Opts),
+                    {ok, Location};
+                not_found ->
+                    {error,
+                        #{
+                            <<"status">> => 404,
+                            <<"body">> =>
+                                <<"No location found for address: ", Address/binary>>
+                            }
+                        }
+            end
+    end.
+
+%% @doc Find the target to be used for during a request.
+find_record(Base, RawReq, Opts) ->
+    % Ensure that the request is signed by the operator.
+    Req =
+        case hb_ao:get_first(
+            [{Base, <<"target">>}, {RawReq, <<"target">>}],
+            not_found,
+            Opts
+        ) of
+            not_found -> RawReq;
+            <<"self">> -> Base;
+            <<"request">> -> RawReq;
+            Target -> hb_ao:get(Target, RawReq, not_found, Opts)
+        end,
+    {ok, OnlyCommitted} = hb_message:with_only_committed(Req, Opts),
+    OnlyCommitted.
+
+%% @doc Generate a new scheduler location record and register it. We both send 
+%% the new scheduler-location to the given registry, and return it to the caller.
+node(Base, RawReq, RawOpts) ->
+    Opts =
+        case dev_whois:ensure_host(RawOpts) of
+            {ok, NewOpts} -> NewOpts;
+            _ -> RawOpts
+        end,
+    Req = find_record(Base, RawReq, Opts),
+    % Ensure that the request is signed by the operator.
+    {ok, OnlyCommitted} = hb_message:with_only_committed(Req, Opts),
+    ?event(
+        location,
+        {scheduler_location_registration_request, OnlyCommitted},
+        Opts
+    ),
+    Signers = hb_message:signers(OnlyCommitted, Opts),
+    Self = hb_util:human_id(hb_opts:get(priv_wallet, hb:wallet(), Opts)),
+    IsOperator = lists:member(Self, Signers),
+    NewNonce = hb_ao:get(<<"nonce">>, OnlyCommitted, not_found, Opts),
+    case NewNonce of
+        not_found when not IsOperator ->
+            % A non-operator has requested that we generate a new location record.
+            % First we check if we have a valid location record already and if
+            % so return that instead.
+            case dev_location_cache:read(Self, Opts) of
+                {ok, Location} ->
+                    {ok, Location};
+                not_found ->
+                    case hb_opts:get(location_open_generation, true, Opts) of
+                        true ->
+                            % We don't have a valid location record, so we generate a new
+                            % one. We will not use any provided parameters as the caller
+                            % is not trusted. Instead, we generate new ones from the
+                            % node's configuration.
+                            generate_new_location(
+                                default_url(Opts),
+                                erlang:system_time(microsecond),
+                                hb_opts:get(location_ttl, ?DEFAULT_TTL, Opts),
+                                hb_opts:get(location_codec, ?DEFAULT_CODEC, Opts),
+                                Opts
+                            );
+                        false ->
+                            {error,
+                                #{
+                                    <<"status">> => 403,
+                                    <<"body">> =>
+                                        <<
+                                            "Unauthorized location generation not",
+                                            "permitted on this node."
+                                        >>
+                                }
+                            }
+                    end
+            end;
+        _ when not IsOperator ->
+            % Specific-nonce generation requests are not permitted for
+            % non-operators.
+            {error, <<"Non-operators cannot request specific nonces.">>};
+        SpecificNonce when IsOperator ->
+            generate_new_location(SpecificNonce, Base, OnlyCommitted, Opts)
+    end.
+
+%% @doc Generate the default location record URL from the node's configuration.
+default_url(Opts) ->
+    Port = hb_util:bin(hb_opts:get(port, 8734, Opts)),
+    Host = hb_opts:get(host, <<"localhost">>, Opts),
+    Protocol = hb_opts:get(protocol, http1, Opts),
+    ProtoStr =
+        case Protocol of
+            http1 -> <<"http">>;
+            _ -> <<"https">>
+        end,
+    <<ProtoStr/binary, "://", Host/binary, ":", Port/binary>>.
+
+%% @doc We have been asked to generate a new location record, given the nonce,
+%% TTL, and codec. We will generate the record, sign it, store it in the cache,
+%% asynchronously upload it to Arweave, and notify the peers specified in the
+%% `location_notify' option. Finally, we will return the signed location record
+%% to the caller.
+generate_new_location(Nonce, Base, OnlyCommitted, Opts) ->
+    TimeToLive =
+        hb_ao:get_first(
+            [
+                {Base, <<"time-to-live">>},
+                {OnlyCommitted, <<"time-to-live">>}
+            ],
+            hb_opts:get(scheduler_location_ttl, 1000 * 60 * 60, Opts),
+            Opts
+        ),
+    URL =
+        case hb_ao:get(<<"url">>, OnlyCommitted, Opts) of
+            not_found -> default_url(Opts);
+            GivenURL -> GivenURL
+        end,
+    % Construct the new scheduler location message.
+    Codec =
+        hb_ao:get_first(
+            [
+                {Base, <<"require-codec">>},
+                {OnlyCommitted, <<"require-codec">>}
+            ],
+            <<"httpsig@1.0">>,
+            Opts
+        ),
+    generate_new_location(URL, Nonce, TimeToLive, Codec, Opts).
+generate_new_location(URL, Nonce, TTL, Codec, Opts) ->
+    NewSchedulerLocation =
+        #{
+            <<"data-protocol">> => <<"ao">>,
+            <<"variant">> => <<"ao.N.1">>,
+            <<"type">> => <<"location">>,
+            <<"url">> => URL,
+            <<"nonce">> => Nonce,
+            <<"time-to-live">> => TTL,
+            <<"codec-device">> => Codec
+        },
+    Signed = hb_message:commit(NewSchedulerLocation, Opts, Codec),
+    dev_location_cache:write(Signed, Opts),
+    ?event(location,
+        {uploading_signed_scheduler_location, Signed}
+    ),
+    % Asynchronously upload the location record to Arweave.
+    spawn(
+        fun() ->
+            hb_client:upload(Signed, Opts)
+        end
+    ),
+    % Post the new scheduler location to the peers specified in the
+    % `location_notify' option.
+    Results =
+        lists:map(
+            fun(Node) ->
+                PostRes = hb_http:post(
+                    Node,
+                    <<"/~scheduler@1.0/location">>,
+                    Signed,
+                    Opts
+                ),
+                ?event(scheduler_location,
+                    {outbound_request, {res, PostRes}}
+                )
+            end,
+            hb_opts:get(location_notify, [], Opts)
+        ),
+    ?event(location,
+        {location_registration_success,
+            {arweave_publication, async_upload_initiated},
+            {foreign_peers_notified, length(Results)}
+        }
+    ),
+    {ok, Signed}.
+
+%% @doc Verify and write a location record for a foreign peer to the cache.
+write_foreign(Base, RawReq, Opts) ->
+    MaybeLocation = find_record(Base, RawReq, Opts),
+    maybe
+        Signers = hb_message:signers(MaybeLocation, Opts),
+        true ?= hb_message:verify(MaybeLocation, signed, Opts)
+            orelse {error, <<"Invalid location record signature.">>},
+        true ?=
+            (hb_maps:get(<<"type">>, MaybeLocation, Opts) =:= <<"scheduler-location">>)
+            orelse {error, <<"Invalid location record type.">>},
+        true ?=
+            (hb_maps:get(<<"url">>, MaybeLocation, Opts) =/= not_found)
+            orelse {error, <<"Missing location record URL.">>},
+        true ?=
+            (hb_maps:get(<<"nonce">>, MaybeLocation, Opts) =/= not_found)
+            orelse {error, <<"Missing location record nonce.">>},
+        true ?=
+            (hb_maps:get(<<"time-to-live">>, MaybeLocation, Opts) =/= not_found)
+            orelse {error, <<"Missing location record time-to-live.">>},
+        Nonce = hb_ao:get(<<"nonce">>, MaybeLocation, Opts),
+        Res = lists:any(
+            fun(Signer) ->
+                case latest_nonce(Signer, Nonce, Opts) of
+                    true ->
+                        dev_location_cache:write(MaybeLocation, Opts);
+                    false ->
+                        ?event(
+                            location,
+                            {newer_foreign_peer_location_already_exists,
+                                {signer, Signer},
+                                {nonce, Nonce},
+                                {location, MaybeLocation}
+                            }
+                        )
+                end
+
+           end,
+            Signers
+        ),
+        case Res of
+            true ->
+                {ok, MaybeLocation};
+            false ->
+                {error,
+                    #{
+                        <<"status">> => 400,
+                        <<"body">> =>
+                            <<"Known nonce(s) higher than requested nonce.">>,
+                        <<"requested-nonce">> => Nonce,
+                        <<"signers">> => Signers
+                    }
+                }
+        end
+    end.
+
+%% @doc Check if a given nonce is the latest nonce for a given signer.
+latest_nonce(Signer, Nonce, Opts) ->
+    case dev_location_cache:read(Signer, Opts) of
+        {ok, Location} ->
+            hb_util:int(hb_ao:get(<<"nonce">>, Location, 0, Opts)) > Nonce;
+        not_found ->
+            -1
+    end.
+
+%%% Tests
+
+register_scheduler_test() ->
+    Opts = #{ store => [hb_test_utils:test_store()], priv_wallet => ar_wallet:new() },
+    Node = hb_http_server:start_node(Opts),
+    Base =
+        hb_message:commit(
+            #{
+                <<"path">> => <<"/~scheduler@1.0/location">>,
+                <<"url">> => <<"https://hyperbeam-test-ignore.com">>,
+                <<"method">> => <<"POST">>,
+                <<"nonce">> => 1,
+                <<"require-codec">> => <<"ans104@1.0">>
+            },
+            Opts
+        ),
+    {ok, Res} = hb_http:post(Node, Base, Opts),
+    ?assertMatch(#{ <<"url">> := Location } when is_binary(Location), Res).
+
+%% @doc Test that a scheduler location is registered on boot.
+register_location_on_boot_test() ->
+    NotifiedPeerWallet = ar_wallet:new(),
+    RegisteringNodeWallet = ar_wallet:new(),
+    hb_http_server:start_node(#{}),
+    NotifiedPeer =
+        hb_http_server:start_node(#{
+            priv_wallet => NotifiedPeerWallet,
+            store => [
+                #{
+                    <<"store-module">> => hb_store_fs,
+                    <<"name">> => <<"cache-TEST/scheduler-location-notified">>
+                }
+            ]
+        }),
+    RegisteringNode = hb_http_server:start_node(
+        #{
+            priv_wallet => RegisteringNodeWallet,
+            on =>
+                #{
+                    <<"start">> => #{
+                        <<"device">> => <<"scheduler@1.0">>,
+                        <<"path">> => <<"location">>,
+                        <<"method">> => <<"POST">>,
+                        <<"target">> => <<"self">>,
+                        <<"require-codec">> => <<"ans104@1.0">>,
+                        <<"url">> => <<"https://hyperbeam-test-ignore.com">>,
+                        <<"hook">> => #{
+                            <<"result">> => <<"ignore">>,
+                            <<"commit-request">> => true
+                        }
+                    }
+                },
+            location_notify => [NotifiedPeer]
+        }
+    ),
+    Address = hb_util:human_id(ar_wallet:to_address(RegisteringNodeWallet)),
+    {ok, CurrentLocation} =
+        hb_http:get(
+            RegisteringNode,
+            #{
+                <<"method">> => <<"GET">>,
+                <<"path">> => <<"/~location@1.0/node">>
+            },
+            #{}
+        ),
+    ?event({current_location, CurrentLocation}),
+    ?assertMatch(
+        #{
+            <<"url">> := <<"https://hyperbeam-test-ignore.com">>,
+            <<"nonce">> := 0
+        },
+        hb_ao:get(<<"body">>, CurrentLocation, #{})
+    ),
+    ?assertMatch(
+        #{
+            <<"url">> := <<"https://hyperbeam-test-ignore.com">>,
+            <<"nonce">> := 0
+        },
+        hb_http:get(RegisteringNode, <<"/~location@1.0/", Address/binary>>, #{})
+    ),
+    ok.

--- a/src/dev_location.erl
+++ b/src/dev_location.erl
@@ -14,7 +14,7 @@
 info() ->
     #{
         excludes => [<<"keys">>, <<"set">>, <<"set-path">>, <<"remove">>],
-        default_handler => fun read/4
+        default => fun read/4
     }.
 
 %% @doc Route either `POST' or `GET' requests to the correct handler for known
@@ -42,33 +42,45 @@ read(Address, Opts) ->
         _ ->
             case hb_gateway_client:location(Address, Opts) of
                 {ok, Location} ->
-                    % Cache the location record locally, now that we have found it.
                     dev_location_cache:write(Location, Opts),
                     {ok, Location};
-                not_found ->
+                _ ->
                     {error,
                         #{
                             <<"status">> => 404,
                             <<"body">> =>
                                 <<"No location found for address: ", Address/binary>>
-                            }
                         }
+                    }
             end
     end.
 
+%% @doc Find the latest known nonce for an address by checking the local cache
+%% first and then the gateway.
+latest_known_nonce(Address, Opts) ->
+    case read(Address, Opts) of
+        {ok, Location} -> hb_maps:get(<<"nonce">>, Location, -1, Opts);
+        _ -> -1
+    end.
+
+
 %% @doc Find the target to be used for during a request.
-find_record(Base, RawReq, Opts) ->
+find_target(Base, RawReq, Opts) ->
     % Ensure that the request is signed by the operator.
-    Req =
-        case hb_ao:get_first(
-            [{Base, <<"target">>}, {RawReq, <<"target">>}],
-            not_found,
+    TargetSpec =
+        hb_maps:get(
+            <<"target">>,
+            Base,
+            hb_maps:get(<<"target">>, RawReq, not_found, Opts),
             Opts
-        ) of
+        ),
+    Req =
+        case TargetSpec of
             not_found -> RawReq;
             <<"self">> -> Base;
             <<"request">> -> RawReq;
-            Target -> hb_ao:get(Target, RawReq, not_found, Opts)
+            Target ->
+                hb_maps:get(Target, RawReq, RawReq, Opts)
         end,
     {ok, OnlyCommitted} = hb_message:with_only_committed(Req, Opts),
     OnlyCommitted.
@@ -81,7 +93,7 @@ node(Base, RawReq, RawOpts) ->
             {ok, NewOpts} -> NewOpts;
             _ -> RawOpts
         end,
-    Req = find_record(Base, RawReq, Opts),
+    Req = find_target(Base, RawReq, Opts),
     % Ensure that the request is signed by the operator.
     {ok, OnlyCommitted} = hb_message:with_only_committed(Req, Opts),
     ?event(
@@ -90,11 +102,17 @@ node(Base, RawReq, RawOpts) ->
         Opts
     ),
     Signers = hb_message:signers(OnlyCommitted, Opts),
-    Self = hb_util:human_id(hb_opts:get(priv_wallet, hb:wallet(), Opts)),
+    Self =
+        hb_util:human_id(
+            ar_wallet:to_address(
+                hb_opts:get(priv_wallet, hb:wallet(), Opts)
+            )
+        ),
     IsOperator = lists:member(Self, Signers),
-    NewNonce = hb_ao:get(<<"nonce">>, OnlyCommitted, not_found, Opts),
-    case NewNonce of
-        not_found when not IsOperator ->
+    ExistingNonce = latest_known_nonce(Self, Opts),
+    RequestedNonce = hb_maps:get(<<"nonce">>, OnlyCommitted, not_found, Opts),
+    case {IsOperator, RequestedNonce} of
+        {false, not_found} ->
             % A non-operator has requested that we generate a new location record.
             % First we check if we have a valid location record already and if
             % so return that instead.
@@ -110,7 +128,7 @@ node(Base, RawReq, RawOpts) ->
                             % node's configuration.
                             generate_new_location(
                                 default_url(Opts),
-                                erlang:system_time(microsecond),
+                                erlang:system_time(millisecond),
                                 hb_opts:get(location_ttl, ?DEFAULT_TTL, Opts),
                                 hb_opts:get(location_codec, ?DEFAULT_CODEC, Opts),
                                 Opts
@@ -126,14 +144,38 @@ node(Base, RawReq, RawOpts) ->
                                         >>
                                 }
                             }
-                    end
+                    end;
+                {error, Reason} ->
+                    {error, Reason}
             end;
-        _ when not IsOperator ->
+        {false, _} ->
             % Specific-nonce generation requests are not permitted for
             % non-operators.
             {error, <<"Non-operators cannot request specific nonces.">>};
-        SpecificNonce when IsOperator ->
-            generate_new_location(SpecificNonce, Base, OnlyCommitted, Opts)
+        {true, not_found} ->
+            % The operator has requested a new location record with an unknown
+            % nonce. We will generate a new one.
+            generate_new_location(
+                erlang:system_time(millisecond),
+                Base,
+                OnlyCommitted,
+                Opts
+            );
+        {true, SpecificNonce} ->
+            case SpecificNonce > ExistingNonce of
+                true ->
+                    generate_new_location(SpecificNonce, Base, OnlyCommitted, Opts);
+                false ->
+                    {error,
+                        #{
+                            <<"status">> => 400,
+                            <<"body">> => <<"Known nonce higher than requested nonce.">>,
+                            <<"requested-nonce">> => SpecificNonce,
+                            <<"existing-nonce">> => ExistingNonce,
+                            <<"signers">> => Signers
+                        }
+                    }
+            end
     end.
 
 %% @doc Generate the default location record URL from the node's configuration.
@@ -154,30 +196,33 @@ default_url(Opts) ->
 %% `location_notify' option. Finally, we will return the signed location record
 %% to the caller.
 generate_new_location(Nonce, Base, OnlyCommitted, Opts) ->
-    TimeToLive =
-        hb_ao:get_first(
-            [
-                {Base, <<"time-to-live">>},
-                {OnlyCommitted, <<"time-to-live">>}
-            ],
+    DefaultTTL =
+        hb_opts:get(
+            location_ttl,
             hb_opts:get(scheduler_location_ttl, 1000 * 60 * 60, Opts),
             Opts
         ),
+    TimeToLive =
+        case hb_maps:get(<<"time-to-live">>, Base, not_found, Opts) of
+            not_found ->
+                hb_maps:get(<<"time-to-live">>, OnlyCommitted, DefaultTTL, Opts);
+            TTLValue ->
+                TTLValue
+        end,
     URL =
-        case hb_ao:get(<<"url">>, OnlyCommitted, Opts) of
+        case hb_maps:get(<<"url">>, OnlyCommitted, not_found, Opts) of
             not_found -> default_url(Opts);
             GivenURL -> GivenURL
         end,
     % Construct the new scheduler location message.
+    DefaultCodec = hb_opts:get(location_codec, ?DEFAULT_CODEC, Opts),
     Codec =
-        hb_ao:get_first(
-            [
-                {Base, <<"require-codec">>},
-                {OnlyCommitted, <<"require-codec">>}
-            ],
-            <<"httpsig@1.0">>,
-            Opts
-        ),
+        case hb_maps:get(<<"require-codec">>, Base, not_found, Opts) of
+            not_found ->
+                hb_maps:get(<<"require-codec">>, OnlyCommitted, DefaultCodec, Opts);
+            CodecValue ->
+                CodecValue
+        end,
     generate_new_location(URL, Nonce, TimeToLive, Codec, Opts).
 generate_new_location(URL, Nonce, TTL, Codec, Opts) ->
     NewSchedulerLocation =
@@ -208,7 +253,7 @@ generate_new_location(URL, Nonce, TTL, Codec, Opts) ->
             fun(Node) ->
                 PostRes = hb_http:post(
                     Node,
-                    <<"/~scheduler@1.0/location">>,
+                    <<"/~location@1.0/known">>,
                     Signed,
                     Opts
                 ),
@@ -228,13 +273,30 @@ generate_new_location(URL, Nonce, TTL, Codec, Opts) ->
 
 %% @doc Verify and write a location record for a foreign peer to the cache.
 write_foreign(Base, RawReq, Opts) ->
-    MaybeLocation = find_record(Base, RawReq, Opts),
+    MaybeLocation = find_target(Base, RawReq, Opts),
     maybe
         Signers = hb_message:signers(MaybeLocation, Opts),
-        true ?= hb_message:verify(MaybeLocation, signed, Opts)
+        LocationType =
+            hb_ao:get_first(
+                [
+                    {MaybeLocation, <<"type">>},
+                    {MaybeLocation, <<"Type">>}
+                ],
+                not_found,
+                Opts
+            ),
+        NormalizedType =
+            case LocationType of
+                not_found -> not_found;
+                _ -> hb_ao:normalize_key(LocationType)
+            end,
+        true ?= hb_message:verify(MaybeLocation, all, Opts)
             orelse {error, <<"Invalid location record signature.">>},
         true ?=
-            (hb_maps:get(<<"type">>, MaybeLocation, Opts) =:= <<"scheduler-location">>)
+            lists:member(
+                NormalizedType,
+                [<<"location">>, <<"scheduler-location">>]
+            )
             orelse {error, <<"Invalid location record type.">>},
         true ?=
             (hb_maps:get(<<"url">>, MaybeLocation, Opts) =/= not_found)
@@ -245,29 +307,50 @@ write_foreign(Base, RawReq, Opts) ->
         true ?=
             (hb_maps:get(<<"time-to-live">>, MaybeLocation, Opts) =/= not_found)
             orelse {error, <<"Missing location record time-to-live.">>},
-        Nonce = hb_ao:get(<<"nonce">>, MaybeLocation, Opts),
-        Res = lists:any(
-            fun(Signer) ->
-                case latest_nonce(Signer, Nonce, Opts) of
-                    true ->
-                        dev_location_cache:write(MaybeLocation, Opts);
-                    false ->
-                        ?event(
-                            location,
-                            {newer_foreign_peer_location_already_exists,
-                                {signer, Signer},
-                                {nonce, Nonce},
-                                {location, MaybeLocation}
-                            }
-                        )
-                end
-
-           end,
-            Signers
+        Nonce = hb_util:int(hb_ao:get(<<"nonce">>, MaybeLocation, 0, Opts)),
+        SignerChecks =
+            lists:map(
+                fun(Signer) ->
+                    {Signer, latest_nonce(Signer, Nonce, Opts)}
+                end,
+                Signers
+            ),
+        lists:foreach(
+            fun
+                ({Signer, false}) ->
+                    ?event(
+                        location,
+                        {newer_foreign_peer_location_already_exists,
+                            {signer, Signer},
+                            {nonce, Nonce},
+                            {location, MaybeLocation}
+                        }
+                    );
+                (_) ->
+                    ok
+            end,
+            SignerChecks
         ),
-        case Res of
+        CanWrite =
+            lists:any(
+                fun({_Signer, IsLatest}) -> IsLatest end,
+                SignerChecks
+            ),
+        case CanWrite of
             true ->
-                {ok, MaybeLocation};
+                case dev_location_cache:write(MaybeLocation, Opts) of
+                    ok ->
+                        {ok, MaybeLocation};
+                    {error, Reason} ->
+                        {error,
+                            #{
+                                <<"status">> => 400,
+                                <<"body">> =>
+                                    <<"Failed to store new location record.">>,
+                                <<"reason">> => Reason
+                            }
+                        }
+                end;
             false ->
                 {error,
                     #{
@@ -285,9 +368,9 @@ write_foreign(Base, RawReq, Opts) ->
 latest_nonce(Signer, Nonce, Opts) ->
     case dev_location_cache:read(Signer, Opts) of
         {ok, Location} ->
-            hb_util:int(hb_ao:get(<<"nonce">>, Location, 0, Opts)) > Nonce;
-        not_found ->
-            -1
+            hb_util:int(hb_ao:get(<<"nonce">>, Location, -1, Opts)) < Nonce;
+        _ ->
+            true
     end.
 
 %%% Tests
@@ -298,7 +381,7 @@ register_scheduler_test() ->
     Base =
         hb_message:commit(
             #{
-                <<"path">> => <<"/~scheduler@1.0/location">>,
+                <<"path">> => <<"/~location@1.0/node">>,
                 <<"url">> => <<"https://hyperbeam-test-ignore.com">>,
                 <<"method">> => <<"POST">>,
                 <<"nonce">> => 1,
@@ -330,8 +413,8 @@ register_location_on_boot_test() ->
             on =>
                 #{
                     <<"start">> => #{
-                        <<"device">> => <<"scheduler@1.0">>,
-                        <<"path">> => <<"location">>,
+                        <<"device">> => <<"location@1.0">>,
+                        <<"path">> => <<"node">>,
                         <<"method">> => <<"POST">>,
                         <<"target">> => <<"self">>,
                         <<"require-codec">> => <<"ans104@1.0">>,
@@ -355,19 +438,25 @@ register_location_on_boot_test() ->
             },
             #{}
         ),
+    CurrentBody = hb_ao:get(<<"body">>, CurrentLocation, CurrentLocation, #{}),
     ?event({current_location, CurrentLocation}),
     ?assertMatch(
         #{
             <<"url">> := <<"https://hyperbeam-test-ignore.com">>,
-            <<"nonce">> := 0
-        },
-        hb_ao:get(<<"body">>, CurrentLocation, #{})
+            <<"nonce">> := Nonce
+        } when Nonce > 0,
+        CurrentBody
     ),
+    {ok, RemoteLocation} =
+        hb_http:get(
+            RegisteringNode,
+            <<"/~location@1.0/", Address/binary>>,
+            #{}
+        ),
     ?assertMatch(
         #{
             <<"url">> := <<"https://hyperbeam-test-ignore.com">>,
-            <<"nonce">> := 0
-        },
-        hb_http:get(RegisteringNode, <<"/~location@1.0/", Address/binary>>, #{})
-    ),
-    ok.
+            <<"nonce">> := Nonce
+        } when Nonce > 0,
+        RemoteLocation
+    ).

--- a/src/dev_location.erl
+++ b/src/dev_location.erl
@@ -413,6 +413,35 @@ register_scheduler_test() ->
     {ok, Res} = hb_http:post(Node, Base, Opts),
     ?assertMatch(#{ <<"url">> := Location } when is_binary(Location), Res).
 
+%% @doc Test that unsigned GET calls to `node' return the same location record
+%% once one has been generated.
+unsigned_get_node_is_idempotent_test() ->
+    Wallet = ar_wallet:new(),
+    Opts = #{
+        store => [hb_test_utils:test_store()],
+        priv_wallet => Wallet
+    },
+    Node = hb_http_server:start_node(Opts),
+    {ok, FirstRes} = hb_http:get(Node, <<"/~location@1.0/node">>, #{}),
+    FirstLocation = hb_ao:get(<<"body">>, FirstRes, FirstRes, #{}),
+    Address = hb_util:human_id(ar_wallet:to_address(Wallet)),
+    {ok, CachedAfterFirst} = dev_location_cache:read(Address, Opts),
+    timer:sleep(10),
+    {ok, SecondRes} = hb_http:get(Node, <<"/~location@1.0/node">>, #{}),
+    SecondLocation = hb_ao:get(<<"body">>, SecondRes, SecondRes, #{}),
+    {ok, CachedAfterSecond} = dev_location_cache:read(Address, Opts),
+    ?assertEqual(CachedAfterFirst, CachedAfterSecond),
+    FirstNonce = hb_util:int(hb_maps:get(<<"nonce">>, FirstLocation, -1, #{})),
+    SecondNonce = hb_util:int(hb_maps:get(<<"nonce">>, SecondLocation, -1, #{})),
+    CachedNonce = hb_util:int(hb_maps:get(<<"nonce">>, CachedAfterSecond, -1, #{})),
+    ?assert(FirstNonce > 0),
+    ?assertEqual(FirstNonce, SecondNonce),
+    ?assertEqual(FirstNonce, CachedNonce),
+    ?assertEqual(
+        hb_maps:get(<<"url">>, FirstLocation, not_found, #{}),
+        hb_maps:get(<<"url">>, SecondLocation, not_found, #{})
+    ).
+
 %% @doc Test that a scheduler location is registered on boot.
 register_location_on_boot_test() ->
     NotifiedPeerWallet = ar_wallet:new(),

--- a/src/dev_location.erl
+++ b/src/dev_location.erl
@@ -2,6 +2,20 @@
 %%% This device allows nodes to specify the physical location (resolved through
 %%% DNS and IP addresses) that their cryptographic addresses will be found at
 %%% for a period of time.
+%%% 
+%%% The interface is as follows:
+%%% 
+%%% `GET /~location@1.0/<address>': Read a location record from the cache or
+%%%                                 gateway. If the record is retreived from a
+%%%                                 gateway it will be cached locally.
+%%% `GET /~location@1.0/node':      Generate a new location record and register it.
+%%%                                 If signed by the operator, the record can
+%%%                                 be generated for a specific nonce. Otherwise,
+%%%                                 the record will be generated with a new nonce
+%%%                                 chosen by the node.
+%%% `POST /~location@1.0/known':    Cache a location record for a foreign peer
+%%%                                 if the record is valid and newer than the
+%%%                                 known nonce for the signer.
 -module(dev_location).
 -export([info/0, read/2, node/3, known/3, all/3]).
 -include("include/hb.hrl").
@@ -62,7 +76,6 @@ latest_known_nonce(Address, Opts) ->
         {ok, Location} -> hb_maps:get(<<"nonce">>, Location, -1, Opts);
         _ -> -1
     end.
-
 
 %% @doc Find the target to be used for during a request.
 find_target(Base, RawReq, Opts) ->
@@ -251,12 +264,13 @@ generate_new_location(URL, Nonce, TTL, Codec, Opts) ->
     Results =
         lists:map(
             fun(Node) ->
-                PostRes = hb_http:post(
-                    Node,
-                    <<"/~location@1.0/known">>,
-                    Signed,
-                    Opts
-                ),
+                PostRes =
+                    hb_http:post(
+                        Node,
+                        <<"/~location@1.0/known">>,
+                        Signed,
+                        Opts
+                    ),
                 ?event(scheduler_location,
                     {outbound_request, {res, PostRes}}
                 )

--- a/src/dev_location_cache.erl
+++ b/src/dev_location_cache.erl
@@ -1,0 +1,89 @@
+%%% @doc Pseudo-path cache for node location records.
+%%% Writes location records to ~location@1.0/ADDRESS -> LocationRecord.
+-module(dev_location_cache).
+-export([write/2, read/2, list/1]).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%%% The pseudo-path prefix which the location cache should use.
+-define(LOCATION_CACHE_PREFIX, <<"~location@1.0">>).
+
+%% @doc Merge the location store with the main store. Used before writing
+%% to the cache.
+opts(Opts) ->
+    Opts#{
+        store =>
+            hb_opts:get(
+                scheduler_store,
+                hb_opts:get(store, no_viable_store, Opts),
+                Opts
+            )
+    }.
+
+%% @doc Read the latest known scheduler location for an address.
+read(Address, RawOpts) ->
+    Opts = opts(RawOpts),
+    Res =
+        hb_cache:read(
+            hb_store:path(
+                hb_opts:get(store, no_viable_store, Opts),
+                [
+                    ?LOCATION_CACHE_PREFIX,
+                    hb_util:human_id(Address)
+                ]
+            ),
+            Opts
+        ),
+    Event =
+        case Res of
+            {ok, _} -> found_in_store;
+            not_found -> not_found_in_store;
+            _ -> local_lookup_unexpected_result
+        end,
+    ?event(scheduler_location, {Event, {address, Address}, {res, Res}}),
+    Res.
+
+%% @doc Write the latest known scheduler location for an address.
+write(LocationMsg, RawOpts) ->
+    Opts = opts(RawOpts),
+    Store = hb_opts:get(store, no_viable_store, Opts),
+    Signers = hb_message:signers(LocationMsg, Opts),
+    ?event(
+        scheduler_location,
+        {caching_locally,
+            {signers, Signers},
+            {location_msg, LocationMsg}
+        }
+    ),
+    case hb_cache:write(LocationMsg, Opts) of
+        {ok, RootPath} ->
+            lists:foreach(
+                fun(Signer) ->
+                    hb_store:make_link(
+                        Store,
+                        RootPath,
+                        hb_store:path(
+                            Store,
+                            [
+                                ?LOCATION_CACHE_PREFIX,
+                                hb_util:human_id(Signer)
+                            ]
+                        )
+                    )
+                end,
+                Signers
+            ),
+            ok;
+        false ->
+            % The message is not valid, so we don't cache it.
+            {error, <<"Invalid scheduler location message. Not caching.">>};
+        {error, Reason} ->
+            ?event(warning, {failed_to_cache_location_msg, {reason, Reason}}),
+            {error, Reason}
+    end.
+
+%% @doc Return a list of all known location records.
+list(RawOpts) ->
+    Opts = opts(RawOpts),
+    Store = hb_opts:get(store, no_viable_store, Opts),
+    hb_store:list(Store, [?LOCATION_CACHE_PREFIX]).

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -18,7 +18,7 @@
 %%% AO-Core API functions:
 -export([info/0]).
 %%% Local scheduling functions:
--export([schedule/3, router/4, location/3]).
+-export([schedule/3, router/4]).
 %%% CU-flow functions:
 -export([slot/3, status/3, next/3]).
 -export([start/0, checkpoint/1]).
@@ -360,201 +360,6 @@ status(_M1, _M2, _Opts) ->
         }
     }.
 
-%% @doc Router for `record' requests. Expects either a `POST' or `GET' request.
-location(Base, Req, Opts) ->
-    case hb_ao:get(<<"method">>, Req, <<"GET">>, Opts) of
-        <<"POST">> -> post_location(Base, Req, Opts);
-        <<"GET">> -> get_location(Base, Req, Opts)
-    end.
-
-%% @doc Search for the location of the scheduler in the scheduler-location
-%% cache. If an address is provided, we search for the location of that
-%% specific scheduler. Otherwise, we return the location record for the current
-%% node's scheduler, if it has been established.
-get_location(_Base, Req, Opts) ->
-    % Get the address of the scheduler from the request.
-    Address =
-        hb_ao:get(
-            <<"address">>,
-            Req,
-            hb_util:human_id(ar_wallet:to_address(
-                hb_opts:get(priv_wallet, hb:wallet(), Opts)
-            )),
-            Opts
-        ),
-    % Search for the location of the scheduler in the scheduler-location cache.
-    case dev_scheduler_cache:read_location(Address, Opts) of
-        not_found ->
-            {ok,
-                #{
-                    <<"status">> => 404,
-                    <<"body">> =>
-                        <<"No location found for address: ", Address/binary>>
-                }
-            };
-        {ok, Location} -> {ok, #{ <<"body">> => Location }}
-    end.
-
-%% @doc Generate a new scheduler location record and register it. We both send 
-%% the new scheduler-location to the given registry, and return it to the caller.
-post_location(Base, RawReq, RawOpts) ->
-    Opts =
-        case dev_whois:ensure_host(RawOpts) of
-            {ok, NewOpts} -> NewOpts;
-            _ -> RawOpts
-        end,
-    % Ensure that the request is signed by the operator.
-    Req =
-        case hb_ao:get_first(
-            [{Base, <<"target">>}, {RawReq, <<"target">>}],
-            not_found,
-            Opts
-        ) of
-            not_found -> RawReq;
-            <<"self">> -> Base;
-            <<"request">> -> RawReq;
-            Target -> hb_ao:get(Target, RawReq, not_found, Opts)
-        end,
-    {ok, OnlyCommitted} = hb_message:with_only_committed(Req, Opts),
-    ?event(scheduler_location,
-        {scheduler_location_registration_request, OnlyCommitted}
-    ),
-    % Gather metadata for request validation.
-    Signers = hb_message:signers(OnlyCommitted, Opts),
-    Self =
-        hb_util:human_id(
-            ar_wallet:to_address(
-                hb_opts:get(priv_wallet, hb:wallet(), Opts)
-            )
-        ),
-    ExistingNonce = 
-        case hb_gateway_client:scheduler_location(Self, Opts) of
-            {ok, SchedulerLocation} ->
-                hb_ao:get(<<"nonce">>, SchedulerLocation, 0, Opts);
-            {error, _} -> -1
-        end,
-    NewNonce = hb_ao:get(<<"nonce">>, OnlyCommitted, ExistingNonce + 1, Opts),
-    case {NewNonce > ExistingNonce, lists:member(Self, Signers)} of
-        {false, _} ->
-            % Invalid request: Known nonce is already higher than requested nonce
-            % for the given operator.
-            {ok,
-                #{
-                    <<"status">> => 400,
-                    <<"body">> => <<"Known nonce higher than requested nonce.">>,
-                    <<"requested-nonce">> => NewNonce,
-                    <<"existing-nonce">> => ExistingNonce,
-                    <<"signers">> => Signers
-                }
-            };
-        {true, false} ->
-            % Received request to store a new scheduler location from a peer
-            % that is not the operator.
-            case dev_scheduler_cache:write_location(OnlyCommitted, Opts) of
-                ok ->
-                    ?event(scheduler_location,
-                        {cached_foreign_peer_location, OnlyCommitted}
-                    ),
-                    {ok, OnlyCommitted};
-                {error, Reason} ->
-                    {error,
-                        #{
-                            <<"status">> => 400,
-                            <<"body">> =>
-                                <<"Failed to store new scheduler location.">>,
-                            <<"reason">> => Reason
-                        }
-                    }
-            end;
-        {true, true} ->
-            % The operator has asked to replace the scheduler location. Get the
-            % details and register the new location. Registration occurs in the
-            % following steps:
-            % 1. Generate a new scheduler location message.
-            % 2. Sign the message.
-            % 3. Upload the message to Arweave.
-            % 4. Post the message to the peers specified in the
-            %    `scheduler_location_notify_peers' option.
-            TimeToLive =
-                hb_ao:get_first(
-                    [
-                        {Base, <<"time-to-live">>},
-                        {OnlyCommitted, <<"time-to-live">>}
-                    ],
-                    hb_opts:get(scheduler_location_ttl, 1000 * 60 * 60, Opts),
-                    Opts
-                ),
-            URL =
-                case hb_ao:get(<<"url">>, OnlyCommitted, Opts) of
-                    not_found ->
-                        Port = hb_util:bin(hb_opts:get(port, 8734, Opts)),
-                        Host = hb_opts:get(host, <<"localhost">>, Opts),
-                        Protocol = hb_opts:get(protocol, http1, Opts),
-                        ProtoStr =
-                            case Protocol of
-                                http1 -> <<"http">>;
-                                _ -> <<"https">>
-                            end,
-                        <<ProtoStr/binary, "://", Host/binary, ":", Port/binary>>;
-                    GivenURL -> GivenURL
-                end,
-            % Construct the new scheduler location message.
-            Codec =
-                hb_ao:get_first(
-                    [
-                        {Base, <<"require-codec">>},
-                        {OnlyCommitted, <<"require-codec">>}
-                    ],
-                    <<"httpsig@1.0">>,
-                    Opts
-                ),
-            NewSchedulerLocation =
-                #{
-                    <<"data-protocol">> => <<"ao">>,
-                    <<"variant">> => <<"ao.N.1">>,
-                    <<"type">> => <<"scheduler-location">>,
-                    <<"url">> => URL,
-                    <<"nonce">> => NewNonce,
-                    <<"time-to-live">> => TimeToLive,
-                    <<"codec-device">> => Codec
-                },
-            Signed = hb_message:commit(NewSchedulerLocation, Opts, Codec),
-            dev_scheduler_cache:write_location(Signed, Opts),
-            ?event(scheduler_location,
-                {uploading_signed_scheduler_location, Signed}
-            ),
-            % Asynchronously upload the location record to Arweave.
-            spawn(
-                fun() ->
-                    hb_client:upload(Signed, Opts)
-                end
-            ),
-            % Post the new scheduler location to the peers specified in the
-            % `scheduler_location_notify_peers' option.
-            Results =
-                lists:map(
-                    fun(Node) ->
-                        PostRes = hb_http:post(
-                            Node,
-                            <<"/~scheduler@1.0/record">>,
-                            Signed,
-                            Opts
-                        ),
-                        ?event(scheduler_location,
-                            {outbound_request, {res, PostRes}}
-                        )
-                    end,
-                    hb_opts:get(scheduler_location_notify_peers, [], Opts)
-                ),
-            ?event(scheduler_location,
-                {scheduler_location_registration_success,
-                    {arweave_publication, async_upload_initiated},
-                    {foreign_peers_notified, length(Results)}
-                }
-            ),
-            {ok, Signed}
-    end.
-
 %% @doc A router for choosing between getting the existing schedule, or
 %% scheduling a new message.
 schedule(Base, Req, Opts) ->
@@ -893,36 +698,14 @@ find_remote_scheduler(ProcID, Scheduler, Opts) ->
             % We have a hint. Construct a redirect message.
             generate_redirect(ProcID, Hint, Opts);
         not_found ->
-            case dev_scheduler_cache:read_location(Scheduler, Opts) of
+            case dev_location:read(Scheduler, Opts) of
                 {ok, SchedMsg} ->
                     % We have a cached scheduler location. Use it to construct a
                     % redirect message.
                     generate_redirect(ProcID, SchedMsg, Opts);
-                not_found ->
-                    % We have not yet cached the location for this address.
-                    % Find it via the gateway.
-                    case hb_gateway_client:scheduler_location(Scheduler, Opts) of
-                        {ok, SchedMsg} ->
-                            % We have found the location. Cache it and use it to
-                            % construct a redirect message.
-                            Res =
-                                dev_scheduler_cache:write_location(
-                                    SchedMsg,
-                                    Opts
-                                ),
-                            ?event(scheduler_location,
-                                {cached_scheduler_location, {res, Res}}
-                            ),
-                            generate_redirect(ProcID, SchedMsg, Opts);
-                        {error, Res} ->
-                            ?event(
-                                scheduler_location,
-                                {failed_to_find_scheduler_location_from_gateway,
-                                    {error, Res}
-                                }
-                            ),
-                            {error, Res}
-                    end
+                {error, Error} ->
+                    ?event({failed_to_find_scheduler_location, {error, Error}}),
+                    {error, Error}
             end
     end.
 
@@ -1695,62 +1478,6 @@ register_new_process_test() ->
         )
     ).
 
-%% @doc Test that a scheduler location is registered on boot.
-register_location_on_boot_test() ->
-    NotifiedPeerWallet = ar_wallet:new(),
-    RegisteringNodeWallet = ar_wallet:new(),
-    start(),
-    NotifiedPeer =
-        hb_http_server:start_node(#{
-            priv_wallet => NotifiedPeerWallet,
-            store => [
-                #{
-                    <<"store-module">> => hb_store_fs,
-                    <<"name">> => <<"cache-TEST/scheduler-location-notified">>
-                }
-            ]
-        }),
-    RegisteringNode = hb_http_server:start_node(
-        #{
-            priv_wallet => RegisteringNodeWallet,
-            on =>
-                #{
-                    <<"start">> => #{
-                        <<"device">> => <<"scheduler@1.0">>,
-                        <<"path">> => <<"location">>,
-                        <<"method">> => <<"POST">>,
-                        <<"target">> => <<"self">>,
-                        <<"require-codec">> => <<"ans104@1.0">>,
-                        <<"url">> => <<"https://hyperbeam-test-ignore.com">>,
-                        <<"hook">> => #{
-                            <<"result">> => <<"ignore">>,
-                            <<"commit-request">> => true
-                        }
-                    }
-                },
-            scheduler_location_notify_peers => [NotifiedPeer]
-        }
-    ),
-    {ok, CurrentLocation} =
-        hb_http:get(
-            RegisteringNode,
-            #{
-                <<"method">> => <<"GET">>,
-                <<"path">> => <<"/~scheduler@1.0/location">>,
-                <<"address">> =>
-                    hb_util:human_id(ar_wallet:to_address(RegisteringNodeWallet))
-            },
-            #{}
-        ),
-    ?event({current_location, CurrentLocation}),
-    ?assertMatch(
-        #{
-            <<"url">> := <<"https://hyperbeam-test-ignore.com">>,
-            <<"nonce">> := 0
-        },
-        hb_ao:get(<<"body">>, CurrentLocation, #{})
-    ).
-
 schedule_message_and_get_slot_test() ->
     start(),
     Base = hb_message:commit(test_process(), #{ priv_wallet => hb:wallet() }),
@@ -1888,19 +1615,6 @@ http_init(Opts) ->
 	},
     Node = hb_http_server:start_node(ExtendedOpts),
     {Node, ExtendedOpts}.
-
-register_scheduler_test() ->
-    start(),
-    {Node, Opts} = http_init(),
-    Base = hb_message:commit(#{
-        <<"path">> => <<"/~scheduler@1.0/location">>,
-        <<"url">> => <<"https://hyperbeam-test-ignore.com">>,
-        <<"method">> => <<"POST">>,
-        <<"nonce">> => 1,
-        <<"require-codec">> => <<"ans104@1.0">>
-    }, Opts),
-    {ok, Res} = hb_http:post(Node, Base, Opts),
-    ?assertMatch(#{ <<"url">> := Location } when is_binary(Location), Res).
 
 http_post_schedule_sign(Node, Msg, ProcessMsg, Opts) ->
     Base = hb_message:commit(#{

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -48,7 +48,6 @@ info() ->
     #{
         exports =>
             [
-                <<"location">>,
                 <<"status">>,
                 <<"next">>,
                 <<"schedule">>,

--- a/src/dev_scheduler_cache.erl
+++ b/src/dev_scheduler_cache.erl
@@ -1,7 +1,6 @@
 %%% @doc A module that provides a cache for scheduler assignments and locations.
 -module(dev_scheduler_cache).
--export([write/2, write_spawn/2, write_location/2]).
--export([read/3, read_location/2]).
+-export([write/2, write_spawn/2, read/3]).
 -export([list/2, latest/2]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -149,66 +148,6 @@ latest(ProcID, RawOpts) ->
                     #{ hashpath => ignore }
                 )
             }
-    end.
-
-%% @doc Read the latest known scheduler location for an address.
-read_location(Address, RawOpts) ->
-    Opts = opts(RawOpts),
-    Res =
-        hb_cache:read(
-            hb_store:path(hb_opts:get(store, no_viable_store, Opts), [
-                ?SCHEDULER_CACHE_PREFIX,
-                "locations",
-                hb_util:human_id(Address)
-            ]),
-            Opts
-        ),
-    Event =
-        case Res of
-            {ok, _} -> found_in_store;
-            not_found -> not_found_in_store;
-            _ -> local_lookup_unexpected_result
-        end,
-    ?event(scheduler_location, {Event, {address, Address}, {res, Res}}),
-    Res.
-
-%% @doc Write the latest known scheduler location for an address.
-write_location(LocationMsg, RawOpts) ->
-    Opts = opts(RawOpts),
-    Signers = hb_message:signers(LocationMsg, Opts),
-    ?event(
-        scheduler_location,
-        {caching_locally,
-            {signers, Signers},
-            {location_msg, LocationMsg}
-        }
-    ),
-    case hb_cache:write(LocationMsg, Opts) of
-        {ok, RootPath} ->
-            lists:foreach(
-                fun(Signer) ->
-                    hb_store:make_link(
-                        hb_opts:get(store, no_viable_store, Opts),
-                        RootPath,
-                        hb_store:path(
-                            hb_opts:get(store, no_viable_store, Opts),
-                            [
-                                ?SCHEDULER_CACHE_PREFIX,
-                                "locations",
-                                hb_util:human_id(Signer)
-                            ]
-                        )
-                    )
-                end,
-                Signers
-            ),
-            ok;
-        false ->
-            % The message is not valid, so we don't cache it.
-            {error, <<"Invalid scheduler location message. Not caching.">>};
-        {error, Reason} ->
-            ?event(warning, {failed_to_cache_location_msg, {reason, Reason}}),
-            {error, Reason}
     end.
 
 %%% Tests
@@ -499,56 +438,6 @@ invalid_assignment_stress_test() ->
         }
     ),
     ?assertEqual(6, ErrorCount).
-
-%% @doc Test scheduler location operations under stress.
-scheduler_location_stress_test() ->
-    VolStore = hb_test_utils:test_store(hb_store_fs, <<"location-vol">>),
-    NonVolStore = hb_test_utils:test_store(hb_store_fs, <<"location-nonvol">>),
-    Wallet = ar_wallet:new(),
-    Opts = #{
-        store => [NonVolStore],
-        scheduler_store => [VolStore],
-        priv_wallet => Wallet
-    },
-    hb_store:start(VolStore),
-    hb_store:start(NonVolStore),
-    LocationCount = 10,
-    ?event(testing, {location_stress_test_starting, LocationCount}),
-    Results =
-        lists:map(
-            fun(N) ->
-                LocationMsg = #{
-                    <<"scheduler">> =>
-                        hb_util:human_id(ar_wallet:to_address(Wallet)),
-                    <<"location">> =>
-                        <<
-                            "http://scheduler",
-                            (integer_to_binary(N))/binary,
-                            ".com"
-                        >>,
-                    <<"timestamp">> => erlang:system_time(millisecond),
-                    <<"ttl">> => 3600000
-                },
-                Result =
-                    try
-                        write_location(LocationMsg, Opts)
-                    catch
-                        Res -> 
-                            ?event(testing, {location_write_error, {error, Res}}),
-                            ok 
-                    end,
-                ?assert(Result == ok orelse element(1, Result) == error),
-                Result
-            end,
-            lists:seq(1, LocationCount)
-        ),
-    SuccessCount = length([R || R <- Results, R == ok]),
-    ?event(
-        {location_stress_results,
-            {successes, SuccessCount},
-            {total, LocationCount}
-        }
-    ).
 
 %% @doc Test system behavior with corrupted data in volatile store.
 volatile_store_corruption_test() ->

--- a/src/hb_examples.erl
+++ b/src/hb_examples.erl
@@ -224,8 +224,8 @@ relay_schedule_ans104_test() ->
             #{
                 on => #{
                     <<"start">> => #{
-                        <<"device">> => <<"scheduler@1.0">>,
-                        <<"path">> => <<"location">>,
+                        <<"device">> => <<"location@1.0">>,
+                        <<"path">> => <<"node">>,
                         <<"method">> => <<"POST">>,
                         <<"target">> => <<"self">>,
                         <<"require-codec">> => <<"ans104@1.0">>,
@@ -260,12 +260,12 @@ relay_schedule_ans104_test() ->
     {ok, SchedulerLocation} =
         hb_http:get(
             Scheduler,
-            <<"/~scheduler@1.0/location">>,
+            <<"/~location@1.0/node">>,
             #{}
         ),
     ?event({scheduler_location, SchedulerLocation}),
-    dev_scheduler_cache:write_location(
-        hb_maps:get(<<"body">>, SchedulerLocation, <<"NO BODY">>, #{}),
+    dev_location_cache:write(
+        SchedulerLocation,
         #{ store => [ComputeStore] }
     ),
     % Create the relaying server.

--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -129,7 +129,7 @@ location(Address, Opts) ->
         <<"query($Addresses: [String!]!) { ",
                 "transactions(",
                 "owners: $Addresses, ",
-                "tags: { name: \"Type\" values: [\"Location\", Scheduler-Location\"] }, ",
+                "tags: { name: \"Type\" values: [\"Location\", \"Scheduler-Location\"] }, ",
                 "first: 1",
             "){ ",
                 "edges { ",

--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -11,7 +11,7 @@
 -export([query/2, query/3, query/4, query/5]).
 -export([read/2, data/2, result_to_message/2, item_spec/0]).
 %% Application-specific data access functions:
--export([scheduler_location/2]).
+-export([location/2]).
 -include_lib("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -124,12 +124,12 @@ data(ID, Opts) ->
     end.
 
 %% @doc Find the location of the scheduler based on its ID, through GraphQL.
-scheduler_location(Address, Opts) ->
+location(Address, Opts) ->
     Query =
-        <<"query($SchedulerAddrs: [String!]!) { ",
+        <<"query($Addresses: [String!]!) { ",
                 "transactions(",
-                "owners: $SchedulerAddrs, ",
-                "tags: { name: \"Type\" values: [\"Scheduler-Location\"] }, ",
+                "owners: $Addresses, ",
+                "tags: { name: \"Type\" values: [\"Location\", Scheduler-Location\"] }, ",
                 "first: 1",
             "){ ",
                 "edges { ",
@@ -137,7 +137,7 @@ scheduler_location(Address, Opts) ->
                 " } ",
             "} ",
         "}">>,
-    Variables = #{ <<"SchedulerAddrs">> => [Address] },
+    Variables = #{ <<"Addresses">> => [Address] },
     case query(Query, Variables, Opts) of
         {error, Reason} ->
             ?event({scheduler_location, {query, Query}, {error, Reason}}),
@@ -403,7 +403,7 @@ scheduler_location_test() ->
     % Start a random node so that all of the services come up.
     _Node = hb_http_server:start_node(#{}),
     {ok, Res} =
-        scheduler_location(
+        location(
             <<"fcoN_xJeisVsPXA-trzVAuIiqO3ydLQxM-L4XbrQKzY">>,
             #{}
         ),

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -160,6 +160,7 @@ default_message() ->
             #{<<"name">> => <<"json@1.0">>, <<"module">> => dev_codec_json},
             #{<<"name">> => <<"json-iface@1.0">>, <<"module">> => dev_json_iface},
             #{<<"name">> => <<"local-name@1.0">>, <<"module">> => dev_local_name},
+            #{<<"name">> => <<"location@1.0">>, <<"module">> => dev_location},
             #{<<"name">> => <<"lookup@1.0">>, <<"module">> => dev_lookup},
             #{<<"name">> => <<"lua@5.3a">>, <<"module">> => dev_lua},
             #{<<"name">> => <<"manifest@1.0">>, <<"module">> => dev_manifest},


### PR DESCRIPTION
This PR introduces a new primitive device that allows for nodes (identified by cryptographic wallet) to find one another via gossip or GraphQL query for location records. A `location` record is a simple message that carries a `Nonce` (defaulting to millisecond timestamp), `Time-To-Live`, a `URL` to find the node (and cryptographic ID) at, as well as a signature of the creator.

This notion is a generalization of `Scheduler-Location`s from AO Legacynet, aimed at allowing peers to gain necessary cryptographic signatures from one another upon computation results, as well as their traditional role in locating SUs.