### PR TITLE
chore: Allows large integer structured field values

### DIFF
--- a/src/hb_structured_fields.erl
+++ b/src/hb_structured_fields.erl
@@ -318,7 +318,7 @@ parse_number(<<C, R/bits>>, L, Acc) when ?IS_DIGIT(C) ->
     parse_number(R, L + 1, <<Acc/binary, C>>);
 parse_number(<<$., R/bits>>, L, Acc) ->
     parse_decimal(R, L, 0, Acc, <<>>);
-parse_number(R, L, Acc) when L =< 15 ->
+parse_number(R, _L, Acc) ->
     {binary_to_integer(Acc), R}.
 
 %% @doc Parse a decimal binary.


### PR DESCRIPTION
Addresses a spec compliance issue where structured field values were limited to 15 digits. The `parse_number` function is modified to remove the length check, allowing integers with more than 15 digits to be parsed, despite the RFC spec. This change is preferable because the alternative -- bailing on too-large integers -- is clearly worse.