### PR TITLE
impr: quiet test mode

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,12 @@
 {eunit_opts, [verbose, {scale_timeouts, 10}]}.
 
 {profiles, [
-    {quiet, [{eunit_opts, [{verbose, false}, {scale_timeouts, 10}]}]},
+    {quiet,
+        [
+            {eunit_opts, [{verbose, false}, {scale_timeouts, 10}]},
+            {erl_opts, [{d, 'QUIET', true}]}
+        ]
+    },
     {no_events, [{erl_opts, [{d, 'NO_EVENTS', true}]}]},
     {top, [{deps, [observer_cli]}, {erl_opts, [{d, 'AO_TOP', true}]}]},
     {store_events, [{erl_opts, [{d, 'STORE_EVENTS', true}]}]},

--- a/src/hb_format.erl
+++ b/src/hb_format.erl
@@ -494,6 +494,7 @@ maybe_short(X, Opts, _Indent) ->
 is_multiline(Str) ->
     lists:member($\n, Str).
 
+-ifndef(QUIET).
 %% @doc Format and print an indented string to standard error.
 eunit_print(FmtStr, FmtArgs) ->
     io:format(
@@ -501,6 +502,9 @@ eunit_print(FmtStr, FmtArgs) ->
         "~n~s ",
         [indent(FmtStr ++ "...", FmtArgs, #{}, 4)]
     ).
+-else.
+eunit_print(_FmtStr, _FmtArgs) -> skipped_print.
+-endif.
 
 %% @doc Print the trace of the current stack, up to the first non-hyperbeam
 %% module. Prints each stack frame on a new line, until it finds a frame that


### PR DESCRIPTION
Coding agents perform better when signal-per-token is higher. The test suite is much faster to execute now, which helps agent velocity, but it still outputted large amounts of text. This PR addresses that by introducing an `as quiet` rebar3 mode which only prints when there are issues. This also makes it easier for humans to run the suite on a loop and check for issues with potentially flaky tests.
