### PR TITLE
feat: compressed Arweave offset storage

### DIFF
--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -11,7 +11,6 @@
 
 -define(IS_BLOCK_ID(X), (is_binary(X) andalso byte_size(X) == 64)).
 
-
 %% @doc Proxy the `/info' endpoint from the Arweave node.
 status(_Base, _Request, Opts) ->
     request(<<"GET">>, <<"/info">>, Opts).
@@ -337,7 +336,9 @@ request(Method, Path, Extra, LogExtra, Opts) ->
                 <<"path">> => <<"/arweave", Path/binary>>,
                 <<"method">> => Method
             },
-            Opts
+            Opts#{
+                cache_control => [<<"no-cache">>, <<"no-store">>]
+            }
         ),
     to_message(Path, Method, best_response(Res), LogExtra, Opts).
 
@@ -406,10 +407,23 @@ to_message(Path = <<"/raw/", _/binary>>, <<"GET">>, {ok, #{ <<"body">> := Body }
     {ok, Body};
 to_message(Path = <<"/block/", _/binary>>, <<"GET">>, {ok, #{ <<"body">> := Body }}, LogExtra, Opts) ->
     event_request(Path, <<"GET">>, 200, LogExtra),
-    Block = hb_message:convert(Body, <<"structured@1.0">>, <<"json@1.0">>, Opts),
-    CacheRes = dev_arweave_block_cache:write(Block, Opts),
+    {ok, Block} =
+        dev_codec_json:from(
+            Body,
+            #{ <<"accept-codec">> => <<"structured@1.0">> },
+            Opts
+        ),
+    CacheRes =
+        case hb_opts:get(arweave_index_blocks, true, Opts) of
+            true -> dev_arweave_block_cache:write(Block, Opts);
+            false -> skipped
+        end,
     ?event(
-        {cached_arweave_block,
+        debug_arweave_index,
+        {
+            if CacheRes == skipped -> skipped_caching_arweave_block;
+            true -> cached_arweave_block
+            end,
             {path, Path},
             {result, CacheRes}
         }

--- a/src/dev_codec_json.erl
+++ b/src/dev_codec_json.erl
@@ -54,9 +54,14 @@ from(JSON, Req, Opts) ->
             Opts
         ),
     ?event(debug_json, {structured, Structured}, Opts),
-    {ok, TABM} = dev_codec_structured:from(Structured, Req, Opts),
-    ?event(debug_json, {tabm, TABM}, Opts),
-    {ok, TABM}.
+    case hb_maps:get(<<"accept-codec">>, Req, undefined, Opts) of
+        <<"structured@1.0">> -> {ok, Structured};
+        _ ->
+            % Re-encode the structured message back to TABM for the caller.
+            {ok, TABM} = dev_codec_structured:from(Structured, Req, Opts),
+            ?event(debug_json, {tabm, TABM}, Opts),
+            {ok, TABM}
+    end.
 
 commit(Msg, Req, Opts) -> dev_codec_httpsig:commit(Msg, Req, Opts).
 

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -49,14 +49,14 @@ is_tx_indexed(TXID, Opts) ->
     case IndexStore of
         no_store -> false;
         #{ <<"index-store">> := Store } ->
-            case hb_store:read(Store, hb_store_arweave:path(TXID)) of
+            case hb_store:read(Store, hb_store_arweave_offset:path(TXID)) of
                 {ok, _} -> true;
                 not_found -> false
             end
     end.
 
 %% @doc List indexed blocks and transactions in the given range.
-%% Returns JSON with block heights as keys, each containing indexed and not_indexed lists.
+%% Returns JSON with block heights as keys, each containing indexed and not-indexed lists.
 list_index(From, To, _Opts) when From < To ->
     {ok, #{
         <<"content-type">> => <<"application/json">>,
@@ -82,7 +82,7 @@ list_index_blocks(Current, To, Opts, Acc) ->
             NewAcc = Acc#{
                 BlockKey => #{
                     <<"indexed">> => IndexedTXs,
-                    <<"not_indexed">> => NotIndexedTXs
+                    <<"not-indexed">> => NotIndexedTXs
                 }
             },
             list_index_blocks(Current - 1, To, Opts, NewAcc);
@@ -91,7 +91,7 @@ list_index_blocks(Current, To, Opts, Acc) ->
             list_index_blocks(Current - 1, To, Opts, Acc)
     end.
 
-%% @doc Classify transactions as indexed or not_indexed.
+%% @doc Classify transactions as indexed or not-indexed.
 classify_txs(TXIDs, Opts) ->
     lists:foldl(
         fun(TXID, {IndexedAcc, NotIndexedAcc}) ->
@@ -312,7 +312,7 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
         hb_store_arweave:write_offset(
             IndexStore,
             TXID,
-            true,
+            <<"tx@1.0">>,
             TXStartOffset,
             TX#tx.data_size
         )
@@ -337,7 +337,7 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
                                 hb_store_arweave:write_offset(
                                     IndexStore,
                                     hb_util:encode(ItemID),
-                                    false,
+                                    <<"ans104@1.0">>,
                                     ItemStartOffset,
                                     Size
                                 ),
@@ -787,9 +787,9 @@ tx_with_no_data_test() ->
     JSONBody = maps:get(<<"body">>, Response),
     IndexData = hb_json:decode(JSONBody),
     BlockInfo = maps:get(BlockBin, IndexData),
-    %% Verify indexed and not_indexed keys exist
+    %% Verify indexed and not-indexed keys exist
     ?assert(maps:is_key(<<"indexed">>, BlockInfo)),
-    ?assert(maps:is_key(<<"not_indexed">>, BlockInfo)),
+    ?assert(maps:is_key(<<"not-indexed">>, BlockInfo)),
     ?assertEqual([
             <<"XSQIgyDY1XUJNz79OeRHFaNpJZyaJSBd7XFsjWlZpNU">>,
             <<"bpd0CzsoTr9-X83sPCx08uNzZC_EgFwb-P8lnHXSeRo">>,
@@ -797,7 +797,7 @@ tx_with_no_data_test() ->
             <<"hvZlThf1B1tY4wMm4cETSsk8vIkOY3QZRmaBnQSzlVo">>,
             <<"3urwRfVyWN35HE5RHGwOUk6CxkJ_lZOaMY7HZbeJyRs">>
         ], maps:get(<<"indexed">>, BlockInfo)),
-    ?assertEqual([ ], maps:get(<<"not_indexed">>, BlockInfo)),
+    ?assertEqual([ ], maps:get(<<"not-indexed">>, BlockInfo)),
     ok.
 
 non_string_tags_test() ->
@@ -842,9 +842,9 @@ list_index_test() ->
     %% Verify the block height is present as a key
     ?assert(maps:is_key(BlockBin, IndexData)),
     BlockInfo = maps:get(BlockBin, IndexData),
-    %% Verify indexed and not_indexed keys exist
+    %% Verify indexed and not-indexed keys exist
     ?assert(maps:is_key(<<"indexed">>, BlockInfo)),
-    ?assert(maps:is_key(<<"not_indexed">>, BlockInfo)),
+    ?assert(maps:is_key(<<"not-indexed">>, BlockInfo)),
     ?assertEqual([
             <<"c2ATDuTgwKCcHpAFZqSt13NC-tA4hdA7Aa2xBPuOzoE">>,
             <<"kK67S13W_8jM9JUw2umVamo0zh9v1DeVxWrru2evNco">>,
@@ -852,7 +852,7 @@ list_index_test() ->
             <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>,
             <<"WbRAQbeyjPHgopBKyi0PLeKWvYZr3rgZvQ7QY3ASJS4">>
         ], maps:get(<<"indexed">>, BlockInfo)),
-    ?assertEqual([ ], maps:get(<<"not_indexed">>, BlockInfo)),
+    ?assertEqual([ ], maps:get(<<"not-indexed">>, BlockInfo)),
     ok.
 
 %% @doc Test `mode=update` with three blocks representing three scenarios:
@@ -900,7 +900,7 @@ update_mode_test() ->
     [_SkippedTXID | RestTXIDs] = TXIDs,
     lists:foreach(
         fun(TXID) ->
-            hb_store_arweave:write_offset(StoreOpts, TXID, true, 0, 0)
+            hb_store_arweave:write_offset(StoreOpts, TXID, <<"tx@1.0">>, 0, 0)
         end,
         RestTXIDs
     ),

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -171,9 +171,10 @@ fetch_and_process_block(Current, To, Opts) ->
 
 %% @doc Process a block.
 process_block(BlockRes, Current, To, Opts) ->
-    ?event(copycat_debug, {{processing_block, Current}, {block, BlockRes}}),
     case BlockRes of
         {ok, Block} ->
+            ?event(copycat_debug, {{processing_block, Current},
+                {indep_hash, hb_maps:get(<<"indep_hash">>, Block, <<>>)}}),
             case maybe_index_ids(Block, Opts) of
                 {block_skipped, Results} ->
                     TotalTXs = maps:get(total_txs, Results, 0),
@@ -192,7 +193,7 @@ process_block(BlockRes, Current, To, Opts) ->
                     SkippedTXs = maps:get(skipped_count, Results, 0),
                     ?event(
                         copycat_short,
-                        {arweave_block_cached,
+                        {arweave_block_indexed,
                             {height, Current},
                             {items_indexed, ItemsIndexed},
                             {total_txs, TotalTXs},

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -26,7 +26,7 @@
 -define(DEFAULT_PRINT_OPTS,
     [
         error, http_error, cron_error,
-        http_short, compute_short, push_short, copycat_short
+        http_short, compute_short, push_short, copycat_short, bundler_short
     ]
 ).
 -endif.

--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -4,11 +4,9 @@
 %%% Store API:
 -export([scope/0, scope/1, type/2, read/2]).
 %%% Indexing API:
--export([write_offset/5, path/1]).
+-export([write_offset/5]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
-
--define(ARWEAVE_INDEX_PATH, <<"~arweave@2.9/offset">>).
 
 %% @doc Although the index is local, loading an item via the index will make
 %% requests to a remote node, so we define the scope as remote.
@@ -20,42 +18,57 @@ scope(_) -> scope().
 %% result, so that we don't have to read the data from the GraphQL route
 %% multiple times.
 type(#{ <<"index-store">> := IndexStore }, ID) ->
-    Type = case hb_store:read(IndexStore, path(ID)) of
-        {ok, _Offset} -> simple;
-        _ -> not_found
-    end,
+    Type =
+        case hb_store:read(IndexStore, hb_store_arweave_offset:path(ID)) of
+            {ok, _Offset} -> simple;
+            _ -> not_found
+        end,
     ?event({type, {id, {explicit, ID}}, {type, Type}}),
     Type.
 
 read(StoreOpts = #{ <<"index-store">> := IndexStore }, ID) ->
-    case hb_store:read(IndexStore, path(ID)) of
-        {ok, Binary} ->
-            [IsTX, StartOffset, Length] = binary:split(Binary, <<":">>, [global]),
-            Loaded = case hb_util:bool(IsTX) of
-                true ->
-                    load_bundle(ID,
-                        hb_util:int(StartOffset), hb_util:int(Length), StoreOpts);
-                false ->
-                    load_item(
-                        hb_util:int(StartOffset), hb_util:int(Length), StoreOpts)
-            end,
+    case hb_store:read(IndexStore, hb_store_arweave_offset:path(ID)) of
+        {ok, OffsetBinary} ->
+            {Version, CodecName, StartOffset, Length} =
+                hb_store_arweave_offset:decode(OffsetBinary),
+            Loaded =
+                case CodecName of
+                    <<"ans104@1.0">> ->
+                        load_item(StartOffset, Length, StoreOpts);
+                    <<"tx@1.0">> ->
+                        load_bundle(ID, StartOffset, Length, StoreOpts)
+                end,
             case Loaded of
                 {ok, _Message} ->
-                    ?event({{read, ok},
-                        {id, {explicit, ID}},
-                        {is_tx, IsTX},
-                        {start_offset, StartOffset},
-                        {length, Length}});
+                    ?event(
+                        arweave_offsets,
+                        {read_ok,
+                            {id, {explicit, ID}},
+                            {format_version, Version},
+                            {type, CodecName},
+                            {start_offset, StartOffset},
+                            {length, Length}
+                        }
+                    );
                 {error, Reason} ->
-                    ?event({{read, error}, 
-                        {id, {explicit, ID}}, 
-                        {is_tx, IsTX},
-                        {start_offset, StartOffset},
-                        {length, Length},
-                        {reason, Reason}})
+                    ?event(
+                        arweave_offsets,
+                        {read_error, 
+                            {id, {explicit, ID}},
+                            {format_version, Version},
+                            {type, CodecName},
+                            {start_offset, StartOffset},
+                            {length, Length},
+                            {reason, Reason}
+                        }
+                    )
             end,
             Loaded;
         not_found ->
+            ?event(
+                arweave_offsets,
+                {miss, {id, {explicit, ID}}}
+            ),
             {error, not_found}
     end.
 
@@ -113,31 +126,24 @@ read_chunks(StartOffset, Length, Opts) ->
     ).
 
 write_offset(
-        #{ <<"index-store">> := IndexStore }, ID, IsTX, StartOffset, Length) ->
-    IsTxInt = hb_util:bool_int(IsTX),
-    Value = <<
-        (hb_util:bin(IsTxInt))/binary,
-        ":",
-        (hb_util:bin(StartOffset))/binary,
-        ":",
-        (hb_util:bin(Length))/binary
-    >>,
-    ?event(store_arweave_debug, 
+        #{ <<"index-store">> := IndexStore },
+        ID,
+        CodecName,
+        StartOffset,
+        Length
+    ) ->
+    Value = hb_store_arweave_offset:encode(CodecName, StartOffset, Length),
+    ?event(
+        store_arweave_debug, 
         {writing_offset, 
             {id, {explicit, ID}},
-            {is_tx, IsTX},
+            {type, CodecName},
             {start_offset, StartOffset},
             {length, Length},
-            {value, {explicit, Value}}}),
-    hb_store:write(IndexStore, path(ID), Value).
-
-path(ID) ->
-    <<
-        ?ARWEAVE_INDEX_PATH/binary,
-        "/",
-        (hb_util:bin(ID))/binary
-    >>.
-
+            {value, {explicit, Value}}
+        }
+    ),
+    hb_store:write(IndexStore, hb_store_arweave_offset:path(ID), Value).
 
 %%% Tests
 
@@ -150,7 +156,7 @@ write_read_tx_test() ->
     EndOffset = 363524457284025,
     Size = 8387,
     StartOffset = EndOffset - Size,
-    ok = write_offset(Opts, ID, true, StartOffset, Size),
+    ok = write_offset(Opts, ID, <<"tx@1.0">>, StartOffset, Size),
     {ok, Bundle} = read(Opts, ID),
     ?assert(hb_message:verify(Bundle, all, #{})),
     {ok, Child} =
@@ -183,9 +189,7 @@ write_read_fake_bundle_tx_test() ->
     ID = <<"cGNURX2IUt98VKVIeXSfYe6eulNwPEqijaQfvatzd_o">>,
     Size = 2,
     StartOffset = 155309918167286,
-    ok = write_offset(Opts, ID, true, StartOffset, Size),
+    ok = write_offset(Opts, ID, <<"tx@1.0">>, StartOffset, Size),
     {ok, TX} = read(Opts, ID),
     ?assert(hb_message:verify(TX, all, #{})),
     ok.
-
-%% XXX TODO: write/read for data item

--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -23,7 +23,8 @@ type(#{ <<"index-store">> := IndexStore }, ID) ->
             {ok, _Offset} -> simple;
             _ -> not_found
         end,
-    ?event({type, {id, {explicit, ID}}, {type, Type}}),
+    ?event(store_arweave_debug,
+        {type, {id, {explicit, ID}}, {type, Type}}),
     Type.
 
 read(StoreOpts = #{ <<"index-store">> := IndexStore }, ID) ->

--- a/src/hb_store_arweave_offset.erl
+++ b/src/hb_store_arweave_offset.erl
@@ -1,0 +1,92 @@
+%%% @doc Succinct encoding and decoding for Arweave data offset indexing.
+%%% Arweave data items are extremely numerous (>25,000,000,000 as of Feb 2026), and
+%%% as such small optimizations to the encoding of their offsets have a significant
+%%% effect. For exampple, a single byte sized in the encoding at time of writing
+%%% saves ~25 GB of storage.
+%%% 
+%%% The encoding is as follows:
+%%%     << Version:4, Codec:4, StartOffset:64, Length/binary >>
+%%% where:
+%%%     - Version: 4-bit unsigned integer. Max: 15. Current: version `1`.
+%%%     - Codec: 4-bit unsigned integer. Max: 15.
+%%%     - StartOffset: 64-bit uint. Max: 2^64-1.
+%%%     - Length: unsigned variable-length integer.
+%%% 
+%%% Codecs:
+%%%     - 0: `tx@1.0`: An Arweave transaction.
+%%%     - 1: [Reserved for ANS-102: The initial JSON data item format.]
+%%%     - 2: `~ans104@1.0`: Binary data items.
+%%%     - 3: [Reserved for `~httpsig@1.0`: RFC-9421 compatible HTTP signed messages.]
+%%% 
+%%% Codec indexes should, in general, be sorted by the time of their first write
+%%% to Arweave: Arweave TXs as 0, ANS-102 as 1, ANS-104 as 2, etc.
+%%% 
+%%% All `length` values are read by decoding all of the remaining bytes in the 
+%%% offset encoding as an unsigned big-endian integer. This allows the length
+%%% to contract to only the number of bytes actually necessary to represent it.
+%%% 
+-module(hb_store_arweave_offset).
+-export([encode/3, decode/1, path/1]).
+-include("include/hb.hrl").
+
+%% @doc Determine if a value is within a given unsigned bit range.
+-define(IN_BIT_RANGE(X, Bits), (X >= 0 andalso X < (1 bsl Bits))).
+
+-define(OFFSET_SZ, (8*8)). % 64-bit uint. Max: 2^64-1.
+-define(FORMAT_VERSION, 1). % 4-bit uint. Max: 15.
+
+%% @doc Reserved for future use. At the present time, store containing offsets are
+%% expected to be utilized only as sub-stores to a `hb_store_arweave' store. As
+%% as consequence, the path is simply the ID of the data item, with the prefix
+%% of `~arweave@2.9/offset/` implied.
+path(ID) when ?IS_ID(ID) -> hb_util:native_id(ID);
+path(ID) -> throw({cannot_encode_path, ID}).
+
+%% @doc Encode the offset of the data if it is valid. Throws `cannot_encode_offset'
+%% if invalid.
+encode(Type, StartOffset, Length)
+        when
+        (Type == true orelse Type == false orelse is_binary(Type))
+        andalso ?IN_BIT_RANGE(StartOffset, ?OFFSET_SZ*8)
+        andalso is_integer(Length) andalso Length >= 0
+    ->
+    <<
+        (encode_format(Type))/binary,
+        StartOffset:?OFFSET_SZ,
+        (binary:encode_unsigned(Length))/binary
+    >>;
+encode(IsTX, StartOffset, Length) ->
+    throw({cannot_encode_offset, {IsTX, StartOffset, Length}}).
+
+decode(<<Format:1/binary, StartOffset:?OFFSET_SZ, Length/binary>>) ->
+    {Version, CodecName} = decode_format(Format),
+    {Version, CodecName, StartOffset, binary:decode_unsigned(Length)};
+decode(Binary) ->
+    throw({cannot_decode_offset, Binary}).
+
+%% @doc Encode the type of the data.
+encode_type(<<"tx@1.0">>) -> 0;
+encode_type(<<"~ans102@1.0">>) -> 1;
+encode_type(<<"ans104@1.0">>) -> 2;
+encode_type(<<"~httpsig@1.0">>) -> 3;
+encode_type(Type) -> throw({cannot_encode_type, Type}).
+
+%% @doc Decode the type of the data to a binary codec name.
+decode_type(0) -> <<"tx@1.0">>;
+decode_type(1) -> <<"~ans102@1.0">>;
+decode_type(2) -> <<"ans104@1.0">>;
+decode_type(3) -> <<"~httpsig@1.0">>;
+decode_type(Type) -> throw({cannot_decode_type, Type}).
+
+%% @doc Encode the format of the offset. See the module documentation for the
+%% present index of supported codecs.
+encode_format(CodecName) ->
+    << ?FORMAT_VERSION:4, (encode_type(CodecName)):4 >>;
+encode_format(CodecName) ->
+    throw({cannot_encode_format, CodecName}).
+
+%% @doc Decode the format of the offset.
+decode_format(<<FormatVersion:4, CodecName:4>>) ->
+    {FormatVersion, decode_type(CodecName)};
+decode_format(Binary) ->
+    throw({cannot_decode_format, Binary}).


### PR DESCRIPTION
Introduces a new and vastly compressed storage format for indexes of Arweave data items. Each key and value pair used to consume approximately 90 bytes of encoded ASCII, where now a typical pair can be expressed in 32 + ~11 bytes.

Additionally, indexers may now opt not to store Arweave block headers that they download during the indexing process. Arweave block headers are widely available and quickly accessible so it is not always desirable to store them on HB nodes.