### PR TITLE
fix: `/raw` route normalization

### DIFF
--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -105,7 +105,7 @@ data(ID, Opts) ->
     Req = #{
         <<"multirequest-accept-status">> => 200,
         <<"multirequest-responses">> => 1,
-        <<"path">> => <<"/raw/", ID/binary>>,
+        <<"path">> => <<"/arweave/raw/", ID/binary>>,
         <<"method">> => <<"GET">>
     },
     case hb_http:request(Req, Opts) of

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -440,6 +440,16 @@ default_message() ->
                 <<"stop-after">> => true,
                 <<"admissible-status">> => 200
             },
+            % Raw data requests via arweave.net gateway.
+            #{
+                <<"template">> => <<"^/arweave/raw">>,
+                <<"node">> =>
+                    #{
+                        <<"match">> => <<"^/arweave">>,
+                        <<"with">> => <<"https://arweave.net">>,
+                        <<"opts">> => #{ http_client => gun, protocol => http2 }
+                    }
+            },
             %% General Arweave requests: race both chain nodes, take
             %% the first 200.
             #{


### PR DESCRIPTION
A prior PR moved the route for `arweave/raw` to a higher position in the default precedence order. This PR did not also change `hb_store_gateway`, however, which was still dependent on the `/raw` (not `/arweave/raw`) route. This PR fixes both `~arweave` and `hb_store_gateway` and its client.
