### PR TITLE
fix: remove slop.

### DIFF
--- a/src/dev_json_iface.erl
+++ b/src/dev_json_iface.erl
@@ -216,7 +216,7 @@ prepare_header_case_tags(TABM, Opts) ->
     lists:map(
         fun({Name, Value}) ->
             #{
-                <<"name">> => header_case_string(maybe_list_to_binary(Name)),
+                <<"name">> => hb_util:to_header_case(maybe_list_to_binary(Name)),
                 <<"value">> => maybe_list_to_binary(Value)
             }
         end,
@@ -274,20 +274,6 @@ maybe_list_to_binary(List) when is_list(List) ->
     list_to_binary(List);
 maybe_list_to_binary(Bin) ->
     Bin.
-
-header_case_string(Key) ->
-    NormKey = hb_ao:normalize_key(Key),
-    Words = string:lexemes(NormKey, "-"),
-    TitleCaseWords =
-        lists:map(
-            fun binary_to_list/1,
-            lists:map(
-                fun string:titlecase/1,
-                Words
-            )
-        ),
-    TitleCaseKey = list_to_binary(string:join(TitleCaseWords, "-")),
-    TitleCaseKey.
 
 %% @doc Read the computed results out of the WASM environment, assuming that
 %% the environment has been set up by `prep_call/3' and that the WASM executor

--- a/src/dev_json_iface.erl
+++ b/src/dev_json_iface.erl
@@ -253,7 +253,11 @@ json_to_message(Resp, Opts) when is_map(Resp) ->
                             )
                     ]
                 ),
-            <<"patches">> => lists:map(fun(Patch) -> tags_to_map(Patch, Opts) end, Patches),
+            <<"patches">> =>
+                lists:map(
+                    fun(Patch) -> tags_to_message(Patch, Opts) end,
+                    Patches
+                ),
             <<"data">> => Data
         },
     {ok, Output};

--- a/src/dev_json_iface.erl
+++ b/src/dev_json_iface.erl
@@ -372,46 +372,63 @@ normalize_results(#{ <<"Error">> := Error }) ->
     {ok, Error, [], []};
 normalize_results(Msg) ->
     try
-        Output = maps:get(<<"Output">>, Msg, #{}),
-        Data = maps:get(<<"data">>, Output, maps:get(<<"Data">>, Msg, <<>>)),
+        Output = case_tolerant_get(<<"Output">>, Msg, #{}),
+        Data =
+            case_tolerant_get(
+                <<"Data">>,
+                Output,
+                case_tolerant_get(<<"data">>, Msg, <<>>)
+            ),
+        Messages = case_tolerant_get(<<"Messages">>, Msg, []),
+        Patches = case_tolerant_get(<<"Patches">>, Msg, []),
+        ?event(
+            {normalized_results,
+                {data, Data},
+                {messages, Messages},
+                {patches, Patches}
+            }
+        ),
         {ok,
             Data,
-            maps:get(<<"Messages">>, Msg, []),
-            maps:get(<<"patches">>, Msg, [])
+            Messages,
+            Patches
         }
     catch
         _:_ ->
             {ok, <<>>, [], []}
     end.
 
+%% @doc Get a value from a map, tolerating case differences in the first 
+%% character of the key.
+case_tolerant_get(Key, Map, Default) ->
+    maps:get(Key, Map, maps:get(hb_util:to_lower(Key), Map, Default)).
+
 %% @doc After the process returns messages from an evaluation, the
 %% signing node needs to add some tags to each message and spawn such that
 %% the target process knows these messages are created by a process.
 preprocess_results(Msg, Opts) ->
-    Tags = tags_to_map(Msg, Opts),
-    FilteredMsg =
-        hb_maps:without(
-            [<<"from-process">>, <<"from-image">>, <<"anchor">>, <<"tags">>],
-            Msg,
-            Opts
-        ),
+    FilteredKeys = [<<"from-process">>, <<"from-image">>, <<"anchor">>, <<"tags">>],
     hb_maps:merge(
         hb_maps:from_list(
-            lists:map(
+            lists:filtermap(
                 fun({Key, Value}) ->
-                    {hb_ao:normalize_key(Key), Value}
+                    NormKey = hb_ao:normalize_key(Key),
+                    LowerNormKey = hb_util:to_lower(NormKey),
+                    case lists:member(LowerNormKey, FilteredKeys) of
+                        true -> false;
+                        false -> {true, {NormKey, Value}}
+                    end
                 end,
-                hb_maps:to_list(FilteredMsg, Opts)
+                hb_maps:to_list(Msg, Opts)
             )
         ),
-        Tags,
+        tags_to_message(Msg, Opts),
         Opts
     ).
 
 %% @doc Convert a message with tags into a map of their key-value pairs.
-tags_to_map(Msg, Opts) ->
-    NormMsg = hb_util:lower_case_keys(hb_ao:normalize_keys(Msg, Opts), Opts),
-    RawTags = hb_maps:get(<<"tags">>, NormMsg, [], Opts),
+tags_to_message(Msg, Opts) ->
+    RawTags = hb_maps:get(<<"Tags">>, Msg, [], Opts),
     TagList =
         [
             {hb_maps:get(<<"name">>, Tag, Opts), hb_maps:get(<<"value">>, Tag, Opts)}

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -498,11 +498,11 @@ choose(N, <<"Nearest-Integer">>, #{ <<"route-by">> := Int }, Nodes, Opts) ->
     NodesWithDistances =
         lists:map(
             fun(Node) ->
-                %% Use 4-arity get with explicit default — the old
-                %% 3-arity call returned the Opts map when `center'
-                %% was missing, crashing field_distance with badarith.
-                %% Centerless nodes get 2^256 (> max distance) so they
-                %% are selected last.
+                % Use 4-arity get with explicit default — the old
+                % 3-arity call returned the Opts map when `center'
+                % was missing, crashing field_distance with badarith.
+                % Centerless nodes get 2^256 (> max distance) so they
+                % are selected last.
                 case hb_maps:get(<<"center">>, Node, not_found, Opts) of
                     not_found ->
                         {Node, 1 bsl 256};
@@ -588,18 +588,7 @@ choose_count(RawChoose, Nodes) ->
     min(NormalizedChoose, length(Nodes)).
 
 normalize_strategy(RawStrategy) ->
-    case hb_util:to_lower(hb_util:bin(RawStrategy)) of
-        <<"all">> -> <<"All">>;
-        <<"random">> -> <<"Random">>;
-        <<"by-base">> -> <<"By-Base">>;
-        <<"by_base">> -> <<"By-Base">>;
-        <<"by-weight">> -> <<"By-Weight">>;
-        <<"by_weight">> -> <<"By-Weight">>;
-        <<"nearest">> -> <<"Nearest">>;
-        <<"nearest-integer">> -> <<"Nearest-Integer">>;
-        <<"nearest_integer">> -> <<"Nearest-Integer">>;
-        _ -> <<"All">>
-    end.
+    hb_util:to_header_case(RawStrategy).
 
 route_integer(Int, _Opts) when is_integer(Int) ->
     Int;
@@ -1952,11 +1941,9 @@ full_route_config_test() ->
             }
         ],
     Opts = #{ routes => Routes },
-
-    %% --- Nearest-Integer strategy for /arweave/chunk ---
-
-    %% A chunk request with route-by near center 8_200_000_000 should pick
-    %% the 3 closest nodes out of the 5 available.
+    % --- Nearest-Integer strategy for /arweave/chunk ---
+    % A chunk request with route-by near center 8_200_000_000 should pick
+    % the 3 closest nodes out of the 5 available.
     {ok, ChunkRoute} =
         route(
             #{
@@ -1969,16 +1956,16 @@ full_route_config_test() ->
     ?assertEqual(2, hb_ao:get(<<"parallel">>, ChunkRoute, #{})),
     ChunkNodes = hb_ao:get(<<"nodes">>, ChunkRoute, #{}),
     ?assertEqual(3, length(ChunkNodes)),
-    %% The three nearest centers to 8_200_000_100 should be
-    %% 8_200_000_000, 3_600_000_000, and 12_200_000_000.
+    % The three nearest centers to 8_200_000_100 should be
+    % 8_200_000_000, 3_600_000_000, and 12_200_000_000.
     ChunkCenters =
         lists:sort(
             [hb_ao:get(<<"center">>, N, #{}) || N <- ChunkNodes]
         ),
     ?event(router_test, {chunk_centers, ChunkCenters}),
     ?assertEqual([3_600_000_000, 8_200_000_000, 12_200_000_000], ChunkCenters),
-    %% Each selected node should have a URI with the match/with regex applied:
-    %% /arweave/chunk/... -> https://data-N.arweave.net/chunk/...
+    % Each selected node should have a URI with the match/with regex applied:
+    % /arweave/chunk/... -> https://data-N.arweave.net/chunk/...
     ChunkURIs =
         lists:sort(
             [hb_ao:get(<<"uri">>, N, #{}) || N <- ChunkNodes]
@@ -1992,9 +1979,8 @@ full_route_config_test() ->
         ],
         ChunkURIs
     ),
-
-    %% A chunk request near the high end should select the 3 closest to
-    %% 16_000_000_000: 16_200_000_000, 12_200_000_000, and 8_200_000_000.
+    % A chunk request near the high end should select the 3 closest to
+    % 16_000_000_000: 16_200_000_000, 12_200_000_000, and 8_200_000_000.
     {ok, HighChunkRoute} =
         route(
             #{
@@ -2033,9 +2019,7 @@ full_route_config_test() ->
     ArweaveURI = hb_ao:get(<<"uri">>, hd(ArweaveNodes), #{}),
     ?event(router_test, {arweave_fallback_uri, ArweaveURI}),
     ?assertEqual(<<"https://arweave.net/tx/RTvlIxbvDOpo7kPisnhnfz0BtgOZE4QlScBSRLEkky4">>, ArweaveURI),
-
-    %% --- Single-node prefix route (/raw) ---
-
+    % --- Single-node prefix route (/raw) ---
     {ok, RawRoute} =
         route(#{ <<"path">> => <<"/raw/RTvlIxbvDOpo7kPisnhnfz0BtgOZE4QlScBSRLEkky4">> }, Opts),
     ?event(router_test, {raw_route, RawRoute}),
@@ -2043,18 +2027,14 @@ full_route_config_test() ->
         <<"https://arweave.net/raw/RTvlIxbvDOpo7kPisnhnfz0BtgOZE4QlScBSRLEkky4">>,
         hb_ao:get(<<"uri">>, RawRoute, #{})
     ),
-
-    %% --- No match ---
-
+    % --- No match ---
     NoMatchResult = route(#{ <<"path">> => <<"/unknown/endpoint">> }, Opts),
     ?event(router_test, {no_match_result, NoMatchResult}),
     ?assertEqual({error, no_matches}, NoMatchResult),
-
     %% --- HTTP GETs through the routes ---
     %% Fire actual requests using hb_http:request/2, the same way the
     %% route_multirequest_parallel_limit test does it.
     HttpReqOpts = #{ routes => Routes, http_only_result => false },
-
     %% Chunk request via Nearest-Integer (parallel=2, choose=3).
     %% With 3 nodes and parallel=2, wave 1 sends to 2 nodes, wave 2 sends
     %% to the remaining 1. We time it to confirm parallelism.
@@ -2071,11 +2051,10 @@ full_route_config_test() ->
     ChunkDuration = os:system_time(millisecond) - ChunkStart,
     ?event(router_test, {chunk_http_result, ChunkHttpRes}),
     ?event(router_test, {chunk_http_duration_ms, ChunkDuration}),
-
-    %% Now test with ALL 5 data nodes to really exercise parallel=2.
-    %% choose=5 means all 5 nodes get hit, but only 2 at a time.
-    %% With ~300-500ms per request, we expect ~3 waves (~900-1500ms)
-    %% instead of fully serial (~1500-2500ms) or fully parallel (~300-500ms).
+    % Now test with ALL 5 data nodes to really exercise parallel=2.
+    % choose=5 means all 5 nodes get hit, but only 2 at a time.
+    % With ~300-500ms per request, we expect ~3 waves (~900-1500ms)
+    % instead of fully serial (~1500-2500ms) or fully parallel (~300-500ms).
     AllChunkRoutes =
         [
             #{
@@ -2139,8 +2118,7 @@ full_route_config_test() ->
             false -> not_a_list
         end
     }),
-
-    %% Fallback /arweave route.
+    % Fallback /arweave route.
     ArweaveHttpRes =
         (catch hb_http:request(
             #{
@@ -2150,8 +2128,7 @@ full_route_config_test() ->
             HttpReqOpts
         )),
     ?event(router_test, {arweave_http_result, ArweaveHttpRes}),
-
-    %% /raw prefix route.
+    % /raw prefix route.
     RawHttpRes =
         (catch hb_http:request(
             #{

--- a/src/hb_util.erl
+++ b/src/hb_util.erl
@@ -16,7 +16,7 @@
 -export([is_string_list/1, list_replace/3, list_without/2, list_with/2]).
 -export([to_sorted_list/1, to_sorted_list/2, to_sorted_keys/1, to_sorted_keys/2]).
 -export([hd/1, hd/2, hd/3]).
--export([remove_common/2, to_lower/1]).
+-export([remove_common/2, to_lower/1, to_header_case/1]).
 -export([maybe_throw/2]).
 -export([is_hb_module/1, is_hb_module/2, all_hb_modules/0]).
 -export([ok/1, ok/2, until/1, until/2, until/3, wait_until/2]).
@@ -173,6 +173,20 @@ id(Data, Type) when is_list(Data) ->
 %% @doc Convert a binary to a lowercase.
 to_lower(Str) ->
     string:lowercase(Str).
+
+%% @doc Convert a binary to HTTP header case (`For-Example-This`).
+to_header_case(Str) ->
+    NormStr = hb_ao:normalize_key(Str),
+    Words = string:lexemes(NormStr, "-"),
+    TitleCaseWords =
+        lists:map(
+            fun binary_to_list/1,
+            lists:map(
+                fun string:titlecase/1,
+                Words
+            )
+        ),
+    bin(string:join(TitleCaseWords, "-")).
 
 %% @doc Is the given term a string list?
 is_string_list(MaybeString) ->


### PR DESCRIPTION
Removes some `slop`iness that crept into `~router@1.0` in the prior PR.