### PR TITLE
feat: gateway independent `/raw` endpoint

### DIFF
--- a/src/ar_bundles.erl
+++ b/src/ar_bundles.erl
@@ -3,7 +3,7 @@
 -export([id/1, id/2, hd/1, member/2, find/2]).
 -export([new_item/4, sign_item/2, verify_item/1]).
 -export([encode_tags/1, decode_tags/1]).
--export([serialize/1, deserialize/1, serialize_bundle/3]).
+-export([serialize/1, deserialize/1, deserialize_item_wrapper/1, serialize_bundle/3]).
 -export([data_item_signature_data/1]).
 -export([bundle_header_size/1, decode_bundle_header/1]).
 -include("include/hb.hrl").
@@ -424,24 +424,30 @@ deserialize(Item) when is_record(Item, tx) ->
 deserialize(Binary) ->
     deserialize_item(Binary).
 
+%% @doc Deserialize an item and unbundle it if it is a bundle, returning a #tx
+%% with possibly deeply nested items in the #tx.data field.
 deserialize_item(Binary) ->
+    maybe_unbundle(deserialize_item_wrapper(Binary)).
+
+%% @doc Deserialize only the _wrapper_ of an item, leaving the data unprocessed
+%% in the case that it is a bundle. It may be unbundled by calling `maybe_unbundle/1'
+%% at any later point.
+deserialize_item_wrapper(Binary) ->
     {SignatureType, Signature, Owner, Rest} = decode_signature(Binary),
     {Target, Rest2} = decode_optional_field(Rest),
     {Anchor, Rest3} = decode_optional_field(Rest2),
     {Tags, Data} = decode_tags(Rest3),
-    maybe_unbundle(
-        dev_arweave_common:reset_ids(#tx{
-            format = ans104,
-            signature_type = SignatureType,
-            signature = Signature,
-            owner = Owner,
-            target = Target,
-            anchor = Anchor,
-            tags = Tags,
-            data = Data,
-            data_size = byte_size(Data)
-        })
-    ).
+    dev_arweave_common:reset_ids(#tx{
+        format = ans104,
+        signature_type = SignatureType,
+        signature = Signature,
+        owner = Owner,
+        target = Target,
+        anchor = Anchor,
+        tags = Tags,
+        data = Data,
+        data_size = byte_size(Data)
+    }).
 
 maybe_unbundle(Item) ->
     case dev_arweave_common:type(Item) of

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -141,7 +141,8 @@ get_tx(Base, Request, Opts) ->
 %% Does not deserialize the message, nor return signature information. Included
 %% only for compatibility with the legacy Arweave gateway `/raw` endpoint.
 raw(Base, Request, Opts) ->
-    case find_key(<<"raw">>, Base, Request, not_found, Opts) of
+    ?event(debug_raw, {raw, {base, Base}, {request, Request}}),
+    case find_txid(Base, Request, Opts) of
         not_found -> {error, not_found};
         TXID ->
             ?event(
@@ -151,7 +152,12 @@ raw(Base, Request, Opts) ->
             % Read the data from the local cache.
             IndexStore = hb_opts:get(arweave_index_store, no_store, Opts),
             case hb_store_arweave:read_offset(IndexStore, TXID) of
-                {ok, Index = #{ <<"codec-device">> := <<"ans104@1.0">> }} ->
+                {ok,
+                    #{
+                        <<"codec-device">> := <<"ans104@1.0">>,
+                        <<"start-offset">> := StartOffset,
+                        <<"length">> := Length
+                    }} ->
                     % Indexed messages of codec `ans104@1.0' are stored with
                     % the `offset` referencing the start of the *header*.
                     % Subsequently, we read the chunks and then deserialize
@@ -159,9 +165,13 @@ raw(Base, Request, Opts) ->
                     % contain a bundle.
                     ?event(
                         debug_raw,
-                        {found_offset, {id, TXID}, {index, Index}}
+                        {found_offset,
+                            {id, TXID},
+                            {start_offset, StartOffset},
+                            {length, Length}
+                        }
                     ),
-                    case get_chunk_range(Index, Opts) of
+                    case hb_store_arweave:read_chunks(StartOffset, Length, Opts) of
                         {ok, Data} ->
                             TX = ar_bundles:deserialize_item_wrapper(Data),
                             ?event(
@@ -180,16 +190,25 @@ raw(Base, Request, Opts) ->
                             }};
                         Error -> Error
                     end;
-                {ok, Index = #{ <<"codec-device">> := <<"tx@1.0">> }} ->
+                {ok,
+                    #{
+                        <<"codec-device">> := <<"tx@1.0">>,
+                        <<"start-offset">> := StartOffset,
+                        <<"length">> := Length
+                    }} ->
                     % Indexed messages of codec `tx@1.0' are stored with
                     % the `offset` referencing the start of the data.
                     % Subsequently, we read the chunks and return them
                     % as-is.
                     ?event(
                         debug_raw,
-                        {found_offset, {id, TXID}, {index, Index}}
+                        {found_offset,
+                            {id, TXID},
+                            {start_offset, StartOffset},
+                            {length, Length}
+                        }
                     ),
-                    case get_chunk_range(Index, Opts) of
+                    case hb_store_arweave:read_chunks(StartOffset, Length, Opts) of
                         {ok, Data} ->
                             ?event(
                                 debug_raw,
@@ -240,14 +259,6 @@ raw(Base, Request, Opts) ->
                     ),
                     Error
             end
-    end.
-
-%% @doc Case-insensitively find a key in a list and return its value.
-list_find(_Key, [], Default) -> Default;
-list_find(Key, [{XKey, Value} | Rest], Default) ->
-    NormalizedKey = hb_util:to_lower(hb_ao:normalize_key(XKey)),
-    if NormalizedKey =:= Key -> Value;
-    true -> list_find(Key, Rest, Default)
     end.
 
 %% @doc Case-insensitively find a key in a list and return its value.
@@ -565,12 +576,10 @@ tx_anchor(_Base, _Request, Opts) ->
 %% @doc Find the transaction ID to retrieve from Arweave based on the request or
 %% base message.
 find_txid(Base, Request, Opts) ->
-    hb_ao:get_first(
-        [
-            {Request, <<"tx">>},
-            {Base, <<"tx">>}
-        ],
-        not_found,
+    hb_maps:get(
+        <<"tx">>,
+        Request,
+        hb_maps:get(<<"tx">>, Base, not_found, Opts),
         Opts
     ).
 

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -127,13 +127,23 @@ post_binary_ans104(SerializedTX, LogExtra, Opts) ->
 %% `tx` key in the request or base message. By default, this embeds the data
 %% payload. Set `exclude_data` to true to return just the header.
 get_tx(Base, Request, Opts) ->
-    case find_txid(Base, Request, Opts) of
+    case find_key(<<"tx">>, Base, Request, Opts) of
         not_found -> {error, not_found};
         TXID ->
             request(
                 <<"GET">>,
                 <<"/tx/", TXID/binary>>,
-                Opts#{ exclude_data => exclude_data(Base, Request, Opts) }
+                Opts#{
+                    exclude_data =>
+                        hb_util:bool(
+                            find_key(
+                                <<"exclude-data">>,
+                                Base,
+                                Request,
+                                Opts
+                            )
+                        )
+                }
             )
     end.
 
@@ -142,16 +152,18 @@ get_tx(Base, Request, Opts) ->
 %% only for compatibility with the legacy Arweave gateway `/raw` endpoint.
 raw(Base, Request, Opts) ->
     ?event(debug_raw, {raw, {base, Base}, {request, Request}}),
-    case find_txid(Base, Request, Opts) of
+    case find_key(<<"raw">>, Base, Request, Opts) of
         not_found -> {error, not_found};
         TXID ->
-            ?event(
-                debug_raw,
-                {found_txid, {id, TXID}}
-            ),
             % Read the data from the local cache.
             IndexStore = hb_opts:get(arweave_index_store, no_store, Opts),
             case hb_store_arweave:read_offset(IndexStore, TXID) of
+                not_found ->
+                    ?event(
+                        arweave,
+                        {raw_read_failed, {id, TXID}},
+                        Opts
+                    );
                 {ok,
                     #{
                         <<"codec-device">> := <<"ans104@1.0">>,
@@ -188,7 +200,13 @@ raw(Base, Request, Opts) ->
                                 <<"content-type">> => ContentType,
                                 <<"data">> => Data
                             }};
-                        Error -> Error
+                        Error ->
+                            ?event(
+                                arweave,
+                                {raw_read_chunks_failed, {id, TXID}, {error, Error}},
+                                Opts
+                            ),
+                            Error
                     end;
                 {ok,
                     #{
@@ -247,17 +265,12 @@ raw(Base, Request, Opts) ->
                             };
                         Error ->
                             ?event(
-                                debug_raw,
-                                {error, {id, TXID}, {returned, Error}}
+                                arweave,
+                                {raw_read_chunks_failed, {id, TXID}, {error, Error}},
+                                Opts
                             ),
                             Error
-                    end;
-                Error ->
-                    ?event(
-                        debug_raw,
-                        {error, {id, TXID}, {returned, Error}}
-                    ),
-                    Error
+                    end
             end
     end.
 
@@ -487,9 +500,7 @@ get_chunk(Offset, Opts) ->
     % leaeve the header out and continue to search for a case where it is
     % needed.
     Path = <<"/chunk/", (hb_util:bin(Offset))/binary>>,
-    request(<<"GET">>, Path, #{
-        <<"route-by">> => Offset
-    }, Opts).
+    request(<<"GET">>, Path, #{ <<"route-by">> => Offset }, Opts).
 
 %% @doc Retrieve (and cache) block information from Arweave. If the `block' key
 %% is present, it is used to look up the associated block. If it is of Arweave
@@ -575,11 +586,11 @@ tx_anchor(_Base, _Request, Opts) ->
 
 %% @doc Find the transaction ID to retrieve from Arweave based on the request or
 %% base message.
-find_txid(Base, Request, Opts) ->
+find_key(Key, Base, Request, Opts) ->
     hb_maps:get(
-        <<"tx">>,
+        Key,
         Request,
-        hb_maps:get(<<"tx">>, Base, not_found, Opts),
+        hb_maps:get(Key, Base, not_found, Opts),
         Opts
     ).
 

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -1041,6 +1041,71 @@ post_tx_json_request(Server, ClientOpts) ->
         ClientOpts
     ).
 
+%% @doc Build isolated test opts and pre-index the blocks for the given TXIDs.
+setup_arweave_index_opts(TXIDs) ->
+    TestStore = hb_test_utils:test_store(hb_store_ets, <<"arweave-index">>),
+    IndexStore = #{ <<"index-store">> => [TestStore] },
+    Opts = #{
+        store => [TestStore],
+        arweave_index_ids => true,
+        arweave_index_store => IndexStore
+    },
+    % Either: Index the blocks containing the TXs...
+    % lists:foreach(
+    %     fun(Block) -> ok = index_test_block(Block, Opts) end,
+    %     lists:usort([tx_index_block(TXID) || TXID <- TXIDs])
+    % ),
+    % ...or: Index the TXs directly. This depends on the `/tx/<TXID>/offset`
+    % endpoint being available in the `/arweave` routes.
+    lists:foreach(
+        fun(TXID) -> ok = index_test_tx(TXID, IndexStore, Opts) end,
+        TXIDs
+    ),
+    Opts.
+
+index_test_block(Block, Opts) ->
+    BlockBin = hb_util:bin(Block),
+    {ok, Block} =
+        hb_ao:resolve(
+            <<
+                "~copycat@1.0/arweave&from=",
+                BlockBin/binary,
+                "&to=",
+                BlockBin/binary
+            >>,
+            Opts#{ arweave_index_ids => true }
+        ),
+    ok.
+
+index_test_tx(TXID, IndexStore, Opts) ->
+    {ok, #{ <<"body">> := OffsetBody }} =
+        hb_http:request(
+            #{
+                <<"path">> => <<"/arweave/tx/", TXID/binary, "/offset">>,
+                <<"method">> => <<"GET">>
+            },
+            Opts
+        ),
+    OffsetMsg = hb_json:decode(OffsetBody),
+    EndOffset = hb_util:int(maps:get(<<"offset">>, OffsetMsg)),
+    Size = hb_util:int(maps:get(<<"size">>, OffsetMsg)),
+    StartOffset = EndOffset - Size,
+    ok =
+        hb_store_arweave:write_offset(
+            IndexStore,
+            TXID,
+            <<"tx@1.0">>,
+            StartOffset,
+            Size
+        ),
+    ?assertMatch({ok, _}, hb_store_arweave:read_offset(IndexStore, TXID)),
+    ok.
+
+tx_index_block(<<"ptBC0UwDmrUTBQX3MqZ1lB57ex20ygwzkjjCrQjIx3o">>) -> 1749502;
+tx_index_block(<<"jI0A4BASHaUdCCsdv249BxDX6IlE0Ko391TuI6REATw">>) -> 1289677;
+tx_index_block(<<"4FnBmvgWmqXWEEprjVqBsV5aRpAgF6_yJX_GTGsSZjY">>) -> 753012;
+tx_index_block(<<"YR9m4c3CrlljCRYEWBLeoKekbAyYZRMo2Kpz61IeNp8">>) -> 1233918.
+
 get_tx_basic_data_test() ->
     {ok, Structured} = hb_ao:resolve(
         #{ <<"device">> => <<"arweave@2.9">> },
@@ -1099,17 +1164,19 @@ get_tx_split_chunk_test() ->
     ok.
 
 get_tx_basic_data_exclude_data_test() ->
+    TXID = <<"ptBC0UwDmrUTBQX3MqZ1lB57ex20ygwzkjjCrQjIx3o">>,
+    Opts = setup_arweave_index_opts([TXID]),
     {ok, Structured} = hb_ao:resolve(
         #{ <<"device">> => <<"arweave@2.9">> },
         #{
             <<"path">> => <<"tx">>,
-            <<"tx">> => <<"ptBC0UwDmrUTBQX3MqZ1lB57ex20ygwzkjjCrQjIx3o">>,
+            <<"tx">> => TXID,
             <<"exclude-data">> => true
         },
-        #{}
+        Opts
     ),
     ?event(debug_test, {structured_tx, Structured}),
-    ?assert(hb_message:verify(Structured, all, #{})),
+    ?assert(hb_message:verify(Structured, all, Opts)),
     ?assertEqual(false, maps:is_key(<<"data">>, Structured)),
     ExpectedMsg = #{
         <<"reward">> => <<"482143296">>,
@@ -1117,32 +1184,35 @@ get_tx_basic_data_exclude_data_test() ->
         <<"content-type">> => <<"application/json">>
     },
     ?assert(hb_message:match(ExpectedMsg, Structured, only_present)),
-    {ok, Data} = hb_ao:resolve(
+    {ok, RawData} = hb_ao:resolve(
         #{ <<"device">> => <<"arweave@2.9">> },
         #{
             <<"path">> => <<"raw">>,
-            <<"tx">> => <<"ptBC0UwDmrUTBQX3MqZ1lB57ex20ygwzkjjCrQjIx3o">>
+            <<"raw">> => TXID
         },
-        #{}
+        Opts
     ),
+    Data = hb_ao:get(<<"data">>, RawData, Opts),
     StructuredWithData = Structured#{ <<"data">> => Data },
-    ?assert(hb_message:verify(StructuredWithData, all, #{})),
+    ?assert(hb_message:verify(StructuredWithData, all, Opts)),
     DataHash = hb_util:encode(crypto:hash(sha256, Data)),
     ?assertEqual(<<"PEShWA1ER2jq7CatAPpOZ30TeLrjOSpaf_Po7_hKPo4">>, DataHash),
     ok.
 
 get_tx_data_tag_exclude_data_test() ->
+    TXID = <<"jI0A4BASHaUdCCsdv249BxDX6IlE0Ko391TuI6REATw">>,
+    Opts = setup_arweave_index_opts([TXID]),
     {ok, Structured} = hb_ao:resolve(
         #{ <<"device">> => <<"arweave@2.9">> },
         #{
             <<"path">> => <<"tx">>,
-            <<"tx">> => <<"jI0A4BASHaUdCCsdv249BxDX6IlE0Ko391TuI6REATw">>,
+            <<"tx">> => TXID,
             <<"exclude-data">> => true
         },
-        #{}
+        Opts
     ),
     ?event(debug_test, {structured_tx, Structured}),
-    ?assert(hb_message:verify(Structured, all, #{})),
+    ?assert(hb_message:verify(Structured, all, Opts)),
     ?assertEqual(false, maps:is_key(<<"data">>, Structured)),
     ExpectedMsg = #{
         <<"reward">> => <<"630923958">>,
@@ -1150,16 +1220,17 @@ get_tx_data_tag_exclude_data_test() ->
         <<"content-type">> => <<"application/json">>
     },
     ?assert(hb_message:match(ExpectedMsg, Structured, only_present)),
-    {ok, Data} = hb_ao:resolve(
+    {ok, RawData} = hb_ao:resolve(
         #{ <<"device">> => <<"arweave@2.9">> },
         #{
             <<"path">> => <<"raw">>,
-            <<"tx">> => <<"jI0A4BASHaUdCCsdv249BxDX6IlE0Ko391TuI6REATw">>
+            <<"raw">> => TXID
         },
-        #{}
+        Opts
     ),
+    Data = hb_ao:get(<<"data">>, RawData, Opts),
     StructuredWithData = Structured#{ <<"data">> => Data },
-    ?assert(hb_message:verify(StructuredWithData, all, #{})),
+    ?assert(hb_message:verify(StructuredWithData, all, Opts)),
     DataHash = hb_util:encode(crypto:hash(sha256, Data)),
     ?assertEqual(<<"IHyJ9BlQaHLWVwwklMwV1XEYXGjwx2B6HXNJZ4yJXeQ">>, DataHash),
     ok.
@@ -1463,7 +1534,7 @@ bucket_based_offset_test() ->
 
 assert_chunk_range(TXID, EndOffset, ExpectedLength, ExpectedHash) ->
     StartOffset = EndOffset - ExpectedLength,
-    Opts = #{},
+    Opts = setup_arweave_index_opts([TXID]),
     T1 = erlang:monotonic_time(millisecond),
     {ok, Data} = hb_ao:resolve(
         #{ <<"device">> => <<"arweave@2.9">> },
@@ -1481,14 +1552,15 @@ assert_chunk_range(TXID, EndOffset, ExpectedLength, ExpectedHash) ->
         {offset, StartOffset + 1},
         {length, ExpectedLength}
     }),
-    {ok, RawData} = hb_ao:resolve(
+    {ok, RawDataMsg} = hb_ao:resolve(
         #{ <<"device">> => <<"arweave@2.9">> },
         #{
             <<"path">> => <<"raw">>,
-            <<"tx">> => TXID
+            <<"raw">> => TXID
         },
         Opts
     ),
+    RawData = hb_ao:get(<<"data">>, RawDataMsg, Opts),
     ?event(debug_test, {chunk_vs_raw_comparison,
         {tx, TXID},
         {start_offset, StartOffset},

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -137,15 +137,128 @@ get_tx(Base, Request, Opts) ->
             )
     end.
 
-%% @doc Get raw transaction data from the Arweave node, as indicated by the
-%% `tx` key in the request or base message.
+%% @doc Get raw transaction *data* and `content-type` of an Arweave message.
+%% Does not deserialize the message, nor return signature information. Included
+%% only for compatibility with the legacy Arweave gateway `/raw` endpoint.
 raw(Base, Request, Opts) ->
-    case find_txid(Base, Request, Opts) of
+    case find_key(<<"raw">>, Base, Request, not_found, Opts) of
         not_found -> {error, not_found};
-        TXID -> data(TXID, Opts)
+        TXID ->
+            ?event(
+                debug_raw,
+                {found_txid, {id, TXID}}
+            ),
+            % Read the data from the local cache.
+            IndexStore = hb_opts:get(arweave_index_store, no_store, Opts),
+            case hb_store_arweave:read_offset(IndexStore, TXID) of
+                {ok, Index = #{ <<"codec-device">> := <<"ans104@1.0">> }} ->
+                    % Indexed messages of codec `ans104@1.0' are stored with
+                    % the `offset` referencing the start of the *header*.
+                    % Subsequently, we read the chunks and then deserialize
+                    % only the wrapper, yielding a #tx record that may
+                    % contain a bundle.
+                    ?event(
+                        debug_raw,
+                        {found_offset, {id, TXID}, {index, Index}}
+                    ),
+                    case get_chunk_range(Index, Opts) of
+                        {ok, Data} ->
+                            TX = ar_bundles:deserialize_item_wrapper(Data),
+                            ?event(
+                                debug_raw,
+                                {deserialized_raw, {id, TXID}, {tx, TX}}
+                            ),
+                            ContentType =
+                                list_find(
+                                    <<"content-type">>,
+                                    TX#tx.tags,
+                                    <<"application/octet-stream">>
+                                ),
+                            {ok, #{
+                                <<"content-type">> => ContentType,
+                                <<"data">> => Data
+                            }};
+                        Error -> Error
+                    end;
+                {ok, Index = #{ <<"codec-device">> := <<"tx@1.0">> }} ->
+                    % Indexed messages of codec `tx@1.0' are stored with
+                    % the `offset` referencing the start of the data.
+                    % Subsequently, we read the chunks and return them
+                    % as-is.
+                    ?event(
+                        debug_raw,
+                        {found_offset, {id, TXID}, {index, Index}}
+                    ),
+                    case get_chunk_range(Index, Opts) of
+                        {ok, Data} ->
+                            ?event(
+                                debug_raw,
+                                {fetched_chunks, {id, TXID}, {data, Data}}
+                            ),
+                            {ok, StructuredTXHeader} =
+                                get_tx(
+                                    #{ <<"tx">> => TXID },
+                                    #{ <<"exclude-data">> => true },
+                                    Opts
+                                ),
+                            ContentType =
+                                hb_ao:get(
+                                    <<"content-type">>,
+                                    StructuredTXHeader,
+                                    <<"application/octet-stream">>,
+                                    Opts#{
+                                        cache_control =>
+                                            [<<"no-cache">>, <<"no-store">>]
+                                    }
+                                ),
+                            ?event(
+                                debug_raw,
+                                {content_type_and_data,
+                                    {id, TXID},
+                                    {content_type, ContentType},
+                                    {data, Data}
+                                }
+                            ),
+                            {
+                                ok,
+                                #{
+                                    <<"content-type">> => ContentType,
+                                    <<"data">> => Data
+                                }
+                            };
+                        Error ->
+                            ?event(
+                                debug_raw,
+                                {error, {id, TXID}, {returned, Error}}
+                            ),
+                            Error
+                    end;
+                Error ->
+                    ?event(
+                        debug_raw,
+                        {error, {id, TXID}, {returned, Error}}
+                    ),
+                    Error
+            end
     end.
 
-%% @doc Retrieve the data of a transaction from Arweave.
+%% @doc Case-insensitively find a key in a list and return its value.
+list_find(_Key, [], Default) -> Default;
+list_find(Key, [{XKey, Value} | Rest], Default) ->
+    NormalizedKey = hb_util:to_lower(hb_ao:normalize_key(XKey)),
+    if NormalizedKey =:= Key -> Value;
+    true -> list_find(Key, Rest, Default)
+    end.
+
+%% @doc Case-insensitively find a key in a list and return its value.
+list_find(_Key, [], Default) -> Default;
+list_find(Key, [{XKey, Value} | Rest], Default) ->
+    NormalizedKey = hb_util:to_lower(hb_ao:normalize_key(XKey)),
+    if NormalizedKey =:= Key -> Value;
+    true -> list_find(Key, Rest, Default)
+    end.
+
+%% @doc Retrieve the data of an Arweave message that has been indexed.
 data(TXID, Opts) ->
     request(<<"GET">>, <<"/raw/", TXID/binary>>, Opts).
 

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -216,7 +216,7 @@ process_block(BlockRes, Current, To, Opts) ->
 %% @doc Index the IDs of all transactions in the block if configured to do so.
 maybe_index_ids(Block, Opts) ->
     TotalTXs = length(hb_maps:get(<<"txs">>, Block, [], Opts)),
-    case hb_opts:get(arweave_index_ids, false, Opts) of
+    case hb_opts:get(arweave_index_ids, true, Opts) of
         false -> 
             {block_skipped, #{
                 items_count => 0,

--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -4,7 +4,7 @@
 %%% Store API:
 -export([scope/0, scope/1, type/2, read/2]).
 %%% Indexing API:
--export([write_offset/5]).
+-export([write_offset/5, read_offset/2]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -27,11 +27,30 @@ type(#{ <<"index-store">> := IndexStore }, ID) ->
         {type, {id, {explicit, ID}}, {type, Type}}),
     Type.
 
-read(StoreOpts = #{ <<"index-store">> := IndexStore }, ID) ->
+%% @doc Read the offset of the data at the given key.
+read_offset(#{ <<"index-store">> := IndexStore }, ID) ->
     case hb_store:read(IndexStore, hb_store_arweave_offset:path(ID)) of
         {ok, OffsetBinary} ->
             {Version, CodecName, StartOffset, Length} =
                 hb_store_arweave_offset:decode(OffsetBinary),
+            {ok, #{
+                <<"version">> => Version,
+                <<"codec-device">> => CodecName,
+                <<"start-offset">> => StartOffset,
+                <<"length">> => Length
+            }};
+        not_found -> not_found
+    end.
+
+read(StoreOpts, ID) ->
+    case read_offset(StoreOpts, ID) of
+        {ok,
+            #{
+                <<"version">> := Version,
+                <<"codec-device">> := CodecName,
+                <<"start-offset">> := StartOffset,
+                <<"length">> := Length
+            }} ->
             Loaded =
                 case CodecName of
                     <<"ans104@1.0">> ->

--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -4,7 +4,7 @@
 %%% Store API:
 -export([scope/0, scope/1, type/2, read/2]).
 %%% Indexing API:
--export([write_offset/5, read_offset/2]).
+-export([write_offset/5, read_offset/2, read_chunks/3]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 

--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -39,7 +39,7 @@ read_offset(#{ <<"index-store">> := IndexStore }, ID) ->
                 <<"start-offset">> => StartOffset,
                 <<"length">> => Length
             }};
-        not_found -> not_found
+        _ -> not_found
     end.
 
 read(StoreOpts, ID) ->


### PR DESCRIPTION
This PR implements the legacy Arweave gateway's `/raw/ID` endpoint at `~arweave@2.9/raw=ID`. This endpoint should generally only be used for legacy applications that do not yet use the AO-Core interfaces. It lacks serving the signatures, parsing, unbundling/bundling capabilities of the `/tx=ID` endpoint, but is necessary for full API compatibility.