### PR TITLE
fix: int matching spec

### DIFF
--- a/src/hb_invariant.erl
+++ b/src/hb_invariant.erl
@@ -529,11 +529,17 @@ pick(Map) when is_map(Map) andalso map_size(Map) == 0 ->
 pick(Map) when is_map(Map) ->
     pick(maps:values(Map)).
 pick(Min, Max, Forbidden) when is_list(Forbidden) ->
-    case lists:member(X = int(Min, Max), Forbidden) of
-      true -> pick(Min, Max, Forbidden);
-      false -> X
+    Floor = num(Min),
+    Ceil = num(Max),
+    case Ceil < Floor of
+        true -> error({invalid_range, Min, Max});
+        false ->
+            Valid = [X || X <- lists:seq(Floor, Ceil), not lists:member(X, Forbidden)],
+            case Valid of
+                [] -> error(cannot_pick_from_fully_forbidden_range);
+                _ -> pick(Valid)
+            end
     end.
-
 %% @doc Generate a random integer.
 int() -> int(?INT_MAX).
 %% @doc Generate a random integer between 0 and the given maximum value --

--- a/src/hb_invariant.erl
+++ b/src/hb_invariant.erl
@@ -569,9 +569,12 @@ num(Other) -> error({invalid_size_spec, Other}).
 float() -> ?MODULE:float(?INT_MAX).
 %% @doc Generate a random float between 0 and the given maximum value --
 %% expressed either explicitly or as a named size constant.
-float(small) -> rand:uniform_real() * (2 * ?SMALL_INT_MAX);
-float(big) -> rand:uniform_real() * (2 * ?BIG_INT_MAX);
-float(Max) -> rand:uniform_real() * (2 * Max).
+float(Max) when is_number(Max), Max < 0 -> error({invalid_range, 0, Max});
+float(Max) when is_number(Max) -> rand:uniform_real() * Max;
+float(tiny) -> rand:uniform_real() * num(tiny);
+float(small) -> rand:uniform_real() * num(small);
+float(big) -> rand:uniform_real() * num(big);
+float(Other) -> error({invalid_size_spec, Other}).
 
 %% @doc Generate a random string.
 string() -> string(?STRING_MAX_LENGTH).

--- a/src/hb_invariant.erl
+++ b/src/hb_invariant.erl
@@ -557,7 +557,7 @@ num(Int) when is_integer(Int) -> Int;
 num(tiny) -> ?INT_TINY_MAX;
 num(small) -> ?SMALL_INT_MAX;
 num(big) -> ?BIG_INT_MAX;
-num(Max) -> error({invalid_size_spec, Max}).
+num(Other) -> error({invalid_size_spec, Other}).
 
 %% @doc Generate a random float.
 float() -> ?MODULE:float(?INT_MAX).

--- a/src/hb_invariant.erl
+++ b/src/hb_invariant.erl
@@ -523,7 +523,7 @@ pick(Int) when is_integer(Int) ->
 pick([]) ->
     error(cannot_pick_from_empty_list);
 pick(List) when is_list(List) ->
-    lists:nth(int(length(List)), List);
+    lists:nth(int(1, length(List)), List);
 pick(Map) when is_map(Map) andalso map_size(Map) == 0 ->
     error(cannot_pick_from_empty_map);
 pick(Map) when is_map(Map) ->
@@ -539,7 +539,8 @@ int() -> int(?INT_MAX).
 %% @doc Generate a random integer between 0 and the given maximum value --
 %% expressed either explicitly or as a named size constant.
 int(Spec) when not is_integer(Spec) -> int(num(Spec));
-int(Max) -> rand:uniform(Max).
+int(Max) when is_integer(Max), Max < 0 -> error({invalid_range, 0, Max});
+int(Max) -> rand:uniform(Max + 1) - 1.
 
 %% @doc Generate a random integer between the given minimum and maximum values --
 %% expressed either explicitly or as a named size constant.
@@ -548,15 +549,15 @@ int(Min, Max) ->
     Offset = num(Max) - Floor,
     case Offset of
         0 -> Floor;
-        _ -> Floor + rand:uniform(Offset)
+        N when N < 0 -> error({invalid_range, Min, Max});
+        _ -> Floor - 1 + rand:uniform(Offset + 1)
     end.
-
 %% @doc Convert a named size constant to an integer.
 num(Int) when is_integer(Int) -> Int;
 num(tiny) -> ?INT_TINY_MAX;
 num(small) -> ?SMALL_INT_MAX;
 num(big) -> ?BIG_INT_MAX;
-num(Max) -> Max.
+num(Max) -> error({invalid_size_spec, Max}).
 
 %% @doc Generate a random float.
 float() -> ?MODULE:float(?INT_MAX).

--- a/src/hb_invariant.erl
+++ b/src/hb_invariant.erl
@@ -532,12 +532,15 @@ pick(Min, Max, Forbidden) when is_list(Forbidden) ->
     Floor = num(Min),
     Ceil = num(Max),
     case Ceil < Floor of
-        true -> error({invalid_range, Min, Max});
+        true ->
+            error({invalid_range, Min, Max});
         false ->
-            Valid = [X || X <- lists:seq(Floor, Ceil), not lists:member(X, Forbidden)],
-            case Valid of
+            Candidates = lists:seq(Floor, Ceil),
+            Allowed =
+                [X || X <- Candidates, not lists:member(X, Forbidden)],
+            case Allowed of
                 [] -> error(cannot_pick_from_fully_forbidden_range);
-                _ -> pick(Valid)
+                _ -> pick(Allowed)
             end
     end.
 %% @doc Generate a random integer.


### PR DESCRIPTION
based the spec:

```erl
%%% - `int/1': Generate a random integer between 0 and the given maximum value.
%%% - `int/2': Generate a random integer between the given values.
```

1- `int/1` range was `1...Max` - 0 was not inclusive
2- `int/2` for Min < Max it was excluding Min and returning `(Min, Max]` so for example, int (1, 2) it would always return 2 (or any 2 consecutive numbers would always return the Max)
3- `int(Spec)` could recurse via `num/1` fallback

## fix
1- `int/1` is inclusive, `[0,Max]`
2- `int/2` now return random over `[Min, Max]` and Min > Max error
3- int(Spec) now it fail fast `error({invalid_size_spec, Spec})`

## impacts 
1- as side effect of `int/1` fix, pick(List) could have do `lists:nth(0, List)` which would crash (lists are 1-index) - fixed
2- !! now as `int/1` (int(Max)) can generate 0, it would affect the upsteam chain, especially in  div cases, or non 0 values for nonce, transfers, etc - i didnt deep dive in the upstream usage, but worth flagging

was the spec not accurate (in/exclusivity cases) or the code didn't match it?