### PR TITLE
feat: reverse index

### DIFF
--- a/src/dev_match.erl
+++ b/src/dev_match.erl
@@ -107,11 +107,13 @@ write(IDs, Base, Opts) ->
                     ValuePath = value_path(Value, Opts),
                     lists:foreach(
                         fun(ID) ->
-                            hb_store:write(
-                                Store,
-                                address(Key, ValuePath, ID),
-                                <<"">>
-                            )
+                            Address = address(Key, ValuePath, ID),
+                            ?event(
+                                debug_match,
+                                {writing_reverse_index, {address, Address},
+                                Opts
+                            }),
+                            hb_store:write(Store, Address, <<"">>)
                         end,
                         IDs
                     )

--- a/src/dev_match.erl
+++ b/src/dev_match.erl
@@ -1,0 +1,170 @@
+%%% @doc A reverse index for finding all message IDs with a given key-value pair.
+-module(dev_match).
+-export([info/0, all/3, write/3]).
+-include("include/hb.hrl").
+
+-define(CACHE_PREFIX, <<"~match@1.0">>).
+
+%% @doc Default all non-message@1.0 and device keys to match a single key in the
+%% index.
+info() ->
+    #{
+        excludes =>
+            [<<"set">>, <<"remove">>, <<"id">>, <<"verify">>, <<"write">>],
+        default => fun match/4
+    }.
+
+%% @doc Get the store configured for the match index.
+store(Opts) ->
+    LocalMatchIndex = local_opt(match_index, Opts, undefined),
+    LocalStore = local_opt(store, Opts, undefined),
+    GlobalMatchIndex = hb_opts:get(match_index, false, #{ only => global }),
+    MatchIndexStore =
+        case {LocalMatchIndex, LocalStore} of
+            {undefined, undefined} ->
+                GlobalMatchIndex;
+            {undefined, _} ->
+                LocalStore;
+            {Local, Store}
+                    when Store =/= undefined andalso
+                        Local =:= GlobalMatchIndex ->
+                Store;
+            {Local, _} ->
+                Local
+        end,
+    case MatchIndexStore of
+        false -> [];
+        true -> hb_opts:get(store, [], Opts);
+        ResolvedStore when not is_list(ResolvedStore) -> [ResolvedStore];
+        ResolvedStore -> ResolvedStore
+    end.
+
+%% @doc Read a local option from either atom or binary key shape.
+local_opt(Key, Opts, Default) ->
+    case maps:find(Key, Opts) of
+        {ok, Value} ->
+            Value;
+        error ->
+            case maps:find(atom_to_binary(Key), Opts) of
+                {ok, Value} -> Value;
+                error -> Default
+            end
+    end.
+
+%% @doc Calculate the address of a key-value pair in the match index. We use the
+%% 'as device with key=value' form of hashpath such that triple is only two
+%% messages, as is typical for AO-Core.
+address(Key, Value) ->
+    KeyBin = to_match_bin(Key),
+    ValueBin = to_match_bin(Value),
+    iolist_to_binary([?CACHE_PREFIX, "&", KeyBin, "=", ValueBin]).
+address(Key, Value, ID) ->
+    IDBin = to_match_bin(ID),
+    <<(address(Key, Value))/binary, "/", IDBin/binary>>.
+
+to_match_bin(Bin) when is_binary(Bin) -> Bin;
+to_match_bin(Atom) when is_atom(Atom) -> atom_to_binary(Atom);
+to_match_bin(Int) when is_integer(Int) -> integer_to_binary(Int);
+to_match_bin(Float) when is_float(Float) ->
+    float_to_binary(Float, [compact]);
+to_match_bin(List) when is_list(List) ->
+    try
+        iolist_to_binary(List)
+    catch
+        _:_ -> term_to_binary(List)
+    end;
+to_match_bin(Other) ->
+    term_to_binary(Other).
+
+%% @doc Return the path representation used by cache key-value links.
+value_path(Bin, Opts) when is_binary(Bin) ->
+    <<"data/", (hb_path:hashpath(Bin, Opts))/binary>>;
+value_path(Map, Opts) when is_map(Map) ->
+    hb_message:id(Map, none, Opts#{ linkify_mode => discard });
+value_path(List, Opts) when is_list(List) ->
+    case io_lib:printable_unicode_list(List) of
+        true ->
+            value_path(iolist_to_binary(List), Opts);
+        false ->
+            value_path(
+                hb_message:convert(List, tabm, <<"structured@1.0">>, Opts),
+                Opts
+            )
+    end;
+value_path(Other, Opts) ->
+    value_path(hb_path:to_binary(Other), Opts).
+
+%% @doc Write all keys in the base message to the match index. Expects the `Base'
+%% message to already be converted to a TABM.
+write(IDs, Base, Opts) ->
+    case store(Opts) of
+        [] -> {skip, <<"No store configured for match index.">>};
+        Store ->
+            IndexBase = hb_message:uncommitted(hb_private:reset(Base)),
+            hb_maps:map(
+                fun(RawKey, Value) ->
+                    Key = hb_ao:normalize_key(RawKey),
+                    ValuePath = value_path(Value, Opts),
+                    lists:foreach(
+                        fun(ID) ->
+                            hb_store:write(
+                                Store,
+                                address(Key, ValuePath, ID),
+                                <<"">>
+                            )
+                        end,
+                        IDs
+                    )
+                end,
+                IndexBase
+            )
+    end.
+
+%% @doc Match a single key-value pair in the index, returning all message IDs that
+%% contain the key-value pair.
+match(Key, Base, _Req, Opts) -> match(Key, Base, Opts).
+match(Key, Base, Opts) ->
+    Store = store(Opts),
+    {ok, Value} = hb_maps:find(Key, Base, Opts),
+    case hb_store:list(
+        Store,
+        address(
+            hb_ao:normalize_key(Key),
+            value_path(Value, Opts)
+        )
+    ) of
+        {ok, Messages} -> {ok, Messages};
+        _ -> {error, not_found}
+    end.
+
+%% @doc Match the full base message against the index, returning the intersection
+%% of all matches for each key.
+all(Base, _Req, Opts) ->
+    IndexBase = hb_message:uncommitted(hb_private:reset(Base)),
+    Keys =
+        hb_maps:keys(
+            IndexBase
+        ),
+    case Keys of
+        [] -> {ok, []};
+        [FirstKey | Rest] ->
+            case match(FirstKey, IndexBase, Opts) of
+                {ok, FirstMatches} ->
+                    lists:foldl(
+                        fun(Key, {ok, Acc}) ->
+                            case match(Key, IndexBase, Opts) of
+                                {ok, Matches} ->
+                                    {ok, hb_util:list_with(Acc, Matches)};
+                                _ ->
+                                    {error, not_found}
+                            end;
+                           (_Key, Error) ->
+                                Error
+                        end,
+                        {ok, FirstMatches},
+                        Rest
+                    );
+                _ ->
+                    {error, not_found}
+            end
+    end.

--- a/src/dev_query.erl
+++ b/src/dev_query.erl
@@ -141,37 +141,73 @@ match(UserSpec, _Base, Req, Opts) ->
     ReturnType = hb_maps:get(<<"return">>, Req, <<"paths">>, Opts),
     ?event({matching, {spec, FilteredSpec}, {return, ReturnType}}),
     case hb_cache:match(FilteredSpec, Opts) of
-        {ok, Matches} when ReturnType == <<"count">> ->
-            ?event({matched, {paths, Matches}}),
-            {ok, length(Matches)};
-        {ok, Matches} when ReturnType == <<"paths">> ->
-            ?event({matched, {paths, Matches}}),
-            {ok, Matches};
-        {ok, Matches} when ReturnType == <<"messages">> ->
-            ?event({matched, {paths, Matches}}),
-            Messages =
-                lists:map(
-                    fun(Path) ->
-                        hb_util:ok(hb_cache:read(Path, Opts))
-                    end,
-                    Matches
-                ),
-            ?event({matched, {messages, Messages}}),
-            {ok, Messages};
-        {ok, Matches} when ReturnType == <<"first-path">> ->
-            ?event({matched, {paths, Matches}}),
-            {ok, hd(Matches)};
-        {ok, Matches} when ReturnType == <<"first">>
-                orelse ReturnType == <<"first-message">> ->
-            ?event({matched, {paths, Matches}}),
-            {ok, hb_util:ok(hb_cache:read(hd(Matches), Opts))};
-        {ok, Matches} when ReturnType == <<"boolean">> ->
-            ?event({matched, {paths, Matches}}),
-            {ok, length(Matches) > 0};
+        {ok, RawMatches} ->
+            Matches = dedupe_query_matches(RawMatches, Opts),
+            case ReturnType of
+                <<"count">> ->
+                    ?event({matched, {paths, Matches}}),
+                    {ok, length(Matches)};
+                <<"paths">> ->
+                    ?event({matched, {paths, Matches}}),
+                    {ok, Matches};
+                <<"messages">> ->
+                    ?event({matched, {paths, Matches}}),
+                    Messages =
+                        lists:map(
+                            fun(Path) ->
+                                hb_util:ok(hb_cache:read(Path, Opts))
+                            end,
+                            Matches
+                        ),
+                    ?event({matched, {messages, Messages}}),
+                    {ok, Messages};
+                <<"first-path">> ->
+                    ?event({matched, {paths, Matches}}),
+                    {ok, hd(Matches)};
+                <<"first">> ->
+                    ?event({matched, {paths, Matches}}),
+                    {ok, hb_util:ok(hb_cache:read(hd(Matches), Opts))};
+                <<"first-message">> ->
+                    ?event({matched, {paths, Matches}}),
+                    {ok, hb_util:ok(hb_cache:read(hd(Matches), Opts))};
+                <<"boolean">> ->
+                    ?event({matched, {paths, Matches}}),
+                    {ok, length(Matches) > 0}
+            end;
         not_found when ReturnType == <<"boolean">> ->
             {ok, false};
         not_found ->
             {error, not_found}
+    end.
+
+dedupe_query_matches(Matches, Opts) ->
+    {_, DedupedRev} =
+        lists:foldl(
+            fun(Path, {Seen, Acc}) ->
+                Key = query_match_key(Path, Opts),
+                case maps:is_key(Key, Seen) of
+                    true ->
+                        {Seen, Acc};
+                    false ->
+                        {maps:put(Key, true, Seen), [Path | Acc]}
+                end
+            end,
+            {#{}, []},
+            Matches
+        ),
+    lists:reverse(DedupedRev).
+
+query_match_key(Path, Opts) ->
+    case hb_cache:read(Path, Opts) of
+        {ok, Msg} when is_map(Msg) ->
+            CanonicalMsg =
+                hb_message:uncommitted_deep(
+                    hb_private:reset(hb_cache:ensure_all_loaded(Msg, Opts)),
+                    Opts
+                ),
+            hb_message:id(CanonicalMsg, none, Opts#{ linkify_mode => discard });
+        _ ->
+            Path
     end.
 
 %%% Tests

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -1617,20 +1617,24 @@ http_init(Opts) ->
     {Node, ExtendedOpts}.
 
 http_post_schedule_sign(Node, Msg, ProcessMsg, Opts) ->
-    Base = hb_message:commit(#{
-        <<"path">> => <<"/~scheduler@1.0/schedule">>,
-        <<"method">> => <<"POST">>,
-        <<"body">> =>
-            hb_message:commit(
-                Msg#{
-                    <<"target">> =>
-                        hb_util:human_id(hb_message:id(ProcessMsg, all)),
-                    <<"type">> => <<"Message">>
-                },
-                Opts
-            )
-    }, Opts),
-    hb_http:post(Node, Base, #{}).
+    Base =
+        hb_message:commit(
+            #{
+                <<"path">> => <<"/~scheduler@1.0/schedule">>,
+                <<"method">> => <<"POST">>,
+                <<"body">> =>
+                    hb_message:commit(
+                        Msg#{
+                            <<"target">> =>
+                                hb_util:human_id(hb_message:id(ProcessMsg, all, Opts)),
+                            <<"type">> => <<"Message">>
+                        },
+                        Opts
+                    )
+            },
+            Opts
+        ),
+    hb_http:post(Node, Base, Opts).
 
 http_get_slot(N, PMsg) ->
     ID = hb_message:id(PMsg, all),

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -198,19 +198,33 @@ list(Path, Store) ->
 %% @doc Match a template message against the cache, returning a list of IDs
 %% that match the template. We match on the binary representation of values,
 %% rather than their types explicitly, such that 'AO-Types' keys that are
-%% only partial matches do not cause the match to fail.
+%% only partial matches do not cause the match to fail. If the `match_index' key
+%% is set, indicating the presence and usage of the `~match@1.0` device, we use
+%% it to find the matching messages. This lowers the complexity class of the
+%% match to `O(keys * log(cache_size))` instead of `O(cache_size)`.
 match(MatchSpec, Opts) ->
     Spec = hb_message:convert(MatchSpec, tabm, <<"structured@1.0">>, Opts),
-    ConvertedMatchSpec =
-        maps:map(
-            fun(_, Value) ->
-                generate_binary_path(Value, Opts)
-            end,
-            maps:without([<<"ao-types">>], hb_ao:normalize_keys(Spec, Opts))
-        ),
-    case hb_store:match(hb_opts:get(store, no_viable_store, Opts), ConvertedMatchSpec) of
-        {ok, Matches} -> {ok, Matches};
-        _ -> not_found
+    NormalizedSpec = maps:without([<<"ao-types">>], hb_ao:normalize_keys(Spec, Opts)),
+    case hb_opts:get(match_index, false, Opts) of
+        false ->
+            ConvertedMatchSpec =
+                maps:map(
+                    fun(_, Value) ->
+                        generate_binary_path(Value, Opts)
+                    end,
+                    NormalizedSpec
+                ),
+            case hb_store:match(hb_opts:get(store, no_viable_store, Opts), ConvertedMatchSpec) of
+                {ok, []} -> not_found;
+                {ok, Matches} -> {ok, Matches};
+                _ -> not_found
+            end;
+        _ ->
+            case dev_match:all(NormalizedSpec, #{}, Opts) of
+                {ok, []} -> not_found;
+                {ok, Matches} -> {ok, Matches};
+                _ -> not_found
+            end
     end.
 
 %% @doc Generate the path at which a binary value should be stored.
@@ -259,7 +273,8 @@ write(Bin, Opts) when is_binary(Bin) ->
 do_write_message(Bin, Store, Opts) when is_binary(Bin) ->
     % Write the binary in the store at its calculated content-hash.
     % Return the path.
-    ok = hb_store:write(Store, Path = generate_binary_path(Bin, Opts), Bin),
+    Path = generate_binary_path(Bin, Opts),
+    hb_store:write(Store, Path, Bin),
     %lists:map(fun(ID) -> hb_store:make_link(Store, Path, ID) end, AllIDs),
     {ok, Path};
 do_write_message(List, Store, Opts) when is_list(List) ->
@@ -272,7 +287,8 @@ do_write_message(Msg, Store, Opts) when is_map(Msg) ->
     ?event(debug_cache, {writing_message, Msg}),
     % Calculate the IDs of the message.
     UncommittedID = hb_message:id(Msg, none, Opts#{ linkify_mode => discard }),
-    AltIDs = calculate_all_ids(Msg, Opts) -- [UncommittedID],
+    AllIDs = calculate_all_ids(Msg, Opts),
+    AltIDs = AllIDs -- [UncommittedID],
     MsgHashpathAlg = hb_path:hashpath_alg(Msg, Opts),
     ?event(debug_cache, {writing_message, {id, UncommittedID}, {alt_ids, AltIDs}, {original, Msg}}),
     % Write all of the keys of the message into the store.
@@ -283,6 +299,8 @@ do_write_message(Msg, Store, Opts) when is_map(Msg) ->
         end,
         maps:without([<<"priv">>], Msg)
     ),
+    % Optionally store the message into the match index, if the index is configured.
+    dev_match:write(AllIDs, Msg, Opts),
     % Write the commitments to the store, linking each commitment ID to the
     % uncommitted message.
     lists:map(
@@ -305,7 +323,7 @@ write_key(Base, <<"commitments">>, _HPAlg, RawCommitments, Store, Opts) ->
     % and link it to `baseCommHP/commitmentID`.
     Commitments = prepare_commitments(RawCommitments, Opts),
     CommitmentsBase = commitment_path(Base, Opts),
-    ok = hb_store:make_group(Store, CommitmentsBase),
+    hb_store:make_group(Store, CommitmentsBase),
     ?event(
         {writing_commitments,
             {base, Base},

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -503,6 +503,7 @@ default_message() ->
                     <<"local-store">> => [?DEFAULT_PRIMARY_STORE]
                 }
             ],
+        match_index => [?DEFAULT_PRIMARY_STORE],
         priv_store =>
             [
                 #{


### PR DESCRIPTION
Implements an optional reverse indexer device and appropriate calls in `hb_cache`. This feature removes the need for table scans in order to  service `hb_cache:match` or (downstream) `~query@1.0[/arweave]` requests.

The device works by creating a pseudo-path index of the form `~match@1.0&[key]=[value]/[ID]`, such that all message IDs featuring the given key and value pair can be listed by omitting all the characters after the `/`.