### PR TITLE
fix: cross-platform WAMR build step in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,11 +55,16 @@ $(WAMR_DIR):
 		--single-branch
 
 $(WAMR_DIR)/lib/libvmlib.a: $(WAMR_DIR)
-	sed -i '742a tbl_inst->is_table64 = 1;' ./_build/wamr/core/iwasm/aot/aot_runtime.c; \
+	@if ! grep -Fq 'tbl_inst->is_table64 = 1;' ./_build/wamr/core/iwasm/aot/aot_runtime.c; then \
+		awk 'NR == 742 { print; print "tbl_inst->is_table64 = 1;"; next } { print }' \
+			./_build/wamr/core/iwasm/aot/aot_runtime.c > ./_build/wamr/core/iwasm/aot/aot_runtime.c.tmp && \
+		mv ./_build/wamr/core/iwasm/aot/aot_runtime.c.tmp ./_build/wamr/core/iwasm/aot/aot_runtime.c; \
+	fi; \
 	cmake \
 		$(WAMR_FLAGS) \
 		-S $(WAMR_DIR) \
 		-B $(WAMR_DIR)/lib \
+		-DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
 		-DWAMR_BUILD_TARGET=$(WAMR_BUILD_TARGET) \
 		-DWAMR_BUILD_PLATFORM=$(WAMR_BUILD_PLATFORM) \
 		-DWAMR_BUILD_MEMORY64=1 \


### PR DESCRIPTION
## Summary
This PR fixes a build failure in the WAMR pre-compile step by replacing a platform-specific in-place `sed` edit with a portable, idempotent patch step.

## Root cause
- The previous `sed -i` command worked on GNU `sed` but fails on BSD/macOS `sed`.
- Newer CMake versions can fail on WAMR's older policy expectations.

## Changes
- Replaced the `sed -i` insertion with a guarded `awk`-based insertion so the patch works on macOS and Linux and does not duplicate on repeated builds.
- Added `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` to the WAMR `cmake` invocation for compatibility with newer CMake releases.

## Validation
- Ran `rebar3 compile` successfully after the change.
- Verified the inserted `tbl_inst->is_table64 = 1;` line appears exactly once in the patched WAMR source.