### PR TITLE
impr: test suite execution performance

### DIFF
--- a/src/dev_bundler.erl
+++ b/src/dev_bundler.erl
@@ -257,7 +257,7 @@ idle_test() ->
     try
         ClientOpts = #{},
         Node = hb_http_server:start_node(NodeOpts#{
-            bundler_max_idle_time => 2000,
+            bundler_max_idle_time => 400,
             priv_wallet => hb:wallet(),
             store => hb_test_utils:test_store()
         }),
@@ -266,12 +266,12 @@ idle_test() ->
         ?assertMatch({ok, _}, post_data_item(Node, Item1, ClientOpts)),
         % Wait just to give the server a chance to post a transaction
         % (but it shouldn't)
-        timer:sleep(1000),
+        timer:sleep(150),
         ?assertEqual(0, length(hb_mock_server:get_requests(tx, 0, ServerHandle))),
         ?assertEqual(0, length(hb_mock_server:get_requests(chunk, 0, ServerHandle))),
         % Wait gain to give the server a chance to trip the max idle time.
         % It should *now* post a transaction.
-        timer:sleep(1000),
+        timer:sleep(300),
         TXs = hb_mock_server:get_requests(tx, 1, ServerHandle),
         ?assertEqual(1, length(TXs)),
         %% Wait for expected chunks
@@ -285,7 +285,7 @@ idle_test() ->
     end.
 
 dispatch_blocking_test() ->
-    BlockTime = 2000,
+    BlockTime = 500,
     Anchor = rand:bytes(32),
     Price = 12345,
     % NodeOpts redirects arweave gateway requests to the mock server.
@@ -462,9 +462,9 @@ test_api_error(Responses) ->
         ?assertMatch({ok, _}, post_data_item(Node, Item1, ClientOpts)),
         % Since there was an error either before or while posting the tx,
         % no bundles should be posted and no chunks should be posted.
-        TXs = hb_mock_server:get_requests(tx, 1, ServerHandle, 1000),
+        TXs = hb_mock_server:get_requests(tx, 1, ServerHandle, 200),
         ?assertEqual([], TXs),
-        Chunks = hb_mock_server:get_requests(chunk, 1, ServerHandle, 1000),
+        Chunks = hb_mock_server:get_requests(chunk, 1, ServerHandle, 200),
         ?assertEqual([], Chunks),
         % Now that we dispatch asynchronously, an error won't cause the
         % Item to remain in the queue. Instead we'll rely on the retry

--- a/src/dev_bundler_dispatch.erl
+++ b/src/dev_bundler_dispatch.erl
@@ -547,7 +547,9 @@ complete_task_sequence_test() ->
     try
         Opts = NodeOpts#{
             priv_wallet => hb:wallet(),
-            store => hb_test_utils:test_store()
+            store => hb_test_utils:test_store(),
+            retry_base_delay_ms => 100,
+            retry_jitter => 0
         },
         hb_http_server:start_node(Opts),
         Items = [new_data_item(1, 10, Opts), new_data_item(2, 10, Opts)],
@@ -595,7 +597,9 @@ post_tx_price_failure_retry_test() ->
         persistent_term:put(price_attempts, 0),
         Opts = NodeOpts#{
             priv_wallet => hb:wallet(),
-            store => hb_test_utils:test_store()
+            store => hb_test_utils:test_store(),
+            retry_base_delay_ms => 50,
+            retry_jitter => 0
         },
         hb_http_server:start_node(Opts),
         Items = [new_data_item(1, 10, Opts)],
@@ -630,7 +634,9 @@ post_tx_anchor_failure_retry_test() ->
         persistent_term:put(anchor_attempts, 0),
         Opts = NodeOpts#{
             priv_wallet => hb:wallet(),
-            store => hb_test_utils:test_store()
+            store => hb_test_utils:test_store(),
+            retry_base_delay_ms => 50,
+            retry_jitter => 0
         },
         hb_http_server:start_node(Opts),
         Items = [new_data_item(1, 10, Opts)],
@@ -665,11 +671,11 @@ post_tx_post_failure_retry_test() ->
     }),
     try
         persistent_term:put(tx_attempts, 0),
-        % Use short retry delays for testing (100ms base, with exponential backoff)
+        % Use short retry delays for testing.
         Opts = NodeOpts#{
             priv_wallet => hb:wallet(),
             store => hb_test_utils:test_store(),
-            retry_base_delay_ms => 100,
+            retry_base_delay_ms => 50,
             retry_jitter => 0  % Disable jitter for deterministic tests
         },
         hb_http_server:start_node(Opts),
@@ -707,7 +713,9 @@ post_proof_failure_retry_test() ->
         persistent_term:put(chunk_attempts, 0),
         Opts = NodeOpts#{
             priv_wallet => hb:wallet(),
-            store => hb_test_utils:test_store()
+            store => hb_test_utils:test_store(),
+            retry_base_delay_ms => 50,
+            retry_jitter => 0
         },
         hb_http_server:start_node(Opts),
         % Large enough for multiple chunks
@@ -741,7 +749,7 @@ rapid_dispatch_test() ->
         price => {200, integer_to_binary(Price)},
         tx_anchor => {200, hb_util:encode(Anchor)},
         tx => fun(_Req) ->
-            timer:sleep(1000),
+            timer:sleep(100),
             {200, <<"OK">>}
         end
     }),
@@ -813,7 +821,7 @@ one_bundle_fails_others_continue_test() ->
 parallel_task_execution_test() ->
     Anchor = rand:bytes(32),
     Price = 12345,
-    SleepTime = 1000,
+    SleepTime = 120,
     {ServerHandle, NodeOpts} = start_mock_gateway(#{
         price => {200, integer_to_binary(Price)},
         tx_anchor => {200, hb_util:encode(Anchor)},
@@ -843,7 +851,7 @@ parallel_task_execution_test() ->
         ElapsedTime = erlang:system_time(millisecond) - StartTime,
         ?assertEqual(10, length(Chunks)),
         % Should take ~2-3 seconds with parallelism, not 9+
-        ?assert(ElapsedTime < 5000, "ElapsedTime: " ++ integer_to_list(ElapsedTime)),
+        ?assert(ElapsedTime < 2000, "ElapsedTime: " ++ integer_to_list(ElapsedTime)),
         ok
     after
         cleanup_dispatcher(ServerHandle)
@@ -875,15 +883,15 @@ exponential_backoff_timing_test() ->
         Opts = NodeOpts#{
             priv_wallet => hb:wallet(),
             store => hb_test_utils:test_store(),
-            retry_base_delay_ms => 1000,
-            retry_max_delay_ms => 5000,  % Cap at 5000ms
+            retry_base_delay_ms => 100,
+            retry_max_delay_ms => 500,  % Cap at 500ms
             retry_jitter => 0  % Disable jitter for deterministic tests
         },
         hb_http_server:start_node(Opts),
         Items = [new_data_item(1, 10, Opts)],
         dispatch(Items, Opts),
         % Wait for TX to eventually succeed
-        TXs = hb_mock_server:get_requests(tx, FailCount+1, ServerHandle, 30000),
+        TXs = hb_mock_server:get_requests(tx, FailCount+1, ServerHandle, 5000),
         ?assertEqual(FailCount+1, length(TXs)),
         % Verify backoff respects cap
         Timestamps = lists:reverse(persistent_term:get(backoff_cap_timestamps, [])),
@@ -895,13 +903,12 @@ exponential_backoff_timing_test() ->
         Delay3 = T4 - T3,
         Delay4 = T5 - T4,
         Delay5 = T6 - T5,
-        % Expected: ~1000ms, ~2000ms, ~4000ms, ~5000ms (capped), ~5000ms (capped)
-        ?assert(Delay1 >= 800 andalso Delay1 =< 1500, Delay1),
-        ?assert(Delay2 >= 1800 andalso Delay2 =< 2500, Delay2),
-        ?assert(Delay3 >= 3800 andalso Delay3 =< 4500, Delay3),
-        % These should be capped at 5000ms, not 8000ms and 16000ms
-        ?assert(Delay4 >= 4800 andalso Delay4 =< 5500, Delay4),
-        ?assert(Delay5 >= 4800 andalso Delay5 =< 5500, Delay5),
+        % Expected: ~100ms, ~200ms, ~400ms, ~500ms (capped), ~500ms (capped)
+        ?assert(Delay1 >= 70 andalso Delay1 =< 200, Delay1),
+        ?assert(Delay2 >= 150 andalso Delay2 =< 300, Delay2),
+        ?assert(Delay3 >= 300 andalso Delay3 =< 500, Delay3),
+        ?assert(Delay4 >= 400 andalso Delay4 =< 700, Delay4),
+        ?assert(Delay5 >= 400 andalso Delay5 =< 700, Delay5),
         ok
     after
         persistent_term:erase(backoff_cap_attempts),
@@ -934,7 +941,7 @@ independent_task_retry_counts_test() ->
         Opts = NodeOpts#{
             priv_wallet => hb:wallet(),
             store => hb_test_utils:test_store(),
-            retry_base_delay_ms => 1000,
+            retry_base_delay_ms => 100,
             retry_jitter => 0  % Disable jitter for deterministic tests
         },
         hb_http_server:start_node(Opts),
@@ -1055,5 +1062,5 @@ start_mock_gateway(Responses) ->
 
 cleanup_dispatcher(ServerHandle) ->
     stop_dispatcher(),
-    timer:sleep(100), % Ensure dispatcher fully stops
+    timer:sleep(10), % Ensure dispatcher fully stops
     hb_mock_server:stop(ServerHandle).

--- a/src/dev_codec_http_auth.erl
+++ b/src/dev_codec_http_auth.erl
@@ -166,7 +166,8 @@ benchmark_pbkdf2_test() ->
         hb_test_utils:benchmark(
             fun() ->
                 hb_crypto:pbkdf2(sha256, Key, <<"salt">>, Iterations, KeyLength)
-            end
+            end,
+            0.5
         ),
     hb_test_utils:benchmark_print(
         <<"Derived">>,

--- a/src/dev_cron.erl
+++ b/src/dev_cron.erl
@@ -254,7 +254,7 @@ stop_every_test() ->
 	hb_name:register({<<"test">>, TestWorkerNameId}, TestWorkerPid),
 	% Create an "every" task that calls the test worker
 	EveryUrlPath = <<"/~cron@1.0/every?test-id=", TestWorkerNameId/binary, 
-				   "&interval=500-milliseconds",
+					   "&interval=200-milliseconds",
 				   "&cron-path=/~test-device@1.0/increment_counter">>,
 	{ok, #{ <<"body">> := CronTaskID }} = hb_http:get(Node, EveryUrlPath, #{}),
 	?event({cron_stop_every_test_created, CronTaskID}),
@@ -263,7 +263,7 @@ stop_every_test() ->
 	?assert(is_pid(CronWorkerPid)),
 	?assert(erlang:is_process_alive(CronWorkerPid)),
 	% Wait a bit to ensure the cron worker has run a few times
-	timer:sleep(1000),
+		timer:sleep(400),
 	% Call stop on the cron task using its ID
 	EveryStopPath = <<"/~cron@1.0/stop?task=", CronTaskID/binary>>,
 	{ok, EveryStopResult} = hb_http:get(Node, EveryStopPath, #{}),
@@ -311,7 +311,7 @@ once_executed_test() ->
 	% the test device should look up the worker via the id given 
 	{ok, #{ <<"body">> := _ReqMsgId }} = hb_http:get(Node, UrlPath, #{}),
 	% wait for the request to be processed
-	timer:sleep(1000),
+		timer:sleep(400),
 	% send a message to the worker to get the state
 	PID ! {get, self()},
 	% receive the state from the worker
@@ -333,7 +333,7 @@ every_worker_loop_test() ->
 	hb_name:register({<<"test">>, ID}, PID),
 	UrlPath =
         <<
-            "/~cron@1.0/500-milliseconds", 
+	            "/~cron@1.0/200-milliseconds", 
 		    "=\"/~test-device@1.0/increment_counter\"",
             "?test-id=",
             ID/binary
@@ -341,7 +341,7 @@ every_worker_loop_test() ->
 	?event({cron_every_test_send_url, UrlPath}),
 	{ok, #{ <<"body">> := ReqMsgId }} = hb_http:get(Node, UrlPath, #{}),
 	?event({cron_every_test_get_done, {req_id, ReqMsgId}}),
-	timer:sleep(1500),
+		timer:sleep(700),
 	PID ! {get, self()},
 	% receive the state from the worker
 	receive

--- a/src/dev_json_iface.erl
+++ b/src/dev_json_iface.erl
@@ -522,7 +522,7 @@ basic_aos_call_test_() ->
 
 aos_stack_benchmark_test_() ->
     {timeout, 20, fun() ->
-        BenchTime = 5,
+        BenchTime = 0.25,
         Opts = #{ store => hb_test_utils:test_store() },
         RawWASMMsg = generate_stack("test/aos-2-pure-xs.wasm", <<"WASM">>, Opts),
         Proc = hb_ao:get(<<"process">>, RawWASMMsg, Opts#{ hashpath => ignore }),
@@ -546,6 +546,6 @@ aos_stack_benchmark_test_() ->
             Iterations,
             BenchTime
         ),
-        ?assert(Iterations >= 10),
+        ?assert(Iterations >= 2),
         ok
     end}.

--- a/src/dev_lua.erl
+++ b/src/dev_lua.erl
@@ -639,7 +639,7 @@ ao_core_resolution_from_lua_test() ->
 
 %% @doc Benchmark the performance of Lua executions.
 direct_benchmark_test() ->
-    BenchTime = 3,
+    BenchTime = 0.25,
     {ok, Module} = file:read_file("test/test.lua"),
     Base = #{
         <<"device">> => <<"lua@5.3a">>,
@@ -745,7 +745,7 @@ pure_lua_process_benchmark_test_() ->
             })
     end}.
 pure_lua_process_benchmark(Opts) ->
-    BenchMsgs = 50,
+    BenchMsgs = 30,
     hb:init(),
     Process = generate_lua_process("test/test.lua", Opts),
     {ok, _} = hb_cache:write(Process, Opts),
@@ -810,7 +810,7 @@ aos_authority_not_trusted_test() ->
 %% @doc Benchmark the performance of Lua executions.
 aos_process_benchmark_test_() ->
     {timeout, 30, fun() ->
-        BenchMsgs = 10,
+        BenchMsgs = 6,
         Opts = #{
             process_async_cache => true,
             hashpath => ignore,

--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -457,10 +457,7 @@ is(initiator, Request, NodeMsg) ->
 
 %% @doc Test that we can get the node message.
 config_test() ->
-	StoreOpts = #{
-		<<"store-module">> => hb_store_fs,
-		<<"name">> => <<"cache-TEST">>
-	},
+	StoreOpts = hb_test_utils:test_store(),
     Node = hb_http_server:start_node(Opts = #{ test_config_item => <<"test">>, store => StoreOpts }),
     {ok, Res} = hb_http:get(Node, <<"/~meta@1.0/info">>, Opts),
     ?assertEqual(<<"test">>, hb_ao:get(<<"test_config_item">>, Res, Opts)).
@@ -481,10 +478,7 @@ priv_inaccessible_test() ->
 %% @doc Test that we can't set the node message if the request is not signed by
 %% the owner of the node.
 unauthorized_set_node_msg_fails_test() ->
-	StoreOpts = #{
-		<<"store-module">> => hb_store_fs,
-		<<"name">> => <<"cache-TEST">>
-	},
+	StoreOpts = hb_test_utils:test_store(),
     Node = hb_http_server:start_node(Opts = #{ store => StoreOpts, priv_wallet => ar_wallet:new() }),
     {error, _} =
         hb_http:post(
@@ -505,10 +499,7 @@ unauthorized_set_node_msg_fails_test() ->
 %% @doc Test that we can set the node message if the request is signed by the
 %% owner of the node.
 authorized_set_node_msg_succeeds_test() ->
-	StoreOpts = #{
-		<<"store-module">> => hb_store_fs,
-		<<"name">> => <<"cache-TEST">>
-	},
+	StoreOpts = hb_test_utils:test_store(),
     Owner = ar_wallet:new(),
     Node = hb_http_server:start_node(
         Opts = #{
@@ -544,10 +535,7 @@ uninitialized_node_test() ->
 
 %% @doc Test that a permanent node message cannot be changed.
 permanent_node_message_test() ->
-	StoreOpts = #{
-		<<"store-module">> => hb_store_fs,
-		<<"name">> => <<"cache-TEST">>
-	},
+	StoreOpts = hb_test_utils:test_store(),
     Owner = ar_wallet:new(),
     Node = hb_http_server:start_node(
         Opts =#{
@@ -594,10 +582,7 @@ permanent_node_message_test() ->
 
 %% @doc Test that we can claim the node correctly and set the node message after.
 claim_node_test() ->
-	StoreOpts = #{
-		<<"store-module">> => hb_store_fs,
-		<<"name">> => <<"cache-TEST">>
-	},
+	StoreOpts = hb_test_utils:test_store(),
     Owner = ar_wallet:new(),
     Address = ar_wallet:to_address(Owner),
     Node = hb_http_server:start_node(

--- a/src/dev_process_test_vectors.erl
+++ b/src/dev_process_test_vectors.erl
@@ -389,10 +389,7 @@ aos_state_access_via_http_test_() ->
             port => 10000 + rand:uniform(10000),
             priv_wallet => Wallet,
             cache_control => <<"always">>,
-            store => #{
-                <<"store-module">> => hb_store_fs,
-                <<"name">> => <<"cache-mainnet">>
-            },
+            store => hb_test_utils:test_store(),
             force_signed_requests => true
         }),
         Proc = aos_process(Opts),
@@ -585,7 +582,7 @@ persistent_process_test() ->
 
 simple_wasm_persistent_worker_benchmark_test() ->
     init(),
-    BenchTime = 1,
+    BenchTime = 0.05,
     Base = wasm_process(<<"test/test-64.wasm">>),
     schedule_wasm_call(Base, <<"fac">>, [5.0]),
     schedule_wasm_call(Base, <<"fac">>, [6.0]),
@@ -618,12 +615,12 @@ simple_wasm_persistent_worker_benchmark_test() ->
         "Scheduled and evaluated ~p simple wasm process messages in ~p s (~s msg/s)",
         [Iterations, BenchTime, hb_util:human_int(Iterations / BenchTime)]
     ),
-    ?assert(Iterations >= 2),
+    ?assert(Iterations >= 1),
     ok.
 
 aos_persistent_worker_benchmark_test_() ->
     {timeout, 30, fun() ->
-        BenchTime = 5,
+        BenchTime = 0.25,
         init(),
         Base = aos_process(),
         schedule_aos_call(Base, <<"X=1337">>),
@@ -657,6 +654,6 @@ aos_persistent_worker_benchmark_test_() ->
             "Scheduled and evaluated ~p AOS process messages in ~p s (~s msg/s)",
             [Iterations, BenchTime, hb_util:human_int(Iterations / BenchTime)]
         ),
-        ?assert(Iterations >= 2),
+        ?assert(Iterations >= 1),
         ok
     end}.

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -1726,32 +1726,33 @@ http_get_schedule_test_() ->
                 )
 		}, Opts),
 		{ok, _} = hb_http:post(Node, Base, Opts),
-		lists:foreach(
-			fun(_) ->
-                {ok, Res} = hb_http:post(Node, Req, Opts),
-                ?event(debug_scheduler_test, {res, Res})
-            end,
-			lists:seq(1, 10)
-		),
-		?assertMatch({ok, #{ <<"current">> := 10 }}, http_get_slot(Node, PMsg)),
-        ?debug_wait(5000),
-		{ok, Schedule} = http_get_schedule(Node, PMsg, 0, 10),
-		Assignments = hb_ao:get(<<"assignments">>, Schedule, Opts),
-		?assertEqual(
-			13, % 11 assignments, +1 for the hashpath, +1 for the commitments
-			hb_maps:size(Assignments, Opts)
-		)
-	end}.
+			lists:foreach(
+				fun(_) ->
+	                {ok, Res} = hb_http:post(Node, Req, Opts),
+	                ?event(debug_scheduler_test, {res, Res})
+	            end,
+					lists:seq(1, 3)
+				),
+				?assertMatch({ok, #{ <<"current">> := 3 }}, http_get_slot(Node, PMsg)),
+			        ?debug_wait(100),
+				{ok, Schedule} = http_get_schedule(Node, PMsg, 0, 3),
+				Assignments = hb_ao:get(<<"assignments">>, Schedule, Opts),
+				?assertEqual(
+					6, % 4 assignments, +1 for the hashpath, +1 for the commitments
+					hb_maps:size(Assignments, Opts)
+				)
+			end}.
     
 
 http_get_legacy_schedule_test_() ->
-    {timeout, 60, fun() ->
-        Target = <<"CtOVB2dBtyN_vw3BdzCOrvcQvd9Y1oUGT-zLit8E3qM">>,
-        {Node, Opts} = http_init(),
-        {ok, Res} = hb_http:get(Node, <<"/~scheduler@1.0/schedule&target=", Target/binary>>, Opts),
-		LoadedRes = hb_cache:ensure_all_loaded(Res, Opts),
-        ?assertMatch(#{ <<"assignments">> := As } when map_size(As) > 0, LoadedRes)
-    end}.
+	    {timeout, 60, fun() ->
+	        Target = <<"CtOVB2dBtyN_vw3BdzCOrvcQvd9Y1oUGT-zLit8E3qM">>,
+	        {Node, Opts} = http_init(),
+	        {ok, Res} =
+	            hb_http:get(Node, <<"/~scheduler@1.0/schedule&target=", Target/binary, "&to=3">>, Opts),
+			LoadedRes = hb_cache:ensure_all_loaded(Res, Opts),
+	        ?assertMatch(#{ <<"assignments">> := As } when map_size(As) > 0, LoadedRes)
+	    end}.
 
 http_get_legacy_slot_test_() ->
     {timeout, 60, fun() ->
@@ -1762,29 +1763,29 @@ http_get_legacy_slot_test_() ->
     end}.
 
 http_get_legacy_schedule_slot_range_test_() ->
-    {timeout, 60, fun() ->
-        Target = <<"zrhm4OpfW85UXfLznhdD-kQ7XijXM-s2fAboha0V5GY">>,
-        {Node, Opts} = http_init(),
-        {ok, Res} = hb_http:get(Node, <<"/~scheduler@1.0/schedule&target=", Target/binary,
-            "&from=0&to=10">>, Opts),
-		LoadedRes = hb_cache:ensure_all_loaded(Res, Opts),
-        ?event({res, LoadedRes}),
-        % 11 assignments, +1 for the commitments
-        ?assertMatch(#{ <<"assignments">> := As } when map_size(As) == 12, LoadedRes)
-    end}.
+	    {timeout, 60, fun() ->
+	        Target = <<"zrhm4OpfW85UXfLznhdD-kQ7XijXM-s2fAboha0V5GY">>,
+	        {Node, Opts} = http_init(),
+	        {ok, Res} = hb_http:get(Node, <<"/~scheduler@1.0/schedule&target=", Target/binary,
+	            "&from=0&to=3">>, Opts),
+			LoadedRes = hb_cache:ensure_all_loaded(Res, Opts),
+	        ?event({res, LoadedRes}),
+	        % 4 assignments, +1 for the commitments
+	        ?assertMatch(#{ <<"assignments">> := As } when map_size(As) == 5, LoadedRes)
+	    end}.
 
 http_get_legacy_schedule_as_aos2_test_() ->
     {timeout, 60, fun() ->
         Target = <<"CtOVB2dBtyN_vw3BdzCOrvcQvd9Y1oUGT-zLit8E3qM">>,
         {Node, Opts} = http_init(),
         {ok, Res} =
-            hb_http:get(
-                Node,
-                #{
-                    <<"path">> => <<"/~scheduler@1.0/schedule?target=", Target/binary>>,
-                    <<"accept">> => <<"application/aos-2">>,
-                    <<"method">> => <<"GET">>
-                },
+	            hb_http:get(
+	                Node,
+	                #{
+	                    <<"path">> => <<"/~scheduler@1.0/schedule?target=", Target/binary, "&to=3">>,
+	                    <<"accept">> => <<"application/aos-2">>,
+	                    <<"method">> => <<"GET">>
+	                },
                 #{}
             ),
         Decoded = hb_json:decode(hb_ao:get(<<"body">>, Res, Opts)),
@@ -1847,26 +1848,26 @@ http_get_json_schedule_test_() ->
 			},
 			Opts
 		),
-		lists:foreach(
-			fun(_) -> {ok, _} = hb_http:post(Node, Req, Opts) end,
-			lists:seq(1, 10)
-		),
-		?assertMatch({ok, #{ <<"current">> := 10 }}, http_get_slot(Node, PMsg)),
-		{ok, Schedule} = http_get_schedule(Node, PMsg, 0, 10, <<"application/aos-2">>),
-		?event({schedule, Schedule}),
-		JSON = hb_ao:get(<<"body">>, Schedule, Opts),
-		Assignments = hb_json:decode(JSON),
-		?assertEqual(
-			11, % +1 for the hashpath
-			length(hb_maps:get(<<"edges">>, Assignments))
-		)
-	end}.
+			lists:foreach(
+				fun(_) -> {ok, _} = hb_http:post(Node, Req, Opts) end,
+					lists:seq(1, 3)
+				),
+				?assertMatch({ok, #{ <<"current">> := 3 }}, http_get_slot(Node, PMsg)),
+				{ok, Schedule} = http_get_schedule(Node, PMsg, 0, 3, <<"application/aos-2">>),
+				?event({schedule, Schedule}),
+				JSON = hb_ao:get(<<"body">>, Schedule, Opts),
+				Assignments = hb_json:decode(JSON),
+				?assertEqual(
+					4, % +1 for the hashpath
+					length(hb_maps:get(<<"edges">>, Assignments))
+				)
+			end}.
 
 %%% Benchmarks
 
 single_resolution(Opts) ->
     start(),
-    BenchTime = 1,
+    BenchTime = 0.25,
     Wallet = hb_opts:get(priv_wallet, hb:wallet(), Opts),
     Base = test_process(Opts#{ priv_wallet => Wallet }),
     ?event({benchmark_start, ?MODULE}),
@@ -1904,7 +1905,7 @@ single_resolution(Opts) ->
     ?assert(Iterations > 3).
 
 many_clients(Opts) ->
-    BenchTime = 1,
+    BenchTime = 0.25,
     Processes = hb_opts:get(workers, 25, Opts),
     {Node, Opts} = http_init(Opts),
     PMsg = hb_message:commit(test_process(Opts), Opts),

--- a/src/dev_scheduler_cache.erl
+++ b/src/dev_scheduler_cache.erl
@@ -304,7 +304,7 @@ large_assignment_volume_test() ->
     },
     hb_store:start(VolStore),
     hb_store:start(NonVolStore),
-    VolumeSize = 1000,
+    VolumeSize = 500,
     ProcID = hb_util:human_id(crypto:strong_rand_bytes(32)),
     StartTime = erlang:monotonic_time(millisecond),
     lists:foreach(

--- a/src/dev_wasm.erl
+++ b/src/dev_wasm.erl
@@ -463,7 +463,7 @@ imported_function_test() ->
     ).
 
 benchmark_test() ->
-    BenchTime = 0.5,
+    BenchTime = 0.25,
     init(),
     Msg0 = cache_wasm_image("test/test-64.wasm"),
     {ok, Base} = hb_ao:resolve(Msg0, <<"init">>, #{}),

--- a/src/hb_beamr.erl
+++ b/src/hb_beamr.erl
@@ -308,7 +308,7 @@ multiclient_test() ->
     end.
 
 benchmark_test() ->
-    BenchTime = 1,
+    BenchTime = 0.25,
     {ok, File} = file:read_file("test/test-64.wasm"),
     {ok, WASM, _ImportMap, _Exports} = start(File),
     Iterations = hb_test_utils:benchmark(

--- a/src/hb_event.erl
+++ b/src/hb_event.erl
@@ -32,11 +32,17 @@ log(Topic, X, Mod, Func, Line, Opts) ->
         true -> hb_format:print(X, Mod, Func, Line, Opts);
         false -> X
     end,
-    try increment(Topic, X, Opts) catch _:_ -> ok end,
+    maybe_increment(Topic, X, Opts),
     % Return the logged value to the caller. This allows callers to insert 
     % `?event(...)' macros into the flow of other executions, without having to
     % break functional style.
     X.
+-ifdef(TEST).
+maybe_increment(_Topic, _X, _Opts) -> ok.
+-else.
+maybe_increment(Topic, X, Opts) ->
+    try increment(Topic, X, Opts) catch _:_ -> ok end.
+-endif.
 -endif.
 
 %% @doc Determine if the topic should be printed. Uses a cache in the process
@@ -251,7 +257,8 @@ benchmark_event_test() ->
         hb_test_utils:benchmark(
             fun() ->
                 log(test_module, {test, 1})
-            end
+            end,
+            0.25
         ),
     hb_test_utils:benchmark_print(<<"Recorded">>, <<"events">>, Iterations),
     ?assert(Iterations >= 1000),
@@ -266,7 +273,8 @@ benchmark_print_lookup_test() ->
             fun() ->
                 should_print(test_module, DefaultOpts)
                     orelse should_print(test_event, DefaultOpts)
-            end
+            end,
+            0.25
         ),
     hb_test_utils:benchmark_print(<<"Looked-up">>, <<"topics">>, Iterations),
     ?assert(Iterations >= 1000),
@@ -276,7 +284,8 @@ benchmark_print_lookup_test() ->
 benchmark_increment_test() ->
     Iterations =
         hb_test_utils:benchmark(
-            fun() -> increment(test_module, {test, 1}, #{}) end
+            fun() -> increment(test_module, {test, 1}, #{}) end,
+            0.25
         ),
     hb_test_utils:benchmark_print(<<"Incremented">>, <<"events">>, Iterations),
     ?assert(Iterations >= 1000),

--- a/src/hb_event.erl
+++ b/src/hb_event.erl
@@ -32,17 +32,11 @@ log(Topic, X, Mod, Func, Line, Opts) ->
         true -> hb_format:print(X, Mod, Func, Line, Opts);
         false -> X
     end,
-    maybe_increment(Topic, X, Opts),
+    try increment(Topic, X, Opts) catch _:_ -> ok end,
     % Return the logged value to the caller. This allows callers to insert 
     % `?event(...)' macros into the flow of other executions, without having to
     % break functional style.
     X.
--ifdef(TEST).
-maybe_increment(_Topic, _X, _Opts) -> ok.
--else.
-maybe_increment(Topic, X, Opts) ->
-    try increment(Topic, X, Opts) catch _:_ -> ok end.
--endif.
 -endif.
 
 %% @doc Determine if the topic should be printed. Uses a cache in the process


### PR DESCRIPTION
Tunes test store fixtures and reduces benchmark/test wait windows to cut EUnit wall time.

- Shortens timer sleeps and reduces benchmark durations in various tests.
- Normalizes use of stores between tests, removing explicitly `hb_store_fs` starts, etc.