### PR TITLE
impr: Increase cowboy last bucket to more than 4

### DIFF
--- a/config/app.config
+++ b/config/app.config
@@ -1,0 +1,7 @@
+[
+    {prometheus, [
+        {cowboy_instrumenter, [
+            {duration_buckets, [0.001, 0.01, 0.1, 0.25, 0.5, 0.75, 1, 2, 4, 10, 30, 60]}
+        ]}
+    ]}
+].

--- a/rebar.config
+++ b/rebar.config
@@ -41,7 +41,8 @@
                     "_build/genesis_wasm/genesis-wasm-server",
                     "genesis-wasm-server"
                 }
-            ]}
+            ]},
+            {sys_config, "config/app.config"}
         ]}
     ]},
     {rocksdb, [
@@ -142,7 +143,8 @@
 ]}.
 
 {shell, [
-	{apps, [hb]}
+	{apps, [hb]},
+	{config, "config/app.config"}
 ]}.
 
 {eunit, [
@@ -151,6 +153,7 @@
 
 {relx, [
 	{release, {'hb', "0.0.1"}, [hb, b64fast, cowboy, gun, luerl, prometheus, prometheus_cowboy, prometheus_ranch, elmdb]},
+	{sys_config, "config/app.config"},
 	{include_erts, true},
 	{extended_start_script, true},
 	{overlay, [


### PR DESCRIPTION
By default, the histogram bucket in cowboy_prometheus metrics ends in 4 seconds. We need more observability, so this increases to 60 seconds.