### PR TITLE
feat: introduce `on/request` name resolver and simplify `~name@1.0` API

### DIFF
--- a/src/dev_name.erl
+++ b/src/dev_name.erl
@@ -4,9 +4,11 @@
 %%% match the key against each resolver in turn, and return the value of the
 %%% first resolver that matches.
 -module(dev_name).
--export([info/1]).
+-export([info/1, request/3]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
+
+%%% Core functionality.
 
 %% @doc Configure the `default' key to proxy to the `resolver/4' function.
 %% Exclude the `keys' and `set' keys from being processed by this device, as
@@ -51,13 +53,73 @@ match_resolver(Key, [Resolver | Resolvers], Opts) ->
     end.
 
 %% @doc Execute a resolver with the given key and return its value.
-execute_resolver(Key, Resolver, Opts) ->
+execute_resolver(Key, Path, Opts) when is_binary(Path) ->
+    hb_ao:resolve(
+        <<Path/binary, "/", Key/binary>>,
+        Opts
+    );
+execute_resolver(Key, Resolver, Opts) when is_map(Resolver) ->
     ?event({executing, {key, Key}, {resolver, Resolver}}),
     hb_ao:resolve(
         Resolver,
-        #{ <<"path">> => <<"lookup">>, <<"key">> => Key },
+        Key,
         Opts
     ).
+
+%%% `on/request` hook functionality.
+
+%% @doc Implements an `on/request' compatible hook that resolves names given in
+%% the `host` key to their corresponding ID and prepends it to the execution path.
+request(HookMsg, HookReq, Opts) ->
+    ?event({request_hook, {hook_msg, HookMsg}, {hook_req, HookReq}, {opts, Opts}}),
+    maybe
+        {ok, Req} ?= hb_maps:find(<<"request">>, HookReq, Opts),
+        {ok, Host} ?= hb_maps:find(<<"host">>, Req, Opts),
+        {ok, Name} ?= name_from_host(Host, hb_opts:get(host, no_host, Opts)),
+        {ok, ResolvedMsg} ?= resolve(Name, HookMsg, #{}, Opts),
+        {ok, [OldBase|Rest]} ?= hb_maps:find(<<"body">>, HookReq, Opts),
+        ModReq = [overlay_loaded(OldBase, ResolvedMsg, Opts)|Rest],
+        ?event(
+            {request_with_prepended_path,
+                {name, Name},
+                {full_host, Host},
+                {resolved_msg, ResolvedMsg},
+                {to_execute, ModReq},
+                {res, hb_ao:resolve_many(ModReq, Opts)}
+            }
+        ),
+        {ok, #{ <<"body">> => ModReq }}
+    else
+        Reason ->
+            ?event({request_hook_skip, {reason, Reason}, {hook_req, HookReq}}),
+            {ok, HookReq}
+    end.
+
+%% @doc Takes a request-given host and the host value in the node message and
+%% returns only the name component of the host, if it is present. If no name is
+%% present, an empty binary is returned.
+name_from_host(Host, no_host) ->
+    case hd(binary:split(Host, <<".">>)) of
+        <<>> -> {error, <<"No name found in `Host`.">>};
+        Name -> {ok, Name}
+    end;
+name_from_host(ReqHost, RawNodeHost) ->
+    NodeHost = uri_string:parse(RawNodeHost),
+    ?event({node_host, NodeHost}),
+    WithoutNodeHost =
+        binary:replace(
+            ReqHost,
+            maps:get(host, uri_string:parse(RawNodeHost)),
+            <<>>
+        ),
+    name_from_host(WithoutNodeHost, no_host).
+
+%% @doc Merge the base message with the resolved message, ensuring that `~` as
+%% device specifiers are preserved.
+overlay_loaded({as, DevID, Base}, Resolved, Opts) ->
+    {as, DevID, hb_maps:merge(Base, Resolved, Opts)};
+overlay_loaded(Base, Resolved, Opts) ->
+    hb_maps:merge(Base, Resolved, Opts).
 
 %%% Tests.
 
@@ -67,21 +129,21 @@ no_resolvers_test() ->
         resolve(<<"hello">>, #{}, #{}, #{ only => local })
     ).
 
-message_lookup_device_resolver(Msg) ->
+device_resolver(Msg) ->
     #{
         <<"device">> => #{
-            <<"lookup">> => fun(_, Req, Opts) ->
-                Key = hb_ao:get(<<"key">>, Req, Opts),
-                ?event({test_resolver_executing, {key, Key}, {req, Req}, {msg, Msg}}),
-                case maps:get(Key, Msg, not_found) of
-                    not_found ->
-                        ?event({test_resolver_not_found, {key, Key}, {msg, Msg}}),
-                        {error, not_found};
-                    Value ->
-                        ?event({test_resolver_found, {key, Key}, {value, Value}}),
-                        {ok, Value}
+            info =>
+                fun() ->
+                    #{
+                        default =>
+                            fun(Key, _, _Req, _Opts) ->
+                                case maps:get(Key, Msg, not_found) of
+                                    not_found -> {error, not_found};
+                                    Value -> {ok, Value}
+                                end
+                            end
+                    }
                 end
-            end
         }
     }.
 
@@ -94,7 +156,23 @@ single_resolver_test() ->
             #{ <<"load">> => false },
             #{
                 name_resolvers => [
-                    message_lookup_device_resolver(
+                    #{<<"hello">> => <<"world">>}
+                ]
+            }
+        )
+    ).
+
+%% @doc Lookup a name in a message and return it.
+message_lookup_test() ->
+    ?assertEqual(
+        {ok, <<"world">>},
+        resolve(
+            <<"hello">>,
+            #{},
+            #{ <<"load">> => false },
+            #{
+                name_resolvers => [
+                    device_resolver(
                         #{<<"hello">> => <<"world">>}
                     )
                 ]
@@ -111,10 +189,10 @@ multiple_resolvers_test() ->
             #{ <<"load">> => false },
             #{
                 name_resolvers => [
-                    message_lookup_device_resolver(
+                    device_resolver(
                         #{<<"irrelevant">> => <<"world">>}
                     ),
-                    message_lookup_device_resolver(
+                    device_resolver(
                         #{<<"hello">> => <<"bigger-world">>}
                     )
                 ]
@@ -141,9 +219,63 @@ load_and_execute_test() ->
             ],
             #{
                 name_resolvers => [
-                    message_lookup_device_resolver(#{ <<"irrelevant">> => ID }),
-                    message_lookup_device_resolver(#{ TestKey => ID })
+                    device_resolver(#{ <<"irrelevant">> => ID }),
+                    device_resolver(#{ TestKey => ID })
                 ]
             }
+        )
+    ).
+
+%% @doc Return an `Opts` for an environment with the default ARNS name export
+%% and a temporary store for the test.
+arns_opts() ->
+    JSONNames = <<"G_gb7SAgogHMtmqycwaHaC6uC-CZ3akACdFv5PUaEE8">>,
+    Path = <<JSONNames/binary, "~json@1.0/deserialize&target=data">>,
+    hb_http_server:start_node(#{}),
+    TempStore = hb_test_utils:test_store(),
+    #{
+        store =>
+            [
+                TempStore,
+                #{
+                    <<"store-module">> => hb_store_gateway,
+                    <<"local-store">> => [TempStore]
+                }
+            ],
+        name_resolvers => [Path],
+        on => #{
+            <<"request">> => #{
+                <<"device">> => <<"name@1.0">>
+            }
+        }
+    }.
+
+%% @doc Names from JSON test.
+arns_json_snapshot_test() ->
+    Opts = arns_opts(),
+    ?assertMatch(
+        {ok, <<"application/pdf">>},
+        hb_ao:resolve_many(
+            [
+                #{ <<"device">> => <<"name@1.0">> },
+                #{ <<"path">> => <<"draft-17_whitepaper">> },
+                <<"content-type">>
+            ],
+            Opts
+        )
+    ).
+
+arns_host_resolution_test() ->
+    Opts = arns_opts(),
+    Node = hb_http_server:start_node(Opts),
+    ?assertMatch(
+        {ok, <<"application/pdf">>},
+        hb_http:get(
+            Node,
+            #{
+                <<"path">> => <<"content-type">>,
+                <<"host">> => <<"draft-17_whitepaper">>
+            },
+            Opts
         )
     ).

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -31,6 +31,21 @@
 ).
 -endif.
 
+%%% Default name resolvers. In test mode, we do not use any name resolvers, but
+%%% in-production mode we preload the ARNS snapshot as a baseline.
+-ifndef(TEST).
+-define(DEFAULT_NAME_RESOLVERS,
+    [
+        <<
+            "G_gb7SAgogHMtmqycwaHaC6uC-CZ3akACdFv5PUaEE8",
+                "~json@1.0/deserialize&target=data"
+        >>
+    ]
+).
+-else.
+-define(DEFAULT_NAME_RESOLVERS, []).
+-endif.
+
 -ifdef(AO_PROFILING).
 -define(DEFAULT_TRACE_TYPE, ao).
 -else.
@@ -249,6 +264,7 @@ default_message() ->
             initrd, append,
             vmm_type, guest_features
         ],
+        name_resolvers => ?DEFAULT_NAME_RESOLVERS,
         routes => [
             %% Local CU routes.
             #{
@@ -532,19 +548,25 @@ default_message() ->
             routes => []
         },
         on => #{
-            <<"request">> => #{
-                <<"device">> => <<"auth-hook@1.0">>,
-                <<"path">> => <<"request">>,
-                <<"when">> => #{
-                    <<"keys">> => [<<"authorization">>, <<"!">>]
-                },
-                <<"secret-provider">> =>
+            <<"request">> =>
+                [
                     #{
-                        <<"device">> => <<"http-auth@1.0">>,
-                        <<"access-control">> =>
-                            #{ <<"device">> => <<"http-auth@1.0">> }
+                        <<"device">> => <<"auth-hook@1.0">>,
+                        <<"path">> => <<"request">>,
+                        <<"when">> => #{
+                            <<"keys">> => [<<"authorization">>, <<"!">>]
+                        },
+                        <<"secret-provider">> =>
+                            #{
+                                <<"device">> => <<"http-auth@1.0">>,
+                                <<"access-control">> =>
+                                    #{ <<"device">> => <<"http-auth@1.0">> }
+                            }
+                    },
+                    #{
+                        <<"device">> => <<"name@1.0">>
                     }
-            }
+                ]
         },
         scheduler_default_commitment_spec => <<"httpsig@1.0">>,
         genesis_wasm_import_authorities =>


### PR DESCRIPTION
Introduces an optional `on/request` hook that looks for `host` keys (headers) on inbound messages and adds their resolved values to the flow of messages to execute. Additionally, this PR introduces improved API semantics for `~name@1.0` as well as a default name resolver utilizing an ARNS snapshot hosted on Arweave.