### PR TITLE
impr: prevent zero div & fix tests

### DIFF
--- a/src/dev_mint_math.erl
+++ b/src/dev_mint_math.erl
@@ -97,7 +97,7 @@ units_to_distribute(State, Opts) ->
         hb_util:int(hb_maps:get(<<"cycle-proportion-denominator">>, State, Opts)),
     Remaining = MintTotal - AlreadyMinted,
     case CycleProportionDenominator of
-        0 -> throw({error, zero_denominator_division});
+        0 -> throw({error, zero_cycle_proportion_denominator});
         _ -> (Remaining * CycleProportionNumerator) div CycleProportionDenominator
     end.
     
@@ -120,7 +120,7 @@ units_per_resource(TotalToDistribute, State, Opts) ->
         {0, _} ->
             ResourceWeights;
         {_, 0} ->
-            throw({error, zero_denominator_division});
+            throw({error, zero_total_resource_weights});
         _ ->
             hb_maps:map(
                 fun(_Resource, Weight) ->
@@ -157,7 +157,7 @@ distribution_per_address(Resource, UnitsForResource, BalanceMessages, Opts) ->
             )
         ),
     case TotalQuantity of
-        0 -> throw({error, zero_denominator_division});
+        0 -> throw({error, zero_total_resource_quantity});
         _ -> ok
     end,
     ?event(debug, {total_quantity, TotalQuantity}),

--- a/src/dev_mint_math.erl
+++ b/src/dev_mint_math.erl
@@ -126,15 +126,7 @@ distribution_per_address(Resource, UnitsForResource, BalanceMessages, Opts) ->
     % Get the accounts from the balance messages. Note that we are careful to
     % ensure that the hashpath is not generated and that we do not write to the
     % store, such that no IDs or writes are performed.
-    {ok, Accounts} =
-        hb_ao:resolve(
-            BalanceMessages,
-            <<"from">>,
-            Opts#{
-                hashpath => ignore,
-                cache_control => [<<"no-cache">>, <<"no-store">>]
-            }
-        ),
+    Accounts = resolve_accounts(BalanceMessages, Opts),
     ?event(debug, {addresses, Accounts}),
     TotalQuantity =
         lists:sum(
@@ -186,6 +178,88 @@ distribution_per_address(Resource, UnitsForResource, BalanceMessages, Opts) ->
         ),
         Opts
     ).
+
+resolve_accounts(BalanceMessages, Opts) ->
+    ResolveOpts =
+        Opts#{
+            hashpath => ignore,
+            cache_control => [<<"no-cache">>, <<"no-store">>]
+        },
+    case hb_ao:resolve(BalanceMessages, <<"from">>, ResolveOpts) of
+        {ok, Accounts} when is_map(Accounts), map_size(Accounts) > 0 ->
+            Accounts;
+        _ ->
+            Parsed = resolve_flattened_accounts(BalanceMessages, Opts),
+            case map_size(Parsed) of
+                0 -> throw({accounts_resolve_failed, {error, not_found}});
+                _ -> Parsed
+            end
+    end.
+
+resolve_flattened_accounts(BalanceMessages, Opts) ->
+    Keys = hb_ao:keys(BalanceMessages, Opts),
+    RawAccounts =
+        lists:foldl(
+            fun(Key, Acc) ->
+                case parse_balance_key(Key) of
+                    {ok, Account, <<"quantity">>} ->
+                        Qty = hb_util:int(hb_ao:get(Key, BalanceMessages, 0, Opts)),
+                        put_account_field(Account, <<"quantity">>, Qty, Acc);
+                    {ok, Account, <<"recipient">>} ->
+                        Recipient = hb_ao:get(Key, BalanceMessages, Account, Opts),
+                        put_account_field(Account, <<"recipient">>, Recipient, Acc);
+                    ignore ->
+                        Acc
+                end
+            end,
+            #{},
+            Keys
+        ),
+    maps:map(
+        fun(Account, Details) ->
+            #{
+                <<"quantity">> => hb_util:int(maps:get(<<"quantity">>, Details, 0)),
+                <<"recipient">> => maps:get(<<"recipient">>, Details, Account)
+            }
+        end,
+        RawAccounts
+    ).
+
+put_account_field(Account, Field, Value, Accounts) ->
+    Current = maps:get(Account, Accounts, #{}),
+    Accounts#{ Account => Current#{ Field => Value } }.
+
+parse_balance_key(Key) when is_binary(Key) ->
+    case binary:split(Key, <<"/">>, [global]) of
+        [Account, <<"quantity">>] when byte_size(Account) > 0 ->
+            {ok, Account, <<"quantity">>};
+        [Account, <<"recipient">>] when byte_size(Account) > 0 ->
+            {ok, Account, <<"recipient">>};
+        _ ->
+            parse_concatenated_balance_key(Key)
+    end.
+
+parse_concatenated_balance_key(Key) ->
+    case split_suffix(Key, <<"quantity">>) of
+        {ok, Account} ->
+            {ok, Account, <<"quantity">>};
+        error ->
+            case split_suffix(Key, <<"recipient">>) of
+                {ok, Account} -> {ok, Account, <<"recipient">>};
+                error -> ignore
+            end
+    end.
+
+split_suffix(Key, Suffix) ->
+    KeySize = byte_size(Key),
+    SuffixSize = byte_size(Suffix),
+    case KeySize > SuffixSize andalso
+            binary:part(Key, KeySize - SuffixSize, SuffixSize) =:= Suffix of
+        true ->
+            {ok, binary:part(Key, 0, KeySize - SuffixSize)};
+        false ->
+            error
+    end.
 
 %% @doc Calculate the total number of units to mint from a list of distributions.
 distributions_to_total_units(Distributions, Opts) ->

--- a/src/dev_mint_math.erl
+++ b/src/dev_mint_math.erl
@@ -96,8 +96,11 @@ units_to_distribute(State, Opts) ->
     CycleProportionDenominator =
         hb_util:int(hb_maps:get(<<"cycle-proportion-denominator">>, State, Opts)),
     Remaining = MintTotal - AlreadyMinted,
-    (Remaining * CycleProportionNumerator) div CycleProportionDenominator.
-
+    case CycleProportionDenominator of
+        0 -> throw({error, zero_denominator_division});
+        _ -> (Remaining * CycleProportionNumerator) div CycleProportionDenominator
+    end.
+    
 %% @doc Return the number of units to distribute accross the addresses in each
 %% resource of the state.
 units_per_resource(TotalToDistribute, State, Opts) ->
@@ -113,12 +116,19 @@ units_per_resource(TotalToDistribute, State, Opts) ->
             Resources
         ),
     TotalWeights = lists:sum(hb_maps:values(ResourceWeights)),
-    hb_maps:map(
-        fun(_Resource, Weight) ->
-            (TotalToDistribute * Weight) div TotalWeights
-        end,
-        ResourceWeights
-    ).
+    case {map_size(ResourceWeights), TotalWeights} of
+        {0, _} ->
+            ResourceWeights;
+        {_, 0} ->
+            throw({error, zero_denominator_division});
+        _ ->
+            hb_maps:map(
+                fun(_Resource, Weight) ->
+                    (TotalToDistribute * Weight) div TotalWeights
+                end,
+                ResourceWeights
+            )
+    end.
 
 %% @doc Return the number of units to distribute for each address in a resource.
 distribution_per_address(Resource, UnitsForResource, BalanceMessages, Opts) ->
@@ -134,13 +144,22 @@ distribution_per_address(Resource, UnitsForResource, BalanceMessages, Opts) ->
                 hb_maps:map(
                     fun(_Address, AddressDetails) ->
                         hb_util:int(
-                            hb_maps:get(<<"quantity">>, AddressDetails, 0, Opts)
+                            hb_maps:get(
+                                <<"quantity">>,
+                                AddressDetails,
+                                0,
+                                Opts
+                            )
                         )
                     end,
                     Accounts
                 )
             )
         ),
+    case TotalQuantity of
+        0 -> throw({error, zero_denominator_division});
+        _ -> ok
+    end,
     ?event(debug, {total_quantity, TotalQuantity}),
     hb_maps:values(
         hb_maps:map(
@@ -148,7 +167,12 @@ distribution_per_address(Resource, UnitsForResource, BalanceMessages, Opts) ->
                 % Gather details for the address.
                 Quantity =
                     hb_util:int(
-                        hb_maps:get(<<"quantity">>, AddressDetails, 0, Opts)
+                        hb_maps:get(
+                            <<"quantity">>,
+                            AddressDetails,
+                            0,
+                            Opts
+                        )
                     ),
                 Recipient =
                     hb_maps:get(

--- a/src/dev_pot_math.erl
+++ b/src/dev_pot_math.erl
@@ -43,7 +43,10 @@ minted_between(Minted, Max, PropN, PropD, LastT, T) ->
     Remaining = Max - Minted,
     NComplementOverTime = bignum_exp(PropD - PropN, Steps),
     DOverTime = bignum_exp(PropD, Steps),
-    (Remaining * (DOverTime - NComplementOverTime)) div DOverTime.
+    case DOverTime of
+        0 -> throw({error, division_with_zero_denominator});
+        _ -> (Remaining * (DOverTime - NComplementOverTime)) div DOverTime
+    end.
 
 bignum_exp(_, 0) -> 1;
 bignum_exp(X, Y) ->

--- a/src/dev_pot_math_props.erl
+++ b/src/dev_pot_math_props.erl
@@ -10,7 +10,7 @@ exponentiation_test() ->
             states => fun(_) -> {hb_invariant:int(tiny), hb_invariant:int(8)} end,
             requests =>
                 fun({X, Y}, _Opts) ->
-                    {ok, dev_pot_math:bignum_exp(X, Y)}
+                    {pow, {ok, dev_pot_math:bignum_exp(X, Y)}}
                 end,
             properties =>
                 [
@@ -28,7 +28,7 @@ large_exponentiation_test() ->
             states => fun(_) -> {hb_invariant:int(200), hb_invariant:int(200)} end,
             requests =>
                 fun({X, Y}, _Opts) ->
-                    {ok, dev_pot_math:bignum_exp(X, Y)}
+                    {pow, {ok, dev_pot_math:bignum_exp(X, Y)}}
                 end,
             properties =>
                 [


### PR DESCRIPTION
## about

`PropD` in `dev_pot.erl` default to 0 if `mint-prop-denominator` is not passed properly/missing:

```erl
PropD = hb_ao:get(<<"mint-prop-denominator">>, S, 0, Opts),
```

and then in `dev_pot_math.erl` - `DOverTime = bignum_exp(PropD, Steps),` can be `0` if PropD = 0 and Steps > 0 -- which would result in a badarith crash instead of a typed failure. patched that

additionally `dev_pot_math_props.erl` tests were failing due to a mislignament with  `hb_invariant` request shape (`{Tag, Req}`) - fixed that, tests pass again:

```bash
  [done in 0.029 s]
=======================================================
  2 tests passed.
  ```