### PR TITLE
impr: Add prometheus metrics to `hb_store_arweave`

### DIFF
--- a/src/hb_http_client.erl
+++ b/src/hb_http_client.erl
@@ -3,7 +3,7 @@
 -module(hb_http_client).
 -behaviour(gen_server).
 -include("include/hb.hrl").
--export([start_link/1, response_status_to_atom/1, request/2]).
+-export([start_link/1, init_prometheus/0, response_status_to_atom/1, request/2]).
 -export([init/1, handle_cast/2, handle_call/3, handle_info/2, terminate/2]).
 
 -record(state, {
@@ -283,7 +283,8 @@ init(Opts) ->
             ),
             try
                 application:ensure_all_started([prometheus, prometheus_cowboy]),
-                init_prometheus(Opts)
+                init_prometheus(),
+                {ok, #state{ opts = Opts }}
             catch
                 Type:Reason:Stack ->
                     ?event(warning,
@@ -298,9 +299,8 @@ init(Opts) ->
         false -> {ok, #state{ opts = Opts }}
     end.
 
-init_prometheus(Opts) ->
-    application:ensure_all_started([prometheus, prometheus_cowboy]),
-	prometheus_counter:new([
+init_prometheus() ->
+	hb_prometheus:declare(counter, [
 		{name, gun_requests_total},
 		{labels, [http_method, status_class]},
 		{
@@ -308,9 +308,9 @@ init_prometheus(Opts) ->
 			"The total number of GUN requests."
 		}
 	]),
-	prometheus_gauge:new([{name, outbound_connections},
+	hb_prometheus:declare(gauge, [{name, outbound_connections},
 		{help, "The current number of the open outbound network connections"}]),
-	prometheus_histogram:new([
+	hb_prometheus:declare(histogram, [
 		{name, http_request_duration_seconds},
 		{buckets, [0.01, 0.1, 0.5, 1, 5, 10, 30, 60]},
         {labels, [http_method, status_class]},
@@ -321,7 +321,7 @@ init_prometheus(Opts) ->
             "throttling, etc...)"
 		}
 	]),
-	prometheus_histogram:new([
+	hb_prometheus:declare(histogram, [
 		{name, http_client_get_chunk_duration_seconds},
 		{buckets, [0.1, 1, 10, 60]},
         {labels, [status_class, peer]},
@@ -330,16 +330,15 @@ init_prometheus(Opts) ->
 			"The total duration of an HTTP GET chunk request made to a peer."
 		}
 	]),
-	prometheus_counter:new([
+	hb_prometheus:declare(counter, [
 		{name, http_client_downloaded_bytes_total},
 		{help, "The total amount of bytes requested via HTTP, per remote endpoint"}
 	]),
-	prometheus_counter:new([
+	hb_prometheus:declare(counter, [
 		{name, http_client_uploaded_bytes_total},
 		{help, "The total amount of bytes posted via HTTP, per remote endpoint"}
 	]),
-    ?event(started),
-	{ok, #state{ opts = Opts }}.
+	ok.
 
 handle_call({get_connection, Args, Opts}, From,
 		#state{ pid_by_peer = PIDPeer, status_by_pid = StatusByPID } = State) ->
@@ -512,7 +511,7 @@ inc_prometheus_gauge(Name) ->
         _ ->
             try prometheus_gauge:inc(Name)
             catch _:_ ->
-                init_prometheus(#{}),
+                init_prometheus(),
                 prometheus_gauge:inc(Name)
             end
     end.

--- a/src/hb_prometheus.erl
+++ b/src/hb_prometheus.erl
@@ -1,0 +1,17 @@
+%%% @doc Handle prometheus metrics
+-module(hb_prometheus).
+
+-export([measure_and_report/2, measure_and_report/3]).
+
+%% @doc Measure function duration and report metric
+measure_and_report(Fun, Metric) -> 
+    measure_and_report(Fun, Metric, []).
+measure_and_report(Fun, Metric, Labels) ->
+    Start = erlang:monotonic_time(),
+    try
+        Result = Fun(),
+        Result
+    after
+        DurationNative = erlang:monotonic_time() - Start,
+        prometheus_histogram:observe(Metric, Labels, DurationNative)
+    end.

--- a/src/hb_prometheus.erl
+++ b/src/hb_prometheus.erl
@@ -1,12 +1,42 @@
-%%% @doc Handle prometheus metrics
+%%% @doc HyperBEAM wrapper for Prometheus metrics.
 -module(hb_prometheus).
+-export([ensure_started/0, declare/2, measure_and_report/2, measure_and_report/3]).
 
--export([measure_and_report/2, measure_and_report/3]).
+%% @doc Ensure the Prometheus application has been started.
+ensure_started() ->
+    case application:get_application(prometheus) of
+        undefined ->
+            application:ensure_all_started(
+                [prometheus, prometheus_cowboy, prometheus_ranch]
+            ),
+            hb_util:until(
+                fun() ->
+                    application:get_application(prometheus) /= undefined
+                end,
+                fun() -> application:ensure_started(prometheus) end
+            ),
+            ok;
+        _ -> ok
+    end.
 
-%% @doc Measure function duration and report metric
+%% @doc Declare a new Prometheus metric in a replay-safe manner.
+declare(Type, Metric) ->
+    ok = ensure_started(),
+    try do_declare(Type, Metric)
+    catch error:mfa_already_exists -> ok
+    end.
+
+do_declare(histogram, Metric) -> prometheus_histogram:declare(Metric);
+do_declare(counter, Metric) -> prometheus_counter:declare(Metric);
+do_declare(gauge, Metric) -> prometheus_gauge:declare(Metric);
+do_declare(Type, _Metric) -> throw({unsupported_metric_type, Type}).
+
+%% @doc Measure function duration and report metric, ensuring that the Prometheus
+%% application has been started first.
 measure_and_report(Fun, Metric) -> 
     measure_and_report(Fun, Metric, []).
 measure_and_report(Fun, Metric, Labels) ->
+    ok = ensure_started(),
     Start = erlang:monotonic_time(),
     try
         Result = Fun(),

--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -44,8 +44,11 @@ type(#{ <<"index-store">> := IndexStore }, ID) when ?IS_ID(ID) ->
 type(_, _) -> not_found.
 
 %% @doc Read the offset of the data at the given key.
-read_offset(#{ <<"index-store">> := IndexStore }, ID) when ?IS_ID(ID) ->
-    case hb_store:read(IndexStore, hb_store_arweave_offset:path(ID)) of
+read_offset(#{ <<"index-store">> := IndexStore }, ID) ->
+    case hb_prometheus:measure_and_report(
+        fun () -> hb_store:read(IndexStore, hb_store_arweave_offset:path(ID)) end,
+        hb_store_arweave_index_check_duration_seconds
+     ) of
         {ok, OffsetBinary} ->
             {Version, CodecName, StartOffset, Length} =
                 hb_store_arweave_offset:decode(OffsetBinary),
@@ -117,7 +120,7 @@ do_read(StoreOpts, ID) ->
     end.
 
 load_item(StartOffset, Length, Opts) ->
-    {Duration, Result} = timer:tc(fun () ->
+    hb_prometheus:measure_and_report(fun () ->
         case read_chunks(StartOffset, Length, Opts) of
             {ok, SerializedItem} ->
                 {
@@ -132,12 +135,10 @@ load_item(StartOffset, Length, Opts) ->
             {error, Reason} ->
                 {error, Reason}
         end
-    end,native),
-    record_chunk_fetch_metric(Duration, load_item),
-    Result.
+    end,hb_store_arweave_chunk_fetch_duration_seconds, [load_item]).
 
 load_tx(ID, StartOffset, Length, Opts) ->
-    {Duration, Result} = timer:tc(fun () ->
+    hb_prometheus:measure_and_report(fun () ->
         {ok, StructuredTXHeader} = hb_ao:resolve(
             #{ <<"device">> => <<"arweave@2.9">> },
             #{ <<"path">> => <<"tx">>, <<"tx">> => ID, <<"exclude-data">> => true },
@@ -162,9 +163,7 @@ load_tx(ID, StartOffset, Length, Opts) ->
             {error, Reason} ->
                 {error, Reason}
         end
-    end, native),
-    record_chunk_fetch_metric(Duration, load_tx),
-    Result.
+    end,hb_store_arweave_chunk_fetch_duration_seconds, [load_tx]).
 
 read_chunks(StartOffset, Length, Opts) ->
     hb_ao:resolve(
@@ -197,6 +196,7 @@ write_offset(
     ),
     hb_store:write(IndexStore, hb_store_arweave_offset:path(ID), Value).
 
+%% @doc Record partition that are requested
 record_partition_metric(Offset) ->
     spawn(fun () ->
         case application:get_application(prometheus) of
@@ -204,22 +204,6 @@ record_partition_metric(Offset) ->
             _ ->
                 Partition = binary_to_integer(Offset) div ?PARTITION_SIZE,
                 prometheus_counter:inc(hb_store_arweave_requests_partition, [Partition], 1)
-        end
-    end).
-
-record_index_check_metric(Duration) ->
-    record_metric(hb_store_arweave_index_check_duration_seconds, [], Duration).
-
-record_chunk_fetch_metric(Duration, Type) ->
-    record_metric(hb_store_arweave_chunk_fetch_duration_seconds, [Type], Duration).
-
-record_metric(Metric, Labels, Duration) ->
-    spawn(fun () ->
-        case application:get_application(prometheus) of
-            undefined ->
-                ok;
-            _ ->
-                prometheus_histogram:observe(Metric, Labels, Duration)
         end
     end).
 

--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -2,7 +2,7 @@
 %%% intermediate cache of offsets as an ID->ArweaveLocation mapping.
 -module(hb_store_arweave).
 %%% Store API:
--export([scope/0, scope/1, type/2, read/2]).
+-export([scope/0, scope/1, type/2, read/2, start/1]).
 %%% Unused Store API:
 -export([resolve/2, write/3, make_link/3, make_group/2]).
 %%% Indexing API:
@@ -22,33 +22,40 @@ scope() -> remote.
 scope(#{ <<"scope">> := Scope }) -> Scope;
 scope(_) -> scope().
 
+%% @doc Resolve a key path in the Arweave store, ignoring other paths.
 resolve(_, ID) when ?IS_ID(ID) -> ID;
 resolve(_, _) -> not_found.
 
+%% @doc Unsupported.
 write(_, _, _) -> not_found.
+
+%% @doc Unsupported.
 make_link(_, _, _) -> not_found.
+
+%% @doc Unsupported.
 make_group(_, _) -> not_found.
 
 %% @doc Get the type of the data at the given key. We potentially cache the
 %% result, so that we don't have to read the data from the GraphQL route
 %% multiple times.
 type(#{ <<"index-store">> := IndexStore }, ID) when ?IS_ID(ID) ->
-    Type =
-        case hb_store:read(IndexStore, hb_store_arweave_offset:path(ID)) of
-            {ok, _Offset} -> simple;
-            _ -> not_found
-        end,
-    ?event(debug_store_arweave,
-        {type, {id, {explicit, ID}}, {type, Type}}),
-    Type;
+    case hb_store:read(IndexStore, hb_store_arweave_offset:path(ID)) of
+        {ok, _Offset} -> simple;
+        _ -> not_found
+    end;
 type(_, _) -> not_found.
 
 %% @doc Read the offset of the data at the given key.
 read_offset(#{ <<"index-store">> := IndexStore }, ID) ->
-    case hb_prometheus:measure_and_report(
-        fun () -> hb_store:read(IndexStore, hb_store_arweave_offset:path(ID)) end,
-        hb_store_arweave_index_check_duration_seconds
-     ) of
+    init_prometheus(),
+    ReadRes =
+        hb_prometheus:measure_and_report(
+            fun() ->
+                hb_store:read(IndexStore, hb_store_arweave_offset:path(ID))
+            end,
+            hb_store_arweave_index_check_duration_seconds
+        ),
+    case ReadRes of
         {ok, OffsetBinary} ->
             {Version, CodecName, StartOffset, Length} =
                 hb_store_arweave_offset:decode(OffsetBinary),
@@ -63,12 +70,17 @@ read_offset(#{ <<"index-store">> := IndexStore }, ID) ->
     end;
 read_offset(_, _) -> not_found.
 
+%% @doc Read the data at the given key, reading the `local-store' first if
+%% available.
 read(StoreOpts, ID) ->
     case hb_store_remote_node:read_local_cache(StoreOpts, ID) of
         {ok, Message} -> {ok, Message};
         not_found -> do_read(StoreOpts, ID)
     end.
 
+%% @doc Read the data at the given key, reading the provided Arweave index store
+%% as a source of offsets. After offsets have been found, the data is loaded
+%% through the `~arweave@2.9` device -- either as an ANS-104 item or a TX.
 do_read(StoreOpts, ID) ->
     case read_offset(StoreOpts, ID) of
         {ok,
@@ -120,52 +132,72 @@ do_read(StoreOpts, ID) ->
             {error, not_found}
     end.
 
+%% @doc Load an ANS-104 item from the given start offset and length.
+%% Returns an `ok' tuple with the deserialized item, or an `error' tuple with
+%% the reason. The `StartOffset` is the precise starting byte of the item _header_,
+%% not the data segment. The `Length` covers the full size of the item, including
+%% header.
 load_item(StartOffset, Length, Opts) ->
-    hb_prometheus:measure_and_report(fun () ->
-        case read_chunks(StartOffset, Length, Opts) of
-            {ok, SerializedItem} ->
-                {
-                    ok,
-                    hb_message:convert(
-                        ar_bundles:deserialize(SerializedItem),
-                        <<"structured@1.0">>,
-                        <<"ans104@1.0">>,
-                        Opts
-                    )
-                };
-            {error, Reason} ->
-                {error, Reason}
-        end
-    end,hb_store_arweave_chunk_fetch_duration_seconds, [load_item]).
+    hb_prometheus:measure_and_report(
+        fun() ->
+            case read_chunks(StartOffset, Length, Opts) of
+                {ok, SerializedItem} ->
+                    {
+                        ok,
+                        hb_message:convert(
+                            ar_bundles:deserialize(SerializedItem),
+                            <<"structured@1.0">>,
+                            <<"ans104@1.0">>,
+                            Opts
+                        )
+                    };
+                {error, Reason} ->
+                    {error, Reason}
+            end
+        end,
+        hb_store_arweave_chunk_fetch_duration_seconds,
+        [load_item]
+    ).
 
+%% @doc Load a TX from the given start offset and length. The `StartOffset' is
+%% the start of the first chunk of the data and runs for the length of the data
+%% segment, ignoring header size.
 load_tx(ID, StartOffset, Length, Opts) ->
-    hb_prometheus:measure_and_report(fun () ->
-        {ok, StructuredTXHeader} = hb_ao:resolve(
-            #{ <<"device">> => <<"arweave@2.9">> },
-            #{ <<"path">> => <<"tx">>, <<"tx">> => ID, <<"exclude-data">> => true },
-            Opts
-        ),
-        TXHeader = hb_message:convert(
-            StructuredTXHeader,
-            <<"tx@1.0">>,
-            <<"structured@1.0">>,
-            Opts),
-        case read_chunks(StartOffset, Length, Opts) of
-            {ok, SerializedItem} ->
-                {
-                    ok,
-                    hb_message:convert(
-                        TXHeader#tx{ data = SerializedItem },
-                        <<"structured@1.0">>,
-                        <<"tx@1.0">>,
-                        Opts
-                    )
-                };
-            {error, Reason} ->
-                {error, Reason}
-        end
-    end,hb_store_arweave_chunk_fetch_duration_seconds, [load_tx]).
+    hb_prometheus:measure_and_report(
+        fun() ->
+            {ok, StructuredTXHeader} = hb_ao:resolve(
+                #{ <<"device">> => <<"arweave@2.9">> },
+                #{ <<"path">> => <<"tx">>, <<"tx">> => ID, <<"exclude-data">> => true },
+                Opts
+            ),
+            TXHeader =
+                hb_message:convert(
+                    StructuredTXHeader,
+                    <<"tx@1.0">>,
+                    <<"structured@1.0">>,
+                    Opts
+                ),
+            case read_chunks(StartOffset, Length, Opts) of
+                {ok, SerializedItem} ->
+                    {
+                        ok,
+                        hb_message:convert(
+                            TXHeader#tx{ data = SerializedItem },
+                            <<"structured@1.0">>,
+                            <<"tx@1.0">>,
+                            Opts
+                        )
+                    };
+                {error, Reason} ->
+                    {error, Reason}
+            end
+        end,
+        hb_store_arweave_chunk_fetch_duration_seconds,
+        [load_tx]
+    ).
 
+%% @doc Read the chunks from the given start offset and length using the 
+%% `~arweave@2.9` device.
 read_chunks(StartOffset, Length, Opts) ->
     hb_ao:resolve(
         #{ <<"device">> => <<"arweave@2.9">> },
@@ -177,6 +209,7 @@ read_chunks(StartOffset, Length, Opts) ->
         Opts
     ).
 
+%% @doc Write offset information to the index store.
 write_offset(
         #{ <<"index-store">> := IndexStore },
         ID,
@@ -197,44 +230,54 @@ write_offset(
     ),
     hb_store:write(IndexStore, hb_store_arweave_offset:path(ID), Value).
 
-%% @doc Record partition that are requested
+%% @doc Record the partition that data is found in when it is requested.
 record_partition_metric(Offset) when is_integer(Offset) ->
-    spawn(fun () ->
-        case application:get_application(prometheus) of
-            undefined -> ok;
-            _ ->
-                Partition = Offset div ?PARTITION_SIZE,
-                prometheus_counter:inc(hb_store_arweave_requests_partition, [Partition], 1)
-        end
-    end).
-
-init_prometheus() ->
-    case application:get_application(prometheus) of
-        undefined -> ok;
-        _ ->
-            try
-                prometheus_histogram:declare([
-                    {name, hb_store_arweave_index_check_duration_seconds},
-                    {buckets, [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10]},
-                    {help, "How much it takes to check the index"}
-                ]),
-                prometheus_histogram:declare([
-                    {name, hb_store_arweave_chunk_fetch_duration_seconds},
-                    {buckets, [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30, 60]},
-                    {labels, [type]},
-                    {help, "How much it takes to check the index"}
-                ]),
-                prometheus_counter:declare([
-                    {name, hb_store_arweave_requests_partition},
-                    {labels, [partition]},
-                    {help, "Partition where chunks are being requested"}
-                ]),
-                ok
-            catch
-                error:mfa_already_exists -> ok;
-                _:_ -> ok
+    spawn(
+        fun () ->
+            case application:get_application(prometheus) of
+                undefined -> ok;
+                _ ->
+                    Partition = Offset div ?PARTITION_SIZE,
+                    prometheus_counter:inc(
+                        hb_store_arweave_requests_partition,
+                        [Partition],
+                        1
+                    )
             end
-    end.
+        end
+    ).
+
+%% @doc Initialize the Prometheus metrics for the Arweave store. Executed on
+%% `start/1' of the store.
+init_prometheus() ->
+    hb_prometheus:declare(
+        histogram,
+        [
+            {name, hb_store_arweave_index_check_duration_seconds},
+            {buckets, [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10]},
+            {help, "How much it takes to check the index"}
+        ]
+    ),
+    hb_prometheus:declare(
+        histogram,
+        [
+            {name, hb_store_arweave_chunk_fetch_duration_seconds},
+            {buckets, [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30, 60]},
+            {labels, [type]},
+            {help, "How much it takes to check the index"}
+        ]
+    ),
+    hb_prometheus:declare(
+        counter,
+        [
+            {name, hb_store_arweave_requests_partition},
+            {labels, [partition]},
+            {help, "Partition where chunks are being requested"}
+        ]
+    ),
+    % We also depend on the HTTP client, so we ensure its prometheus metrics are
+    % initialized, too.
+    hb_http_client:init_prometheus().
 
 %%% Tests
 
@@ -258,7 +301,15 @@ write_read_tx_test() ->
         ),
     ?assert(hb_message:verify(Child, all, #{})),
     ExpectedChild = #{
-        <<"data">> => <<"{\"totalTickedRewardsDistributed\":0,\"distributedEpochIndexes\":[],\"newDemandFactors\":[],\"newEpochIndexes\":[],\"tickedRewardDistributions\":[],\"newPruneGatewaysResults\":[{\"delegateStakeReturned\":0,\"stakeSlashed\":0,\"gatewayStakeReturned\":0,\"delegateStakeWithdrawing\":0,\"prunedGateways\":[],\"slashedGateways\":[],\"gatewayStakeWithdrawing\":0}]}">>,
+        <<"data">> =>
+            <<
+                "{\"totalTickedRewardsDistributed\":0,\"distributedEpochIndexes\""
+                ":[],\"newDemandFactors\":[],\"newEpochIndexes\":[],\""
+                "tickedRewardDistributions\":[],\"newPruneGatewaysResults\""
+                ":[{\"delegateStakeReturned\":0,\"stakeSlashed\":0,\""
+                "gatewayStakeReturned\":0,\"delegateStakeWithdrawing\":0,\""
+                "prunedGateways\":[],\"slashedGateways\":[],\""
+                "gatewayStakeWithdrawing\":0}]}">>,
         <<"data-protocol">> => <<"ao">>,
         <<"from-module">> => <<"cbn0KKrBZH7hdNkNokuXLtGryrWM--PjSTBqIzw9Kkk">>,
         <<"from-process">> => <<"agYcCFJtrMG6cqMuZfskIkFTGvUPddICmtQSBIoPdiA">>,

--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -52,6 +52,7 @@ read_offset(#{ <<"index-store">> := IndexStore }, ID) ->
         {ok, OffsetBinary} ->
             {Version, CodecName, StartOffset, Length} =
                 hb_store_arweave_offset:decode(OffsetBinary),
+            record_partition_metric(StartOffset),
             {ok, #{
                 <<"version">> => Version,
                 <<"codec-device">> => CodecName,

--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -198,12 +198,12 @@ write_offset(
     hb_store:write(IndexStore, hb_store_arweave_offset:path(ID), Value).
 
 %% @doc Record partition that are requested
-record_partition_metric(Offset) ->
+record_partition_metric(Offset) when is_integer(Offset) ->
     spawn(fun () ->
         case application:get_application(prometheus) of
             undefined -> ok;
             _ ->
-                Partition = binary_to_integer(Offset) div ?PARTITION_SIZE,
+                Partition = Offset div ?PARTITION_SIZE,
                 prometheus_counter:inc(hb_store_arweave_requests_partition, [Partition], 1)
         end
     end).

--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -10,6 +10,12 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-define(PARTITION_SIZE, 3_600_000_000_000).
+
+start(#{<<"index-store">> := IndexStore}) ->
+    init_prometheus(),
+    hb_store:start(IndexStore).
+
 %% @doc Although the index is local, loading an item via the index will make
 %% requests to a remote node, so we define the scope as remote.
 scope() -> remote.
@@ -32,7 +38,7 @@ type(#{ <<"index-store">> := IndexStore }, ID) when ?IS_ID(ID) ->
             {ok, _Offset} -> simple;
             _ -> not_found
         end,
-    ?event(store_arweave_debug,
+    ?event(debug_store_arweave,
         {type, {id, {explicit, ID}}, {type, Type}}),
     Type;
 type(_, _) -> not_found.
@@ -111,46 +117,54 @@ do_read(StoreOpts, ID) ->
     end.
 
 load_item(StartOffset, Length, Opts) ->
-    case read_chunks(StartOffset, Length, Opts) of
-        {ok, SerializedItem} ->
-            {
-                ok,
-                hb_message:convert(
-                    ar_bundles:deserialize(SerializedItem),
-                    <<"structured@1.0">>,
-                    <<"ans104@1.0">>,
-                    Opts
-                )
-            };
-        {error, Reason} ->
-            {error, Reason}
-    end.
+    {Duration, Result} = timer:tc(fun () ->
+        case read_chunks(StartOffset, Length, Opts) of
+            {ok, SerializedItem} ->
+                {
+                    ok,
+                    hb_message:convert(
+                        ar_bundles:deserialize(SerializedItem),
+                        <<"structured@1.0">>,
+                        <<"ans104@1.0">>,
+                        Opts
+                    )
+                };
+            {error, Reason} ->
+                {error, Reason}
+        end
+    end,native),
+    record_chunk_fetch_metric(Duration, load_item),
+    Result.
 
 load_tx(ID, StartOffset, Length, Opts) ->
-    {ok, StructuredTXHeader} = hb_ao:resolve(
-        #{ <<"device">> => <<"arweave@2.9">> },
-        #{ <<"path">> => <<"tx">>, <<"tx">> => ID, <<"exclude-data">> => true },
-        Opts
-    ),
-    TXHeader = hb_message:convert(
-        StructuredTXHeader,
-        <<"tx@1.0">>,
-        <<"structured@1.0">>,
-        Opts),
-    case read_chunks(StartOffset, Length, Opts) of
-        {ok, SerializedItem} ->
-            {
-                ok,
-                hb_message:convert(
-                    TXHeader#tx{ data = SerializedItem },
-                    <<"structured@1.0">>,
-                    <<"tx@1.0">>,
-                    Opts
-                )
-            };
-        {error, Reason} ->
-            {error, Reason}
-    end.
+    {Duration, Result} = timer:tc(fun () ->
+        {ok, StructuredTXHeader} = hb_ao:resolve(
+            #{ <<"device">> => <<"arweave@2.9">> },
+            #{ <<"path">> => <<"tx">>, <<"tx">> => ID, <<"exclude-data">> => true },
+            Opts
+        ),
+        TXHeader = hb_message:convert(
+            StructuredTXHeader,
+            <<"tx@1.0">>,
+            <<"structured@1.0">>,
+            Opts),
+        case read_chunks(StartOffset, Length, Opts) of
+            {ok, SerializedItem} ->
+                {
+                    ok,
+                    hb_message:convert(
+                        TXHeader#tx{ data = SerializedItem },
+                        <<"structured@1.0">>,
+                        <<"tx@1.0">>,
+                        Opts
+                    )
+                };
+            {error, Reason} ->
+                {error, Reason}
+        end
+    end, native),
+    record_chunk_fetch_metric(Duration, load_tx),
+    Result.
 
 read_chunks(StartOffset, Length, Opts) ->
     hb_ao:resolve(
@@ -172,7 +186,7 @@ write_offset(
     ) ->
     Value = hb_store_arweave_offset:encode(CodecName, StartOffset, Length),
     ?event(
-        store_arweave_debug, 
+        debug_store_arweave,
         {writing_offset, 
             {id, {explicit, ID}},
             {type, CodecName},
@@ -182,6 +196,60 @@ write_offset(
         }
     ),
     hb_store:write(IndexStore, hb_store_arweave_offset:path(ID), Value).
+
+record_partition_metric(Offset) ->
+    spawn(fun () ->
+        case application:get_application(prometheus) of
+            undefined -> ok;
+            _ ->
+                Partition = binary_to_integer(Offset) div ?PARTITION_SIZE,
+                prometheus_counter:inc(hb_store_arweave_requests_partition, [Partition], 1)
+        end
+    end).
+
+record_index_check_metric(Duration) ->
+    record_metric(hb_store_arweave_index_check_duration_seconds, [], Duration).
+
+record_chunk_fetch_metric(Duration, Type) ->
+    record_metric(hb_store_arweave_chunk_fetch_duration_seconds, [Type], Duration).
+
+record_metric(Metric, Labels, Duration) ->
+    spawn(fun () ->
+        case application:get_application(prometheus) of
+            undefined ->
+                ok;
+            _ ->
+                prometheus_histogram:observe(Metric, Labels, Duration)
+        end
+    end).
+
+init_prometheus() ->
+    case application:get_application(prometheus) of
+        undefined -> ok;
+        _ ->
+            try
+                prometheus_histogram:declare([
+                    {name, hb_store_arweave_index_check_duration_seconds},
+                    {buckets, [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10]},
+                    {help, "How much it takes to check the index"}
+                ]),
+                prometheus_histogram:declare([
+                    {name, hb_store_arweave_chunk_fetch_duration_seconds},
+                    {buckets, [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30, 60]},
+                    {labels, [type]},
+                    {help, "How much it takes to check the index"}
+                ]),
+                prometheus_counter:declare([
+                    {name, hb_store_arweave_requests_partition},
+                    {labels, [partition]},
+                    {help, "Partition where chunks are being requested"}
+                ]),
+                ok
+            catch
+                error:mfa_already_exists -> ok;
+                _:_ -> ok
+            end
+    end.
 
 %%% Tests
 


### PR DESCRIPTION
Add Prometheus metrics to monitor the performance of `hb_store_arweave`, mainly:
- Index search
- Chunk retrieval

Also, adds statistics on Arweave partitions.