### PR TITLE
feat: add tunable `batch_size` setting for LMDB store

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -127,7 +127,7 @@
 ]}.
 
 {deps, [
-    {elmdb, {git, "https://github.com/permaweb/elmdb-rs.git", {ref, "f025513db3a34edf1cee26c11c1c750020140314"}}},
+    {elmdb, {git, "https://github.com/permaweb/elmdb-rs.git", {ref, "bfda2facebdb433eea753f82e7e8d45aefc6d87a"}}},
 	{b64fast, {git, "https://github.com/ArweaveTeam/b64fast.git", {ref, "58f0502e49bf73b29d95c6d02460d1fb8d2a5273"}}},
     {cowlib, "2.16.0"},
 	{cowboy, "2.14.0"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -9,7 +9,7 @@
  {<<"ddskerl">>,{pkg,<<"ddskerl">>,<<"0.4.2">>},1},
  {<<"elmdb">>,
   {git,"https://github.com/permaweb/elmdb-rs.git",
-       {ref,"f025513db3a34edf1cee26c11c1c750020140314"}},
+       {ref,"bfda2facebdb433eea753f82e7e8d45aefc6d87a"}},
   0},
  {<<"graphql">>,{pkg,<<"graphql_erl">>,<<"0.17.1">>},0},
  {<<"gun">>,{pkg,<<"gun">>,<<"2.2.0">>},0},

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -31,6 +31,8 @@
 
 %% Configuration constants with reasonable defaults
 -define(DEFAULT_SIZE, 16 * 1024 * 1024 * 1024). % 16GB default database size
+-define(DEFAULT_BATCH_SIZE, 5_000).             % Flush keys on every read or 
+                                                % every 5,000 write operations.
 -define(MAX_REDIRECTS, 1000).                   % Only resolve 1000 links to data
 
 %% @doc Start the LMDB storage system for a given database configuration.
@@ -52,7 +54,14 @@ start(Opts = #{ <<"name">> := DataDir }) ->
     ok = ensure_dir(DataDirPath),
     EnvOpts =
         [
-            {map_size, maps:get(<<"capacity">>, Opts, ?DEFAULT_SIZE)},
+            {
+                map_size,
+                hb_util:int(maps:get(<<"capacity">>, Opts, ?DEFAULT_SIZE))
+            },
+            {
+                batch_size,
+                hb_util:int(maps:get(<<"batch-size">>, Opts, ?DEFAULT_BATCH_SIZE))
+            },
             no_mem_init,
             no_sync
         ] ++


### PR DESCRIPTION
As [#6](https://github.com/permaweb/elmdb-rs/pull/6) describes:

> `elmdb-rs` uses write buffers internally to batch its commitments to the underlying database. This PR exposes control of the size of those batches under an environment option as follows: `{batch_size, X} when is_integer(X)`.

In HyperBEAM, the setting is exposed as with the underlying library, aside two differences:
- The config key is `<<"batch-size">>` in the store definition message.
- The setting will accept any value coercible to an integer.
