### PR TITLE
impr: miscellaneous demo fixes

### DIFF
--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -28,7 +28,8 @@ tx(Base, Request, Opts) ->
 %% Note: When uploading ans104 transactions, this function will use the
 %% node's default bundler. If instead you want to use this node as a bundler
 %% you should use the ~bundler@1.0 device.
-post_tx(Base, Request, Opts) ->
+post_tx(Base, RawRequest, Opts) ->
+    {ok, Request} = extract_target(Base, RawRequest, Opts),
     case hb_message:commitment_devices(Request, Opts) of
         [Device] -> post_tx(Base, Request, Opts, Device);
         [] -> 
@@ -42,6 +43,21 @@ post_tx(Base, Request, Opts) ->
         Devices ->
             ?event({too_many_commitment_devices, Devices}),
             {error, too_many_commitment_devices}
+    end.
+
+%% @doc Extract the target from the request or base message.
+extract_target(Base, Request, Opts) ->
+    case hb_maps:get(<<"target">>, Request, <<"request">>, Opts) of
+        <<"request">> ->
+            {ok, Request};
+        <<"base">> ->
+            {ok, Base};
+        <<"base:", BaseTarget/binary>> ->
+            hb_maps:find(BaseTarget, Base, Opts);
+        <<"request:", RequestTarget/binary>> ->
+            hb_maps:find(RequestTarget, Request, Opts);
+        _ ->
+            not_found
     end.
 
 post_tx(Base, Request, Opts, <<"tx@1.0">>) ->

--- a/src/dev_cron.erl
+++ b/src/dev_cron.erl
@@ -63,9 +63,10 @@ once_worker(Path, Req, Opts) ->
 	catch
 		Class:Reason:Stacktrace ->
 			?event(
+                cron_error,
                 {cron_every_worker_error,
                     {path, Path},
-                    {error, Class, Reason, Stacktrace}
+                    {error, Class, Reason, {trace, Stacktrace}}
                 }
             ),
 			throw({error, Class, Reason, Stacktrace})
@@ -173,9 +174,13 @@ every_worker_loop(CronPath, Req, Opts, IntervalMillis) ->
         ?event({cron_every_worker_executed, {path, CronPath}})
     catch
         Class:Reason:Stack ->
-            ?event(cron_error, {cron_every_worker_error,
+            ?event(
+                cron_error,
+                {cron_every_worker_error,
                     {path, CronPath},
-                    {error, Class, Reason, Stack}})
+                    {error, Class, Reason, {trace, Stack}}
+                }
+            )
     end,
     timer:sleep(IntervalMillis),
     every_worker_loop(CronPath, Req, Opts, IntervalMillis).

--- a/src/dev_gzip.erl
+++ b/src/dev_gzip.erl
@@ -1,0 +1,82 @@
+%%% @doc Encode and decode data using the `zlib` standard library.
+-module(dev_gzip).
+-export([unzip/3, zip/3]).
+-include_lib("eunit/include/eunit.hrl").
+-include("include/hb.hrl").
+
+%% @doc Unzip a message with a `content-encoding' key of `gzip' and a `body' key, 
+%% containting a gzip-encoded payload. Returns the rest of the base message 
+%% unchanged, with the `content-encoding' key unset.
+%% 
+unzip(Base, _Req, Opts) ->
+    case hb_maps:get(<<"content-encoding">>, Base, <<"gzip">>, Opts) of
+        <<"gzip">> ->
+            case hb_maps:find(<<"body">>, Base, Opts) of
+                error ->
+                    ?event(
+                        debug_gzip,
+                        {unzip_ignoring_no_body, Base},
+                        Opts
+                    ),
+                    {ok, Base};
+                {ok, Body} ->
+                    ?event(
+                        debug_gzip,
+                        {unzipping_body, {size, byte_size(Body)}},
+                        Opts
+                    ),
+                    {
+                        ok,
+                        hb_ao:set(
+                            Base,
+                            #{
+                                <<"body">> => zlib:gunzip(Body),
+                                <<"content-encoding">> => unset
+                            },
+                            Opts
+                        )
+                    }
+            end;
+        _ ->
+            ?event(
+                debug_gzip,
+                {unzip_ignoring_unencoded, Base},
+                Opts
+            ),
+            {ok, Base}
+    end.
+
+%% @doc Take a base message with a `body' key and return it zipped, in-place.
+%% Add a `content-encoding' key with the value `gzip'.
+zip(Base, _Req, Opts) ->
+    case hb_maps:find(<<"body">>, Base, Opts) of
+        {ok, Body} ->
+            {
+                ok,
+                hb_ao:set(
+                    Base,
+                    #{
+                        <<"body">> => zlib:gzip(Body),
+                        <<"content-encoding">> => <<"gzip">>
+                    },
+                    Opts
+                )
+            };
+        error ->
+            {error, <<"No `body' key to zip found in message.">>}
+    end.
+
+%%% Tests
+
+unzip_encoded_response_test() ->
+    Opts = #{},
+    Base = #{ <<"body">> => <<"Hello, world!">> },
+    {ok, ID} = hb_cache:write(Base, Opts),
+    {ok, Encoded} = hb_ao:resolve(<<ID/binary, "/zip~gzip@1.0">>, Opts),
+    {ok, EncodedID} = hb_cache:write(Encoded, Opts),
+    {ok, Unzipped} =
+        hb_ao:resolve(
+            <<EncodedID/binary, "/unzip~gzip@1.0/body">>,
+            Opts
+        ),
+    ?assertEqual(<<"Hello, world!">>, Unzipped).

--- a/src/dev_lua.erl
+++ b/src/dev_lua.erl
@@ -7,6 +7,9 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+%%% Utility macro to check if a binary is a Lua script content-type.
+-define(IS_LUA_TYPE(CT), CT == <<"application/lua">> orelse CT == <<"text/x-lua">>).
+
 %%% The set of functions that will be sandboxed by default if `sandbox' is set 
 %%% to only `true'. Setting `sandbox' to a map allows the invoker to specify
 %%% which functions should be sandboxed and what to return instead. Providing
@@ -67,27 +70,53 @@ ensure_initialized(Base, _Req, Opts) ->
             end
     end.
 
-%% @doc Find the script in the base message, either by ID or by string.
+%% @doc Find the script(s) specified in the base message. If the `content-type'
+%% key is set to `application/lua' or `text/x-lua', we assume that the `body' key
+%% contains a Lua script. Additionally, if a `module' key may be present with
+%% the following forms:
+%% 1. A binary ID of a Lua module.
+%% 2. A list of binary IDs of Lua modules.
+%% 3. A message containing a series of named Lua modules.
 find_modules(Base, Opts) ->
-    case hb_ao:get(<<"module">>, {as, <<"message@1.0">>, Base}, Opts) of
-        not_found ->
-            {error, <<"no-modules-found">>};
-        Module when is_binary(Module) ->
+    MaybeBodyMod =
+        case hb_ao:get(<<"content-type">>, {as, <<"message@1.0">>, Base}, Opts) of
+            CT when ?IS_LUA_TYPE(CT) -> [Base];
+            _ -> []
+        end,
+    ?event(
+        debug_lua,
+        {finding_modules, {base, Base}, {body_mod, MaybeBodyMod}},
+        Opts
+    ),
+    case {hb_ao:get(<<"module">>, {as, <<"message@1.0">>, Base}, Opts), MaybeBodyMod} of
+        {not_found, []} ->
+            {error, <<"No Lua modules found when preparing environment for call.">>};
+        {not_found, _} ->
+            load_modules(MaybeBodyMod, Opts);
+        {Module, _} when is_binary(Module)->
             find_modules(Base#{ <<"module">> => [Module] }, Opts);
-        Module when is_map(Module) ->
+        {Module, _} when is_map(Module) ->
             % If the module is a map, check its content type to see if it is 
             % a literal Lua module, or a map of modules with content types.
             case hb_ao:get(<<"content-type">>, Module, Opts) of
-                CT when CT == <<"application/lua">> orelse CT == <<"text/x-lua">> ->
-                    find_modules(Base#{ <<"module">> => [Module] }, Opts);
+                LuaCT when ?IS_LUA_TYPE(LuaCT) ->
+                    find_modules(
+                        Base#{ <<"module">> => [Module] },
+                        Opts
+                    );
                 _ ->
-                    % If the script is not a literal Lua script, assume it is a
-                    % map of scripts with content types, and recurse.
-                    find_modules(Base#{ <<"module">> => maps:values(Module) }, Opts)
+                    % If the script is not a literal Lua script binary, assume
+                    % it is a map of scripts with content types, and recurse.
+                    find_modules(
+                        Base#{
+                            <<"module">> => maps:values(Module)
+                        },
+                        Opts
+                    )
             end;
-        Modules when is_list(Modules) ->
+        {Modules, _} when is_list(Modules) ->
             % We have found a list of scripts, load them.
-            load_modules(Modules, Opts)
+            load_modules(MaybeBodyMod ++ Modules, Opts)
     end.
 
 %% @doc Load a list of modules for installation into the Lua VM.
@@ -110,7 +139,7 @@ load_modules([ModuleID | Rest], Opts, Acc) when ?IS_ID(ModuleID) ->
                 <<"body">> => <<"Lua module '", ModuleID/binary, "' not found.">>
             }}
     end;
-load_modules([Module | Rest], Opts, Acc) when is_map(Module) ->
+load_modules([Module|Rest], Opts, Acc) when is_map(Module) ->
     % We have found a message with a Lua module inside. Search for the binary
     % of the program in the body and the data.
     ModuleBin =
@@ -138,17 +167,13 @@ load_modules([Module | Rest], Opts, Acc) when is_map(Module) ->
         ModuleBin ->
             % Get the `name' key from the script message if it exists, or 
             % return the module ID as the module name.
-            Name =
-                hb_ao:get_first(
-                    [
-                        {Module, <<"name">>},
-                        {Module, <<"id">>}
-                    ],
-                    Module,
-                    Opts
-                ),
+            ModuleRef =
+                case hb_maps:find(<<"name">>, Module, Opts) of
+                    {ok, Name} -> Name;
+                    error -> hb_message:id(Module, all, Opts)
+                end,
             % Load the module into the Lua state.
-            load_modules(Rest, Opts, [{Name, ModuleBin}|Acc])
+            load_modules(Rest, Opts, [{ModuleRef, ModuleBin}|Acc])
     end.
 
 %% @doc Initialize a new Lua state with a given base message and module.

--- a/src/dev_lua.erl
+++ b/src/dev_lua.erl
@@ -38,13 +38,22 @@
 %% Additionally, we exclude the `keys', `set', `encode' and `decode' functions
 %% which are `message@1.0' core functions, and Lua public utility functions.
 info(Base) ->
-    #{ keys := MessageKeys } = dev_message:info(),
     #{
         default => fun compute/4,
         excludes =>
-            MessageKeys ++
-                [<<"encode">>, <<"decode">>] ++
-                maps:keys(Base)
+            [
+                <<"id">>,
+                <<"commitments">>,
+                <<"committers">>,
+                <<"keys">>,
+                <<"path">>,
+                <<"set">>,
+                <<"remove">>,
+                <<"verify">>,
+                <<"encode">>,
+                <<"decode">>
+            ] ++
+            maps:keys(Base)
     }.
 
 %% @doc Initialize the device state, loading the script into memory if it is 

--- a/src/dev_lua.erl
+++ b/src/dev_lua.erl
@@ -35,11 +35,13 @@
 %% Additionally, we exclude the `keys', `set', `encode' and `decode' functions
 %% which are `message@1.0' core functions, and Lua public utility functions.
 info(Base) ->
+    #{ keys := MessageKeys } = dev_message:info(),
     #{
         default => fun compute/4,
         excludes =>
-            [<<"keys">>, <<"set">>, <<"encode">>, <<"decode">>]
-                ++ maps:keys(Base)
+            MessageKeys ++
+                [<<"encode">>, <<"decode">>] ++
+                maps:keys(Base)
     }.
 
 %% @doc Initialize the device state, loading the script into memory if it is 
@@ -156,6 +158,14 @@ initialize(Base, Modules, Opts) ->
     State1 =
         lists:foldl(
             fun({ModuleID, ModuleBin}, StateIn) ->
+                ?event(
+                    debug_lua,
+                    {loading_module,
+                        {module_id, ModuleID},
+                        {module_bin, ModuleBin}
+                    },
+                    Opts
+                ),
                 {ok, _, StateOut} =
                     luerl:do_dec(
                         ModuleBin,

--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -33,7 +33,8 @@
 %% @doc Return the info for the identity device.
 info() ->
     #{
-        default => fun dev_message:get/4
+        default => fun dev_message:get/4,
+        keys => ?DEVICE_KEYS
     }.
 
 %% @doc Generate an index page for a message, in the event that the `body' and

--- a/src/dev_message.erl
+++ b/src/dev_message.erl
@@ -33,8 +33,7 @@
 %% @doc Return the info for the identity device.
 info() ->
     #{
-        default => fun dev_message:get/4,
-        keys => ?DEVICE_KEYS
+        default => fun dev_message:get/4
     }.
 
 %% @doc Generate an index page for a message, in the event that the `body' and

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -1340,7 +1340,7 @@ find_target_id(Base, Req, Opts) ->
 %% 2. A key in `Req' with another value, present in that message.
 %% 3. The body of the message.
 %% 4. The message itself.
-find_message_to_schedule(_Base, Req, Opts) ->
+find_message_to_schedule(Base, Req, Opts) ->
     Subject =
         hb_ao:get(
             <<"subject">>,
@@ -1349,6 +1349,7 @@ find_message_to_schedule(_Base, Req, Opts) ->
             Opts#{ hashpath => ignore }
         ),
     case Subject of
+        <<"base">> -> Base;
         <<"self">> -> Req;
         not_found ->
             hb_ao:get(<<"body">>, Req, Req, Opts#{ hashpath => ignore });

--- a/src/dev_snp.erl
+++ b/src/dev_snp.erl
@@ -216,9 +216,22 @@ extract_and_normalize_message(M2, NodeOpts) ->
                 )
             ),
         ?event({msg_with_json_report, {explicit, MsgWithJSONReport}}),
-        % Normalize the request message
-        ReportJSON = hb_ao:get(<<"report">>, MsgWithJSONReport, NodeOpts),
-        Report = hb_json:decode(ReportJSON),
+        % Normalize the request message. First try to get the report from the
+        % committed message. If not found (e.g., message not signed), fall back
+        % to the raw message.
+        ReportJSON = case hb_ao:get(<<"report">>, MsgWithJSONReport, NodeOpts) of
+            not_found ->
+                ?event({report_not_in_committed, falling_back_to_raw}),
+                hb_ao:get(<<"report">>, RawMsg, NodeOpts);
+            Found -> Found
+        end,
+        {ok, ValidReportJSON} ?= case ReportJSON of
+            not_found -> 
+                ?event({report_not_found, {m2, M2}, {raw_msg, RawMsg}}),
+                {error, {report_not_found, <<"No 'report' key found in message">>}};
+            _ -> {ok, ReportJSON}
+        end,
+        Report = hb_json:decode(ValidReportJSON),
         Msg =
             maps:merge(
                 maps:without([<<"report">>], MsgWithJSONReport),

--- a/src/dev_snp.erl
+++ b/src/dev_snp.erl
@@ -61,8 +61,17 @@
 verify(M1, M2, NodeOpts) ->
     ?event(snp_verify, verify_called),
     maybe
+        % In pipeline flows (e.g., /~relay@1.0/call/verify~snp@1.0), the report
+        % comes from M1 (result of previous stage). For direct calls, it may be
+        % in M2. Try M1 first, then fall back to M2.
         {ok, {Msg, Address, NodeMsgID, ReportJSON, MsgWithJSONReport}} 
-            ?= extract_and_normalize_message(M2, NodeOpts),
+            ?= case extract_and_normalize_message(M1, NodeOpts) of
+                {ok, Result} -> {ok, Result};
+                {error, {report_not_found, _}} ->
+                    ?event(snp_verify, {report_not_in_m1_trying_m2}),
+                    extract_and_normalize_message(M2, NodeOpts);
+                {error, ExtractReason} -> {error, ExtractReason}
+            end,
         % Perform all validation steps
         {ok, NonceResult} ?= verify_nonce(Address, NodeMsgID, Msg, NodeOpts),
         {ok, SigResult} ?= 

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -21,7 +21,7 @@
 
 %%% Environment variables that can be used to override the default message.
 -ifdef(TEST).
--define(DEFAULT_PRINT_OPTS, [error, http_error]).
+-define(DEFAULT_PRINT_OPTS, [error, http_error, cron_error]).
 -else.
 -define(DEFAULT_PRINT_OPTS,
     [

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -151,6 +151,7 @@ default_message() ->
             #{<<"name">> => <<"faff@1.0">>, <<"module">> => dev_faff},
             #{<<"name">> => <<"flat@1.0">>, <<"module">> => dev_codec_flat},
             #{<<"name">> => <<"genesis-wasm@1.0">>, <<"module">> => dev_genesis_wasm},
+            #{<<"name">> => <<"gzip@1.0">>, <<"module">> => dev_gzip},
             #{<<"name">> => <<"greenzone@1.0">>, <<"module">> => dev_green_zone},
             #{<<"name">> => <<"httpsig@1.0">>, <<"module">> => dev_codec_httpsig},
             #{<<"name">> => <<"http-auth@1.0">>, <<"module">> => dev_codec_http_auth},

--- a/test/arbundles.js/upload-items.js
+++ b/test/arbundles.js/upload-items.js
@@ -4,7 +4,7 @@ const { ArweaveSigner, createData } = require("@dha-team/arbundles");
 
 // Configuration
 const BUNDLER_URL = "http://localhost:8734";
-const WALLET_PATH = "/Users/piechota/dev/arweave/repos/wallets/4OPKVB3dDtm1SP_8icx5ILil87Bh_JduGHzj8cuI36k.json";
+const WALLET_PATH = "../../hyperbeam-key.json";
 const CONCURRENT_UPLOADS = 100; // Number of parallel uploads
 
 async function performanceTest(itemCount, bytesPerItem = 0) {


### PR DESCRIPTION
Adds a number of small fixes to various devices across the system. These edits were made in preparation for [this](https://x.com/aoTheComputer/status/2021694557423796248) demo, but have now been tidied and are ready for edge.

The most significant change is the addition of the `zlib` device, which allows us to compress and inflate data from messages. This device should be helpful in numerous obvious areas, but also for some less obvious purposes like nesting of bundled messages etc. For example a path as follows could be used to upload data with signatures in a codec that does not support bundles inside an encoding that does:
```
GET /do/something/serialize~no-bundles-codec@1.0/compress~zlib@1.0/commit~ans104@1.0/tx~arweave@2.9-pre
```