### PR TITLE
impr: LMDB store handle management

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -127,7 +127,7 @@
 ]}.
 
 {deps, [
-    {elmdb, {git, "https://github.com/permaweb/elmdb-rs.git", {ref, "0276d6b04dcf47b7a74fe446c11e15ff3469c37a"}}},
+    {elmdb, {git, "https://github.com/permaweb/elmdb-rs.git", {ref, "f025513db3a34edf1cee26c11c1c750020140314"}}},
 	{b64fast, {git, "https://github.com/ArweaveTeam/b64fast.git", {ref, "58f0502e49bf73b29d95c6d02460d1fb8d2a5273"}}},
     {cowlib, "2.16.0"},
 	{cowboy, "2.14.0"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -9,7 +9,7 @@
  {<<"ddskerl">>,{pkg,<<"ddskerl">>,<<"0.4.2">>},1},
  {<<"elmdb">>,
   {git,"https://github.com/permaweb/elmdb-rs.git",
-       {ref,"0276d6b04dcf47b7a74fe446c11e15ff3469c37a"}},
+       {ref,"f025513db3a34edf1cee26c11c1c750020140314"}},
   0},
  {<<"graphql">>,{pkg,<<"graphql_erl">>,<<"0.17.1">>},0},
  {<<"gun">>,{pkg,<<"gun">>,<<"2.2.0">>},0},

--- a/src/dev_codec_ans104.erl
+++ b/src/dev_codec_ans104.erl
@@ -753,7 +753,7 @@ bundle_commitment_test() ->
     ok.
 
 test_bundle_commitment(Commit, Encode, Decode) ->
-    Opts = #{ priv_wallet => hb:wallet() },
+    Opts = #{ priv_wallet => hb:wallet(), store => hb_test_utils:test_store() },
     Structured = #{ <<"list">> => [1, 2, 3] },
     ToBool = fun(unbundled) -> false; (bundled) -> true end,
     Label = lists:flatten(io_lib:format("~p -> ~p -> ~p",

--- a/src/dev_trie.erl
+++ b/src/dev_trie.erl
@@ -283,7 +283,7 @@ longest_prefix_match({BestLabel, BestSize}, Key, [EdgeLabel | EdgeLabels], N) ->
 %%% Tests
 test_opts() ->
     #{
-        store => [hb_test_utils:test_store(hb_store_lmdb)],
+        store => [hb_test_utils:test_store()],
         priv_wallet => hb:wallet()
     }.
 count_nodes(TrieNode, Opts) when not is_map(TrieNode) -> 0;

--- a/src/hb_private.erl
+++ b/src/hb_private.erl
@@ -177,9 +177,9 @@ get_deep_key_test() ->
 
 priv_opts_store_read_link_test() ->
     % Write a message to the public store.
-    PublicStore = [hb_test_utils:test_store(hb_store_lmdb)],
+    PublicStore = [hb_test_utils:test_store()],
     timer:sleep(1),
-    OnlyPrivStore = [hb_test_utils:test_store(hb_store_fs)],
+    OnlyPrivStore = [hb_test_utils:test_store()],
     ok = hb_store:write(PublicStore, <<"key">>, <<"test-message">>),
     {ok, <<"test-message">>} = hb_store:read(PublicStore, <<"key">>),
     % Make a link to the key in the public store.
@@ -199,8 +199,8 @@ priv_opts_store_read_link_test() ->
 
 priv_opts_cache_read_message_test() ->
     hb:init(),
-    PublicStore = [hb_test_utils:test_store(hb_store_lmdb)],
-    OnlyPrivStore = [hb_test_utils:test_store(hb_store_fs)],
+    PublicStore = [hb_test_utils:test_store()],
+    OnlyPrivStore = [hb_test_utils:test_store()],
     Opts = #{ store => PublicStore, priv_store => OnlyPrivStore },
     PrivOpts = opts(Opts),
     % Use the `~scheduler@1.0' and `~process@1.0' infrastructure to write a

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -98,10 +98,8 @@ type(Opts, Key) ->
                     type(Opts, Link);
                 false ->
                     case Value of
-                        <<"group">> -> 
-                            composite;
-                        _ -> 
-                            simple
+                        <<"group">> -> composite;
+                        _ -> simple
                     end
             end;
         not_found -> not_found
@@ -668,11 +666,7 @@ group_test() ->
 %% and verifies that reading from the link location returns the original value.
 %% This demonstrates the transparent link resolution mechanism.
 link_test() ->
-    StoreOpts = #{
-        <<"store-module">> => ?MODULE,
-        <<"name">> => <<"/tmp/store3">>,
-        <<"capacity">> => ?DEFAULT_SIZE
-    },
+    StoreOpts = hb_test_utils:test_store(?MODULE),
     reset(StoreOpts),
     write(StoreOpts, <<"foo/bar/baz">>, <<"Bam">>),
     make_link(StoreOpts, <<"foo/bar/baz">>, <<"foo/beep/baz">>),
@@ -681,11 +675,7 @@ link_test() ->
     ?assertEqual(<<"Bam">>, Result).
 
 link_fragment_test() ->
-    StoreOpts = #{
-        <<"store-module">> => ?MODULE,
-        <<"name">> => <<"/tmp/store3">>,
-        <<"capacity">> => ?DEFAULT_SIZE
-    },
+    StoreOpts = hb_test_utils:test_store(?MODULE),
     reset(StoreOpts),
     write(StoreOpts, [<<"data">>, <<"bar">>, <<"baz">>], <<"Bam">>),
     make_link(StoreOpts, [<<"data">>, <<"bar">>], <<"my-link">>),
@@ -699,11 +689,7 @@ link_fragment_test() ->
 %% then verifies that the type detection function correctly identifies each one.
 %% This demonstrates the semantic classification system used by the store.
 type_test() ->
-    StoreOpts = #{
-        <<"store-module">> => ?MODULE,
-        <<"name">> => <<"/tmp/store-6">>,
-        <<"capacity">> => ?DEFAULT_SIZE
-    },
+    StoreOpts = hb_test_utils:test_store(?MODULE),
     reset(StoreOpts),
     make_group(StoreOpts, <<"assets">>),
     Type = type(StoreOpts, <<"assets">>),
@@ -730,11 +716,7 @@ type_test() ->
 %% hierarchical structures where keys represent nested paths or categories,
 %% and need to create shortcuts or aliases to deeply nested data.
 link_key_list_test() ->
-    StoreOpts = #{
-        <<"store-module">> => ?MODULE,
-        <<"name">> => <<"/tmp/store-7">>,
-        <<"capacity">> => ?DEFAULT_SIZE
-    },
+    StoreOpts = hb_test_utils:test_store(?MODULE),
     reset(StoreOpts),
     write(StoreOpts, [ <<"parent">>, <<"key">> ], <<"value">>),
     make_link(StoreOpts, [ <<"parent">>, <<"key">> ], <<"my-link">>),
@@ -753,11 +735,7 @@ link_key_list_test() ->
 %% allowing reorganization of hierarchical data without breaking existing
 %% access patterns.
 path_traversal_link_test() ->
-    StoreOpts = #{
-        <<"store-module">> => ?MODULE,
-        <<"name">> => <<"/tmp/store-8">>,
-        <<"capacity">> => ?DEFAULT_SIZE
-    },
+    StoreOpts = hb_test_utils:test_store(?MODULE),
     reset(StoreOpts),
     % Create the actual data at group/key
     write(StoreOpts, [<<"group">>, <<"key">>], <<"target-value">>),
@@ -771,11 +749,7 @@ path_traversal_link_test() ->
 
 %% @doc Test that matches the exact hb_store hierarchical test pattern
 exact_hb_store_test() ->
-    StoreOpts = #{
-        <<"store-module">> => ?MODULE,
-        <<"name">> => <<"/tmp/store-exact">>,
-        <<"capacity">> => ?DEFAULT_SIZE
-    },
+    StoreOpts = hb_test_utils:test_store(?MODULE),
     % Follow exact same pattern as hb_store test
     ?event(step1_make_group),
     make_group(StoreOpts, <<"test-dir1">>),
@@ -803,11 +777,7 @@ exact_hb_store_test() ->
 %% @doc Test cache-style usage through hb_store interface
 cache_style_test() ->
     hb:init(),
-    StoreOpts = #{
-        <<"store-module">> => ?MODULE,
-        <<"name">> => <<"/tmp/store-cache-style">>,
-        <<"capacity">> => ?DEFAULT_SIZE
-    },
+    StoreOpts = hb_test_utils:test_store(?MODULE),
     reset(StoreOpts),
     % Start the store
     hb_store:start(StoreOpts),
@@ -826,11 +796,7 @@ cache_style_test() ->
 %% 2. Links are created to compose the values back into the original map structure
 %% 3. Reading the composed structure reconstructs the original nested map
 nested_map_cache_test() ->
-    StoreOpts = #{
-        <<"store-module">> => ?MODULE,
-        <<"name">> => <<"/tmp/store-nested-cache">>,
-        <<"capacity">> => ?DEFAULT_SIZE
-    },
+    StoreOpts = hb_test_utils:test_store(?MODULE),
     % Clean up any previous test data
     reset(StoreOpts),
     % Original nested map structure
@@ -933,11 +899,7 @@ reconstruct_map(StoreOpts, Path) ->
 
 %% @doc Debug test to understand cache linking behavior
 cache_debug_test() ->
-    StoreOpts = #{
-        <<"store-module">> => ?MODULE,
-        <<"name">> => <<"/tmp/cache-debug">>,
-        <<"capacity">> => ?DEFAULT_SIZE
-    },
+    StoreOpts = hb_test_utils:test_store(?MODULE),
     reset(StoreOpts),
     % Simulate what the cache does:
     % 1. Create a group for message ID
@@ -971,11 +933,7 @@ cache_debug_test() ->
 
 %% @doc Isolated test focusing on the exact cache issue
 isolated_type_debug_test() ->
-    StoreOpts = #{
-        <<"store-module">> => ?MODULE,
-        <<"name">> => <<"/tmp/isolated-debug">>,
-        <<"capacity">> => ?DEFAULT_SIZE
-    },
+    StoreOpts = hb_test_utils:test_store(?MODULE),
     reset(StoreOpts),
     % Create the exact scenario from user's description:
     % 1. A message ID with nested structure
@@ -1011,11 +969,7 @@ isolated_type_debug_test() ->
 
 %% @doc Test that list function resolves links correctly
 list_with_link_test() ->
-    StoreOpts = #{
-        <<"store-module">> => ?MODULE,
-        <<"name">> => <<"/tmp/store-list-link">>,
-        <<"capacity">> => ?DEFAULT_SIZE
-    },
+    StoreOpts = hb_test_utils:test_store(?MODULE),
     reset(StoreOpts),
     % Create a group with some children
     make_group(StoreOpts, <<"real-group">>),

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -49,7 +49,7 @@
 start(Opts = #{ <<"name">> := DataDir }) ->
     % Ensure the directory exists before opening LMDB environment
     DataDirPath = hb_util:list(DataDir),
-    ok = filelib:ensure_dir(filename:join(DataDirPath, "dummy")),
+    ok = ensure_dir(DataDirPath),
     EnvOpts =
         [
             {map_size, maps:get(<<"capacity">>, Opts, ?DEFAULT_SIZE)},
@@ -74,6 +74,12 @@ start(Opts = #{ <<"name">> := DataDir }) ->
     {ok, #{ <<"env">> => Env, <<"db">> => DBInstance }};
 start(_) ->
     {error, {badarg, <<"StoreOpts must be a map">>}}.
+
+%% @doc Ensure that the database directory exists.
+ensure_dir(DataDirPath) ->
+    % `filelib` interprets the last path element as a filename, so we add a 
+    % dummy one, else the final directory will not be created.
+    filelib:ensure_dir(filename:join(DataDirPath, "dummy.mdb")).
 
 %% @doc Determine whether a key represents a simple value or composite group.
 %%
@@ -570,6 +576,7 @@ reset(Opts) ->
             % Stop the store and remove the database.
             stop(Opts),
             os:cmd(binary_to_list(<< "rm -Rf ", DataDir/binary >>)),
+            ensure_dir(DataDir),
             ok
     end.
 

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -71,9 +71,6 @@ start(Opts = #{ <<"name">> := DataDir }) ->
     % Create the LMDB environment with specified size limit
     {ok, Env} = elmdb:env_open(DataDirPath, EnvOpts),
     {ok, DBInstance} = elmdb:db_open(Env, [create]),
-    % Store both environment and DB instance in persistent_term for later cleanup
-    StoreKey = {lmdb, ?MODULE, DataDir},
-    persistent_term:put(StoreKey, {Env, DBInstance, DataDir}),
     {ok, #{ <<"env">> => Env, <<"db">> => DBInstance }};
 start(_) ->
     {error, {badarg, <<"StoreOpts must be a map">>}}.
@@ -547,73 +544,11 @@ find_env(Opts) -> hb_store:find(Opts).
 
 %% Shutdown LMDB environment and cleanup resources
 stop(#{ <<"store-module">> := ?MODULE, <<"name">> := DataDir }) ->
-    % Clear the generic store cache entry so a subsequent `start/1` will
-    % create a fresh LMDB environment instead of reusing closed handles.
-    StoreRef = {store, ?MODULE, DataDir},
-    erlang:erase(StoreRef),
-    persistent_term:erase(StoreRef),
-    StoreKey = {lmdb, ?MODULE, DataDir},
-    close_environment(StoreKey, DataDir);
+    % Soft-close by name; refs stay valid and reopen lazily on next access.
+    catch elmdb:env_close_by_name(hb_util:list(DataDir)),
+    ok;
 stop(_InvalidStoreOpts) ->
     ok.
-
-%% Close environment using persistent_term lookup with fallback
-close_environment(StoreKey, DataDir) ->
-    case safe_get_persistent_term(StoreKey) of
-        {ok, {Env, DBInstance}} ->
-            close_and_cleanup(Env, DBInstance, StoreKey, DataDir);
-        not_found ->
-            ?event({lmdb_stop_not_found_in_persistent_term, DataDir}),
-            safe_close_by_name(DataDir)
-    end,
-    ok.
-
-%% Get environment and DB instance from persistent_term without exceptions
-safe_get_persistent_term(Key) ->
-    case persistent_term:get(Key, undefined) of
-        {Env, DBInstance, _DataDir} -> {ok, {Env, DBInstance}};
-        {Env, _DataDir} -> {ok, {Env, undefined}};  % Backwards compatibility
-        _ -> not_found
-    end.
-
-%% Close DB instance and environment, then cleanup persistent_term entry
-close_and_cleanup(Env, DBInstance, StoreKey, DataDir) ->
-    % Close DB instance first if it exists
-    DBCloseResult = safe_close_db(DBInstance),
-    ?event({db_close_result, DBCloseResult}),
-    % Then close the environment
-    EnvCloseResult = safe_close_env(Env),
-    persistent_term:erase(StoreKey),
-    case EnvCloseResult of
-        ok -> ?event({lmdb_stop_success, DataDir});
-        {error, Reason} -> ?event({lmdb_stop_error, Reason})
-    end.
-
-%% Close DB instance with error capture
-safe_close_db(undefined) ->
-    ok;  % No DB instance to close
-safe_close_db(DBInstance) ->
-    try
-        elmdb:db_close(DBInstance)
-    catch
-        error:Reason -> {error, Reason}
-    end.
-
-%% Close environment handle with error capture
-safe_close_env(Env) ->
-    try
-        elmdb:env_close(Env)
-    catch
-        error:Reason -> {error, Reason}
-    end.
-
-%% Fallback close by name with error suppression
-safe_close_by_name(DataDir) ->
-    try
-        elmdb:env_close_by_name(binary_to_list(DataDir))
-    catch
-        error:_ -> ok
-    end.
 
 %% @doc Completely delete the database directory and all its contents.
 %%


### PR DESCRIPTION
Improves LMDB store handle management by removing explicit handle management and upgrading the `elmdb-rs` dependency. The associated core `elmdb-rs` feature is described in [#5](https://github.com/permaweb/elmdb-rs/pull/5) as:

> Introduces a pattern in which each DB is referenced by an immutable term. Those with the term are always able to instantly access the DB -- re-opening the underlying LMDB connection as necessary -- while those without it may receive it from an 'open' request. This way, handles never go stale from the POV of the caller, regardless of what others may do with the DB (closing it, re-opening it, etc). One intricacy to note: Calling the opens again with differing parameters will lead them to be updated.

This PR utilizes this new pattern to simplify store reference management in `hb_store_lmdb`.