### PR TITLE
Improve router multi-request: Nearest-Integer strategy, bounded parallelism, route-by support

### DIFF
--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -202,6 +202,7 @@ block({height, Height}, Opts) ->
             request(
                 <<"GET">>,
                 <<"/block/height/", (hb_util:bin(Height))/binary>>,
+                #{ <<"route-by">> => Height },
                 Opts
             )
     end.
@@ -249,16 +250,34 @@ find_txid(Base, Request, Opts) ->
 %% a `content-type' header. Subsequently, we parse the response manually and
 %% pass it back as a message.
 request(Method, Path, Opts) ->
+    request(Method, Path, #{}, Opts).
+request(Method, Path, Extra, Opts) ->
     ?event({arweave_request, {method, Method}, {path, Path}}),
     Res =
         hb_http:request(
-            #{
+            Extra#{
                 <<"path">> => <<"/arweave", Path/binary>>,
-                <<"method">> => Method
+                <<"method">> => Method,
+                <<"multirequest-admissible">> => <<"~arweave@2.9-pre/admissible">>
             },
             Opts
         ),
     to_message(Path, Res, Opts).
+
+admissible(Base, Request, Opts) ->
+    case hb_maps:get(<<"path">>, Request, <<>>, Opts) of
+        <<"/arweave/chunk=", IntPlus/binary>> -> verify_chunk(IntPlus, Opts);
+        _ -> true
+    end.
+
+%%% 1. `multirequest-parallel` integer support
+%%% 2. `Nearest-Integer` strategy (for the `chunk` route)
+%%% 3. `
+
+verify_chunk(IntPlus, Opts) ->
+    [BinInt|_] = binary:split(IntPlus, [<<"+">>, <<"/">>, <<"=">>, <<">">>], [global]),
+    Int = binary_to_integer(BinInt),
+    {ok, Int}.
 
 %% @doc Transform a response from the Arweave node into an AO-Core message.
 to_message(_Path, {error, #{ <<"status">> := 404 }}, _Opts) ->

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -257,27 +257,11 @@ request(Method, Path, Extra, Opts) ->
         hb_http:request(
             Extra#{
                 <<"path">> => <<"/arweave", Path/binary>>,
-                <<"method">> => Method,
-                <<"multirequest-admissible">> => <<"~arweave@2.9-pre/admissible">>
+                <<"method">> => Method
             },
             Opts
         ),
     to_message(Path, Res, Opts).
-
-admissible(Base, Request, Opts) ->
-    case hb_maps:get(<<"path">>, Request, <<>>, Opts) of
-        <<"/arweave/chunk=", IntPlus/binary>> -> verify_chunk(IntPlus, Opts);
-        _ -> true
-    end.
-
-%%% 1. `multirequest-parallel` integer support
-%%% 2. `Nearest-Integer` strategy (for the `chunk` route)
-%%% 3. `
-
-verify_chunk(IntPlus, Opts) ->
-    [BinInt|_] = binary:split(IntPlus, [<<"+">>, <<"/">>, <<"=">>, <<">">>], [global]),
-    Int = binary_to_integer(BinInt),
-    {ok, Int}.
 
 %% @doc Transform a response from the Arweave node into an AO-Core message.
 to_message(_Path, {error, #{ <<"status">> := 404 }}, _Opts) ->

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -498,7 +498,17 @@ choose(N, <<"Nearest-Integer">>, #{ <<"route-by">> := Int }, Nodes, Opts) ->
     NodesWithDistances =
         lists:map(
             fun(Node) ->
-                {Node, field_distance(RouteInt, hb_maps:get(<<"center">>, Node, Opts))}
+                %% Use 4-arity get with explicit default — the old
+                %% 3-arity call returned the Opts map when `center'
+                %% was missing, crashing field_distance with badarith.
+                %% Centerless nodes get 2^256 (> max distance) so they
+                %% are selected last.
+                case hb_maps:get(<<"center">>, Node, not_found, Opts) of
+                    not_found ->
+                        {Node, 1 bsl 256};
+                    Center ->
+                        {Node, field_distance(RouteInt, Center)}
+                end
             end,
             Nodes
         ),
@@ -1870,6 +1880,285 @@ route_multirequest_parallel_limit() ->
     % waves (~600ms), not one (~300ms) or fully serial (~900ms).
     ?assert(Duration >= 450),
     ?assert(Duration < 850).
+
+%% @doc Test that a full production-style route configuration (matching a
+%% typical config.json) resolves every request type correctly: single-node
+%% prefix routes, multi-node All-strategy routes, Nearest-Integer chunk
+%% routes, match/with regex routes, and fallback routes.
+full_route_config_test() ->
+    Routes =
+        [
+            #{
+                <<"template">> => <<"^/arweave/chunk">>,
+                <<"nodes">> =>
+                    [
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 3_600_000_000,
+                            <<"with">> => <<"https://data-1.arweave.net">>,
+                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 8_200_000_000,
+                            <<"with">> => <<"https://data-2.arweave.net">>,
+                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 12_200_000_000,
+                            <<"with">> => <<"https://data-3.arweave.net">>,
+                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"with">> => <<"https://data-4.arweave.net">>,
+                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 16_200_000_000,
+                            <<"with">> => <<"https://data-5.arweave.net">>,
+                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                        }
+                    ],
+                <<"strategy">> => <<"Nearest-Integer">>,
+                <<"choose">> => 3,
+                <<"parallel">> => 2
+            },
+            #{
+                <<"template">> => <<"^/arweave">>,
+                <<"nodes">> =>
+                    [
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"with">> => <<"https://arweave.net">>,
+                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                        }
+                    ],
+                <<"parallel">> => true,
+                <<"stop-after">> => 1,
+                <<"admissible-status">> => 200
+            },
+            #{
+                <<"template">> => <<"/raw">>,
+                <<"node">> =>
+                    #{
+                        <<"prefix">> => <<"https://arweave.net">>,
+                        <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                    }
+            }
+        ],
+    Opts = #{ routes => Routes },
+
+    %% --- Nearest-Integer strategy for /arweave/chunk ---
+
+    %% A chunk request with route-by near center 8_200_000_000 should pick
+    %% the 3 closest nodes out of the 5 available.
+    {ok, ChunkRoute} =
+        route(
+            #{
+                <<"path">> => <<"/arweave/chunk/8200000100">>,
+                <<"route-by">> => 8_200_000_100
+            },
+            Opts
+        ),
+    ?event(router_test, {chunk_route, {route_by, 8_200_000_100}, {route, ChunkRoute}}),
+    ?assertEqual(2, hb_ao:get(<<"parallel">>, ChunkRoute, #{})),
+    ChunkNodes = hb_ao:get(<<"nodes">>, ChunkRoute, #{}),
+    ?assertEqual(3, length(ChunkNodes)),
+    %% The three nearest centers to 8_200_000_100 should be
+    %% 8_200_000_000, 3_600_000_000, and 12_200_000_000.
+    ChunkCenters =
+        lists:sort(
+            [hb_ao:get(<<"center">>, N, #{}) || N <- ChunkNodes]
+        ),
+    ?event(router_test, {chunk_centers, ChunkCenters}),
+    ?assertEqual([3_600_000_000, 8_200_000_000, 12_200_000_000], ChunkCenters),
+    %% Each selected node should have a URI with the match/with regex applied:
+    %% /arweave/chunk/... -> https://data-N.arweave.net/chunk/...
+    ChunkURIs =
+        lists:sort(
+            [hb_ao:get(<<"uri">>, N, #{}) || N <- ChunkNodes]
+        ),
+    ?event(router_test, {chunk_uris, ChunkURIs}),
+    ?assertEqual(
+        [
+            <<"https://data-1.arweave.net/chunk/8200000100">>,
+            <<"https://data-2.arweave.net/chunk/8200000100">>,
+            <<"https://data-3.arweave.net/chunk/8200000100">>
+        ],
+        ChunkURIs
+    ),
+
+    %% A chunk request near the high end should select the 3 closest to
+    %% 16_000_000_000: 16_200_000_000, 12_200_000_000, and 8_200_000_000.
+    {ok, HighChunkRoute} =
+        route(
+            #{
+                <<"path">> => <<"/arweave/chunk/16000000000">>,
+                <<"route-by">> => 16_000_000_000
+            },
+            Opts
+        ),
+    ?event(router_test, {high_chunk_route, {route_by, 16_000_000_000}, {route, HighChunkRoute}}),
+    HighChunkCenters =
+        lists:sort(
+            [
+                hb_ao:get(<<"center">>, N, #{})
+            ||
+                N <- hb_ao:get(<<"nodes">>, HighChunkRoute, #{})
+            ]
+        ),
+    ?event(router_test, {high_chunk_centers, HighChunkCenters}),
+    ?assertEqual(
+        [8_200_000_000, 12_200_000_000, 16_200_000_000],
+        HighChunkCenters
+    ),
+
+    %% --- Fallback /arweave route (non-chunk) ---
+
+    %% A non-chunk arweave request (e.g. /arweave/tx/...) should fall
+    %% through the chunk template and match the general ^/arweave route.
+    {ok, ArweaveRoute} =
+        route(#{ <<"path">> => <<"/arweave/tx/RTvlIxbvDOpo7kPisnhnfz0BtgOZE4QlScBSRLEkky4">> }, Opts),
+    ?event(router_test, {arweave_fallback_route, ArweaveRoute}),
+    ?assertEqual(true, hb_ao:get(<<"parallel">>, ArweaveRoute, #{})),
+    ?assertEqual(1, hb_ao:get(<<"stop-after">>, ArweaveRoute, #{})),
+    ?assertEqual(200, hb_ao:get(<<"admissible-status">>, ArweaveRoute, #{})),
+    ArweaveNodes = hb_ao:get(<<"nodes">>, ArweaveRoute, #{}),
+    ?assertEqual(1, length(ArweaveNodes)),
+    ArweaveURI = hb_ao:get(<<"uri">>, hd(ArweaveNodes), #{}),
+    ?event(router_test, {arweave_fallback_uri, ArweaveURI}),
+    ?assertEqual(<<"https://arweave.net/tx/RTvlIxbvDOpo7kPisnhnfz0BtgOZE4QlScBSRLEkky4">>, ArweaveURI),
+
+    %% --- Single-node prefix route (/raw) ---
+
+    {ok, RawRoute} =
+        route(#{ <<"path">> => <<"/raw/RTvlIxbvDOpo7kPisnhnfz0BtgOZE4QlScBSRLEkky4">> }, Opts),
+    ?event(router_test, {raw_route, RawRoute}),
+    ?assertEqual(
+        <<"https://arweave.net/raw/RTvlIxbvDOpo7kPisnhnfz0BtgOZE4QlScBSRLEkky4">>,
+        hb_ao:get(<<"uri">>, RawRoute, #{})
+    ),
+
+    %% --- No match ---
+
+    NoMatchResult = route(#{ <<"path">> => <<"/unknown/endpoint">> }, Opts),
+    ?event(router_test, {no_match_result, NoMatchResult}),
+    ?assertEqual({error, no_matches}, NoMatchResult),
+
+    %% --- HTTP GETs through the routes ---
+    %% Fire actual requests using hb_http:request/2, the same way the
+    %% route_multirequest_parallel_limit test does it.
+    HttpReqOpts = #{ routes => Routes, http_only_result => false },
+
+    %% Chunk request via Nearest-Integer (parallel=2, choose=3).
+    %% With 3 nodes and parallel=2, wave 1 sends to 2 nodes, wave 2 sends
+    %% to the remaining 1. We time it to confirm parallelism.
+    ChunkStart = os:system_time(millisecond),
+    ChunkHttpRes =
+        (catch hb_http:request(
+            #{
+                <<"method">> => <<"GET">>,
+                <<"path">> => <<"/arweave/chunk/8200000100">>,
+                <<"route-by">> => 8_200_000_100
+            },
+            HttpReqOpts
+        )),
+    ChunkDuration = os:system_time(millisecond) - ChunkStart,
+    ?event(router_test, {chunk_http_result, ChunkHttpRes}),
+    ?event(router_test, {chunk_http_duration_ms, ChunkDuration}),
+
+    %% Now test with ALL 5 data nodes to really exercise parallel=2.
+    %% choose=5 means all 5 nodes get hit, but only 2 at a time.
+    %% With ~300-500ms per request, we expect ~3 waves (~900-1500ms)
+    %% instead of fully serial (~1500-2500ms) or fully parallel (~300-500ms).
+    AllChunkRoutes =
+        [
+            #{
+                <<"template">> => <<"^/arweave/chunk">>,
+                <<"nodes">> =>
+                    [
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 3_600_000_000,
+                            <<"with">> => <<"https://data-1.arweave.net">>,
+                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 8_200_000_000,
+                            <<"with">> => <<"https://data-2.arweave.net">>,
+                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 12_200_000_000,
+                            <<"with">> => <<"https://data-3.arweave.net">>,
+                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 14_000_000_000,
+                            <<"with">> => <<"https://data-4.arweave.net">>,
+                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 16_200_000_000,
+                            <<"with">> => <<"https://data-5.arweave.net">>,
+                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                        }
+                    ],
+                <<"strategy">> => <<"Nearest-Integer">>,
+                <<"choose">> => 5,
+                <<"parallel">> => 2,
+                <<"responses">> => 5,
+                <<"stop-after">> => false
+            }
+        ],
+    AllChunkStart = os:system_time(millisecond),
+    AllChunkHttpRes =
+        (catch hb_http:request(
+            #{
+                <<"method">> => <<"GET">>,
+                <<"path">> => <<"/arweave/chunk/8200000100">>,
+                <<"route-by">> => 8_200_000_100
+            },
+            #{ routes => AllChunkRoutes, http_only_result => false }
+        )),
+    AllChunkDuration = os:system_time(millisecond) - AllChunkStart,
+    ?event(router_test, {all_chunk_http_result, AllChunkHttpRes}),
+    ?event(router_test, {all_chunk_http_duration_ms, AllChunkDuration}),
+    ?event(router_test, {all_chunk_responses,
+        case is_list(AllChunkHttpRes) of
+            true -> length(AllChunkHttpRes);
+            false -> not_a_list
+        end
+    }),
+
+    %% Fallback /arweave route.
+    ArweaveHttpRes =
+        (catch hb_http:request(
+            #{
+                <<"method">> => <<"GET">>,
+                <<"path">> => <<"/arweave/tx/RTvlIxbvDOpo7kPisnhnfz0BtgOZE4QlScBSRLEkky4">>
+            },
+            HttpReqOpts
+        )),
+    ?event(router_test, {arweave_http_result, ArweaveHttpRes}),
+
+    %% /raw prefix route.
+    RawHttpRes =
+        (catch hb_http:request(
+            #{
+                <<"method">> => <<"GET">>,
+                <<"path">> => <<"/raw/RTvlIxbvDOpo7kPisnhnfz0BtgOZE4QlScBSRLEkky4">>
+            },
+            HttpReqOpts
+        )),
+    ?event(router_test, {raw_http_result, RawHttpRes}).
 
 %%% Statistical test utilities
 

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -325,21 +325,6 @@ load_routes(Opts) ->
             end
     end.
 
-%% @doc Extract the base message ID from a request message. Produces a single
-%% binary ID that can be used for routing decisions.
-extract_base(#{ <<"path">> := Path }, Opts) ->
-    extract_base(Path, Opts);
-extract_base(RawPath, Opts) when is_binary(RawPath) ->
-    BasePath = hb_path:hd(#{ <<"path">> => RawPath }, Opts),
-    case ?IS_ID(BasePath) of
-        true -> BasePath;
-        false ->
-            case binary:split(BasePath, [<<"\~">>, <<"?">>, <<"&">>], [global]) of
-                [BaseMsgID|_] when ?IS_ID(BaseMsgID) -> BaseMsgID;
-                _ -> hb_crypto:sha256(BasePath)
-            end
-    end.
-
 %% @doc Generate a `uri' key for each node in a route.
 apply_routes(Msg, R, Opts) ->
     Nodes = hb_ao:get(<<"nodes">>, R, Opts),
@@ -404,11 +389,7 @@ do_apply_route(
             {ok, NewPath};
         _ ->
             {error, invalid_replace_args}
-    end;
-do_apply_route(_, Route, _Opts) when is_binary(Route) ->
-    {ok, Route};
-do_apply_route(_, _, _) ->
-    {error, invalid_route}.
+    end.
 
 %% @doc Find the first matching template in a list of known routes. Allows the
 %% path to be specified by either the explicit `path' (for internal use by this
@@ -493,8 +474,13 @@ choose(N, <<"By-Weight">>, _, Nodes, Opts) ->
     |
         choose(N - 1, <<"By-Weight">>, nop, lists:delete(Node, Nodes), Opts)
     ];
-choose(N, <<"By-Base">>, Selector, Nodes, Opts) ->
-    HashInt = selector_to_integer(Selector, Opts),
+choose(N, <<"By-Base">>, #{ <<"path">> := Path }, Nodes, Opts) when is_binary(Path) ->
+    choose(N, <<"By-Base">>, route_hash_int(Path, Opts), Nodes, Opts);
+choose(N, <<"By-Base">>, #{ <<"route-by">> := RouteBy }, Nodes, Opts) ->
+    choose(N, <<"By-Base">>, route_hash_int(RouteBy, Opts), Nodes, Opts);
+choose(N, <<"By-Base">>, Hashpath, Nodes, Opts) when is_binary(Hashpath) ->
+    choose(N, <<"By-Base">>, route_hash_int(Hashpath, Opts), Nodes, Opts);
+choose(N, <<"By-Base">>, HashInt, Nodes, Opts) when is_integer(HashInt) ->
     Node = lists:nth((HashInt rem length(Nodes)) + 1, Nodes),
     [
         Node
@@ -507,17 +493,12 @@ choose(N, <<"By-Base">>, Selector, Nodes, Opts) ->
             Opts
         )
     ];
-choose(N, <<"Nearest-Integer">>, Selector, Nodes, Opts) ->
-    RouteInt = selector_to_integer(Selector, Opts),
+choose(N, <<"Nearest-Integer">>, #{ <<"route-by">> := Int }, Nodes, Opts) ->
+    RouteInt = route_integer(Int, Opts),
     NodesWithDistances =
         lists:map(
             fun(Node) ->
-                case hb_maps:find(<<"center">>, Node, Opts) of
-                    {ok, Center} ->
-                        {Node, field_distance(RouteInt, selector_to_integer(Center, Opts))};
-                    error ->
-                        {Node, infinity}
-                end
+                {Node, field_distance(RouteInt, hb_maps:get(<<"center">>, Node, Opts))}
             end,
             Nodes
         ),
@@ -534,35 +515,44 @@ choose(N, <<"Nearest-Integer">>, Selector, Nodes, Opts) ->
             )
         )
     );
-choose(N, <<"Nearest">>, Selector, Nodes, Opts) ->
-    HashSeed = selector_to_seed(Selector, Opts),
-    HashPath = selector_to_binary(Selector, Opts),
+choose(N, <<"Nearest-Integer">>, #{ <<"path">> := Path }, Nodes, Opts)
+        when is_binary(Path) ->
+    choose(
+        N,
+        <<"Nearest-Integer">>,
+        #{ <<"route-by">> => route_hash_int(Path, Opts) },
+        Nodes,
+        Opts
+    );
+choose(N, <<"Nearest-Integer">>, RouteBy, Nodes, Opts) ->
+    choose(N, <<"Nearest-Integer">>, #{ <<"route-by">> => RouteBy }, Nodes, Opts);
+choose(N, <<"Nearest">>, #{ <<"path">> := HashPath }, Nodes, Opts)
+        when is_binary(HashPath) ->
+    choose(N, <<"Nearest">>, normalize_hashpath(HashPath), Nodes, Opts);
+choose(N, <<"Nearest">>, HashPath, Nodes, Opts) when is_binary(HashPath) ->
+    BareHashPath = hb_util:native_id(HashPath),
     NodesWithDistances =
         lists:map(
             fun(Node) ->
-                case hb_maps:find(<<"wallet">>, Node, Opts) of
-                    {ok, Wallet} when is_binary(Wallet) ->
-                        Salt =
-                            case hb_maps:find(<<"salt">>, Node, Opts) of
-                                {ok, S} -> <<":", S/binary>>;
-                                error -> <<>>
-                            end,
-                        DistanceScore =
-                            field_distance(
-                                hb_crypto:sha256(
-                                    <<
-                                        HashSeed/binary,
-                                        ":",
-                                        Wallet/binary,
-                                        Salt/binary
-                                    >>
-                                ),
-                                HashPath
-                            ),
-                        {Node, DistanceScore};
-                    _ ->
-                        {Node, infinity}
-                end
+                Wallet = hb_maps:get(<<"wallet">>, Node, Opts),
+                Salt =
+                    case hb_maps:find(<<"salt">>, Node, Opts) of
+                        {ok, S} -> <<":", S/binary>>;
+                        error -> <<>>
+                    end,
+                DistanceScore =
+                    field_distance(
+                        hb_crypto:sha256(
+                            <<
+                                HashPath/binary,
+                                ":",
+                                Wallet/binary,
+                                Salt/binary
+                            >>
+                        ),
+                        BareHashPath
+                    ),
+                {Node, DistanceScore}
             end,
             Nodes
         ),
@@ -601,38 +591,36 @@ normalize_strategy(RawStrategy) ->
         _ -> <<"All">>
     end.
 
-selector_to_binary(#{ <<"route-by">> := RouteBy }, Opts) ->
-    selector_to_binary(RouteBy, Opts);
-selector_to_binary(#{ <<"path">> := Path }, Opts) when is_binary(Path) ->
-    selector_to_binary(extract_base(Path, Opts), Opts);
-selector_to_binary(Bin, _Opts) when is_binary(Bin), byte_size(Bin) == 32 ->
-    Bin;
-selector_to_binary(Bin, _Opts) when is_binary(Bin), ?IS_ID(Bin) ->
-    hb_util:native_id(Bin);
-selector_to_binary(Bin, _Opts) when is_binary(Bin) ->
+route_integer(Int, _Opts) when is_integer(Int) ->
+    Int;
+route_integer(Bin, Opts) when is_binary(Bin) ->
     case safe_to_integer(Bin) of
-        {ok, I} -> <<(normalize_u256(I)):256/unsigned-integer>>;
-        error -> hb_crypto:sha256(Bin)
+        {ok, Int} -> Int;
+        error -> route_hash_int(Bin, Opts)
     end;
-selector_to_binary(Int, _Opts) when is_integer(Int) ->
-    <<(normalize_u256(Int)):256/unsigned-integer>>;
-selector_to_binary(Value, _Opts) ->
-    hb_crypto:sha256(hb_util:bin(Value)).
+route_integer(Value, Opts) ->
+    route_hash_int(Value, Opts).
 
-selector_to_seed(#{ <<"route-by">> := RouteBy }, Opts) ->
-    selector_to_seed(RouteBy, Opts);
-selector_to_seed(#{ <<"path">> := Path }, Opts) when is_binary(Path) ->
-    selector_to_seed(extract_base(Path, Opts), Opts);
-selector_to_seed(Bin, _Opts) when is_binary(Bin) ->
+route_hash_int(Int, _Opts) when is_integer(Int) ->
+    Int;
+route_hash_int(Bin, _Opts) when is_binary(Bin), ?IS_ID(Bin) ->
+    binary_to_bignum(Bin);
+route_hash_int(Bin, _Opts) when is_binary(Bin), byte_size(Bin) == 32 ->
+    <<Int:256/unsigned-integer>> = Bin,
+    Int;
+route_hash_int(Bin, Opts) when is_binary(Bin) ->
+    route_hash_int(hb_crypto:sha256(Bin), Opts);
+route_hash_int(#{ <<"path">> := Path }, Opts) when is_binary(Path) ->
+    route_hash_int(Path, Opts);
+route_hash_int(Value, Opts) ->
+    route_hash_int(hb_util:bin(Value), Opts).
+
+normalize_hashpath(Bin) when is_binary(Bin), ?IS_ID(Bin) ->
     Bin;
-selector_to_seed(Int, _Opts) when is_integer(Int) ->
-    integer_to_binary(Int);
-selector_to_seed(Value, _Opts) ->
-    hb_util:bin(Value).
-
-selector_to_integer(Selector, Opts) ->
-    <<Int:256/unsigned-integer>> = selector_to_binary(Selector, Opts),
-    Int.
+normalize_hashpath(Bin) when is_binary(Bin), byte_size(Bin) == 32 ->
+    Bin;
+normalize_hashpath(Bin) when is_binary(Bin) ->
+    hb_crypto:sha256(Bin).
 
 safe_to_integer(Value) when is_integer(Value) ->
     {ok, Value};
@@ -650,9 +638,6 @@ safe_to_integer(Value) when is_list(Value) ->
     end;
 safe_to_integer(_) ->
     error.
-
-normalize_u256(Int) ->
-    Int band ((1 bsl 256) - 1).
 
 %% @doc Calculate the minimum distance between two numbers
 %% (either progressing backwards or forwards), assuming a

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -1,12 +1,3 @@
-%% TODOs:
-%% 
-%% 1. Matching routes: Take `routes` from Opts and return first hit.
-%% 2. Apply route: Transform the route message with the request data
-%% 3. Choose nodes: If the route has multiple nodes, choose a node based on the
-%%    given strategy.
-%% 4. Return _with_ the route `Opts`, which `hb_http` uses to make the request.
-
-
 %%% @doc A device that routes outbound messages from the node to their
 %%% appropriate network recipients via HTTP. All messages are initially
 %%% routed to a single process per node, which then load-balances them
@@ -243,47 +234,77 @@ routes(M1, M2, Opts) ->
 route(Msg, Opts) -> route(undefined, Msg, Opts).
 route(_, Msg, Opts) ->
     Routes = load_routes(Opts),
-    R = match_routes(Msg, Routes, Opts),
-    ?event({find_route, {msg, Msg}, {routes, Routes}, {res, R}}),
-    case (R =/= no_matches) andalso hb_ao:get(<<"node">>, R, Opts) of
-        false -> {error, no_matches};
-        Node when is_binary(Node) -> {ok, Node};
-        Node when is_map(Node) -> apply_route(Msg, Node, Opts);
-        not_found ->
-            ModR = apply_routes(Msg, R, Opts),
-            case hb_ao:get(<<"strategy">>, R, <<"All">>, Opts) of
-                <<"All">> -> {ok, ModR};
-                Strategy ->
-                    ChooseN = hb_ao:get(<<"choose">>, R, 1, Opts),
-                    % Get the first element of the path -- the `base' message
-                    % of the request.
-                    Nodes = hb_ao:get(<<"nodes">>, ModR, Opts),
-                    Chosen = choose(ChooseN, Strategy, Msg, Nodes, Opts),
-                    ?event({choose,
-                        {strategy, Strategy},
-                        {choose_n, ChooseN},
-                        {nodes, Nodes},
-                        {msg, Msg},
-                        {chosen, Chosen}
-                    }),
-                    case Chosen of
-                        [Node] when is_map(Node) ->
-                            apply_route(Msg, Node, Opts);
-                        [NodeURI] -> {ok, NodeURI};
-                        _ChosenNodes ->
-                            {ok,
-                                hb_ao:set(
-                                    <<"nodes">>,
-                                    hb_maps:map(
-                                        fun(Node) ->
-                                            hb_util:ok(apply_route(Msg, Node, Opts))
-                                        end,
-                                        Chosen,
+    MatchedRoute = match_routes(Msg, Routes, Opts),
+    ?event({find_route, {msg, Msg}, {routes, Routes}, {res, MatchedRoute}}),
+    case MatchedRoute of
+        no_matches ->
+            {error, no_matches};
+        R ->
+            case hb_ao:get(<<"node">>, R, Opts) of
+                Node when is_binary(Node) ->
+                    {ok, Node};
+                Node when is_map(Node) ->
+                    apply_route(Msg, Node, Opts);
+                not_found ->
+                    case hb_ao:get(<<"nodes">>, R, not_found, Opts) of
+                        not_found ->
+                            {error, no_matches};
+                        _ ->
+                            RouteWithAppliedNodes = apply_routes(Msg, R, Opts),
+                            Strategy =
+                                normalize_strategy(
+                                    hb_ao:get(
+                                        <<"strategy">>,
+                                        RouteWithAppliedNodes,
+                                        <<"All">>,
                                         Opts
-                                    ),
-                                    Opts
-                                )
-                            }
+                                    )
+                                ),
+                            case Strategy of
+                                <<"All">> ->
+                                    {ok, RouteWithAppliedNodes};
+                                _ ->
+                                    Nodes =
+                                        hb_ao:get(
+                                            <<"nodes">>,
+                                            RouteWithAppliedNodes,
+                                            [],
+                                            Opts
+                                        ),
+                                    ChooseN =
+                                        choose_count(
+                                            hb_ao:get(
+                                                <<"choose">>,
+                                                RouteWithAppliedNodes,
+                                                1,
+                                                Opts
+                                            ),
+                                            Nodes
+                                        ),
+                                    Chosen = choose(ChooseN, Strategy, Msg, Nodes, Opts),
+                                    ?event({choose,
+                                        {strategy, Strategy},
+                                        {choose_n, ChooseN},
+                                        {nodes, Nodes},
+                                        {msg, Msg},
+                                        {chosen, Chosen}
+                                    }),
+                                    case Chosen of
+                                        [] ->
+                                            {error, no_matches};
+                                        [Node] when is_map(Node) ->
+                                            {ok, Node};
+                                        [NodeURI] when is_binary(NodeURI) ->
+                                            {ok, NodeURI};
+                                        _ ->
+                                            {
+                                                ok,
+                                                RouteWithAppliedNodes#{
+                                                    <<"nodes">> => Chosen
+                                                }
+                                            }
+                                    end
+                            end
                     end
             end
     end.
@@ -360,6 +381,8 @@ apply_route(Msg, Route, Opts) ->
     }}.
 do_apply_route(#{ <<"route-path">> := Path }, R, Opts) ->
     do_apply_route(#{ <<"path">> => Path }, R, Opts);
+do_apply_route(_, #{ <<"uri">> := URI }, _Opts) ->
+    {ok, URI};
 do_apply_route(#{ <<"path">> := RawPath }, #{ <<"prefix">> := RawPrefix }, Opts) ->
     Path = hb_cache:ensure_loaded(RawPath, Opts),
     Prefix = hb_cache:ensure_loaded(RawPrefix, Opts),
@@ -381,7 +404,11 @@ do_apply_route(
             {ok, NewPath};
         _ ->
             {error, invalid_replace_args}
-    end.
+    end;
+do_apply_route(_, Route, _Opts) when is_binary(Route) ->
+    {ok, Route};
+do_apply_route(_, _, _) ->
+    {error, invalid_route}.
 
 %% @doc Find the first matching template in a list of known routes. Allows the
 %% path to be specified by either the explicit `path' (for internal use by this
@@ -448,6 +475,7 @@ match_routes(ToMatch, Routes, [XKey|Keys], Opts) ->
 
 %% @doc Implements the load distribution strategies if given a cluster.
 choose(0, _, _, _, _) -> [];
+choose(_, _, _, [], _) -> [];
 choose(N, <<"Random">>, _, Nodes, _Opts) ->
     Node = lists:nth(rand:uniform(length(Nodes)), Nodes),
     [Node | choose(N - 1, <<"Random">>, nop, lists:delete(Node, Nodes), _Opts)];
@@ -465,9 +493,8 @@ choose(N, <<"By-Weight">>, _, Nodes, Opts) ->
     |
         choose(N - 1, <<"By-Weight">>, nop, lists:delete(Node, Nodes), Opts)
     ];
-choose(N, <<"By-Base">>, #{ <<"path">> := Hashpath }, Nodes, Opts) when is_binary(Hashpath) ->
-    choose(N, <<"By-Base">>, binary_to_bignum(Hashpath), Nodes, Opts);
-choose(N, <<"By-Base">>, #{ <<"path">> := HashInt }, Nodes, Opts) ->
+choose(N, <<"By-Base">>, Selector, Nodes, Opts) ->
+    HashInt = selector_to_integer(Selector, Opts),
     Node = lists:nth((HashInt rem length(Nodes)) + 1, Nodes),
     [
         Node
@@ -480,11 +507,17 @@ choose(N, <<"By-Base">>, #{ <<"path">> := HashInt }, Nodes, Opts) ->
             Opts
         )
     ];
-choose(N, <<"Nearest-Integer">>, #{ <<"route-by">> := Int }, Nodes, Opts) ->
+choose(N, <<"Nearest-Integer">>, Selector, Nodes, Opts) ->
+    RouteInt = selector_to_integer(Selector, Opts),
     NodesWithDistances =
         lists:map(
             fun(Node) ->
-                {Node, field_distance(Int, hb_maps:get(<<"center">>, Node, Opts))}
+                case hb_maps:find(<<"center">>, Node, Opts) of
+                    {ok, Center} ->
+                        {Node, field_distance(RouteInt, selector_to_integer(Center, Opts))};
+                    error ->
+                        {Node, infinity}
+                end
             end,
             Nodes
         ),
@@ -501,30 +534,35 @@ choose(N, <<"Nearest-Integer">>, #{ <<"route-by">> := Int }, Nodes, Opts) ->
             )
         )
     );
-choose(N, <<"Nearest">>, #{ <<"path">> := HashPath }, Nodes, Opts) ->
-    BareHashPath = hb_util:native_id(HashPath),
+choose(N, <<"Nearest">>, Selector, Nodes, Opts) ->
+    HashSeed = selector_to_seed(Selector, Opts),
+    HashPath = selector_to_binary(Selector, Opts),
     NodesWithDistances =
         lists:map(
             fun(Node) ->
-                Wallet = hb_maps:get(<<"wallet">>, Node, Opts),
-                Salt =
-                    case hb_maps:find(<<"salt">>, Node, Opts) of
-                        {ok, S} -> <<":", S/binary>>;
-                        error -> <<>>
-                    end,
-                DistanceScore =
-                    field_distance(
-                        hb_crypto:sha256(
-                            <<
-                                HashPath/binary,
-                                ":",
-                                Wallet/binary,
-                                Salt/binary
-                            >>
-                        ),
-                        BareHashPath
-                    ),
-                {Node, DistanceScore}
+                case hb_maps:find(<<"wallet">>, Node, Opts) of
+                    {ok, Wallet} when is_binary(Wallet) ->
+                        Salt =
+                            case hb_maps:find(<<"salt">>, Node, Opts) of
+                                {ok, S} -> <<":", S/binary>>;
+                                error -> <<>>
+                            end,
+                        DistanceScore =
+                            field_distance(
+                                hb_crypto:sha256(
+                                    <<
+                                        HashSeed/binary,
+                                        ":",
+                                        Wallet/binary,
+                                        Salt/binary
+                                    >>
+                                ),
+                                HashPath
+                            ),
+                        {Node, DistanceScore};
+                    _ ->
+                        {Node, infinity}
+                end
             end,
             Nodes
         ),
@@ -540,6 +578,81 @@ choose(N, <<"Nearest">>, #{ <<"path">> := HashPath }, Nodes, Opts) ->
             )
         )
     ).
+
+choose_count(RawChoose, Nodes) ->
+    NormalizedChoose =
+        case safe_to_integer(RawChoose) of
+            {ok, X} when X > 0 -> X;
+            _ -> 0
+        end,
+    min(NormalizedChoose, length(Nodes)).
+
+normalize_strategy(RawStrategy) ->
+    case hb_util:to_lower(hb_util:bin(RawStrategy)) of
+        <<"all">> -> <<"All">>;
+        <<"random">> -> <<"Random">>;
+        <<"by-base">> -> <<"By-Base">>;
+        <<"by_base">> -> <<"By-Base">>;
+        <<"by-weight">> -> <<"By-Weight">>;
+        <<"by_weight">> -> <<"By-Weight">>;
+        <<"nearest">> -> <<"Nearest">>;
+        <<"nearest-integer">> -> <<"Nearest-Integer">>;
+        <<"nearest_integer">> -> <<"Nearest-Integer">>;
+        _ -> <<"All">>
+    end.
+
+selector_to_binary(#{ <<"route-by">> := RouteBy }, Opts) ->
+    selector_to_binary(RouteBy, Opts);
+selector_to_binary(#{ <<"path">> := Path }, Opts) when is_binary(Path) ->
+    selector_to_binary(extract_base(Path, Opts), Opts);
+selector_to_binary(Bin, _Opts) when is_binary(Bin), byte_size(Bin) == 32 ->
+    Bin;
+selector_to_binary(Bin, _Opts) when is_binary(Bin), ?IS_ID(Bin) ->
+    hb_util:native_id(Bin);
+selector_to_binary(Bin, _Opts) when is_binary(Bin) ->
+    case safe_to_integer(Bin) of
+        {ok, I} -> <<(normalize_u256(I)):256/unsigned-integer>>;
+        error -> hb_crypto:sha256(Bin)
+    end;
+selector_to_binary(Int, _Opts) when is_integer(Int) ->
+    <<(normalize_u256(Int)):256/unsigned-integer>>;
+selector_to_binary(Value, _Opts) ->
+    hb_crypto:sha256(hb_util:bin(Value)).
+
+selector_to_seed(#{ <<"route-by">> := RouteBy }, Opts) ->
+    selector_to_seed(RouteBy, Opts);
+selector_to_seed(#{ <<"path">> := Path }, Opts) when is_binary(Path) ->
+    selector_to_seed(extract_base(Path, Opts), Opts);
+selector_to_seed(Bin, _Opts) when is_binary(Bin) ->
+    Bin;
+selector_to_seed(Int, _Opts) when is_integer(Int) ->
+    integer_to_binary(Int);
+selector_to_seed(Value, _Opts) ->
+    hb_util:bin(Value).
+
+selector_to_integer(Selector, Opts) ->
+    <<Int:256/unsigned-integer>> = selector_to_binary(Selector, Opts),
+    Int.
+
+safe_to_integer(Value) when is_integer(Value) ->
+    {ok, Value};
+safe_to_integer(Value) when is_binary(Value) ->
+    try binary_to_integer(Value) of
+        Int -> {ok, Int}
+    catch
+        _:_ -> error
+    end;
+safe_to_integer(Value) when is_list(Value) ->
+    try list_to_integer(Value) of
+        Int -> {ok, Int}
+    catch
+        _:_ -> error
+    end;
+safe_to_integer(_) ->
+    error.
+
+normalize_u256(Int) ->
+    Int band ((1 bsl 256) - 1).
 
 %% @doc Calculate the minimum distance between two numbers
 %% (either progressing backwards or forwards), assuming a
@@ -1633,6 +1746,145 @@ request_hook_reroute_to_nearest_test() ->
         Peers
     ),
     ?assert(HasValidSigner).
+
+route_nearest_integer_preserves_opts_test() ->
+    Routes =
+        [
+            #{
+                <<"template">> => <<"/chunk">>,
+                <<"nodes">> =>
+                    [
+                        #{
+                            <<"center">> => 100,
+                            <<"prefix">> => <<"http://node-100">>,
+                            <<"opts">> => #{ protocol => http2 }
+                        },
+                        #{
+                            <<"center">> => 200,
+                            <<"prefix">> => <<"http://node-200">>,
+                            <<"opts">> => #{ protocol => http2 }
+                        },
+                        #{
+                            <<"center">> => 400,
+                            <<"prefix">> => <<"http://node-400">>,
+                            <<"opts">> => #{ protocol => http2 }
+                        }
+                    ],
+                <<"strategy">> => <<"nearest-integer">>,
+                <<"choose">> => 2,
+                <<"parallel">> => 2,
+                <<"responses">> => 2,
+                <<"stop-after">> => false,
+                <<"admissible-status">> => 200
+            },
+            #{
+                <<"template">> => <<".*">>,
+                <<"node">> => <<"fallback">>
+            }
+        ],
+    {ok, Route} =
+        route(
+            #{ <<"path">> => <<"/chunk">>, <<"route-by">> => 210 },
+            #{ routes => Routes }
+        ),
+    ?assertEqual(2, hb_ao:get(<<"parallel">>, Route, #{})),
+    ?assertEqual(2, hb_ao:get(<<"responses">>, Route, #{})),
+    ?assertEqual(false, hb_ao:get(<<"stop-after">>, Route, #{})),
+    SelectedNodes = hb_ao:get(<<"nodes">>, Route, #{}),
+    ?assertEqual(2, length(SelectedNodes)),
+    SelectedCenters =
+        lists:sort(
+            [
+                hb_ao:get(<<"center">>, Node, #{})
+            ||
+                Node <- SelectedNodes
+            ]
+        ),
+    ?assertEqual([100, 200], SelectedCenters),
+    SelectedURIs =
+        lists:sort(
+            [
+                hb_ao:get(<<"uri">>, Node, #{})
+            ||
+                Node <- SelectedNodes
+            ]
+        ),
+    ?assertEqual(
+        [<<"http://node-100/chunk">>, <<"http://node-200/chunk">>],
+        SelectedURIs
+    ).
+
+route_multirequest_parallel_limit_test_() ->
+    {timeout, 30, fun route_multirequest_parallel_limit/0}.
+route_multirequest_parallel_limit() ->
+    DelayMs = 300,
+    WorkerNodes =
+        lists:map(
+            fun(N) ->
+                hb_http_server:start_node(
+                    #{
+                        store => hb_test_utils:test_store(),
+                        on =>
+                            #{
+                                <<"request">> =>
+                                    #{
+                                        <<"device">> => <<"test-device@1.0">>,
+                                        <<"path">> => <<"delay">>,
+                                        <<"duration">> => DelayMs,
+                                        <<"return">> =>
+                                            #{
+                                                <<"body">> =>
+                                                    [
+                                                        #{ <<"worker">> => N },
+                                                        <<"worker">>
+                                                    ]
+                                            }
+                                    }
+                            }
+                    }
+                )
+            end,
+            lists:seq(1, 3)
+        ),
+    Routes =
+        [
+            #{
+                <<"template">> => <<"/worker">>,
+                <<"nodes">> =>
+                    lists:map(
+                        fun(Node) -> #{ <<"prefix">> => Node } end,
+                        WorkerNodes
+                    ),
+                <<"strategy">> => <<"all">>,
+                <<"parallel">> => 2,
+                <<"responses">> => 3,
+                <<"stop-after">> => false
+            }
+        ],
+    Start = os:system_time(millisecond),
+    Results =
+        hb_http:request(
+            #{ <<"method">> => <<"GET">>, <<"path">> => <<"/worker">> },
+            #{
+                routes => Routes,
+                http_only_result => false
+            }
+        ),
+    Duration = os:system_time(millisecond) - Start,
+    ?assertEqual(3, length(Results)),
+    WorkerBodies =
+        lists:sort(
+            [
+                hb_ao:get(<<"body">>, Res, #{})
+            ||
+                {ok, Res} <- Results
+            ]
+        ),
+    ?assertEqual([1, 2, 3], WorkerBodies),
+    % With 3 peers of 300ms each: `parallel = 2` should complete in about two
+    % waves (~600ms), not one (~300ms) or fully serial (~900ms).
+    ?assert(Duration >= 450),
+    ?assert(Duration < 850).
 
 %%% Statistical test utilities
 

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -1,3 +1,12 @@
+%% TODOs:
+%% 
+%% 1. Matching routes: Take `routes` from Opts and return first hit.
+%% 2. Apply route: Transform the route message with the request data
+%% 3. Choose nodes: If the route has multiple nodes, choose a node based on the
+%%    given strategy.
+%% 4. Return _with_ the route `Opts`, which `hb_http` uses to make the request.
+
+
 %%% @doc A device that routes outbound messages from the node to their
 %%% appropriate network recipients via HTTP. All messages are initially
 %%% routed to a single process per node, which then load-balances them
@@ -242,21 +251,19 @@ route(_, Msg, Opts) ->
         Node when is_map(Node) -> apply_route(Msg, Node, Opts);
         not_found ->
             ModR = apply_routes(Msg, R, Opts),
-            case hb_ao:get(<<"strategy">>, R, Opts) of
-                not_found -> {ok, ModR};
+            case hb_ao:get(<<"strategy">>, R, <<"All">>, Opts) of
                 <<"All">> -> {ok, ModR};
                 Strategy ->
                     ChooseN = hb_ao:get(<<"choose">>, R, 1, Opts),
                     % Get the first element of the path -- the `base' message
                     % of the request.
-                    Base = extract_base(Msg, Opts),
                     Nodes = hb_ao:get(<<"nodes">>, ModR, Opts),
-                    Chosen = choose(ChooseN, Strategy, Base, Nodes, Opts),
+                    Chosen = choose(ChooseN, Strategy, Msg, Nodes, Opts),
                     ?event({choose,
                         {strategy, Strategy},
                         {choose_n, ChooseN},
-                        {base, Base},
                         {nodes, Nodes},
+                        {msg, Msg},
                         {chosen, Chosen}
                     }),
                     case Chosen of
@@ -458,9 +465,9 @@ choose(N, <<"By-Weight">>, _, Nodes, Opts) ->
     |
         choose(N - 1, <<"By-Weight">>, nop, lists:delete(Node, Nodes), Opts)
     ];
-choose(N, <<"By-Base">>, Hashpath, Nodes, Opts) when is_binary(Hashpath) ->
+choose(N, <<"By-Base">>, #{ <<"path">> := Hashpath }, Nodes, Opts) when is_binary(Hashpath) ->
     choose(N, <<"By-Base">>, binary_to_bignum(Hashpath), Nodes, Opts);
-choose(N, <<"By-Base">>, HashInt, Nodes, Opts) ->
+choose(N, <<"By-Base">>, #{ <<"path">> := HashInt }, Nodes, Opts) ->
     Node = lists:nth((HashInt rem length(Nodes)) + 1, Nodes),
     [
         Node
@@ -473,7 +480,28 @@ choose(N, <<"By-Base">>, HashInt, Nodes, Opts) ->
             Opts
         )
     ];
-choose(N, <<"Nearest">>, HashPath, Nodes, Opts) ->
+choose(N, <<"Nearest-Integer">>, #{ <<"route-by">> := Int }, Nodes, Opts) ->
+    NodesWithDistances =
+        lists:map(
+            fun(Node) ->
+                {Node, field_distance(Int, hb_maps:get(<<"center">>, Node, Opts))}
+            end,
+            Nodes
+        ),
+    lists:reverse(
+        element(
+            1,
+            lists:foldl(
+                fun(_, {Current, Remaining}) ->
+                    Res = {Lowest, _} = lowest_distance(Remaining),
+                    {[Lowest|Current], lists:delete(Res, Remaining)}
+                end,
+                {[], NodesWithDistances},
+                lists:seq(1, N)
+            )
+        )
+    );
+choose(N, <<"Nearest">>, #{ <<"path">> := HashPath }, Nodes, Opts) ->
     BareHashPath = hb_util:native_id(HashPath),
     NodesWithDistances =
         lists:map(

--- a/src/hb_http_multi.erl
+++ b/src/hb_http_multi.erl
@@ -62,31 +62,33 @@ request(Config, Method, Path, Message, Opts) ->
             {raw_message, Message},
             {message_to_send, MultirequestMsg}
         }),
+    ParallelWorkers = parse_parallel(Parallel, Nodes),
     AllResults =
-        if Parallel =/= false ->
-            parallel_multirequest(
-                Parallel,
-                Nodes,
-                Responses,
-                StopAfter,
-                Method,
-                Path,
-                MultirequestMsg,
-                Admissible,
-                Statuses,
-                Opts
-            );
-        true ->
-            serial_multirequest(
-                Nodes,
-                Responses,
-                Method,
-                Path,
-                MultirequestMsg,
-                Admissible,
-                Statuses,
-                Opts
-            )
+        case ParallelWorkers of
+            false ->
+                serial_multirequest(
+                    Nodes,
+                    Responses,
+                    Method,
+                    Path,
+                    MultirequestMsg,
+                    Admissible,
+                    Statuses,
+                    Opts
+                );
+            WorkerCount ->
+                parallel_multirequest(
+                    WorkerCount,
+                    Nodes,
+                    Responses,
+                    StopAfter,
+                    Method,
+                    Path,
+                    MultirequestMsg,
+                    Admissible,
+                    Statuses,
+                    Opts
+                )
         end,
     ?event(http, {multirequest_results, {results, AllResults}}),
     case AllResults of
@@ -183,18 +185,20 @@ serial_multirequest([Node|Nodes], Remaining, Method, Path, Message, Admissible, 
     end.
 
 %% @doc Dispatch the same HTTP request to many nodes in parallel.
-parallel_multirequest(true, Nodes, Responses, StopAfter, Method, Path, Message, Admissible, Statuses, Opts) ->
-    parallel_multirequest(length(Nodes), Nodes, Responses, StopAfter, Method, Path, Message, Admissible, Statuses, Opts);
 parallel_multirequest(MaxWorkers, Nodes, Responses, StopAfter, Method, Path, Message, Admissible, Statuses, Opts) ->
     Ref = make_ref(),
     {Workers, Queue} = start_workers(MaxWorkers, Ref, Nodes, Method, Path, Message, Opts),
     parallel_responses([], Workers, Queue, {Method, Path, Message}, Ref, Responses, StopAfter, Admissible, Statuses, Opts).
 
 %% @doc Start a new fleet of workers, returning the list of worker PIDs.
+start_workers(Count, _Ref, Nodes, _Method, _Path, _Message, _Opts) when Count =< 0 ->
+    {[], Nodes};
+start_workers(_Count, _Ref, [], _Method, _Path, _Message, _Opts) ->
+    {[], []};
 start_workers(Count, Ref, Nodes, Method, Path, Message, Opts) ->
     Parent = self(),
-    NewWorkerNodes = lists:sublist(Nodes, Count),
-    NewRemainingNodes = lists:nthtail(Count, Nodes),
+    {NewWorkerNodes, NewRemainingNodes} =
+        lists:split(min(Count, length(Nodes)), Nodes),
     {
         lists:map(
             fun(Node) ->
@@ -277,23 +281,15 @@ parallel_responses(Res, Procs, Queue, {Method, Path, Message}, Ref, Awaiting, St
     receive
         {Ref, Pid, {Status, NewRes}} ->
             WorkersWithoutPid = lists:delete(Pid, Procs),
-            [NewWorker] =
-                start_workers(
-                    length(WorkersWithoutPid),
-                    Ref,
-                    Queue,
-                    Method,
-                    Path,
-                    Message,
-                    Opts
-                ),
-            NewProcs = [NewWorker | WorkersWithoutPid],
+            {RefilledWorkers, NewQueue} =
+                start_workers(1, Ref, Queue, Method, Path, Message, Opts),
+            NewProcs = RefilledWorkers ++ WorkersWithoutPid,
             case is_admissible(Status, NewRes, Admissible, Statuses, Opts) of
                 true ->
                     parallel_responses(
                         [{Status, NewRes} | Res],
                         NewProcs,
-                        Queue,
+                        NewQueue,
                         {Method, Path, Message},
                         Ref,
                         Awaiting - 1,
@@ -306,7 +302,7 @@ parallel_responses(Res, Procs, Queue, {Method, Path, Message}, Ref, Awaiting, St
                 parallel_responses(
                     Res,
                     NewProcs,
-                    Queue,
+                    NewQueue,
                     {Method, Path, Message},
                     Ref,
                     Awaiting,
@@ -321,4 +317,41 @@ end.
 %% @doc Empty the inbox of the current process for all messages with the given
 %% reference.
 empty_inbox(Ref) ->
-    receive {Ref, _} -> empty_inbox(Ref) after 0 -> ok end.
+    receive
+        {Ref, _, _} -> empty_inbox(Ref);
+        {Ref, _} -> empty_inbox(Ref)
+    after 0 ->
+        ok
+    end.
+
+parse_parallel(false, _Nodes) ->
+    false;
+parse_parallel(true, Nodes) ->
+    length(Nodes);
+parse_parallel(Parallel, _Nodes) when is_integer(Parallel), Parallel =< 0 ->
+    false;
+parse_parallel(Parallel, Nodes) when is_integer(Parallel) ->
+    min(Parallel, length(Nodes));
+parse_parallel(Parallel, Nodes) when is_binary(Parallel) ->
+    case hb_util:to_lower(Parallel) of
+        <<"false">> ->
+            false;
+        <<"true">> ->
+            length(Nodes);
+        _ ->
+            case safe_binary_to_integer(Parallel) of
+                {ok, I} when I > 0 -> min(I, length(Nodes));
+                _ -> length(Nodes)
+            end
+    end;
+parse_parallel(Parallel, Nodes) when is_atom(Parallel) ->
+    parse_parallel(hb_util:bin(Parallel), Nodes);
+parse_parallel(_Parallel, Nodes) ->
+    length(Nodes).
+
+safe_binary_to_integer(Value) ->
+    try binary_to_integer(Value) of
+        Int -> {ok, Int}
+    catch
+        _:_ -> error
+    end.

--- a/src/hb_http_multi.erl
+++ b/src/hb_http_multi.erl
@@ -63,8 +63,9 @@ request(Config, Method, Path, Message, Opts) ->
             {message_to_send, MultirequestMsg}
         }),
     AllResults =
-        if Parallel ->
+        if Parallel =/= false ->
             parallel_multirequest(
+                Parallel,
                 Nodes,
                 Responses,
                 StopAfter,
@@ -182,10 +183,19 @@ serial_multirequest([Node|Nodes], Remaining, Method, Path, Message, Admissible, 
     end.
 
 %% @doc Dispatch the same HTTP request to many nodes in parallel.
-parallel_multirequest(Nodes, Responses, StopAfter, Method, Path, Message, Admissible, Statuses, Opts) ->
+parallel_multirequest(true, Nodes, Responses, StopAfter, Method, Path, Message, Admissible, Statuses, Opts) ->
+    parallel_multirequest(length(Nodes), Nodes, Responses, StopAfter, Method, Path, Message, Admissible, Statuses, Opts);
+parallel_multirequest(MaxWorkers, Nodes, Responses, StopAfter, Method, Path, Message, Admissible, Statuses, Opts) ->
     Ref = make_ref(),
+    {Workers, Queue} = start_workers(MaxWorkers, Ref, Nodes, Method, Path, Message, Opts),
+    parallel_responses([], Workers, Queue, {Method, Path, Message}, Ref, Responses, StopAfter, Admissible, Statuses, Opts).
+
+%% @doc Start a new fleet of workers, returning the list of worker PIDs.
+start_workers(Count, Ref, Nodes, Method, Path, Message, Opts) ->
     Parent = self(),
-    Procs =
+    NewWorkerNodes = lists:sublist(Nodes, Count),
+    NewRemainingNodes = lists:nthtail(Count, Nodes),
+    {
         lists:map(
             fun(Node) ->
                 spawn(
@@ -197,9 +207,10 @@ parallel_multirequest(Nodes, Responses, StopAfter, Method, Path, Message, Admiss
                     end
                 )
             end,
-            Nodes
+            NewWorkerNodes
         ),
-    parallel_responses([], Procs, Ref, Responses, StopAfter, Admissible, Statuses, Opts).
+        NewRemainingNodes
+    }.
 
 %% @doc Check if a status is allowed, according to the configuration. Statuses
 %% can be a single integer, a comma-separated list of integers, or the string
@@ -251,25 +262,39 @@ admissible_response(Response, Msg, Opts) ->
 
 %% @doc Collect the necessary number of responses, and stop workers if
 %% configured to do so.
-parallel_responses(Res,  [], Ref, _Awaiting, _StopAfter, _Admissible, _Statuses, _Opts) ->
+parallel_responses(Res, [], _, _, Ref, _Awaiting, _StopAfter, _Admissible, _Statuses, _Opts) ->
     empty_inbox(Ref),
     Res;
-parallel_responses(Res, Procs, Ref, 0, false, _Admissible, _Statuses, _Opts) ->
+parallel_responses(Res, Procs, _, _, Ref, 0, false, _Admissible, _Statuses, _Opts) ->
     lists:foreach(fun(P) -> P ! no_reply end, Procs),
     empty_inbox(Ref),
     Res;
-parallel_responses(Res, Procs, Ref, 0, true, _Admissible, _Statuses, _Opts) ->
+parallel_responses(Res, Procs, _, _, Ref, 0, true, _Admissible, _Statuses, _Opts) ->
     lists:foreach(fun(P) -> exit(P, kill) end, Procs),
     empty_inbox(Ref),
     Res;
-parallel_responses(Res, Procs, Ref, Awaiting, StopAfter, Admissible, Statuses, Opts) ->
+parallel_responses(Res, Procs, Queue, {Method, Path, Message}, Ref, Awaiting, StopAfter, Admissible, Statuses, Opts) ->
     receive
         {Ref, Pid, {Status, NewRes}} ->
+            WorkersWithoutPid = lists:delete(Pid, Procs),
+            [NewWorker] =
+                start_workers(
+                    length(WorkersWithoutPid),
+                    Ref,
+                    Queue,
+                    Method,
+                    Path,
+                    Message,
+                    Opts
+                ),
+            NewProcs = [NewWorker | WorkersWithoutPid],
             case is_admissible(Status, NewRes, Admissible, Statuses, Opts) of
                 true ->
                     parallel_responses(
                         [{Status, NewRes} | Res],
-                        lists:delete(Pid, Procs),
+                        NewProcs,
+                        Queue,
+                        {Method, Path, Message},
                         Ref,
                         Awaiting - 1,
                         StopAfter,
@@ -280,7 +305,9 @@ parallel_responses(Res, Procs, Ref, Awaiting, StopAfter, Admissible, Statuses, O
             false ->
                 parallel_responses(
                     Res,
-                    lists:delete(Pid, Procs),
+                    NewProcs,
+                    Queue,
+                    {Method, Path, Message},
                     Ref,
                     Awaiting,
                     StopAfter,

--- a/src/hb_http_multi.erl
+++ b/src/hb_http_multi.erl
@@ -62,33 +62,31 @@ request(Config, Method, Path, Message, Opts) ->
             {raw_message, Message},
             {message_to_send, MultirequestMsg}
         }),
-    ParallelWorkers = parse_parallel(Parallel, Nodes),
     AllResults =
-        case ParallelWorkers of
-            false ->
-                serial_multirequest(
-                    Nodes,
-                    Responses,
-                    Method,
-                    Path,
-                    MultirequestMsg,
-                    Admissible,
-                    Statuses,
-                    Opts
-                );
-            WorkerCount ->
-                parallel_multirequest(
-                    WorkerCount,
-                    Nodes,
-                    Responses,
-                    StopAfter,
-                    Method,
-                    Path,
-                    MultirequestMsg,
-                    Admissible,
-                    Statuses,
-                    Opts
-                )
+        if Parallel =/= false ->
+            parallel_multirequest(
+                Parallel,
+                Nodes,
+                Responses,
+                StopAfter,
+                Method,
+                Path,
+                MultirequestMsg,
+                Admissible,
+                Statuses,
+                Opts
+            );
+        true ->
+            serial_multirequest(
+                Nodes,
+                Responses,
+                Method,
+                Path,
+                MultirequestMsg,
+                Admissible,
+                Statuses,
+                Opts
+            )
         end,
     ?event(http, {multirequest_results, {results, AllResults}}),
     case AllResults of
@@ -185,16 +183,14 @@ serial_multirequest([Node|Nodes], Remaining, Method, Path, Message, Admissible, 
     end.
 
 %% @doc Dispatch the same HTTP request to many nodes in parallel.
+parallel_multirequest(true, Nodes, Responses, StopAfter, Method, Path, Message, Admissible, Statuses, Opts) ->
+    parallel_multirequest(length(Nodes), Nodes, Responses, StopAfter, Method, Path, Message, Admissible, Statuses, Opts);
 parallel_multirequest(MaxWorkers, Nodes, Responses, StopAfter, Method, Path, Message, Admissible, Statuses, Opts) ->
     Ref = make_ref(),
     {Workers, Queue} = start_workers(MaxWorkers, Ref, Nodes, Method, Path, Message, Opts),
     parallel_responses([], Workers, Queue, {Method, Path, Message}, Ref, Responses, StopAfter, Admissible, Statuses, Opts).
 
 %% @doc Start a new fleet of workers, returning the list of worker PIDs.
-start_workers(Count, _Ref, Nodes, _Method, _Path, _Message, _Opts) when Count =< 0 ->
-    {[], Nodes};
-start_workers(_Count, _Ref, [], _Method, _Path, _Message, _Opts) ->
-    {[], []};
 start_workers(Count, Ref, Nodes, Method, Path, Message, Opts) ->
     Parent = self(),
     {NewWorkerNodes, NewRemainingNodes} =
@@ -322,36 +318,4 @@ empty_inbox(Ref) ->
         {Ref, _} -> empty_inbox(Ref)
     after 0 ->
         ok
-    end.
-
-parse_parallel(false, _Nodes) ->
-    false;
-parse_parallel(true, Nodes) ->
-    length(Nodes);
-parse_parallel(Parallel, _Nodes) when is_integer(Parallel), Parallel =< 0 ->
-    false;
-parse_parallel(Parallel, Nodes) when is_integer(Parallel) ->
-    min(Parallel, length(Nodes));
-parse_parallel(Parallel, Nodes) when is_binary(Parallel) ->
-    case hb_util:to_lower(Parallel) of
-        <<"false">> ->
-            false;
-        <<"true">> ->
-            length(Nodes);
-        _ ->
-            case safe_binary_to_integer(Parallel) of
-                {ok, I} when I > 0 -> min(I, length(Nodes));
-                _ -> length(Nodes)
-            end
-    end;
-parse_parallel(Parallel, Nodes) when is_atom(Parallel) ->
-    parse_parallel(hb_util:bin(Parallel), Nodes);
-parse_parallel(_Parallel, Nodes) ->
-    length(Nodes).
-
-safe_binary_to_integer(Value) ->
-    try binary_to_integer(Value) of
-        Int -> {ok, Int}
-    catch
-        _:_ -> error
     end.

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -249,28 +249,25 @@ default_message() ->
             vmm_type, guest_features
         ],
         routes => [
+            %% Local CU routes.
             #{
-                % Routes for the genesis-wasm device to use a local CU, if requested.
                 <<"template">> => <<"/result/.*">>,
                 <<"node">> => #{ <<"prefix">> => <<"http://localhost:6363">> }
             },
             #{
-                % Routes for the genesis-wasm device to use a local CU, if requested.
                 <<"template">> => <<"/snapshot/.*">>,
                 <<"node">> => #{ <<"prefix">> => <<"http://localhost:6363">> }
             },
             #{
-                % Routes for the genesis-wasm device to use a local CU, if requested.
                 <<"template">> => <<"/dry-run.*">>,
                 <<"node">> => #{ <<"prefix">> => <<"http://localhost:6363">> }
             },
             #{
-                % Routes for the genesis-wasm device to use a local CU, if requested.
                 <<"template">> => <<"/state.*">>,
                 <<"node">> => #{ <<"prefix">> => <<"http://localhost:6363">> }
             },
+            %% GraphQL: race all gateways, take the first 200.
             #{
-                % Routes for GraphQL requests to use a remote GraphQL API.
                 <<"template">> => <<"/graphql">>,
                 <<"nodes">> =>
                     [
@@ -288,63 +285,183 @@ default_message() ->
                         }
                     ]
             },
+            %% Chunk requests: route to the nearest data nodes by
+            %% partition midpoint (byte offset). Tries 4 at a time,
+            %% ordered by proximity, until one returns 200.
             #{
-                % Routes for Arweave transaction requests to use a remote gateway.
                 <<"template">> => <<"^/arweave/chunk">>,
                 <<"nodes">> =>
                     [
+                        %% Partitions 0-15
                         #{
                             <<"match">> => <<"^/arweave">>,
-                            <<"center">> => 3_600_000_000,
-                            <<"with">> => <<"https://data-1.arweave.net">>,
-                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                            <<"center">> => 28_800_000_000_000,
+                            <<"with">> => <<"http://data-1.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
                         },
                         #{
                             <<"match">> => <<"^/arweave">>,
-                            <<"center">> => 8_200_000_000,
-                            <<"with">> => <<"https://data-2.arweave.net">>,
-                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                            <<"center">> => 28_800_000_000_000,
+                            <<"with">> => <<"http://data-13.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
+                        },
+                        %% Partitions 16-31
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 86_400_000_000_000,
+                            <<"with">> => <<"http://data-2.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
                         },
                         #{
                             <<"match">> => <<"^/arweave">>,
-                            <<"center">> => 12_200_000_000,
-                            <<"with">> => <<"https://data-3.arweave.net">>,
-                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                            <<"center">> => 86_400_000_000_000,
+                            <<"with">> => <<"http://data-3.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
                         },
                         #{
                             <<"match">> => <<"^/arweave">>,
-                            <<"with">> => <<"https://data-4.arweave.net">>,
-                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                            <<"center">> => 86_400_000_000_000,
+                            <<"with">> => <<"http://data-14.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
                         },
                         #{
                             <<"match">> => <<"^/arweave">>,
-                            <<"center">> => 16_200_000_000,
-                            <<"with">> => <<"https://data-5.arweave.net">>,
-                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                            <<"center">> => 86_400_000_000_000,
+                            <<"with">> => <<"http://data-15.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
+                        },
+                        %% Partitions 32-47
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 144_000_000_000_000,
+                            <<"with">> => <<"http://data-4.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 144_000_000_000_000,
+                            <<"with">> => <<"http://data-5.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 144_000_000_000_000,
+                            <<"with">> => <<"http://data-16.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 144_000_000_000_000,
+                            <<"with">> => <<"http://data-17.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
+                        },
+                        %% Partitions 48-63
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 201_600_000_000_000,
+                            <<"with">> => <<"http://data-6.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 201_600_000_000_000,
+                            <<"with">> => <<"http://data-7.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
+                        },
+                        %% Partitions 48-107 (tip nodes)
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 280_800_000_000_000,
+                            <<"with">> => <<"http://tip-1.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 280_800_000_000_000,
+                            <<"with">> => <<"http://tip-2.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 280_800_000_000_000,
+                            <<"with">> => <<"http://tip-3.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 280_800_000_000_000,
+                            <<"with">> => <<"http://tip-4.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 280_800_000_000_000,
+                            <<"with">> => <<"http://tip-5.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
+                        },
+                        %% Partitions 64-126
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 343_800_000_000_000,
+                            <<"with">> => <<"http://data-8.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
+                        },
+                        %% Partitions 75-138
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 385_200_000_000_000,
+                            <<"with">> => <<"http://data-9.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 385_200_000_000_000,
+                            <<"with">> => <<"http://data-10.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 385_200_000_000_000,
+                            <<"with">> => <<"http://data-11.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 385_200_000_000_000,
+                            <<"with">> => <<"http://data-12.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc }
                         }
-
                     ],
                 <<"strategy">> => <<"Nearest-Integer">>,
-                <<"choose">> => 3,
-                <<"parallel">> => 2
-           },
+                <<"choose">> => 22,
+                <<"parallel">> => 4,
+                <<"responses">> => 1,
+                <<"stop-after">> => true,
+                <<"admissible-status">> => 200
+            },
+            %% General Arweave requests: race both chain nodes, take
+            %% the first 200.
             #{
-                % Routes for Arweave transaction requests to use a remote gateway.
                 <<"template">> => <<"^/arweave">>,
                 <<"nodes">> =>
                     [
                         #{
                             <<"match">> => <<"^/arweave">>,
-                            <<"with">> => <<"https://arweave.net">>,
+                            <<"with">> => <<"http://chain-1.arweave.xyz:1984">>,
+                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"with">> => <<"http://chain-2.arweave.xyz:1984">>,
                             <<"opts">> => #{ http_client => httpc, protocol => http2 }
                         }
                     ],
                 <<"parallel">> => true,
                 <<"stop-after">> => 1,
                 <<"admissible-status">> => 200
-           },
+            },
+            %% Raw data requests via arweave.net gateway. TODO: Update later.
             #{
-                % Routes for raw data requests to use a remote gateway.
                 <<"template">> => <<"/raw">>,
                 <<"node">> =>
                     #{

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -315,10 +315,16 @@ default_message() ->
                             <<"match">> => <<"^/arweave">>,
                             <<"with">> => <<"https://data-4.arweave.net">>,
                             <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 16_200_000_000,
+                            <<"with">> => <<"https://data-5.arweave.net">>,
+                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
                         }
 
                     ],
-                <<"strategy">> => <<"nearest">>,
+                <<"strategy">> => <<"Nearest-Integer">>,
                 <<"choose">> => 3,
                 <<"parallel">> => 2
            },
@@ -329,16 +335,10 @@ default_message() ->
                     [
                         #{
                             <<"match">> => <<"^/arweave">>,
-                            <<"with">> => <<"https://data-1.arweave.net">>,
-                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
-                        },
-                        #{
-                            <<"match">> => <<"^/arweave">>,
-                            <<"with">> => <<"https://data-2.arweave.net">>,
+                            <<"with">> => <<"https://arweave.net">>,
                             <<"opts">> => #{ http_client => httpc, protocol => http2 }
                         }
                     ],
-                <<"strategy">> => <<"nearest">>,
                 <<"parallel">> => true,
                 <<"stop-after">> => 1,
                 <<"admissible-status">> => 200

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -290,14 +290,59 @@ default_message() ->
             },
             #{
                 % Routes for Arweave transaction requests to use a remote gateway.
-                <<"template">> => <<"/arweave">>,
-                <<"node">> =>
-                    #{
-                        <<"match">> => <<"^/arweave">>,
-                        <<"with">> => <<"https://arweave.net">>,
-                        <<"opts">> => #{ http_client => httpc, protocol => http2 }
-                    }
-            },
+                <<"template">> => <<"^/arweave/chunk">>,
+                <<"nodes">> =>
+                    [
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 3_600_000_000,
+                            <<"with">> => <<"https://data-1.arweave.net">>,
+                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 8_200_000_000,
+                            <<"with">> => <<"https://data-2.arweave.net">>,
+                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"center">> => 12_200_000_000,
+                            <<"with">> => <<"https://data-3.arweave.net">>,
+                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"with">> => <<"https://data-4.arweave.net">>,
+                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                        }
+
+                    ],
+                <<"strategy">> => <<"nearest">>,
+                <<"choose">> => 3,
+                <<"parallel">> => 2
+           },
+            #{
+                % Routes for Arweave transaction requests to use a remote gateway.
+                <<"template">> => <<"^/arweave">>,
+                <<"nodes">> =>
+                    [
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"with">> => <<"https://data-1.arweave.net">>,
+                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                        },
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"with">> => <<"https://data-2.arweave.net">>,
+                            <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                        }
+                    ],
+                <<"strategy">> => <<"nearest">>,
+                <<"parallel">> => true,
+                <<"stop-after">> => 1,
+                <<"admissible-status">> => 200
+           },
             #{
                 % Routes for raw data requests to use a remote gateway.
                 <<"template">> => <<"/raw">>,


### PR DESCRIPTION
## Summary

- Add `Nearest-Integer` routing strategy that selects nodes by proximity of
  their `center` field to a `route-by` integer value (e.g. weave byte offset),
  with supporting helpers (`route_integer`, `route_hash_int`, `normalize_strategy`,
  `choose_count`, `safe_to_integer`, `normalize_hashpath`)
- Add `route-by` key support so requests can carry an explicit routing value
  independent of the URL path; `dev_arweave` block-height requests now pass
  `route-by => Height` for Nearest-Integer chunk routing
- Upgrade `parallel` from boolean to integer in `hb_http_multi`, enabling bounded
  concurrency with a worker pool and backfill queue (`parallel = 2` sends at most
  2 requests at a time, refilling as each completes; `true` preserves full
  parallelism for backward compatibility)
- Restructure `route/3` into a clearer nested decision tree with better edge-case
  handling (missing nodes, empty chosen list, single-node short-circuit)
- Remove `extract_base/2` in favor of the unified `route-by` mechanism
- Add `do_apply_route` clause for nodes that already have a `uri` key
- Expand default Arweave routes in `hb_opts` to a 5-node data cluster using
  `Nearest-Integer` with `parallel = 2` for chunk requests
- Fix `Nearest-Integer` crash when a node has no `center` field (was passing Opts
  map to `field_distance/2`, causing `badarith`)
- Add `route_nearest_integer_preserves_opts_test` verifying strategy selection and
  route option preservation
- Add `route_multirequest_parallel_limit_test` confirming bounded parallelism
  timing with local test nodes
- Add `full_route_config_test` exercising a production-style route config with
  real HTTP GETs against Arweave data nodes, including a 5-node `parallel=2`
  timing check
