### PR TITLE
fix: auto-filter `debug*` events from counters.

### DIFF
--- a/src/hb_event.erl
+++ b/src/hb_event.erl
@@ -79,18 +79,10 @@ increment(signature_base, _Message, _Opts, _Count) -> ignored;
 increment(id_base, _Message, _Opts, _Count) -> ignored;
 increment(parsing, _Message, _Opts, _Count) -> ignored;
 increment(Topic, Message, _Opts, Count) ->
-    case parse_name(Message) of
+    case parse_name(Topic) of
         <<"debug", _/binary>> -> ignored;
-        EventName ->
-            TopicBin = parse_name(Topic),
-            case find_event_server() of
-                Pid when is_pid(Pid) ->
-                    Pid ! {increment, TopicBin, EventName, Count};
-                undefined ->
-                    PID = spawn(fun() -> server() end),
-                    hb_name:register(?MODULE, PID),
-                    PID ! {increment, TopicBin, EventName, Count}
-            end
+        TopicBin ->
+            find_event_server() ! {increment, TopicBin, parse_name(Message), Count}
     end.
 
 %% @doc Increment the call paths and individual upstream calling functions of


### PR DESCRIPTION
Fixes a prior bug in which the name for filtration was derived from the `Message` component, rather than the `Topic`. Additionally, the logic of this function has been simplified.
