### PR TITLE
impr: use dynamic name process for name resolution

### DIFF
--- a/src/dev_name.erl
+++ b/src/dev_name.erl
@@ -229,10 +229,14 @@ load_and_execute_test() ->
 %% @doc Return an `Opts` for an environment with the default ARNS name export
 %% and a temporary store for the test.
 arns_opts() ->
-    JSONNames = <<"G_gb7SAgogHMtmqycwaHaC6uC-CZ3akACdFv5PUaEE8">>,
-    Path = <<JSONNames/binary, "~json@1.0/deserialize&target=data">>,
+    JSONNames = <<"4DnLccQGh0zfyNdEBQSbuB3cMXmnTr5uF9j5GgXl2Rg">>,
+    Path = <<JSONNames/binary, "~process@1.0/compute/records">>,
     hb_http_server:start_node(#{}),
-    TempStore = hb_test_utils:test_store(),
+    TempStore =
+        #{
+            <<"name">> => <<"cache-mainnet/lmdb">>,
+            <<"store-module">> => hb_store_lmdb
+        },
     #{
         store =>
             [

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -37,8 +37,8 @@
 -define(DEFAULT_NAME_RESOLVERS,
     [
         <<
-            "G_gb7SAgogHMtmqycwaHaC6uC-CZ3akACdFv5PUaEE8",
-                "~json@1.0/deserialize&target=data"
+            "4DnLccQGh0zfyNdEBQSbuB3cMXmnTr5uF9j5GgXl2Rg",
+            "~process@1.0/compute/records"
         >>
     ]
 ).


### PR DESCRIPTION
This PR replaces the static name resolution Tx ID with a HyperBEAM process that is updated dynamically as names are updated.