### PR TITLE
fix: enforce undelegation over delegation guard

### DIFF
--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -650,13 +650,13 @@ undelegate(State, Assignment, Opts) ->
         Reason -> {error, Reason}
     end.
 undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
+    GlobalDrippedS = drip_global(S, Opts),
+    S0 = drip_resource(ResourceID, GlobalDrippedS, Opts),
+    S1 = drip_user(FromAddr, S0, Opts),
+    S2 = drip_user(ToAddr, S1, Opts),
     % Self-undelegation is a noop
     case FromAddr =:= ToAddr of
-        true ->
-            GlobalDrippedS = drip_global(S, Opts),
-            DrippedS = drip_resource(ResourceID, GlobalDrippedS, Opts),
-            S0 = drip_user(FromAddr, DrippedS, Opts),
-            drip_user(ToAddr, S0, Opts);
+        true -> S2;
         false ->
             ExistingDelegation =
                 hb_ao:get(
@@ -668,7 +668,7 @@ undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
                         "/delegations/",
                         ToAddr/binary
                     >>,
-                    S,
+                    S2,
                     0,
                     Opts
                 ),
@@ -676,17 +676,17 @@ undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
                 false ->
                     {error, <<"Undelegation amount exceeds existing delegation.">>};
                 true ->
-                    RecipientDeposit = get_deposit(ToAddr, ResourceID, S, Opts),
+                    RecipientDeposit = get_deposit(ToAddr, ResourceID, S2, Opts),
                     Liquidated =
-                        liquidate(ToAddr, ResourceID, Amount - RecipientDeposit, S, Opts),
-                    GlobalDrippedS = drip_global(Liquidated, Opts),
-                    DrippedS = drip_resource(ResourceID, GlobalDrippedS, Opts),
-                    S0 = drip_user(FromAddr, DrippedS, Opts),
-                    S1 = drip_user(ToAddr, S0, Opts),
-                    NewRecipientDeposit = get_deposit(ToAddr, ResourceID, S1, Opts),
-                    S2 =
+                        liquidate(ToAddr, ResourceID, Amount - RecipientDeposit, S2, Opts),
+                    PostLiqGlobalDrippedS = drip_global(Liquidated, Opts),
+                    PostLiqDrippedS = drip_resource(ResourceID, PostLiqGlobalDrippedS, Opts),
+                    S3 = drip_user(FromAddr, PostLiqDrippedS, Opts),
+                    S4 = drip_user(ToAddr, S3, Opts),
+                    NewRecipientDeposit = get_deposit(ToAddr, ResourceID, S4, Opts),
+                    S5 =
                         hb_ao:set(
-                            S1,
+                            S4,
                             <<
                                 "/resources/",
                                 ResourceID/binary,
@@ -697,10 +697,10 @@ undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
                             NewRecipientDeposit - Amount,
                             Opts
                         ),
-                    DelegatorDeposit = get_deposit(FromAddr, ResourceID, S1, Opts),
-                    S3 =
+                    DelegatorDeposit = get_deposit(FromAddr, ResourceID, S4, Opts),
+                    S6 =
                         hb_ao:set(
-                            S2,
+                            S5,
                             <<
                                 "/resources/",
                                 ResourceID/binary,
@@ -711,9 +711,9 @@ undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
                             DelegatorDeposit + Amount,
                             Opts
                         ),
-                    S4 =
+                    S7 =
                         hb_ao:set(
-                            S3,
+                            S6,
                             <<
                                 "/resources/",
                                 ResourceID/binary,
@@ -725,23 +725,23 @@ undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
                             ExistingDelegation - Amount,
                             Opts
                         ),
-                    S5 =
+                    S8 =
                         update_deposit_index(
                             FromAddr,
                             ResourceID,
-                            get_deposit(FromAddr, ResourceID, S3, Opts),
-                            S4,
+                            get_deposit(FromAddr, ResourceID, S6, Opts),
+                            S7,
                             Opts
                         ),
-                    S6 =
+                    S9 =
                         update_deposit_index(
                             ToAddr,
                             ResourceID,
-                            get_deposit(ToAddr, ResourceID, S4, Opts),
-                            S5,
+                            get_deposit(ToAddr, ResourceID, S7, Opts),
+                            S8,
                             Opts
                         ),
-                    send_delegation_notice(FromAddr, ToAddr, ResourceID, -Amount, S6, Opts)
+                    send_delegation_notice(FromAddr, ToAddr, ResourceID, -Amount, S9, Opts)
             end
     end.
 

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -650,15 +650,10 @@ undelegate(State, Assignment, Opts) ->
         Reason -> {error, Reason}
     end.
 undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
-    GlobalDrippedS = drip_global(S, Opts),
-    S0 = drip_resource(ResourceID, GlobalDrippedS, Opts),
-    S1 = drip_user(FromAddr, S0, Opts),
-    S2 = drip_user(ToAddr, S1, Opts),
-    % Self-undelegation is a noop
-    case FromAddr =:= ToAddr of
-        true -> S2;
-        false ->
-            ExistingDelegation =
+    ExistingDelegationBefore =
+        case FromAddr =:= ToAddr of
+            true -> 0;
+            false ->
                 hb_ao:get(
                     <<
                         "/resources/",
@@ -668,25 +663,38 @@ undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
                         "/delegations/",
                         ToAddr/binary
                     >>,
-                    S2,
+                    S,
                     0,
                     Opts
-                ),
-            case ExistingDelegation >= Amount of
+                )
+        end,
+    Validation =
+        case FromAddr =:= ToAddr of
+            true -> ok;
+            false ->
+                case ExistingDelegationBefore >= Amount of
+                    true -> ok;
+                    false ->
+                        {error, <<"Undelegation amount exceeds existing delegation.">>}
+                end
+        end,
+    case Validation of
+        {error, _} = Err -> Err;
+        ok ->
+            RecipientDeposit = get_deposit(ToAddr, ResourceID, S, Opts),
+            Liquidated = liquidate(ToAddr, ResourceID, Amount - RecipientDeposit, S, Opts),
+            GlobalDrippedS = drip_global(Liquidated, Opts),
+            DrippedS = drip_resource(ResourceID, GlobalDrippedS, Opts),
+            S0 = drip_user(FromAddr, DrippedS, Opts),
+            S1 = drip_user(ToAddr, S0, Opts),
+            % Self-undelegation is a noop
+            case FromAddr =:= ToAddr of
+                true -> S1;
                 false ->
-                    {error, <<"Undelegation amount exceeds existing delegation.">>};
-                true ->
-                    RecipientDeposit = get_deposit(ToAddr, ResourceID, S2, Opts),
-                    Liquidated =
-                        liquidate(ToAddr, ResourceID, Amount - RecipientDeposit, S2, Opts),
-                    PostLiqGlobalDrippedS = drip_global(Liquidated, Opts),
-                    PostLiqDrippedS = drip_resource(ResourceID, PostLiqGlobalDrippedS, Opts),
-                    S3 = drip_user(FromAddr, PostLiqDrippedS, Opts),
-                    S4 = drip_user(ToAddr, S3, Opts),
-                    NewRecipientDeposit = get_deposit(ToAddr, ResourceID, S4, Opts),
-                    S5 =
+                    NewRecipientDeposit = get_deposit(ToAddr, ResourceID, S1, Opts),
+                    S2 =
                         hb_ao:set(
-                            S4,
+                            S1,
                             <<
                                 "/resources/",
                                 ResourceID/binary,
@@ -697,10 +705,10 @@ undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
                             NewRecipientDeposit - Amount,
                             Opts
                         ),
-                    DelegatorDeposit = get_deposit(FromAddr, ResourceID, S4, Opts),
-                    S6 =
+                    DelegatorDeposit = get_deposit(FromAddr, ResourceID, S1, Opts),
+                    S3 =
                         hb_ao:set(
-                            S5,
+                            S2,
                             <<
                                 "/resources/",
                                 ResourceID/binary,
@@ -711,9 +719,23 @@ undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
                             DelegatorDeposit + Amount,
                             Opts
                         ),
-                    S7 =
+                    ExistingDelegation =
+                        hb_ao:get(
+                            <<
+                                "/resources/",
+                                ResourceID/binary,
+                                "/deposits/",
+                                FromAddr/binary,
+                                "/delegations/",
+                                ToAddr/binary
+                            >>,
+                            S1,
+                            0,
+                            Opts
+                        ),
+                    S4 =
                         hb_ao:set(
-                            S6,
+                            S3,
                             <<
                                 "/resources/",
                                 ResourceID/binary,
@@ -725,23 +747,23 @@ undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
                             ExistingDelegation - Amount,
                             Opts
                         ),
-                    S8 =
+                    S5 =
                         update_deposit_index(
                             FromAddr,
                             ResourceID,
-                            get_deposit(FromAddr, ResourceID, S6, Opts),
-                            S7,
+                            get_deposit(FromAddr, ResourceID, S3, Opts),
+                            S4,
                             Opts
                         ),
-                    S9 =
+                    S6 =
                         update_deposit_index(
                             ToAddr,
                             ResourceID,
-                            get_deposit(ToAddr, ResourceID, S7, Opts),
-                            S8,
+                            get_deposit(ToAddr, ResourceID, S4, Opts),
+                            S5,
                             Opts
                         ),
-                    send_delegation_notice(FromAddr, ToAddr, ResourceID, -Amount, S9, Opts)
+                    send_delegation_notice(FromAddr, ToAddr, ResourceID, -Amount, S6, Opts)
             end
     end.
 

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -344,9 +344,10 @@ withdraw(Base, Req, Opts) ->
     end.
 withdraw(Addr, ResourceID, Amount, S0, Opts) when is_integer(Amount), Amount > 0 ->
     ExistingDeposit = get_deposit(Addr, ResourceID, S0, Opts),
-    S1 = liquidate(Addr, ResourceID, Amount - ExistingDeposit, S0, Opts),
-    modify_deposit_state(Addr, ResourceID, -Amount, S1, Opts).
-
+    case liquidate(Addr, ResourceID, Amount - ExistingDeposit, S0, Opts) of
+        {error, _} = Err -> Err;
+        S1 -> modify_deposit_state(Addr, ResourceID, -Amount, S1, Opts)
+    end.
 %% @doc Parse a request to modify a deposit and verify that it originates from
 %% the valid resource authority. Returns `{ok, {Address, ResourceID, Amount}}'
 %% if the request is valid, otherwise returns `{error, Reason}'.
@@ -458,21 +459,29 @@ liquidate(Addr, ResourceID, Amount, S, Opts) ->
             #{},
             Opts
         ),
-    LargestDelegation =
-        lists:max(
-            hb_maps:values(
-                hb_private:reset(ExistingDelegations)
-            )
+    DelegationPairs =
+        lists:filter(
+            fun({ToAddr, Qty}) ->
+                is_binary(ToAddr) andalso is_integer(Qty) andalso Qty > 0
+            end,
+            hb_maps:to_list(hb_private:reset(ExistingDelegations))
         ),
-    {LargestDelegationAddr, _} =
-        lists:keyfind(
-            LargestDelegation,
-            2,
-            hb_maps:to_list(ExistingDelegations)
-        ),
-    RevokeAmount = min(Amount, LargestDelegation),
-    S0 = undelegate(Addr, LargestDelegationAddr, ResourceID, RevokeAmount, S, Opts),
-    liquidate(Addr, ResourceID, Amount - RevokeAmount, S0, Opts).
+    ExistingDelegationsVals = lists:map(fun({_ToAddr, Qty}) -> Qty end, DelegationPairs),
+    case ExistingDelegationsVals of
+        [] -> {error, <<"Insufficient delegated balance to liquidate withdrawal">>};
+        _ -> LargestDelegation = lists:max(ExistingDelegationsVals),
+            {LargestDelegationAddr, _} =
+            lists:keyfind(
+                LargestDelegation,
+                2,
+                DelegationPairs
+            ),
+            RevokeAmount = min(Amount, LargestDelegation),
+            case undelegate(Addr, LargestDelegationAddr, ResourceID, RevokeAmount, S, Opts) of
+                {error, _} = Err -> Err;
+                S0 -> liquidate(Addr, ResourceID, Amount - RevokeAmount, S0, Opts)
+            end
+end.
 
 %% @doc Delegate some quantity of a resource from one address to another.
 delegate(State, Assignment, Opts) ->

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -481,7 +481,7 @@ liquidate(Addr, ResourceID, Amount, S, Opts) ->
             RevokeAmount = min(Amount, LargestDelegation),
             case undelegate(Addr, LargestDelegationAddr, ResourceID, RevokeAmount, S, Opts) of
                 {error, _} = Err -> Err;
-                S0 -> liquidate(Addr, ResourceID, Amount - RevokeAmount, S0, Opts)
+                {ok, S0} -> liquidate(Addr, ResourceID, Amount - RevokeAmount, S0, Opts)
             end
     end.
 
@@ -519,11 +519,11 @@ delegate(State, Assignment, Opts) ->
             ),
         NewT = hb_maps:get(<<"t">>, Req, hb_maps:get(<<"t">>, State)),
         StateWithT = State#{ <<"t">> := NewT },
-        case delegate(FromAddr, ToAddr, ResourceID, Amount, StateWithT, Opts) of
-            {error, _} = Err -> Err;
-            NewState -> {ok, NewState}
-        end
+        {ok, NewState} ?=
+            delegate(FromAddr, ToAddr, ResourceID, Amount, StateWithT, Opts),
+        {ok, NewState}
     else
+        {error, _} = Err -> Err;
         Reason -> {error, Reason}
     end.
 delegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
@@ -541,7 +541,7 @@ delegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
     S2 = drip_user(ToAddr, S1, Opts),
     % Self-delegation is a noop
     case FromAddr =:= ToAddr of
-        true -> S2;
+        true -> {ok, S2};
         false ->
             DelegatorDeposit = get_deposit(FromAddr, ResourceID, S2, Opts),
             case DelegatorDeposit >= Amount of
@@ -639,7 +639,15 @@ delegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
                             S7,
                             Opts
                         ),
-                    send_delegation_notice(FromAddr, ToAddr, ResourceID, Amount, S8, Opts)
+                    {ok,
+                        send_delegation_notice(
+                            FromAddr,
+                            ToAddr,
+                            ResourceID,
+                            Amount,
+                            S8,
+                            Opts
+                        )}
             end
     end.
 
@@ -653,11 +661,11 @@ undelegate(State, Assignment, Opts) ->
         {ok, Amount} ?= hb_maps:find(<<"quantity">>, Req, Opts),
         NewT = hb_maps:get(<<"t">>, Req, hb_maps:get(<<"t">>, State)),
         StateWithT = State#{ <<"t">> := NewT },
-        case undelegate(FromAddr, ToAddr, ResourceID, Amount, StateWithT, Opts) of
-            {error, _} = Err -> Err;
-            NewState -> {ok, NewState}
-        end
+        {ok, NewState} ?=
+            undelegate(FromAddr, ToAddr, ResourceID, Amount, StateWithT, Opts),
+        {ok, NewState}
     else
+        {error, _} = Err -> Err;
         Reason -> {error, Reason}
     end.
 undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
@@ -702,7 +710,7 @@ undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
                     S1 = drip_user(ToAddr, S0, Opts),
                     % Self-undelegation is a noop
                     case FromAddr =:= ToAddr of
-                        true -> S1;
+                        true -> {ok, S1};
                         false ->
                             NewRecipientDeposit = get_deposit(ToAddr, ResourceID, S1, Opts),
                             S2 =
@@ -776,14 +784,15 @@ undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
                                     S5,
                                     Opts
                                 ),
-                            send_delegation_notice(
-                                FromAddr,
-                                ToAddr,
-                                ResourceID,
-                                -Amount,
-                                S6,
-                                Opts
-                            )
+                            {ok,
+                                send_delegation_notice(
+                                    FromAddr,
+                                    ToAddr,
+                                    ResourceID,
+                                    -Amount,
+                                    S6,
+                                    Opts
+                                )}
                     end
             end
     end.

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -642,49 +642,22 @@ undelegate(State, Assignment, Opts) ->
         {ok, Amount} ?= hb_maps:find(<<"quantity">>, Req, Opts),
         NewT = hb_maps:get(<<"t">>, Req, hb_maps:get(<<"t">>, State)),
         StateWithT = State#{ <<"t">> := NewT },
-        {ok, undelegate(FromAddr, ToAddr, ResourceID, Amount, StateWithT, Opts)}
+        case undelegate(FromAddr, ToAddr, ResourceID, Amount, StateWithT, Opts) of
+            {error, _} = Err -> Err;
+            NewState -> {ok, NewState}
+        end
     else
-        Reason -> Reason
+        Reason -> {error, Reason}
     end.
 undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
-    RecipientDeposit = get_deposit(ToAddr, ResourceID, S, Opts),
-    Liquidated = liquidate(ToAddr, ResourceID, Amount - RecipientDeposit, S, Opts),
-    GlobalDrippedS = drip_global(Liquidated, Opts),
-    DrippedS = drip_resource(ResourceID, GlobalDrippedS, Opts),
-    S0 = drip_user(FromAddr, DrippedS, Opts),
-    S1 = drip_user(ToAddr, S0, Opts),
     % Self-undelegation is a noop
     case FromAddr =:= ToAddr of
-        true -> S1;
+        true ->
+            GlobalDrippedS = drip_global(S, Opts),
+            DrippedS = drip_resource(ResourceID, GlobalDrippedS, Opts),
+            S0 = drip_user(FromAddr, DrippedS, Opts),
+            drip_user(ToAddr, S0, Opts);
         false ->
-            NewRecipientDeposit = get_deposit(ToAddr, ResourceID, S1, Opts),
-            S2 =
-                hb_ao:set(
-                    S1,
-                    <<
-                        "/resources/",
-                        ResourceID/binary,
-                        "/deposits/",
-                        ToAddr/binary,
-                        "/quantity"
-                    >>,
-                    NewRecipientDeposit - Amount,
-                    Opts
-                ),
-            DelegatorDeposit = get_deposit(FromAddr, ResourceID, S1, Opts),
-            S3 =
-                hb_ao:set(
-                    S2,
-                    <<
-                        "/resources/",
-                        ResourceID/binary,
-                        "/deposits/",
-                        FromAddr/binary,
-                        "/quantity"
-                    >>,
-                    DelegatorDeposit + Amount,
-                    Opts
-                ),
             ExistingDelegation =
                 hb_ao:get(
                     <<
@@ -695,41 +668,81 @@ undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
                         "/delegations/",
                         ToAddr/binary
                     >>,
-                    S1,
+                    S,
                     0,
                     Opts
                 ),
-            S4 =
-                hb_ao:set(
-                    S3,
-                    <<
-                        "/resources/",
-                        ResourceID/binary,
-                        "/deposits/",
-                        FromAddr/binary,
-                        "/delegations/",
-                        ToAddr/binary
-                    >>,
-                    ExistingDelegation - Amount,
-                    Opts
-                ),
-            S5 =
-                update_deposit_index(
-                    FromAddr,
-                    ResourceID,
-                    get_deposit(FromAddr, ResourceID, S3, Opts),
-                    S4,
-                    Opts
-                ),
-            S6 =
-                update_deposit_index(
-                    ToAddr,
-                    ResourceID,
-                    get_deposit(ToAddr, ResourceID, S4, Opts),
-                    S5,
-                    Opts
-                ),
-            send_delegation_notice(FromAddr, ToAddr, ResourceID, -Amount, S6, Opts)
+            case ExistingDelegation >= Amount of
+                false ->
+                    {error, <<"Undelegation amount exceeds existing delegation.">>};
+                true ->
+                    RecipientDeposit = get_deposit(ToAddr, ResourceID, S, Opts),
+                    Liquidated =
+                        liquidate(ToAddr, ResourceID, Amount - RecipientDeposit, S, Opts),
+                    GlobalDrippedS = drip_global(Liquidated, Opts),
+                    DrippedS = drip_resource(ResourceID, GlobalDrippedS, Opts),
+                    S0 = drip_user(FromAddr, DrippedS, Opts),
+                    S1 = drip_user(ToAddr, S0, Opts),
+                    NewRecipientDeposit = get_deposit(ToAddr, ResourceID, S1, Opts),
+                    S2 =
+                        hb_ao:set(
+                            S1,
+                            <<
+                                "/resources/",
+                                ResourceID/binary,
+                                "/deposits/",
+                                ToAddr/binary,
+                                "/quantity"
+                            >>,
+                            NewRecipientDeposit - Amount,
+                            Opts
+                        ),
+                    DelegatorDeposit = get_deposit(FromAddr, ResourceID, S1, Opts),
+                    S3 =
+                        hb_ao:set(
+                            S2,
+                            <<
+                                "/resources/",
+                                ResourceID/binary,
+                                "/deposits/",
+                                FromAddr/binary,
+                                "/quantity"
+                            >>,
+                            DelegatorDeposit + Amount,
+                            Opts
+                        ),
+                    S4 =
+                        hb_ao:set(
+                            S3,
+                            <<
+                                "/resources/",
+                                ResourceID/binary,
+                                "/deposits/",
+                                FromAddr/binary,
+                                "/delegations/",
+                                ToAddr/binary
+                            >>,
+                            ExistingDelegation - Amount,
+                            Opts
+                        ),
+                    S5 =
+                        update_deposit_index(
+                            FromAddr,
+                            ResourceID,
+                            get_deposit(FromAddr, ResourceID, S3, Opts),
+                            S4,
+                            Opts
+                        ),
+                    S6 =
+                        update_deposit_index(
+                            ToAddr,
+                            ResourceID,
+                            get_deposit(ToAddr, ResourceID, S4, Opts),
+                            S5,
+                            Opts
+                        ),
+                    send_delegation_notice(FromAddr, ToAddr, ResourceID, -Amount, S6, Opts)
+            end
     end.
 
 %% @doc Set the weight of a specific resource in the pot. Valid requesters to

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -468,7 +468,7 @@ liquidate(Addr, ResourceID, Amount, S, Opts) ->
         ),
     ExistingDelegationsVals = lists:map(fun({_ToAddr, Qty}) -> Qty end, DelegationPairs),
     case ExistingDelegationsVals of
-        [] -> {error, <<"Insufficient delegated balance to liquidate withdrawal">>};
+        [] -> {error, <<"Insufficient delegated balance to liquidate.">>};
         _ -> LargestDelegation = lists:max(ExistingDelegationsVals),
             {LargestDelegationAddr, _} =
             lists:keyfind(
@@ -691,88 +691,98 @@ undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
         {error, _} = Err -> Err;
         ok ->
             RecipientDeposit = get_deposit(ToAddr, ResourceID, S, Opts),
-            Liquidated = liquidate(ToAddr, ResourceID, Amount - RecipientDeposit, S, Opts),
-            GlobalDrippedS = drip_global(Liquidated, Opts),
-            DrippedS = drip_resource(ResourceID, GlobalDrippedS, Opts),
-            S0 = drip_user(FromAddr, DrippedS, Opts),
-            S1 = drip_user(ToAddr, S0, Opts),
-            % Self-undelegation is a noop
-            case FromAddr =:= ToAddr of
-                true -> S1;
-                false ->
-                    NewRecipientDeposit = get_deposit(ToAddr, ResourceID, S1, Opts),
-                    S2 =
-                        hb_ao:set(
-                            S1,
-                            <<
-                                "/resources/",
-                                ResourceID/binary,
-                                "/deposits/",
-                                ToAddr/binary,
-                                "/quantity"
-                            >>,
-                            NewRecipientDeposit - Amount,
-                            Opts
-                        ),
-                    DelegatorDeposit = get_deposit(FromAddr, ResourceID, S1, Opts),
-                    S3 =
-                        hb_ao:set(
-                            S2,
-                            <<
-                                "/resources/",
-                                ResourceID/binary,
-                                "/deposits/",
-                                FromAddr/binary,
-                                "/quantity"
-                            >>,
-                            DelegatorDeposit + Amount,
-                            Opts
-                        ),
-                    ExistingDelegation =
-                        hb_ao:get(
-                            <<
-                                "/resources/",
-                                ResourceID/binary,
-                                "/deposits/",
-                                FromAddr/binary,
-                                "/delegations/",
-                                ToAddr/binary
-                            >>,
-                            S1,
-                            0,
-                            Opts
-                        ),
-                    S4 =
-                        hb_ao:set(
-                            S3,
-                            <<
-                                "/resources/",
-                                ResourceID/binary,
-                                "/deposits/",
-                                FromAddr/binary,
-                                "/delegations/",
-                                ToAddr/binary
-                            >>,
-                            ExistingDelegation - Amount,
-                            Opts
-                        ),
-                    S5 =
-                        update_deposit_index(
-                            FromAddr,
-                            ResourceID,
-                            get_deposit(FromAddr, ResourceID, S3, Opts),
-                            S4,
-                            Opts
-                        ),
-                    S6 =
-                        update_deposit_index(
-                            ToAddr,
-                            ResourceID,
-                            get_deposit(ToAddr, ResourceID, S4, Opts),
-                            S5,
-                            Opts
-                        ),
-                    send_delegation_notice(FromAddr, ToAddr, ResourceID, -Amount, S6, Opts)
+            case liquidate(ToAddr, ResourceID, Amount - RecipientDeposit, S, Opts) of
+                {error, _} = Err -> Err;
+                Liquidated ->
+                    GlobalDrippedS = drip_global(Liquidated, Opts),
+                    DrippedS = drip_resource(ResourceID, GlobalDrippedS, Opts),
+                    S0 = drip_user(FromAddr, DrippedS, Opts),
+                    S1 = drip_user(ToAddr, S0, Opts),
+                    % Self-undelegation is a noop
+                    case FromAddr =:= ToAddr of
+                        true -> S1;
+                        false ->
+                            NewRecipientDeposit = get_deposit(ToAddr, ResourceID, S1, Opts),
+                            S2 =
+                                hb_ao:set(
+                                    S1,
+                                    <<
+                                        "/resources/",
+                                        ResourceID/binary,
+                                        "/deposits/",
+                                        ToAddr/binary,
+                                        "/quantity"
+                                    >>,
+                                    NewRecipientDeposit - Amount,
+                                    Opts
+                                ),
+                            DelegatorDeposit = get_deposit(FromAddr, ResourceID, S1, Opts),
+                            S3 =
+                                hb_ao:set(
+                                    S2,
+                                    <<
+                                        "/resources/",
+                                        ResourceID/binary,
+                                        "/deposits/",
+                                        FromAddr/binary,
+                                        "/quantity"
+                                    >>,
+                                    DelegatorDeposit + Amount,
+                                    Opts
+                                ),
+                            ExistingDelegation =
+                                hb_ao:get(
+                                    <<
+                                        "/resources/",
+                                        ResourceID/binary,
+                                        "/deposits/",
+                                        FromAddr/binary,
+                                        "/delegations/",
+                                        ToAddr/binary
+                                    >>,
+                                    S1,
+                                    0,
+                                    Opts
+                                ),
+                            S4 =
+                                hb_ao:set(
+                                    S3,
+                                    <<
+                                        "/resources/",
+                                        ResourceID/binary,
+                                        "/deposits/",
+                                        FromAddr/binary,
+                                        "/delegations/",
+                                        ToAddr/binary
+                                    >>,
+                                    ExistingDelegation - Amount,
+                                    Opts
+                                ),
+                            S5 =
+                                update_deposit_index(
+                                    FromAddr,
+                                    ResourceID,
+                                    get_deposit(FromAddr, ResourceID, S3, Opts),
+                                    S4,
+                                    Opts
+                                ),
+                            S6 =
+                                update_deposit_index(
+                                    ToAddr,
+                                    ResourceID,
+                                    get_deposit(ToAddr, ResourceID, S4, Opts),
+                                    S5,
+                                    Opts
+                                ),
+                            send_delegation_notice(
+                                FromAddr,
+                                ToAddr,
+                                ResourceID,
+                                -Amount,
+                                S6,
+                                Opts
+                            )
+                    end
             end
     end.
 

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -344,9 +344,15 @@ withdraw(Base, Req, Opts) ->
     end.
 withdraw(Addr, ResourceID, Amount, S0, Opts) when is_integer(Amount), Amount > 0 ->
     ExistingDeposit = get_deposit(Addr, ResourceID, S0, Opts),
-    case liquidate(Addr, ResourceID, Amount - ExistingDeposit, S0, Opts) of
-        {error, _} = Err -> Err;
-        S1 -> modify_deposit_state(Addr, ResourceID, -Amount, S1, Opts)
+    maybe
+        {ok, S1} ?=
+            case liquidate(Addr, ResourceID, Amount - ExistingDeposit, S0, Opts) of
+                {error, _} = LiquidateErr -> LiquidateErr;
+                Liquidated -> {ok, Liquidated}
+            end,
+        modify_deposit_state(Addr, ResourceID, -Amount, S1, Opts)
+    else
+        {error, _} = WithdrawErr -> WithdrawErr
     end.
 %% @doc Parse a request to modify a deposit and verify that it originates from
 %% the valid resource authority. Returns `{ok, {Address, ResourceID, Amount}}'

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -40,12 +40,6 @@
 -export([user/3, balance/3, balances/1, balances/2]).
 -export([get_deposit/4, get_deposits/2, get_deposits/3]).
 
-%%% Types
--type addr() :: binary().
--type resource_id() :: binary().
--type pot_state() :: map().
--type pot_reason() :: term().
-
 %%% Pot Model Functions.
 
 info(_S) ->
@@ -323,7 +317,7 @@ unclaimed_yield(Addr, ResourceID, UndrippedS, Opts) ->
     end.
 
 %% @doc Deposit a quantity of a resource for a given address.
--spec deposit(pot_state(), map(), map()) -> pot_state() | {error, pot_reason()}.
+-spec deposit(map(), map(), map()) -> map() | {error, term()}.
 deposit(State, Assignment, Opts) ->
     maybe
         {ok, {Address, ResourceID, Amount}} ?=
@@ -335,13 +329,13 @@ deposit(State, Assignment, Opts) ->
     else
         Reason -> {error, Reason}
     end.
--spec deposit(addr(), resource_id(), pos_integer(), pot_state(), map()) -> pot_state().
+-spec deposit(binary(), binary(), pos_integer(), map(), map()) -> map().
 deposit(Addr, ResourceID, Amount, S0, Opts) when is_integer(Amount), Amount > 0 ->
     modify_deposit_state(Addr, ResourceID, Amount, S0, Opts).
 
 %% @doc Withdraw a quantity of a resource for a given address. If the quantity
 %% is insufficient, we'll revoke delegations until the withdrawal can be completed.
--spec withdraw(pot_state(), map(), map()) -> pot_state() | {error, pot_reason()}.
+-spec withdraw(map(), map(), map()) -> map() | {error, term()}.
 withdraw(Base, Req, Opts) ->
     maybe
         {ok, {Address, ResourceID, Amount}} ?=
@@ -351,7 +345,7 @@ withdraw(Base, Req, Opts) ->
         BaseWithT = Base#{<<"t">> := NewT},
         withdraw(Address, ResourceID, Amount, BaseWithT, Opts)
     end.
--spec withdraw(addr(), resource_id(), pos_integer(), pot_state(), map()) -> pot_state() | {error, pot_reason()}.
+-spec withdraw(binary(), binary(), pos_integer(), map(), map()) -> map() | {error, term()}.
 withdraw(Addr, ResourceID, Amount, S0, Opts) when is_integer(Amount), Amount > 0 ->
     ExistingDeposit = get_deposit(Addr, ResourceID, S0, Opts),
     maybe
@@ -457,7 +451,7 @@ notify(State, Assignment, Opts) ->
 
 %% @doc For a given address, undelegate their delegations until the specified
 %% quantity has been reclaimed.
--spec liquidate(addr(), resource_id(), integer(), pot_state(), map()) -> {ok, pot_state()} | {error, pot_reason()}.
+-spec liquidate(binary(), binary(), integer(), map(), map()) -> {ok, map()} | {error, term()}.
 liquidate(_Addr, _ResourceID, Amount, S, _Opts) when Amount =< 0 -> {ok, S};
 liquidate(Addr, ResourceID, Amount, S, Opts) ->
     ExistingDelegations =
@@ -497,7 +491,7 @@ liquidate(Addr, ResourceID, Amount, S, Opts) ->
     end.
 
 %% @doc Delegate some quantity of a resource from one address to another.
--spec delegate(pot_state(), map(), map()) -> {ok, pot_state()} | {error, pot_reason()}.
+-spec delegate(map(), map(), map()) -> {ok, map()} | {error, term()}.
 delegate(State, Assignment, Opts) ->
     Req = hb_ao:get(<<"body">>, Assignment, Opts),
     maybe
@@ -538,7 +532,7 @@ delegate(State, Assignment, Opts) ->
         {error, _} = Err -> Err;
         Reason -> {error, Reason}
     end.
--spec delegate(addr(), addr(), resource_id(), pos_integer(), pot_state(), map()) -> {ok, pot_state()} | {error, pot_reason()}.
+-spec delegate(binary(), binary(), binary(), pos_integer(), map(), map()) -> {ok, map()} | {error, term()}.
 delegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
     ?event(
         {delegating,
@@ -665,7 +659,7 @@ delegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
     end.
 
 %% @doc Undelegate some quantity of a resource from one address to another.
--spec undelegate(pot_state(), map(), map()) -> {ok, pot_state()} | {error, pot_reason()}.
+-spec undelegate(map(), map(), map()) -> {ok, map()} | {error, term()}.
 undelegate(State, Assignment, Opts) ->
     Req = hb_ao:get(<<"body">>, Assignment, Opts),
     maybe
@@ -682,7 +676,7 @@ undelegate(State, Assignment, Opts) ->
         {error, _} = Err -> Err;
         Reason -> {error, Reason}
     end.
--spec undelegate(addr(), addr(), resource_id(), pos_integer(), pot_state(), map()) -> {ok, pot_state()} | {error, pot_reason()}.
+-spec undelegate(binary(), binary(), binary(), pos_integer(), map(), map()) -> {ok, map()} | {error, term()}.
 undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
     ExistingDelegationBefore =
         case FromAddr =:= ToAddr of

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -40,6 +40,12 @@
 -export([user/3, balance/3, balances/1, balances/2]).
 -export([get_deposit/4, get_deposits/2, get_deposits/3]).
 
+%%% Types
+-type addr() :: binary().
+-type resource_id() :: binary().
+-type pot_state() :: map().
+-type pot_reason() :: term().
+
 %%% Pot Model Functions.
 
 info(_S) ->
@@ -317,6 +323,7 @@ unclaimed_yield(Addr, ResourceID, UndrippedS, Opts) ->
     end.
 
 %% @doc Deposit a quantity of a resource for a given address.
+-spec deposit(pot_state(), map(), map()) -> pot_state() | {error, pot_reason()}.
 deposit(State, Assignment, Opts) ->
     maybe
         {ok, {Address, ResourceID, Amount}} ?=
@@ -328,11 +335,13 @@ deposit(State, Assignment, Opts) ->
     else
         Reason -> {error, Reason}
     end.
+-spec deposit(addr(), resource_id(), pos_integer(), pot_state(), map()) -> pot_state().
 deposit(Addr, ResourceID, Amount, S0, Opts) when is_integer(Amount), Amount > 0 ->
     modify_deposit_state(Addr, ResourceID, Amount, S0, Opts).
 
 %% @doc Withdraw a quantity of a resource for a given address. If the quantity
 %% is insufficient, we'll revoke delegations until the withdrawal can be completed.
+-spec withdraw(pot_state(), map(), map()) -> pot_state() | {error, pot_reason()}.
 withdraw(Base, Req, Opts) ->
     maybe
         {ok, {Address, ResourceID, Amount}} ?=
@@ -342,6 +351,7 @@ withdraw(Base, Req, Opts) ->
         BaseWithT = Base#{<<"t">> := NewT},
         withdraw(Address, ResourceID, Amount, BaseWithT, Opts)
     end.
+-spec withdraw(addr(), resource_id(), pos_integer(), pot_state(), map()) -> pot_state() | {error, pot_reason()}.
 withdraw(Addr, ResourceID, Amount, S0, Opts) when is_integer(Amount), Amount > 0 ->
     ExistingDeposit = get_deposit(Addr, ResourceID, S0, Opts),
     maybe
@@ -447,6 +457,7 @@ notify(State, Assignment, Opts) ->
 
 %% @doc For a given address, undelegate their delegations until the specified
 %% quantity has been reclaimed.
+-spec liquidate(addr(), resource_id(), integer(), pot_state(), map()) -> {ok, pot_state()} | {error, pot_reason()}.
 liquidate(_Addr, _ResourceID, Amount, S, _Opts) when Amount =< 0 -> {ok, S};
 liquidate(Addr, ResourceID, Amount, S, Opts) ->
     ExistingDelegations =
@@ -486,6 +497,7 @@ liquidate(Addr, ResourceID, Amount, S, Opts) ->
     end.
 
 %% @doc Delegate some quantity of a resource from one address to another.
+-spec delegate(pot_state(), map(), map()) -> {ok, pot_state()} | {error, pot_reason()}.
 delegate(State, Assignment, Opts) ->
     Req = hb_ao:get(<<"body">>, Assignment, Opts),
     maybe
@@ -526,6 +538,7 @@ delegate(State, Assignment, Opts) ->
         {error, _} = Err -> Err;
         Reason -> {error, Reason}
     end.
+-spec delegate(addr(), addr(), resource_id(), pos_integer(), pot_state(), map()) -> {ok, pot_state()} | {error, pot_reason()}.
 delegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
     ?event(
         {delegating,
@@ -652,6 +665,7 @@ delegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
     end.
 
 %% @doc Undelegate some quantity of a resource from one address to another.
+-spec undelegate(pot_state(), map(), map()) -> {ok, pot_state()} | {error, pot_reason()}.
 undelegate(State, Assignment, Opts) ->
     Req = hb_ao:get(<<"body">>, Assignment, Opts),
     maybe
@@ -668,6 +682,7 @@ undelegate(State, Assignment, Opts) ->
         {error, _} = Err -> Err;
         Reason -> {error, Reason}
     end.
+-spec undelegate(addr(), addr(), resource_id(), pos_integer(), pot_state(), map()) -> {ok, pot_state()} | {error, pot_reason()}.
 undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
     ExistingDelegationBefore =
         case FromAddr =:= ToAddr of

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -345,11 +345,7 @@ withdraw(Base, Req, Opts) ->
 withdraw(Addr, ResourceID, Amount, S0, Opts) when is_integer(Amount), Amount > 0 ->
     ExistingDeposit = get_deposit(Addr, ResourceID, S0, Opts),
     maybe
-        {ok, S1} ?=
-            case liquidate(Addr, ResourceID, Amount - ExistingDeposit, S0, Opts) of
-                {error, _} = LiquidateErr -> LiquidateErr;
-                Liquidated -> {ok, Liquidated}
-            end,
+        {ok, S1} ?= liquidate(Addr, ResourceID, Amount - ExistingDeposit, S0, Opts),
         modify_deposit_state(Addr, ResourceID, -Amount, S1, Opts)
     else
         {error, _} = WithdrawErr -> WithdrawErr
@@ -451,7 +447,7 @@ notify(State, Assignment, Opts) ->
 
 %% @doc For a given address, undelegate their delegations until the specified
 %% quantity has been reclaimed.
-liquidate(_Addr, _ResourceID, Amount, S, _Opts) when Amount =< 0 -> S;
+liquidate(_Addr, _ResourceID, Amount, S, _Opts) when Amount =< 0 -> {ok, S};
 liquidate(Addr, ResourceID, Amount, S, Opts) ->
     ExistingDelegations =
         hb_ao:get(
@@ -487,7 +483,7 @@ liquidate(Addr, ResourceID, Amount, S, Opts) ->
                 {error, _} = Err -> Err;
                 S0 -> liquidate(Addr, ResourceID, Amount - RevokeAmount, S0, Opts)
             end
-end.
+    end.
 
 %% @doc Delegate some quantity of a resource from one address to another.
 delegate(State, Assignment, Opts) ->
@@ -699,7 +695,7 @@ undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
             RecipientDeposit = get_deposit(ToAddr, ResourceID, S, Opts),
             case liquidate(ToAddr, ResourceID, Amount - RecipientDeposit, S, Opts) of
                 {error, _} = Err -> Err;
-                Liquidated ->
+                {ok, Liquidated} ->
                     GlobalDrippedS = drip_global(Liquidated, Opts),
                     DrippedS = drip_resource(ResourceID, GlobalDrippedS, Opts),
                     S0 = drip_user(FromAddr, DrippedS, Opts),

--- a/src/dev_pot_test_vectors.erl
+++ b/src/dev_pot_test_vectors.erl
@@ -938,7 +938,7 @@ liquidate_insufficient_delegations_test() ->
     S1 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 10, S0, Opts),
     % Alice has 0 deposits, 10 delegated to Bob. Try to withdraw 15 - impossible
     ?assertMatch(
-        {error, <<"Insufficient delegated balance to liquidate withdrawal">>},
+        {error, <<"Insufficient delegated balance to liquidate.">>},
         dev_pot:withdraw(Alice, ResourceOxygen, 15, S1, Opts)
     ).
 

--- a/src/dev_pot_test_vectors.erl
+++ b/src/dev_pot_test_vectors.erl
@@ -948,7 +948,23 @@ undelegate_more_than_delegated_test() ->
     S0 = pot_state_multi(ResourceOxygen, [{Alice, 10}, {Bob, 0}]),
     S1 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 5, S0, Opts),
     % Delegation record shows 5, try to undelegate 10
-    ?assertError(_, dev_pot:undelegate(Alice, Bob, ResourceOxygen, 10, S1, Opts)).
+    ?assertMatch(
+        {error, <<"Undelegation amount exceeds existing delegation.">>},
+        dev_pot:undelegate(Alice, Bob, ResourceOxygen, 10, S1, Opts)
+    ).
+
+undelegate_exceeds_delegated_rejected_with_recipient_buffer_test() ->
+    Alice = <<"alice">>,
+    Bob = <<"bob">>,
+    ResourceOxygen = <<"oxygen">>,
+    Opts = #{},
+    % Bob starts with own deposits, this should still reject over undelegation
+    S0 = pot_state_multi(ResourceOxygen, [{Alice, 10}, {Bob, 20}]),
+    S1 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 5, S0, Opts),
+    ?assertMatch(
+        {error, <<"Undelegation amount exceeds existing delegation.">>},
+        dev_pot:undelegate(Alice, Bob, ResourceOxygen, 10, S1, Opts)
+    ).
 
 %%% Weight Change Scenarios
 

--- a/src/dev_pot_test_vectors.erl
+++ b/src/dev_pot_test_vectors.erl
@@ -937,7 +937,10 @@ liquidate_insufficient_delegations_test() ->
     S0 = pot_state_multi(ResourceOxygen, [{Alice, 10}, {Bob, 0}]),
     S1 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 10, S0, Opts),
     % Alice has 0 deposits, 10 delegated to Bob. Try to withdraw 15 - impossible
-    ?assertError(_, dev_pot:withdraw(Alice, ResourceOxygen, 15, S1, Opts)).
+    ?assertMatch(
+        {error, <<"Insufficient delegated balance to liquidate withdrawal">>},
+        dev_pot:withdraw(Alice, ResourceOxygen, 15, S1, Opts)
+    ).
 
 undelegate_more_than_delegated_test() ->
     Alice = <<"alice">>,

--- a/src/dev_pot_test_vectors.erl
+++ b/src/dev_pot_test_vectors.erl
@@ -96,6 +96,18 @@ pot_state_empty(EmptyResources, MintCap, MintPropN, MintPropD) ->
         <<"balances">> => #{}
     }.
 
+delegate(FromAddr, ToAddr, ResourceID, Amount, State, Opts) ->
+    case dev_pot:delegate(FromAddr, ToAddr, ResourceID, Amount, State, Opts) of
+        {ok, NewState} -> NewState;
+        Other -> Other
+    end.
+
+undelegate(FromAddr, ToAddr, ResourceID, Amount, State, Opts) ->
+    case dev_pot:undelegate(FromAddr, ToAddr, ResourceID, Amount, State, Opts) of
+        {ok, NewState} -> NewState;
+        Other -> Other
+    end.
+
 mint_quantity_test() ->
     ?assertEqual(50, dev_pot_math:minted_between(0, 100, 1, 2, 0, 1)),
     ?assertEqual(75, dev_pot_math:minted_between(0, 100, 1, 2, 0, 2)),
@@ -293,7 +305,7 @@ simple_delegation_test() ->
         <<"total-weighted-units">> => 250
     },
     % Alice delegates 20 hydrogen to Bob
-    S1 = dev_pot:delegate(Alice, Bob, ResourceHydrogen, 20, S0, Opts),
+    S1 = delegate(Alice, Bob, ResourceHydrogen, 20, S0, Opts),
     ?assertEqual(
         20,
         hb_ao:get(
@@ -335,7 +347,7 @@ simple_delegation_test() ->
         )
     ),
     % Alice undelegates 10 hydrogen from Bob
-    S2 = dev_pot:undelegate(Alice, Bob, ResourceHydrogen, 10, S1, Opts),
+    S2 = undelegate(Alice, Bob, ResourceHydrogen, 10, S1, Opts),
     ?assertEqual(
         10,
         hb_ao:get(
@@ -377,7 +389,7 @@ simple_delegation_test() ->
         )
     ),
     % Bob delegates 21 oxygen to Alice
-    S3 = dev_pot:delegate(Bob, Alice, ResourceOxygen, 21, S2, Opts),
+    S3 = delegate(Bob, Alice, ResourceOxygen, 21, S2, Opts),
     ?assertEqual(
         21,
         hb_ao:get(
@@ -410,10 +422,10 @@ delegation_liquidation_test() ->
                 {Charlie, 0}
             ]
         ),
-    S1 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 1, S0, Opts),
-    S2 = dev_pot:delegate(Bob, Charlie, ResourceOxygen, 1, S1, Opts),
+    S1 = delegate(Alice, Bob, ResourceOxygen, 1, S0, Opts),
+    S2 = delegate(Bob, Charlie, ResourceOxygen, 1, S1, Opts),
     report(S2, Opts),
-    S3 = dev_pot:undelegate(Alice, Bob, ResourceOxygen, 1, S2, Opts),
+    S3 = undelegate(Alice, Bob, ResourceOxygen, 1, S2, Opts),
     ?assertEqual(1, dev_pot:get_deposit(Alice, ResourceOxygen, S3, Opts)),
     ?assertEqual(0, dev_pot:get_deposit(Bob, ResourceOxygen, S3, Opts)),
     ?assertEqual(0, dev_pot:get_deposit(Charlie, ResourceOxygen, S3, Opts)).
@@ -435,14 +447,14 @@ multiple_delegations_liquidation_test() ->
                 {Denis, 0}
             ]
         ),
-    S1 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 2, S0, Opts),
-    S2 = dev_pot:delegate(Bob, Charlie, ResourceOxygen, 1, S1, Opts),
-    S3 = dev_pot:delegate(Bob, Denis, ResourceOxygen, 1, S2, Opts),
-    S4 = dev_pot:delegate(Denis, Alice, ResourceOxygen, 1, S3, Opts),
+    S1 = delegate(Alice, Bob, ResourceOxygen, 2, S0, Opts),
+    S2 = delegate(Bob, Charlie, ResourceOxygen, 1, S1, Opts),
+    S3 = delegate(Bob, Denis, ResourceOxygen, 1, S2, Opts),
+    S4 = delegate(Denis, Alice, ResourceOxygen, 1, S3, Opts),
     report(S4, Opts),
     ?assertEqual(1, dev_pot:get_deposit(Alice, ResourceOxygen, S4, Opts)),
     ?assertEqual(1, dev_pot:get_deposit(Charlie, ResourceOxygen, S4, Opts)),
-    S5 = dev_pot:undelegate(Alice, Bob, ResourceOxygen, 2, S4, Opts),
+    S5 = undelegate(Alice, Bob, ResourceOxygen, 2, S4, Opts),
     ?assertEqual(2, dev_pot:get_deposit(Alice, ResourceOxygen, S5, Opts)),
     ?assertEqual(0, dev_pot:get_deposit(Bob, ResourceOxygen, S5, Opts)),
     ?assertEqual(0, dev_pot:get_deposit(Charlie, ResourceOxygen, S5, Opts)),
@@ -461,14 +473,14 @@ cyclic_delegations_test() ->
                 {Bob, 0}
             ]
         ),
-    S1 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 1, S0, Opts),
-    S2 = dev_pot:delegate(Bob, Alice, ResourceOxygen, 1, S1, Opts),
-    S3 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 1, S2, Opts),
-    S4 = dev_pot:delegate(Bob, Alice, ResourceOxygen, 1, S3, Opts),
+    S1 = delegate(Alice, Bob, ResourceOxygen, 1, S0, Opts),
+    S2 = delegate(Bob, Alice, ResourceOxygen, 1, S1, Opts),
+    S3 = delegate(Alice, Bob, ResourceOxygen, 1, S2, Opts),
+    S4 = delegate(Bob, Alice, ResourceOxygen, 1, S3, Opts),
     ?assertEqual(1, dev_pot:get_deposit(Alice, ResourceOxygen, S4, Opts)),
     ?assertEqual(0, dev_pot:get_deposit(Bob, ResourceOxygen, S4, Opts)),
     report(S4, Opts),
-    S5 = dev_pot:undelegate(Bob, Alice, ResourceOxygen, 1, S4, Opts),
+    S5 = undelegate(Bob, Alice, ResourceOxygen, 1, S4, Opts),
     report(S5, Opts),
     ?assertEqual(0, dev_pot:get_deposit(Alice, ResourceOxygen, S5, Opts)),
     ?assertEqual(1, dev_pot:get_deposit(Bob, ResourceOxygen, S5, Opts)).
@@ -489,9 +501,9 @@ deposit_removal_while_delegated_test() ->
             ]
         
         ),
-    S1 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 3, S0, Opts),
-    S2 = dev_pot:delegate(Bob, Charlie, ResourceOxygen, 2, S1, Opts),
-    S3 = dev_pot:delegate(Charlie, Alice, ResourceOxygen, 1, S2, Opts),
+    S1 = delegate(Alice, Bob, ResourceOxygen, 3, S0, Opts),
+    S2 = delegate(Bob, Charlie, ResourceOxygen, 2, S1, Opts),
+    S3 = delegate(Charlie, Alice, ResourceOxygen, 1, S2, Opts),
     report(S1, Opts),
     ?assertEqual(1, dev_pot:get_deposit(Alice, ResourceOxygen, S3, Opts)),
     ?assertEqual(1, dev_pot:get_deposit(Bob, ResourceOxygen, S3, Opts)),
@@ -685,7 +697,7 @@ delegate_zero_amount_test() ->
     S0 = pot_state_multi(ResourceOxygen, [{Alice, 10}, {Bob, 0}]),
     ?assertError(
         function_clause, 
-        dev_pot:delegate(Alice, Bob, ResourceOxygen, 0, S0, Opts)
+        delegate(Alice, Bob, ResourceOxygen, 0, S0, Opts)
     ).
 
 delegate_to_self_test() ->
@@ -694,7 +706,7 @@ delegate_to_self_test() ->
     Opts = #{},
     % Alice delegates to herself - should work but is a no-op in practice
     S0 = pot_state(Alice, ResourceOxygen, 10),
-    S1 = dev_pot:delegate(Alice, Alice, ResourceOxygen, 5, S0, Opts),
+    S1 = delegate(Alice, Alice, ResourceOxygen, 5, S0, Opts),
     % After delegating to self, deposit should still be 10 (5 removed, 5 added back)
     ?assertEqual(10, dev_pot:get_deposit(Alice, ResourceOxygen, S1, Opts)),
     % Self delegation is a noop, so no delegation record should be written
@@ -718,7 +730,7 @@ delegate_entire_balance_test() ->
     Opts = #{},
     % Delegate 100% of deposits
     S0 = pot_state_multi(ResourceOxygen, [{Alice, 10}, {Bob, 0}]),
-    S1 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 10, S0, Opts),
+    S1 = delegate(Alice, Bob, ResourceOxygen, 10, S0, Opts),
     ?assertEqual(0, dev_pot:get_deposit(Alice, ResourceOxygen, S1, Opts)),
     ?assertEqual(10, dev_pot:get_deposit(Bob, ResourceOxygen, S1, Opts)).
 
@@ -730,7 +742,7 @@ delegate_exceeds_available_balance_rejected_test() ->
     S0 = pot_state_multi(ResourceOxygen, [{Alice, 10}, {Bob, 0}]),
     ?assertMatch(
         {error, <<"Delegation amount exceeds available deposit.">>},
-        dev_pot:delegate(Alice, Bob, ResourceOxygen, 15, S0, Opts)
+        delegate(Alice, Bob, ResourceOxygen, 15, S0, Opts)
     ).
 
 %%% Delegation Chain Tests
@@ -751,10 +763,10 @@ deep_delegation_chain_test() ->
         {Denis, 0},
         {Eve, 0}
     ]),
-    S1 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 10, S0, Opts),
-    S2 = dev_pot:delegate(Bob, Charlie, ResourceOxygen, 10, S1, Opts),
-    S3 = dev_pot:delegate(Charlie, Denis, ResourceOxygen, 10, S2, Opts),
-    S4 = dev_pot:delegate(Denis, Eve, ResourceOxygen, 10, S3, Opts),
+    S1 = delegate(Alice, Bob, ResourceOxygen, 10, S0, Opts),
+    S2 = delegate(Bob, Charlie, ResourceOxygen, 10, S1, Opts),
+    S3 = delegate(Charlie, Denis, ResourceOxygen, 10, S2, Opts),
+    S4 = delegate(Denis, Eve, ResourceOxygen, 10, S3, Opts),
     % Final state: Alice:0, Bob:0, Charlie:0, Denis:0, Eve:10
     ?assertEqual(0, dev_pot:get_deposit(Alice, ResourceOxygen, S4, Opts)),
     ?assertEqual(0, dev_pot:get_deposit(Bob, ResourceOxygen, S4, Opts)),
@@ -776,11 +788,11 @@ wide_delegation_tree_test() ->
         {Alice, 10}, {Bob, 0}, {Charlie, 0},
         {Denis, 0}, {Eve, 0}, {Frank, 0}
     ]),
-    S1 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 2, S0, Opts),
-    S2 = dev_pot:delegate(Alice, Charlie, ResourceOxygen, 2, S1, Opts),
-    S3 = dev_pot:delegate(Alice, Denis, ResourceOxygen, 2, S2, Opts),
-    S4 = dev_pot:delegate(Alice, Eve, ResourceOxygen, 2, S3, Opts),
-    S5 = dev_pot:delegate(Alice, Frank, ResourceOxygen, 2, S4, Opts),
+    S1 = delegate(Alice, Bob, ResourceOxygen, 2, S0, Opts),
+    S2 = delegate(Alice, Charlie, ResourceOxygen, 2, S1, Opts),
+    S3 = delegate(Alice, Denis, ResourceOxygen, 2, S2, Opts),
+    S4 = delegate(Alice, Eve, ResourceOxygen, 2, S3, Opts),
+    S5 = delegate(Alice, Frank, ResourceOxygen, 2, S4, Opts),
     % Alice should have 0 left, each delegate has 2
     ?assertEqual(0, dev_pot:get_deposit(Alice, ResourceOxygen, S5, Opts)),
     ?assertEqual(2, dev_pot:get_deposit(Bob, ResourceOxygen, S5, Opts)),
@@ -805,7 +817,7 @@ total_deposits_conservation_test() ->
         dev_pot:get_deposit(Alice, ResourceOxygen, S2, Opts) +
         dev_pot:get_deposit(Bob, ResourceOxygen, S2, Opts)),
     % Delegate
-    S3 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 5, S2, Opts),
+    S3 = delegate(Alice, Bob, ResourceOxygen, 5, S2, Opts),
     ?assertEqual(TotalAfterDeposits,
         dev_pot:get_deposit(Alice, ResourceOxygen, S3, Opts) +
         dev_pot:get_deposit(Bob, ResourceOxygen, S3, Opts)),
@@ -843,7 +855,7 @@ liquidate_partial_delegation_test() ->
     Opts = #{},
     % Overdraw is less than largest delegation - should partially liquidate
     S0 = pot_state_multi(ResourceOxygen, [{Alice, 10}, {Bob, 0}]),
-    S1 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 10, S0, Opts),
+    S1 = delegate(Alice, Bob, ResourceOxygen, 10, S0, Opts),
     % Alice tries to withdraw 3, but has 0 deposits. Should liquidate 3 from Bob
     S2 = dev_pot:withdraw(Alice, ResourceOxygen, 3, S1, Opts),
     report(S2, Opts),
@@ -874,7 +886,7 @@ liquidate_exact_delegation_test() ->
     Opts = #{},
     % Overdraw equals largest delegation - should fully liquidate one
     S0 = pot_state_multi(ResourceOxygen, [{Alice, 10}, {Bob, 0}]),
-    S1 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 10, S0, Opts),
+    S1 = delegate(Alice, Bob, ResourceOxygen, 10, S0, Opts),
     S2 = dev_pot:withdraw(Alice, ResourceOxygen, 10, S1, Opts),
     ?assertEqual(0, dev_pot:get_deposit(Alice, ResourceOxygen, S2, Opts)),
     ?assertEqual(0, dev_pot:get_deposit(Bob, ResourceOxygen, S2, Opts)),
@@ -914,9 +926,9 @@ liquidate_requiring_multiple_delegations_test() ->
                 {Denis, 0}
             ]
         ),
-    S1 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 5, S0, Opts),
-    S2 = dev_pot:delegate(Alice, Charlie, ResourceOxygen, 5, S1, Opts),
-    S3 = dev_pot:delegate(Alice, Denis, ResourceOxygen, 5, S2, Opts),
+    S1 = delegate(Alice, Bob, ResourceOxygen, 5, S0, Opts),
+    S2 = delegate(Alice, Charlie, ResourceOxygen, 5, S1, Opts),
+    S3 = delegate(Alice, Denis, ResourceOxygen, 5, S2, Opts),
     % Alice has 0 deposits, 3 delegations of 5 each. Try to withdraw 12
     S4 = dev_pot:withdraw(Alice, ResourceOxygen, 12, S3, Opts),
     % After withdrawal, alice should have 0 (withdrew everything)
@@ -935,7 +947,7 @@ liquidate_insufficient_delegations_test() ->
     Opts =#{},
     % Overdraw exceeds total delegations - what happens?
     S0 = pot_state_multi(ResourceOxygen, [{Alice, 10}, {Bob, 0}]),
-    S1 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 10, S0, Opts),
+    S1 = delegate(Alice, Bob, ResourceOxygen, 10, S0, Opts),
     % Alice has 0 deposits, 10 delegated to Bob. Try to withdraw 15 - impossible
     ?assertMatch(
         {error, <<"Insufficient delegated balance to liquidate.">>},
@@ -949,11 +961,11 @@ undelegate_more_than_delegated_test() ->
     Opts =#{},
     % Try to revoke more than was delegated
     S0 = pot_state_multi(ResourceOxygen, [{Alice, 10}, {Bob, 0}]),
-    S1 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 5, S0, Opts),
+    S1 = delegate(Alice, Bob, ResourceOxygen, 5, S0, Opts),
     % Delegation record shows 5, try to undelegate 10
     ?assertMatch(
         {error, <<"Undelegation amount exceeds existing delegation.">>},
-        dev_pot:undelegate(Alice, Bob, ResourceOxygen, 10, S1, Opts)
+        undelegate(Alice, Bob, ResourceOxygen, 10, S1, Opts)
     ).
 
 undelegate_exceeds_delegated_rejected_with_recipient_buffer_test() ->
@@ -963,10 +975,10 @@ undelegate_exceeds_delegated_rejected_with_recipient_buffer_test() ->
     Opts = #{},
     % Bob starts with own deposits, this should still reject over undelegation
     S0 = pot_state_multi(ResourceOxygen, [{Alice, 10}, {Bob, 20}]),
-    S1 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 5, S0, Opts),
+    S1 = delegate(Alice, Bob, ResourceOxygen, 5, S0, Opts),
     ?assertMatch(
         {error, <<"Undelegation amount exceeds existing delegation.">>},
-        dev_pot:undelegate(Alice, Bob, ResourceOxygen, 10, S1, Opts)
+        undelegate(Alice, Bob, ResourceOxygen, 10, S1, Opts)
     ).
 
 %%% Weight Change Scenarios
@@ -1156,7 +1168,7 @@ delegate_negative_amount_test() ->
     S0 = pot_state_multi(ResourceOxygen, [{Alice, 10}, {Bob, 0}]),
     ?assertError(
         function_clause, 
-        dev_pot:delegate(Alice, Bob, ResourceOxygen, -5, S0, Opts)
+        delegate(Alice, Bob, ResourceOxygen, -5, S0, Opts)
     ).
 
 deposit_to_nonexistent_resource_test() ->
@@ -1180,7 +1192,7 @@ delegation_notice_message_format_test() ->
     % Verify delegation notice has correct format
     S0 = pot_state_multi(ResourceOxygen, [{Alice, 10}, {Bob, 0}]),
     S0WithOutbox = S0#{ <<"results">> => #{ <<"outbox">> => [] } },
-    S1 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 5, S0WithOutbox, Opts),
+    S1 = delegate(Alice, Bob, ResourceOxygen, 5, S0WithOutbox, Opts),
     Outbox = hb_ao:get(<<"results/outbox">>, S1, [], Opts),
     ?assertEqual(1, length(Outbox)),
     [Notice] = Outbox,
@@ -1203,8 +1215,8 @@ undelegate_notice_has_negative_quantity_test() ->
     % Undelegation notice should have negative or zero quantity
     S0 = pot_state_multi(ResourceOxygen, [{Alice, 10}, {Bob, 0}]),
     S0WithOutbox = S0#{ <<"results">> => #{ <<"outbox">> => [] } },
-    S1 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 5, S0WithOutbox, Opts),
-    S2 = dev_pot:undelegate(Alice, Bob, ResourceOxygen, 5, S1, Opts),
+    S1 = delegate(Alice, Bob, ResourceOxygen, 5, S0WithOutbox, Opts),
+    S2 = undelegate(Alice, Bob, ResourceOxygen, 5, S1, Opts),
     Outbox = hb_ao:get(<<"results/outbox">>, S2, [], Opts),
     ?assertEqual(2, length(Outbox)),
     % Outbox is newest first, so undelegate notice is first
@@ -1221,8 +1233,8 @@ multiple_delegations_outbox_order_test() ->
     % Multiple delegations should appear in outbox in order
     S0 = pot_state_multi(ResourceOxygen, [{Alice, 20}, {Bob, 0}, {Charlie, 0}]),
     S0WithOutbox = S0#{ <<"results">> => #{ <<"outbox">> => [] } },
-    S1 = dev_pot:delegate(Alice, Bob, ResourceOxygen, 5, S0WithOutbox, Opts),
-    S2 = dev_pot:delegate(Alice, Charlie, ResourceOxygen, 5, S1, Opts),
+    S1 = delegate(Alice, Bob, ResourceOxygen, 5, S0WithOutbox, Opts),
+    S2 = delegate(Alice, Charlie, ResourceOxygen, 5, S1, Opts),
     Outbox = hb_ao:get(<<"results/outbox">>, S2, [], Opts),
     ?assertEqual(2, length(Outbox)),
     % Outbox is newest first: [Charlie (S2), Bob (S1)]


### PR DESCRIPTION
### issue
pot undelegation was missing a delegation bound check (`Amount <= ExistingDelegation`) inside `undelegate/6` which would have let a delegator to undelegate more than his ExistingDelegation (up from the upsteam undelegation msg flow). 

and true there is a `undelegate_more_than_delegated_test` test, but it was failing on a different path, `liquidate` instead of over undelegation guard check (which was skipped as it didnt exist). therefore that test was an edge case test instead of classic undelegation test (undelegating more than what is delegated) - failing on liquidation throw

the original flow was: `RecipientDeposit -> liquidate/5 -> drip -> state transitions (S)`

### fix

the fix introduced in this PR does a pre-validation in `undelegate/6` before going in the original flow on success: `Validation (non-self over-undelegation?) -> RecipientDeposit -> liquidate -> drip -> Ss`

validation returns `{error, <<"Undelegation amount exceeds existing delegation.">>}` on failure

additionally `undelegate/3` has been improved to return `{ok, NewState}` on sucess and `{error, Reason}` on failure, as same as request in #665 review

### tests

i added `undelegate_exceeds_delegated_rejected_with_recipient_buffer_test` - this case was previously unprotected and is now rejected

```
  [done in 2.685 s]
=======================================================
  All 64 tests passed.
```

i will do the response-shapre alignment cleanup in the next PR 