### PR TITLE
impr: Ranch configuration and metrics

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -134,6 +134,7 @@
     {ranch, "2.2.0"},
     {gun, "2.2.0"},
     {prometheus_cowboy, "0.2.0"},
+    {prometheus_ranch, {git, "https://github.com/permaweb/prometheus_ranch.git", {ref, "73f16ed9856972ced3fb8f4168004fffe742d5b2"}}},
     {prometheus_httpd,  "2.1.15"},
     {prometheus,        "6.0.3"},
 	{graphql, "0.17.1", {pkg, graphql_erl}},
@@ -149,7 +150,7 @@
 ]}.
 
 {relx, [
-	{release, {'hb', "0.0.1"}, [hb, b64fast, cowboy, gun, luerl, prometheus, prometheus_cowboy, elmdb]},
+	{release, {'hb', "0.0.1"}, [hb, b64fast, cowboy, gun, luerl, prometheus, prometheus_cowboy, prometheus_ranch, elmdb]},
 	{include_erts, true},
 	{extended_start_script, true},
 	{overlay, [
@@ -160,7 +161,7 @@
 ]}.
 
 {dialyzer, [
-	{plt_extra_apps, [public_key, ranch, cowboy, prometheus, prometheus_cowboy, b64fast, eunit, gun]},
+	{plt_extra_apps, [public_key, ranch, cowboy, prometheus, prometheus_cowboy, prometheus_ranch, b64fast, eunit, gun]},
 	incremental,
 	{warnings, [no_improper_lists, no_unused]}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -17,6 +17,10 @@
  {<<"prometheus">>,{pkg,<<"prometheus">>,<<"6.0.3">>},0},
  {<<"prometheus_cowboy">>,{pkg,<<"prometheus_cowboy">>,<<"0.2.0">>},0},
  {<<"prometheus_httpd">>,{pkg,<<"prometheus_httpd">>,<<"2.1.15">>},0},
+ {<<"prometheus_ranch">>,
+  {git,"https://github.com/permaweb/prometheus_ranch.git",
+       {ref,"73f16ed9856972ced3fb8f4168004fffe742d5b2"}},
+  0},
  {<<"ranch">>,{pkg,<<"ranch">>,<<"2.2.0">>},0}]}.
 [
 {pkg_hash,[

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -195,7 +195,7 @@ new_server(RawNodeMsg) ->
                 ),
                 % Attempt to start the prometheus application, if possible.
                 try
-                    application:ensure_all_started([prometheus, prometheus_cowboy]),
+                    application:ensure_all_started([prometheus, prometheus_cowboy, prometheus_ranch]),
                     prometheus_registry:register_collector(hb_metrics_collector),
                     ProtoOpts#{
                         metrics_callback =>
@@ -299,10 +299,17 @@ http3_conn_sup_loop() ->
 
 start_http2(ServerID, ProtoOpts, NodeMsg) ->
     ?event(http, {start_http2, ServerID}),
+    MaxConnections = maps:get(max_connections, NodeMsg, 10000),
+    NumAcceptors = maps:get(num_acceptors, NodeMsg, erlang:system_info(schedulers) * 4),
+    TransportOpts = #{
+        socket_opts => [{port, RequestedPort = hb_opts:get(port, 0, NodeMsg)}],
+        max_connections => MaxConnections,
+        num_acceptors => NumAcceptors
+    },
     StartRes =
         cowboy:start_clear(
             ServerID,
-            [{port, RequestedPort = hb_opts:get(port, 0, NodeMsg)}],
+            TransportOpts,
             ProtoOpts
         ),
     case StartRes of


### PR DESCRIPTION
- Add metrics to ranch (prometheus).
- Support configuration for `max_connections` and `num_acceptors`.