### PR TITLE
feat: parallel execution store implementation

### DIFF
--- a/src/hb_store_multi.erl
+++ b/src/hb_store_multi.erl
@@ -9,7 +9,6 @@
 -export([start/1, stop/1, reset/1, scope/0, scope/1]).
 -export([read/2, type/2, list/2, match/2]).
 -export([write/3, make_group/2, make_link/3]).
--include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 %%% Initialization and teardown functions.
@@ -22,10 +21,11 @@ scope() -> local.
 
 %% @doc Find (causing a spawn and caching of the instance data) each store.
 start(StoreOpts) ->
-    store_with_workers(StoreOpts).
+    {ok, store_with_workers(StoreOpts)}.
 
 %% @doc Stop each store and its worker process.
-stop(#{ <<"stores">> := Stores }) ->
+stop(StoreOpts) ->
+    #{ <<"stores">> := Stores } = hb_store:find(StoreOpts),
     operation(
         length(Stores),
         Stores,
@@ -38,7 +38,8 @@ stop(#{ <<"stores">> := Stores }) ->
     ).
 
 %% @doc Reset each store.
-reset(#{ <<"stores">> := Stores }) ->
+reset(StoreOpts) ->
+    #{ <<"stores">> := Stores } = hb_store:find(StoreOpts),
     operation(
         length(Stores),
         Stores,
@@ -49,33 +50,58 @@ reset(#{ <<"stores">> := Stores }) ->
 %%% Read operations.
 
 %% @doc Read a key from the stores. Return the first successful result.
-read(#{ <<"stores">> := Stores }, Key) ->
-    case operation(1, Stores, fun(XOpts) -> hb_store:read(XOpts, Key) end, [Key]) of
+read(StoreOpts, Key) ->
+    #{ <<"stores">> := Stores } = hb_store:find(StoreOpts),
+    case
+        operation(
+            1,
+            Stores,
+            fun(XOpts, XKey) -> hb_store:read(XOpts, XKey) end,
+            [Key]
+        )
+    of
         [Res] -> Res;
         _ -> not_found
     end.
 
 %% @doc List the keys in the stores. Return the first successful result.
-list(#{ <<"stores">> := Stores }, Key) ->
-    case operation(1, Stores, fun(XOpts) -> hb_store:list(XOpts, Key) end, [Key]) of
+list(StoreOpts, Key) ->
+    #{ <<"stores">> := Stores } = hb_store:find(StoreOpts),
+    case
+        operation(
+            1,
+            Stores,
+            fun(XOpts, XKey) -> hb_store:list(XOpts, XKey) end,
+            [Key]
+        )
+    of
         [Res] -> Res;
         _ -> not_found
     end.
 
 %% @doc Type a key in the stores. Return the first successful result.
-type(#{ <<"stores">> := Stores }, Key) ->
-    case operation(1, Stores, fun(XOpts) -> hb_store:type(XOpts, Key) end, [Key]) of
+type(StoreOpts, Key) ->
+    #{ <<"stores">> := Stores } = hb_store:find(StoreOpts),
+    case
+        operation(
+            1,
+            Stores,
+            fun(XOpts, XKey) -> hb_store:type(XOpts, XKey) end,
+            [Key]
+        )
+    of
         [Res] -> Res;
         _ -> not_found
     end.
 
 %% @doc Match a key in the stores. Return the first successful result.
-match(#{ <<"stores">> := Stores }, Match) ->
+match(StoreOpts, Match) ->
+    #{ <<"stores">> := Stores } = hb_store:find(StoreOpts),
     MatchRes = 
         operation(
             1,
             Stores,
-            fun(XOpts) -> hb_store:match(XOpts, Match) end,
+            fun(XOpts, XMatch) -> hb_store:match(XOpts, XMatch) end,
             [Match]
         ),
     case MatchRes of
@@ -91,12 +117,14 @@ confirmations(#{ <<"stores">> := Stores }) -> length(Stores).
 
 %% @doc Write a key to the stores. By default writes to all stores, but can be
 %% configured to return after only a count of `write-confirmations`, as necessary.
-write(StoreOpts = #{ <<"stores">> := Stores }, Key, Value) ->
+write(StoreOpts, Key, Value) ->
+    StoreOptsWithWorkers = hb_store:find(StoreOpts),
+    #{ <<"stores">> := Stores } = StoreOptsWithWorkers,
     Res = 
         operation(
-            confirmations(StoreOpts),
+            confirmations(StoreOptsWithWorkers),
             Stores,
-            fun(XOpts) -> hb_store:write(XOpts, Key, Value) end,
+            fun(XOpts, XKey, XValue) -> hb_store:write(XOpts, XKey, XValue) end,
             [Key, Value]
         ),
     case Res of
@@ -107,12 +135,16 @@ write(StoreOpts = #{ <<"stores">> := Stores }, Key, Value) ->
 %% @doc Make a link in the stores. By default makes a link in all stores, but
 %% consults the `write-confirmations' configuration to determine how many stores
 %% as with `write/2`.
-make_link(StoreOpts = #{ <<"stores">> := Stores }, Existing, New) ->
+make_link(StoreOpts, Existing, New) ->
+    StoreOptsWithWorkers = hb_store:find(StoreOpts),
+    #{ <<"stores">> := Stores } = StoreOptsWithWorkers,
     Res =
         operation(
-            confirmations(StoreOpts),
+            confirmations(StoreOptsWithWorkers),
             Stores,
-            fun(XOpts) -> hb_store:make_link(XOpts, Existing, New) end,
+            fun(XOpts, XExisting, XNew) ->
+                hb_store:make_link(XOpts, XExisting, XNew)
+            end,
             [Existing, New]
         ),
     case Res of
@@ -125,11 +157,13 @@ make_link(StoreOpts = #{ <<"stores">> := Stores }, Existing, New) ->
 %% @doc Make a group in the stores. By default makes a group in all stores, but
 %% consults the `write-confirmations' configuration to determine how many stores
 %% as with `write/2`.
-make_group(StoreOpts = #{ <<"stores">> := Stores }, Path) ->
+make_group(StoreOpts, Path) ->
+    StoreOptsWithWorkers = hb_store:find(StoreOpts),
+    #{ <<"stores">> := Stores } = StoreOptsWithWorkers,
     Res = operation(
-        confirmations(StoreOpts),
+        confirmations(StoreOptsWithWorkers),
         Stores,
-        fun(XOpts) -> hb_store:make_group(XOpts, Path) end,
+        fun(XOpts, XPath) -> hb_store:make_group(XOpts, XPath) end,
         [Path]
     ),
     case Res of
@@ -144,7 +178,7 @@ store_with_workers(StoreOpts = #{ <<"stores">> := Stores }) ->
     StoreOpts#{
         <<"stores">> :=
             lists:map(
-                fun(Store) -> Store#{ <<"worker">> := start_worker(Store) } end,
+                fun(Store) -> Store#{ <<"worker">> => start_worker(Store) } end,
                 Stores
             )
     }.
@@ -179,38 +213,38 @@ dispatch(Worker, Function, Args) ->
     Ref = make_ref(),
     Caller = self(),
     Worker ! {operation, Ref, Caller, Function, Args},
-    {Worker, {waiting, Ref}}.
+    {Ref, {waiting, Worker}}.
 
 %% @doc Collect result messages from worker processes, cancelling operations
 %% that are no longer needed.
-collect(Required, PIDRefs) when is_list(PIDRefs) ->
-    collect(Required, maps:from_list(PIDRefs));
-collect(0, PIDRefs) ->
+collect(Required, RefStates) when is_list(RefStates) ->
+    collect(Required, maps:from_list(RefStates));
+collect(0, RefStates) ->
     % Cancel all remaining operations and return the result values.
     maps:values(
         maps:filtermap(
-            fun(PID, {waiting, Ref}) -> cancel(PID, Ref), false;
-               (_PID, Res) -> {true, Res}
+            fun(Ref, {waiting, Worker}) -> cancel(Worker, Ref), false;
+               (_Ref, Res) -> {true, Res}
             end,
-            PIDRefs
+            RefStates
         )
     );
 collect(Count, Refs) when Count > map_size(Refs) ->
     % Threre are more results still to gather than remaining store references.
     % Cancel the remaining operations and return an error.
-    maps:map(
-        fun(PID, {waiting, Ref}) -> cancel(PID, Ref);
-           (_PID, _Res) -> ok
+    maps:foreach(
+        fun(Ref, {waiting, Worker}) -> cancel(Worker, Ref);
+           (_Ref, _Res) -> ok
         end,
         Refs
     ),
     {error, not_enough_results};
 collect(Count, Refs) ->
     receive
-        {result, Ref, Res} when is_map_key(Ref, Refs) ->
+        {result, Ref, Result} when is_map_key(Ref, Refs) ->
             % Add new `ok' or `{ok, Res}' to the results, but remove erroring
             % store references.
-            case Res of
+            case Result of
                 ok -> collect(Count - 1, maps:put(Ref, ok, Refs));
                 {ok, Res} -> collect(Count - 1, maps:put(Ref, {ok, Res}, Refs));
                 _ -> collect(Count, maps:remove(Ref, Refs))
@@ -233,3 +267,78 @@ server(StoreOpts) ->
                 server(StoreOpts)
             end
     end.
+
+%%% Tests
+
+key_in_any_store_is_found_test() ->
+    with_multi_store(
+        fun(#{ multi_store := MultiStore, stores := Stores }) ->
+            [_Store1, Store2, _Store3] = Stores,
+            Key = <<"found-in-second-store">>,
+            Value = <<"value-in-second-store">>,
+            ok = hb_store:write(Store2, Key, Value),
+            ?assertEqual({ok, Value}, hb_store:read(MultiStore, Key))
+        end
+    ).
+
+write_meets_confirmation_threshold_test() ->
+    with_multi_store(
+        fun(#{ multi_store := MultiStore, stores := Stores }) ->
+            StoreWithConfirmations = MultiStore#{ <<"confirmations">> => 2 },
+            Key = <<"minimum-confirmations-key">>,
+            Value = <<"minimum-confirmations-value">>,
+            ?assertEqual(ok, hb_store:write(StoreWithConfirmations, Key, Value)),
+            Copies = stores_with_key(Stores, Key, Value),
+            ?assert(Copies >= 2),
+            ?assert(Copies =< length(Stores))
+        end
+    ).
+
+write_replicates_to_all_stores_by_default_test() ->
+    with_multi_store(
+        fun(#{ multi_store := MultiStore, stores := Stores }) ->
+            Key = <<"all-stores-key">>,
+            Value = <<"all-stores-value">>,
+            ?assertEqual(ok, hb_store:write(MultiStore, Key, Value)),
+            ?assertEqual(length(Stores), stores_with_key(Stores, Key, Value))
+        end
+    ).
+
+setup_multi_store() ->
+    Unique = integer_to_binary(erlang:unique_integer([positive])),
+    MultiStore =
+        #{
+            <<"store-module">> => ?MODULE,
+            <<"name">> => <<"multi-store-", Unique/binary>>,
+            <<"stores">> => Stores =
+                [
+                    hb_test_utils:test_store(hb_store_fs),
+                    hb_test_utils:test_store(hb_store_fs),
+                    hb_test_utils:test_store(hb_store_fs)
+                ]
+        },
+    ok = hb_store:start(MultiStore),
+    #{ multi_store => MultiStore, stores => Stores }.
+
+cleanup_multi_store(#{ multi_store := MultiStore, stores := Stores }) ->
+    hb_store:stop(MultiStore),
+    lists:foreach(
+        fun(Store) -> hb_store:reset(Store) end,
+        Stores
+    ).
+
+with_multi_store(TestFun) ->
+    Context = setup_multi_store(),
+    try TestFun(Context)
+    after cleanup_multi_store(Context)
+    end.
+
+stores_with_key(Stores, Key, Value) ->
+    length(
+        [
+            Store
+        ||
+            Store <- Stores,
+            hb_store:read(Store, Key) =:= {ok, Value}
+        ]
+    ).

--- a/src/hb_store_multi.erl
+++ b/src/hb_store_multi.erl
@@ -4,6 +4,8 @@
 %%% Expects a store options message of the following form:
 %%%      /stores/1..n: Sub-store definition messages.
 %%%      /confirmations: Number of confirmations to require for write operations.
+%%%      /workers-per-store: Number of worker processes to spawn for each store
+%%%                          (default: 3). Work is distributed evenly across each.
 %%% Each sub-store may additionally specify:
 %%%      /num_workers: Number of worker processes to spawn for the store (default: 1).
 -module(hb_store_multi).
@@ -13,7 +15,7 @@
 -export([write/3, make_group/2, make_link/3]).
 -include_lib("eunit/include/eunit.hrl").
 
--define(DEFAULT_STORE_WORKERS, 1).
+-define(DEFAULT_STORE_WORKERS, 3).
 
 %%% Initialization and teardown functions.
 
@@ -187,7 +189,12 @@ store_with_workers(StoreOpts = #{ <<"stores">> := Stores }) ->
         <<"stores">> :=
             lists:map(
                 fun(Store) ->
-                    NumWorkers = maps:get(<<"num_workers">>, Store, ?DEFAULT_STORE_WORKERS),
+                    NumWorkers =
+                        maps:get(
+                            <<"workers-per-store">>,
+                            Store,
+                            ?DEFAULT_STORE_WORKERS
+                        ),
                     Workers = [start_worker(Store) || _ <- lists:seq(1, NumWorkers)],
                     Store#{ <<"workers">> => Workers }
                 end,

--- a/src/hb_store_multi.erl
+++ b/src/hb_store_multi.erl
@@ -1,0 +1,235 @@
+%%% @doc A store implementation that wraps many other stores and dispatches
+%%% operations to them in parallel. It can be configured to wait for a certain
+%%% number of results before returning, or to return as soon as possible.
+%%% Expects a store options message of the following form:
+%%%      /stores/1..n: Sub-store definition messages.
+%%%      /confirmations: Number of confirmations to require for write operations.
+-module(hb_store_multi).
+-behaviour(hb_store).
+-export([start/1, stop/1, reset/1, scope/0, scope/1]).
+-export([read/2, type/2, list/2, match/2]).
+-export([write/3, make_group/2, make_link/3]).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%%% Initialization and teardown functions.
+
+%% @doc Return the scope of the stores: Use the `scope' configuration if present,
+%% otherwise default to `local'.
+scope(#{ <<"scope">> := Scope }) -> Scope;
+scope(_) -> scope().
+scope() -> local.
+
+%% @doc Find (causing a spawn and caching of the instance data) each store.
+start(StoreOpts) ->
+    store_with_workers(StoreOpts).
+
+%% @doc Stop each store and its worker process.
+stop(#{ <<"stores">> := Stores }) ->
+    operation(
+        length(Stores),
+        Stores,
+        fun(XOpts) -> hb_store:stop(XOpts) end,
+        []
+    ),
+    lists:foreach(
+        fun(#{ <<"worker">> := Worker }) -> Worker ! stop end,
+        Stores
+    ).
+
+%% @doc Reset each store.
+reset(#{ <<"stores">> := Stores }) ->
+    operation(
+        length(Stores),
+        Stores,
+        fun(XOpts) -> hb_store:reset(XOpts) end,
+        []
+    ).
+
+%%% Read operations.
+
+%% @doc Read a key from the stores. Return the first successful result.
+read(#{ <<"stores">> := Stores }, Key) ->
+    case operation(1, Stores, fun(XOpts) -> hb_store:read(XOpts, Key) end, [Key]) of
+        [Res] -> Res;
+        _ -> not_found
+    end.
+
+%% @doc List the keys in the stores. Return the first successful result.
+list(#{ <<"stores">> := Stores }, Key) ->
+    case operation(1, Stores, fun(XOpts) -> hb_store:list(XOpts, Key) end, [Key]) of
+        [Res] -> Res;
+        _ -> not_found
+    end.
+
+%% @doc Type a key in the stores. Return the first successful result.
+type(#{ <<"stores">> := Stores }, Key) ->
+    case operation(1, Stores, fun(XOpts) -> hb_store:type(XOpts, Key) end, [Key]) of
+        [Res] -> Res;
+        _ -> not_found
+    end.
+
+%% @doc Match a key in the stores. Return the first successful result.
+match(#{ <<"stores">> := Stores }, Match) ->
+    MatchRes = 
+        operation(
+            1,
+            Stores,
+            fun(XOpts) -> hb_store:match(XOpts, Match) end,
+            [Match]
+        ),
+    case MatchRes of
+        [Res] -> Res;
+        _ -> not_found
+    end.
+
+%%% Write operations.
+
+%% @doc Calculate the number of confirmations to wait for on write operations.
+confirmations(#{ <<"confirmations">> := Confirmations }) -> Confirmations;
+confirmations(#{ <<"stores">> := Stores }) -> length(Stores).
+
+%% @doc Write a key to the stores. By default writes to all stores, but can be
+%% configured to return after only a count of `write-confirmations`, as necessary.
+write(StoreOpts = #{ <<"stores">> := Stores }, Key, Value) ->
+    Res = 
+        operation(
+            confirmations(StoreOpts),
+            Stores,
+            fun(XOpts) -> hb_store:write(XOpts, Key, Value) end,
+            [Key, Value]
+        ),
+    case Res of
+        {error, not_enough_results} -> not_found;
+        _ -> ok
+    end.
+
+%% @doc Make a link in the stores. By default makes a link in all stores, but
+%% consults the `write-confirmations' configuration to determine how many stores
+%% as with `write/2`.
+make_link(StoreOpts = #{ <<"stores">> := Stores }, Existing, New) ->
+    Res =
+        operation(
+            confirmations(StoreOpts),
+            Stores,
+            fun(XOpts) -> hb_store:make_link(XOpts, Existing, New) end,
+            [Existing, New]
+        ),
+    case Res of
+        {error, not_enough_results} -> not_found;
+        _ -> ok
+    end.
+
+%%% Group operations.
+
+%% @doc Make a group in the stores. By default makes a group in all stores, but
+%% consults the `write-confirmations' configuration to determine how many stores
+%% as with `write/2`.
+make_group(StoreOpts = #{ <<"stores">> := Stores }, Path) ->
+    Res = operation(
+        confirmations(StoreOpts),
+        Stores,
+        fun(XOpts) -> hb_store:make_group(XOpts, Path) end,
+        [Path]
+    ),
+    case Res of
+        {error, not_enough_results} -> not_found;
+        _ -> ok
+    end.
+
+%%% Worker operations.
+
+%% @doc Start a worker process for each store and return the updated store options.
+store_with_workers(StoreOpts = #{ <<"stores">> := Stores }) ->
+    StoreOpts#{
+        <<"stores">> :=
+            lists:map(
+                fun(Store) -> Store#{ <<"worker">> := start_worker(Store) } end,
+                Stores
+            )
+    }.
+
+%% @doc Create a new worker process for the given store options.
+start_worker(StoreOpts) ->
+    spawn(
+        fun() ->
+            % Trigger a `find' of the store in the background on the process to
+            % populate its process dictionary with the store's environment.
+            hb_store:find(StoreOpts),
+            % Start the server loop for this worker.
+            server(StoreOpts)
+        end
+    ).
+
+%% @doc Dispatch an operation across all of the stores, then return the results.
+operation(Required, Stores, Function, Args) ->
+    collect(
+        Required,
+        lists:map(
+            fun(Store) -> dispatch(Store, Function, Args) end,
+            Stores
+        )
+    ).
+
+%% @doc Dispatch an operation to a specific worker process, returning the ref
+%% that can be used to collect the result.
+dispatch(#{ <<"worker">> := Worker }, Function, Args) ->
+    dispatch(Worker, Function, Args);
+dispatch(Worker, Function, Args) ->
+    Ref = make_ref(),
+    Caller = self(),
+    Worker ! {operation, Ref, Caller, Function, Args},
+    {Worker, {waiting, Ref}}.
+
+%% @doc Collect result messages from worker processes, cancelling operations
+%% that are no longer needed.
+collect(Required, PIDRefs) when is_list(PIDRefs) ->
+    collect(Required, maps:from_list(PIDRefs));
+collect(0, PIDRefs) ->
+    % Cancel all remaining operations and return the result values.
+    maps:values(
+        maps:filtermap(
+            fun(PID, {waiting, Ref}) -> cancel(PID, Ref), false;
+               (_PID, Res) -> {true, Res}
+            end,
+            PIDRefs
+        )
+    );
+collect(Count, Refs) when Count > map_size(Refs) ->
+    % Threre are more results still to gather than remaining store references.
+    % Cancel the remaining operations and return an error.
+    maps:map(
+        fun(PID, {waiting, Ref}) -> cancel(PID, Ref);
+           (_PID, _Res) -> ok
+        end,
+        Refs
+    ),
+    {error, not_enough_results};
+collect(Count, Refs) ->
+    receive
+        {result, Ref, Res} when is_map_key(Ref, Refs) ->
+            % Add new `ok' or `{ok, Res}' to the results, but remove erroring
+            % store references.
+            case Res of
+                ok -> collect(Count - 1, maps:put(Ref, ok, Refs));
+                {ok, Res} -> collect(Count - 1, maps:put(Ref, {ok, Res}, Refs));
+                _ -> collect(Count, maps:remove(Ref, Refs))
+            end
+    end.
+
+%% @doc Cancel an operation on a worker process.
+cancel(PID, Ref) -> PID ! {cancel, Ref}.
+
+%% @doc Server loop for a worker process. Waits for operations to perform,
+%% checks that they have not been cancelled before performing them, and sends
+%% the result back to the caller. Terminates on `stop' message.
+server(StoreOpts) ->
+    receive
+        stop -> ok;
+        {operation, Ref, Caller, Function, Args} ->
+            receive {cancel, Ref} -> server(StoreOpts)
+            after 0 ->
+                Caller ! {result, Ref, apply(Function, [StoreOpts | Args])},
+                server(StoreOpts)
+            end
+    end.

--- a/src/hb_store_multi.erl
+++ b/src/hb_store_multi.erl
@@ -4,12 +4,16 @@
 %%% Expects a store options message of the following form:
 %%%      /stores/1..n: Sub-store definition messages.
 %%%      /confirmations: Number of confirmations to require for write operations.
+%%% Each sub-store may additionally specify:
+%%%      /num_workers: Number of worker processes to spawn for the store (default: 1).
 -module(hb_store_multi).
 -behaviour(hb_store).
 -export([start/1, stop/1, reset/1, scope/0, scope/1]).
 -export([read/2, type/2, list/2, match/2]).
 -export([write/3, make_group/2, make_link/3]).
 -include_lib("eunit/include/eunit.hrl").
+
+-define(DEFAULT_STORE_WORKERS, 1).
 
 %%% Initialization and teardown functions.
 
@@ -33,7 +37,9 @@ stop(StoreOpts) ->
         []
     ),
     lists:foreach(
-        fun(#{ <<"worker">> := Worker }) -> Worker ! stop end,
+        fun(#{ <<"workers">> := Workers }) ->
+            lists:foreach(fun(Worker) -> Worker ! stop end, Workers)
+        end,
         Stores
     ).
 
@@ -174,11 +180,17 @@ make_group(StoreOpts, Path) ->
 %%% Worker operations.
 
 %% @doc Start a worker process for each store and return the updated store options.
+%% The number of workers per store is controlled by the `num_workers' key in
+%% the store options (default: 1).
 store_with_workers(StoreOpts = #{ <<"stores">> := Stores }) ->
     StoreOpts#{
         <<"stores">> :=
             lists:map(
-                fun(Store) -> Store#{ <<"worker">> => start_worker(Store) } end,
+                fun(Store) ->
+                    NumWorkers = maps:get(<<"num_workers">>, Store, ?DEFAULT_STORE_WORKERS),
+                    Workers = [start_worker(Store) || _ <- lists:seq(1, NumWorkers)],
+                    Store#{ <<"workers">> => Workers }
+                end,
                 Stores
             )
     }.
@@ -205,9 +217,10 @@ operation(Required, Stores, Function, Args) ->
         )
     ).
 
-%% @doc Dispatch an operation to a specific worker process, returning the ref
-%% that can be used to collect the result.
-dispatch(#{ <<"worker">> := Worker }, Function, Args) ->
+%% @doc Dispatch an operation to a worker process chosen at random from the
+%% store's pool, returning the ref that can be used to collect the result.
+dispatch(#{ <<"workers">> := Workers }, Function, Args) ->
+    Worker = lists:nth(rand:uniform(length(Workers)), Workers),
     dispatch(Worker, Function, Args);
 dispatch(Worker, Function, Args) ->
     Ref = make_ref(),


### PR DESCRIPTION
As the moduledoc explains:

```
%%% @doc A store implementation that wraps many other stores and dispatches
%%% operations to them in parallel. It can be configured to wait for a certain
%%% number of results before returning, or to return as soon as possible.
%%% Expects a store options message of the following form:
%%%      /stores/1..n: Sub-store definition messages.
%%%      /confirmations: Number of confirmations to require for write operations.
```