### PR TITLE
fix: Verify loop

### DIFF
--- a/src/dev_codec_ans104.erl
+++ b/src/dev_codec_ans104.erl
@@ -62,7 +62,7 @@ commit(Msg, #{ <<"type">> := <<"unsigned-sha256">> }, Opts) ->
 
 %% @doc Verify an ANS-104 commitment.
 verify(Msg, Req, Opts) ->
-    ?event({verify, {base, Msg}, {req, Req}}),
+    dev_arweave_common:log_conversion(ans104_verify, {verify, {base, Msg}, {req, Req}}),
     OnlyWithCommitment =
         hb_private:reset(
             hb_message:with_commitments(
@@ -71,7 +71,7 @@ verify(Msg, Req, Opts) ->
                 Opts
             )
         ),
-    ?event({verify, {only_with_commitment, OnlyWithCommitment}}),
+    dev_arweave_common:log_conversion(ans104_verify, {verify, {only_with_commitment, OnlyWithCommitment}}),
     {ok, TX} = to(OnlyWithCommitment, Req, Opts),
     ?event({verify, {encoded, TX}}),
     Res = ar_bundles:verify_item(TX),


### PR DESCRIPTION
Running the following command still triggers a loop, because the verify is the function being called (and any other function inside it).

```HB_PRINT=dev_codec_ans104 rebar3 eunit --test dev_codec_ans104:ao_data_key_test```