### PR TITLE
impr: do not fully read IDs to return the type in `hb_store_arweave`

### DIFF
--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -19,16 +19,10 @@ scope(_) -> scope().
 %% @doc Get the type of the data at the given key. We potentially cache the
 %% result, so that we don't have to read the data from the GraphQL route
 %% multiple times.
-type(StoreOpts, Key) ->
-    case read(StoreOpts, Key) of
-        {error, not_found} -> not_found;
-        {ok, _Data} ->
-            % TODO:
-            % - should this return composite for any index L1 bundles?
-            % - if so, I guess we need to implement list/2?
-            % - for now we don't index nested bundle children, but once we
-            %   do we may nalso need to return composite for them.
-            simple
+type(#{ <<"index-store">> := IndexStore }, ID) ->
+    case hb_store:read(IndexStore, path(ID)) of
+        {ok, _Offset} -> simple;
+        _ -> not_found
     end.
 
 read(StoreOpts = #{ <<"index-store">> := IndexStore }, ID) ->


### PR DESCRIPTION
In setups where the `read` operation is not cached to another store, the prior behavior led to the full data item being read once for `hb_cache`'s `type` operation and once for the subsequent read. This effectively doubled the amount of data access requests required for the Arweave node.

The fix is simple: If the pseudo-path exists in the cache, then we know that the data should be accessible as an Arweave data item. Thus, we can return a type for it without making any data access requests.
