### PR TITLE
fixes(omnibus): JSON types in nested lists; `~query@1.0` ID choice; parallel test exec; and `eunit` quiet mode

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,11 @@
 {erl_opts, [debug_info, {d, 'COWBOY_QUICER', 1}, {d, 'GUN_QUICER', 1}]}.
 {plugins, [pc, rebar3_rustler, rebar_edown_plugin]}.
 
+% Increase `scale_timeouts` when running on a slower machine.
+{eunit_opts, [verbose, {scale_timeouts, 10}]}.
+
 {profiles, [
+    {quiet, [{eunit_opts, [{verbose, false}, {scale_timeouts, 10}]}]},
     {no_events, [{erl_opts, [{d, 'NO_EVENTS', true}]}]},
     {top, [{deps, [observer_cli]}, {erl_opts, [{d, 'AO_TOP', true}]}]},
     {store_events, [{erl_opts, [{d, 'STORE_EVENTS', true}]}]},
@@ -138,9 +142,6 @@
 {eunit, [
 	{apps, [hb]}
 ]}.
-
-% Increase `scale_timeouts` when running on a slower machine.
-{eunit_opts, [verbose, {scale_timeouts, 10}]}.
 
 {relx, [
 	{release, {'hb', "0.0.1"}, [hb, b64fast, cowboy, gun, luerl, prometheus, prometheus_cowboy, elmdb]},

--- a/src/dev_codec_json.erl
+++ b/src/dev_codec_json.erl
@@ -36,27 +36,28 @@ to(Msg, Req, Opts) ->
     {ok, JSONStructured} =
         dev_codec_structured:from(
             Loaded,
-            Req#{ <<"encode-types">> => [<<"atom">>] },
+            Req,%#{ <<"encode-types">> => [<<"atom">>] },
             Opts
         ),
     {ok, hb_json:encode(JSONStructured)}.
 
 %% @doc Decode a JSON string to a message.
 from(Map, _Req, _Opts) when is_map(Map) -> {ok, Map};
-from(JSON, _Req, Opts) ->
+from(JSON, Req, Opts) ->
     % The JSON string will be a partially-TABM encoded message: Rich number
     % and list types, but no `atom's. Subsequently, we convert it to a fully
     % structured message after decoding, then turn the result back into a TABM.
     % This is resource-intensive and could be improved, but ensures that the
     % results are fully normalized.
-    Decoded = json:decode(JSON),
     {ok, Structured} =
         dev_codec_structured:to(
-            Decoded,
+            json:decode(JSON),
             #{},
             Opts
         ),
-    {ok, TABM} = dev_codec_structured:from(Structured, #{}, Opts),
+    ?event(debug_json, {structured, Structured}, Opts),
+    {ok, TABM} = dev_codec_structured:from(Structured, Req, Opts),
+    ?event(debug_json, {tabm, TABM}, Opts),
     {ok, TABM}.
 
 commit(Msg, Req, Opts) -> dev_codec_httpsig:commit(Msg, Req, Opts).
@@ -123,7 +124,7 @@ decode_with_atom_test() ->
         hb_cache:ensure_all_loaded(Msg, #{})
     ).
 
-roundtrip_with_deeply_nested_atoms_test() ->
+deeply_nested_typed_keys_test() ->
     Opts = #{ store => [hb_test_utils:test_store()] },
     Msg = #{
         <<"message">> =>

--- a/src/dev_codec_json.erl
+++ b/src/dev_codec_json.erl
@@ -122,3 +122,35 @@ decode_with_atom_test() ->
         [#{ <<"store-module">> := hb_store_fs }|_],
         hb_cache:ensure_all_loaded(Msg, #{})
     ).
+
+roundtrip_with_deeply_nested_atoms_test() ->
+    Opts = #{ store => [hb_test_utils:test_store()] },
+    Msg = #{
+        <<"message">> =>
+            [
+                #{
+                    <<"deep-integer">> => 456,
+                    <<"deep-atom">> => atom,
+                    <<"deep-list">> => [1,2,3]
+                }
+            ]
+    },
+    Encoded =
+        hb_message:convert(
+            Msg,
+            #{
+                <<"device">> => <<"json@1.0">>,
+                <<"bundle">> => true
+            },
+            Opts
+        ),
+    ?event(debug_json, {encoded, Encoded}, Opts),
+    Decoded =
+        hb_message:convert(
+            Encoded,
+            <<"structured@1.0">>,
+            <<"json@1.0">>,
+            Opts
+        ),
+    ?event(debug_json, {decoded, Decoded}, Opts),
+    ?assert(hb_message:match(Msg, Decoded, strict, Opts)).

--- a/src/dev_codec_json.erl
+++ b/src/dev_codec_json.erl
@@ -28,15 +28,13 @@ to(Msg, Req, Opts) ->
         ),
     Loaded =
         case hb_maps:get(<<"bundle">>, Req, false, Opts) of
-            true ->
-                hb_cache:ensure_all_loaded(Restructured, Opts);
-            false ->
-                Restructured
+            true -> hb_cache:ensure_all_loaded(Restructured, Opts);
+            false -> Restructured
         end,
     {ok, JSONStructured} =
         dev_codec_structured:from(
             Loaded,
-            Req,%#{ <<"encode-types">> => [<<"atom">>] },
+            Req#{ <<"encode-types">> => [<<"atom">>] },
             Opts
         ),
     {ok, hb_json:encode(JSONStructured)}.

--- a/src/dev_codec_structured.erl
+++ b/src/dev_codec_structured.erl
@@ -196,7 +196,7 @@ to(TABM0, Req, Opts) ->
                     {ok, Type} ->
                         Acc#{ RawKey => decode_value(Type, BinValue) }
                 end;
-            (RawKey, ChildTABM, Acc) when is_map(ChildTABM) ->
+            (RawKey, ChildTABM, Acc) when is_map(ChildTABM) or is_list(ChildTABM) ->
                 % Decode the child TABM
                 Acc#{
                     RawKey => hb_util:ok(to(ChildTABM, Req, Opts))

--- a/src/dev_query_arweave.erl
+++ b/src/dev_query_arweave.erl
@@ -299,7 +299,7 @@ all_ids(ID, Opts) ->
     case hb_store:list(Store, << ID/binary, "/commitments">>) of
         {ok, []} -> [ID];
         {ok, CommitmentIDs} -> CommitmentIDs;
-        _ -> []
+        _ -> [ID]
     end.
 
 %% @doc Scope the stores used for block matching. The searched stores can be

--- a/src/hb_ao_test_vectors.erl
+++ b/src/hb_ao_test_vectors.erl
@@ -117,18 +117,20 @@ benchmark_suite() ->
     ].
 
 test_opts() ->
+    CachedExecStore = hb_test_utils:test_store(),
     [
         #{
             name => normal,
             desc => "Default opts",
-            opts => #{},
+            opts => #{ store => hb_test_utils:test_store() },
             skip => []
         },
         #{
             name => without_hashpath,
             desc => "Default without hashpath",
             opts => #{
-                hashpath => ignore
+                hashpath => ignore,
+                store => hb_test_utils:test_store()
             },
             skip => []
         },
@@ -139,10 +141,7 @@ test_opts() ->
                 hashpath => ignore,
                 cache_control => [<<"no-cache">>, <<"no-store">>],
                 spawn_worker => false,
-                store => #{
-                    <<"store-module">> => hb_store_fs,
-                    <<"name">> => <<"cache-TEST/fs">>
-                }
+                store => hb_test_utils:test_store()
             },
             skip => [load_as]
         },
@@ -153,10 +152,7 @@ test_opts() ->
                 hashpath => update,
                 cache_control => [<<"no-cache">>],
                 spawn_worker => false,
-                store => #{
-                    <<"store-module">> => hb_store_fs,
-                    <<"name">> => <<"cache-TEST/fs">>
-                }
+                store => CachedExecStore
             },
             skip => [
                 denormalized_device_name,
@@ -172,10 +168,7 @@ test_opts() ->
                 hashpath => ignore,
                 cache_control => [<<"only-if-cached">>],
                 spawn_worker => false,
-                store => #{
-                    <<"store-module">> => hb_store_fs,
-                    <<"name">> => <<"cache-TEST/fs">>
-                }
+                store => CachedExecStore
             },
             skip => [
                 % Skip test with locally defined device, amongst others.
@@ -849,6 +842,8 @@ load_as_test(Opts) ->
         <<"test_func">> => #{ <<"test_key">> => <<"MESSAGE">> }
     },
     {ok, ID} = hb_cache:write(Msg, Opts),
+    {ok, ReadMsg} = hb_cache:read(ID, Opts),
+    ?assert(hb_message:match(Msg, ReadMsg, primary, Opts)),
     ?assertEqual(
         {ok, <<"MESSAGE">>},
         hb_ao:resolve_many(

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -1072,93 +1072,105 @@ normalize_unsigned(PrimMsg, Req = #{ headers := RawHeaders }, Msg, Opts) ->
 
 %%% Tests
 
+test_opts() ->
+    #{ store => hb_test_utils:test_store(), priv_wallet => hb:wallet() }.
+
 simple_ao_resolve_unsigned_test() ->
     URL = hb_http_server:start_node(),
     TestMsg = #{ <<"path">> => <<"/key1">>, <<"key1">> => <<"Value1">> },
-    ?assertEqual({ok, <<"Value1">>}, post(URL, TestMsg, #{})).
+    ?assertEqual({ok, <<"Value1">>}, post(URL, TestMsg, test_opts())).
 
 simple_ao_resolve_signed_test() ->
     URL = hb_http_server:start_node(),
     TestMsg = #{ <<"path">> => <<"/key1">>, <<"key1">> => <<"Value1">> },
-    Wallet = hb:wallet(),
     {ok, Res} =
         post(
             URL,
-            hb_message:commit(TestMsg, #{ priv_wallet => Wallet }),
-            #{}
+            hb_message:commit(TestMsg, test_opts()),
+            test_opts()
         ),
     ?assertEqual(<<"Value1">>, Res).
 
 nested_ao_resolve_test() ->
     URL = hb_http_server:start_node(),
-    Wallet = hb:wallet(),
+    Opts = #{ store => hb_test_utils:test_store(), priv_wallet => hb:wallet() },
     {ok, Res} =
         post(
             URL,
-            hb_message:commit(#{
-                <<"path">> => <<"/key1/key2/key3">>,
-                <<"key1">> =>
-                    #{<<"key2">> =>
-                        #{
-                            <<"key3">> => <<"Value2">>
+            hb_message:commit(
+                #{
+                    <<"path">> => <<"/key1/key2/key3">>,
+                    <<"key1">> =>
+                        #{<<"key2">> =>
+                            #{
+                                <<"key3">> => <<"Value2">>
+                            }
                         }
-                    }
-            }, #{ priv_wallet => Wallet }),
-            #{}
+                },
+                Opts
+            ),
+            Opts
         ),
     ?assertEqual(<<"Value2">>, Res).
 
-wasm_compute_request(ImageFile, Func, Params) ->
-    wasm_compute_request(ImageFile, Func, Params, <<"">>).
-wasm_compute_request(ImageFile, Func, Params, ResultPath) ->
+wasm_compute_request(ImageFile, Func, Params, Opts) ->
+    wasm_compute_request(ImageFile, Func, Params, <<"">>, Opts).
+wasm_compute_request(ImageFile, Func, Params, ResultPath, Opts) ->
     {ok, Bin} = file:read_file(ImageFile),
-    Wallet = hb:wallet(),
-    hb_message:commit(#{
-        <<"path">> => <<"/init/compute/results", ResultPath/binary>>,
-        <<"device">> => <<"wasm-64@1.0">>,
-        <<"function">> => Func,
-        <<"parameters">> => Params,
-        <<"body">> => Bin
-    }, #{ priv_wallet => Wallet }).
+    hb_message:commit(
+        #{
+            <<"path">> => <<"/init/compute/results", ResultPath/binary>>,
+            <<"device">> => <<"wasm-64@1.0">>,
+            <<"function">> => Func,
+            <<"parameters">> => Params,
+            <<"body">> => Bin
+        },
+        Opts
+    ).
 
 run_wasm_unsigned_test() ->
-    Node = hb_http_server:start_node(#{force_signed => false}),
-    Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [3.0]),
-    {ok, Res} = post(Node, Msg, #{}),
+    Node = hb_http_server:start_node(#{ force_signed => false }),
+    LocalOpts = test_opts(),
+    Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [3.0], LocalOpts),
+    {ok, Res} = post(Node, Msg, LocalOpts),
     ?event({res, Res}),
-    ?assertEqual(6.0, hb_ao:get(<<"output/1">>, Res, #{})).
+    ?assertEqual(6.0, hb_ao:get(<<"output/1">>, Res, LocalOpts)).
 
 run_wasm_signed_test() ->
-    Opts = #{ priv_wallet => hb:wallet() },
+    Opts = test_opts(),
     URL = hb_http_server:start_node(#{force_signed => true}),
-    Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [3.0], <<"">>),
+    Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [3.0], <<"">>, Opts),
     {ok, Res} = post(URL, hb_message:commit(Msg, Opts), Opts),
-    ?assertEqual(6.0, hb_ao:get(<<"output/1">>, Res, #{})).
+    ?assertEqual(6.0, hb_ao:get(<<"output/1">>, Res, Opts)).
 
 get_deep_unsigned_wasm_state_test() ->
     URL = hb_http_server:start_node(#{force_signed => false}),
-    Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [3.0], <<"">>),
-    {ok, Res} = post(URL, Msg, #{}),
-    ?assertEqual(6.0, hb_ao:get(<<"/output/1">>, Res, #{})).
+    LocalOpts = test_opts(),
+    Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [3.0], <<"">>, LocalOpts),
+    {ok, Res} = post(URL, Msg, LocalOpts),
+    ?assertEqual(6.0, hb_ao:get(<<"/output/1">>, Res, LocalOpts)).
 
 get_deep_signed_wasm_state_test() ->
     URL = hb_http_server:start_node(#{force_signed => true}),
+    LocalOpts = test_opts(),
     Msg =
         wasm_compute_request(
             <<"test/test-64.wasm">>,
             <<"fac">>,
             [3.0],
-            <<"/output">>
+            <<"/output">>,
+            LocalOpts
         ),
-    {ok, Res} = post(URL, Msg, #{}),
-    ?assertEqual(6.0, hb_ao:get(<<"1">>, Res, #{})).
+    {ok, Res} = post(URL, Msg, LocalOpts),
+    ?assertEqual(6.0, hb_ao:get(<<"1">>, Res, LocalOpts)).
 
 cors_get_test() ->
     URL = hb_http_server:start_node(),
-    {ok, Res} = get(URL, <<"/~meta@1.0/info">>, #{}),
+    LocalOpts = test_opts(),
+    {ok, Res} = get(URL, <<"/~meta@1.0/info">>, LocalOpts),
     ?assertEqual(
         <<"*">>,
-        hb_ao:get(<<"access-control-allow-origin">>, Res, #{})
+        hb_ao:get(<<"access-control-allow-origin">>, Res, LocalOpts)
     ).
 
 ans104_wasm_test() ->

--- a/src/hb_message_test_vectors.erl
+++ b/src/hb_message_test_vectors.erl
@@ -37,6 +37,7 @@ suite_test_opts() ->
     [
         #{
             name => normal,
+            parallel => true,
             desc => <<"Default opts">>,
             opts => test_opts(normal)
         }

--- a/src/hb_message_test_vectors.erl
+++ b/src/hb_message_test_vectors.erl
@@ -9,8 +9,8 @@
 %% Disable/enable as needed.
 run_test() ->
     hb:init(),
-    nested_empty_map_test(
-        <<"structured@1.0">>,
+    sign_node_message_test(
+        #{ <<"device">> => <<"json@1.0">>, <<"bundle">> => true },
         test_opts(normal)
     ).
 

--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -500,6 +500,7 @@ remote_hyperbeam_node_ans104_test() ->
             store => hb_test_utils:test_store()
         },
     Server = hb_http_server:start_node(ServerOpts),
+    ?debug_wait(1000),
     Msg =
         hb_message:commit(
             #{
@@ -524,6 +525,7 @@ remote_hyperbeam_node_ans104_test() ->
                     }
                 ]
         },
+    ?debug_wait(1000),
     {ok, Req} = hb_cache:read(ID, ClientOpts),
     ?assert(hb_message:verify(Req)),
     ?assert(hb_message:match(Msg, Req)).

--- a/src/hb_test_utils.erl
+++ b/src/hb_test_utils.erl
@@ -46,32 +46,37 @@ suite_with_opts(Suite, OptsList) ->
             Skip = hb_maps:get(skip, OptSpec, [], Opts),
             case satisfies_requirements(OptSpec) of
                 true ->
-                    {true, {foreach,
-                        fun() ->
-                            ?event({starting, Store}),
-                            % Create and set a random server ID for the test
-                            % process.
-                            hb_http_server:set_proc_server_id(
-                                hb_util:human_id(crypto:strong_rand_bytes(32))
-                            ),
-                            hb_store:reset(Store),
-                            hb_store:start(Store)
-                        end,
-                        fun(_) ->
-                            hb_store:reset(Store),
-                            ok
-                        end,
-                        [
-                            {
-                                hb_util:list(ODesc)
-                                    ++ ": "
-                                    ++ hb_util:list(TestDesc),
-                                fun() -> Test(Opts) end}
-                        ||
-                            {TestAtom, TestDesc, Test} <- Suite, 
-                                not lists:member(TestAtom, Skip)
-                        ]
-                    }};
+                    Each = 
+                        {foreach,
+                            fun() ->
+                                ?event({starting, Store}),
+                                % Create and set a random server ID for the test
+                                % process.
+                                hb_http_server:set_proc_server_id(
+                                    hb_util:human_id(crypto:strong_rand_bytes(32))
+                                ),
+                                hb_store:reset(Store),
+                                hb_store:start(Store)
+                            end,
+                            fun(_) ->
+                                hb_store:reset(Store),
+                                ok
+                            end,
+                            [
+                                {
+                                    hb_util:list(ODesc)
+                                        ++ ": "
+                                        ++ hb_util:list(TestDesc),
+                                    fun() -> Test(Opts) end}
+                            ||
+                                {TestAtom, TestDesc, Test} <- Suite, 
+                                    not lists:member(TestAtom, Skip)
+                            ]
+                        },
+                    case maps:get(parallel, OptSpec, true) of
+                        true -> {true, {inparallel, Each}};
+                        false -> {true, Each}
+                    end;
                 false -> false
             end
         end,


### PR DESCRIPTION
- Fixes an issue where restructuring was not applied recursively to lists during JSON decoding.
- Introduces a new test case (`deeply_nested_typed_keys_test`) to verify correct handling of deeply nested typed keys during JSON conversion.
- Ensures that at least the known ID is always returned in  `~query@1.0`s `all_ids` function.
- Execute tests in parallel by default in `hb_ao_test_vectors` and `hb_message_test_vectors`. All suites that use the `hb_test_util`s will now also execute in parallel by default.
- Introduce `rebar3 as quiet eunit` for reduced test prints during eunit runs.

After these edits there are no deterministic test failures on edge and test flakiness is relatively rare (often 0 out of 1431 tests, but sometimes 1 or 2).