### PR TITLE
feat: Introduce `~blacklist@1.0` content policy device

### DIFF
--- a/src/dev_blacklist.erl
+++ b/src/dev_blacklist.erl
@@ -26,16 +26,16 @@
 
 %% @doc Hook handler: block requests that involve blacklisted IDs.
 request(_Base, HookReq, Opts) ->
-    ensure_cache_table(),
     case is_match(HookReq, Opts) of
         false -> {ok, HookReq};
-        ID -> {error, block_response(ID)}
+        ID -> {ok, HookReq#{ <<"body">> => [block_response(ID)] }}
     end.
 
 %% @doc Check if the message contains any blacklisted IDs.
 is_match(Msg, Opts) ->
+    ensure_cache_table(Opts),
     IDs = collect_ids(Msg, Opts),
-    case lists:filter(fun(ID) -> not ets:lookup(?CACHE_TABLE, ID) /= [] end, IDs) of
+    case lists:filter(fun(ID) -> ets:lookup(?CACHE_TABLE, ID) =/= [] end, IDs) of
         [] -> false;
         [ID|_] -> ID
     end.
@@ -49,10 +49,12 @@ refresh(_Base, _Req, Opts) ->
 
 %% @doc Fetch the blacklist and store the results in the cache table.
 update_blacklist_cache(Opts) ->
+    ensure_cache_table(Opts),
     case execute_provider(Opts) of
         {ok, Blacklist} ->
             {ok, IDs} = parse_blacklist(Blacklist, Opts),
             BlacklistID = hb_message:id(Blacklist, all, Opts),
+            ?event({update_blacklist_cache, {ids, IDs}, {blacklist_id, BlacklistID}}),
             {ok, insert_ids(IDs, BlacklistID, Opts)};
         {error, _} = Error ->
             Error
@@ -64,6 +66,7 @@ execute_provider(Opts) ->
     Request =
         case hb_cache:ensure_loaded(Path, Opts) of
             Msg when is_map(Msg) -> Msg;
+            List when is_list(List) -> #{ <<"body">> => List };
             Bin when is_binary(Bin) -> #{ <<"path">> => Path }
         end,
     hb_ao:resolve(Request, Opts).
@@ -134,30 +137,57 @@ insert_ids([ID | IDs], Value, Opts) when ?IS_ID(ID) ->
     end.
 
 %% @doc Ensure the cache table exists.
-ensure_cache_table() ->
+ensure_cache_table(Opts) ->
     case ets:info(?CACHE_TABLE) of
         undefined ->
-            try
-                ets:new(
-                    ?CACHE_TABLE,
-                    [
-                        named_table,
-                        set,
-                        public,
-                        {read_concurrency, true},
-                        {write_concurrency, true}
-                    ]
-                )
-            catch
-                error:badarg -> ok
-            end;
+            ets:new(
+                ?CACHE_TABLE,
+                [
+                    named_table,
+                    set,
+                    public,
+                    {read_concurrency, true},
+                    {write_concurrency, true}
+                ]
+            ),
+            update_blacklist_cache(Opts);
         _ -> ok
     end,
     ?CACHE_TABLE.
 
-%% @doc Clear the entire cache table.
-clear_cache() ->
-    case ets:info(?CACHE_TABLE) of
-        undefined -> ok;
-        _ -> ets:delete_all_objects(?CACHE_TABLE)
-    end.
+%%% Tests
+
+basic_test() ->
+    Opts0 = #{ store => hb_test_utils:test_store(), priv_wallet => hb:wallet() },
+    Msg1 = hb_message:commit(#{ <<"body">> => <<"test-1">> }, Opts0),
+    Msg2 = hb_message:commit(#{ <<"body">> => <<"test-2">> }, Opts0),
+    Msg3 = hb_message:commit(#{ <<"body">> => <<"test-3">> }, Opts0),
+    SignedID1 = hb_message:id(Msg1, signed, Opts0),
+    {ok, _UnsignedID1} = hb_cache:write(Msg1, Opts0),
+    {ok, UnsignedID2} = hb_cache:write(Msg2, Opts0),
+    {ok, UnsignedID3} = hb_cache:write(Msg3, Opts0),
+    Opts1 =
+        Opts0#{
+            blacklist_provider => [SignedID1, UnsignedID2],
+            on => #{
+                <<"request">> => #{
+                    <<"device">> => <<"blacklist@1.0">>,
+                    <<"path">> => <<"request">>
+                }
+            }
+        },
+    Node = hb_http_server:start_node(Opts1),
+    refresh(#{}, #{}, Opts1),
+    ?assertMatch(
+        {ok, <<"test-3">>},
+        hb_http:get(Node, <<"/", UnsignedID3/binary, "/body">>, Opts1)
+    ),
+    ?event({table, ets:tab2list(?CACHE_TABLE)}),
+    ?assertMatch(
+        {error,
+            #{
+                <<"status">> := 451,
+                <<"reason">> := <<"content-policy">>
+            }},
+        hb_http:get(Node, SignedID1, Opts1)
+    ).

--- a/src/dev_blacklist.erl
+++ b/src/dev_blacklist.erl
@@ -33,8 +33,27 @@
 request(_Base, HookReq, Opts) ->
     ?event({hook_req, HookReq}),
     case is_match(HookReq, Opts) of
-        false -> {ok, HookReq};
-        ID -> {ok, HookReq#{ <<"body">> => [block_response(ID)] }}
+        false ->
+            ?event(blacklist, {allowed, HookReq}, Opts),
+            {ok, HookReq};
+        ID ->
+            ?event(blacklist, {blocked, ID}, Opts),
+            {
+                ok,
+                HookReq#{
+                    <<"body">> =>
+                        [#{
+                            <<"status">> => 451,
+                            <<"reason">> => <<"content-policy">>,
+                            <<"blocked-id">> => ID,
+                            <<"body">> =>
+                                <<
+                                    "Requested message blocked by this node's ",
+                                    "content policy. Blocked ID: ", ID/binary
+                                >>
+                        }]
+                }
+            }
     end.
 
 %% @doc Check if the message contains any blacklisted IDs.
@@ -58,7 +77,14 @@ refresh(Base, Req, Opts) ->
 %% @doc Fetch the blacklist and store the results in the cache table.
 maybe_refresh(Opts) ->
     ensure_cache_table(Opts),
-    MinWait = hb_util:int(hb_opts:get(blacklist_refresh_frequency, ?DEFAULT_MIN_WAIT, Opts)),
+    MinWait =
+        hb_util:int(
+            hb_opts:get(
+                blacklist_refresh_frequency,
+                ?DEFAULT_MIN_WAIT,
+                Opts
+            )
+        ),
     Time = erlang:system_time(second),
     case hb_opts:get(blacklist_last_refresh, 0, Opts) of
         LastRefresh when (Time - LastRefresh) > MinWait ->
@@ -102,7 +128,6 @@ parse_blacklist(Body, _Opts) when is_list(Body) ->
     {ok, lists:filtermap(fun parse_blacklist_line/1, Body)};
 parse_blacklist(Msg, Opts) when is_map(Msg) ->
     maybe
-        {ok, <<"content-policy">>} ?= hb_maps:find(<<"data-protocol">>, Msg, Opts),
         {ok, Body} = hb_maps:find(<<"body">>, Msg, Opts),
         parse_blacklist(Body, Opts)
     end;
@@ -140,14 +165,6 @@ collect_ids(List, Acc, Opts) when is_list(List) ->
         List
     );
 collect_ids(_Other, Acc, _Opts) -> Acc.
-
-block_response(BlockedID) ->
-    #{
-        <<"status">> => 451,
-        <<"body">> => <<"Requested message blocked by this node's content policy.">>,
-        <<"reason">> => <<"content-policy">>,
-        <<"blocked-id">> => BlockedID
-    }.
 
 %% @doc Insert a list of IDs into the cache table, returning the number of new IDs
 %% inserted. Each ID is inserted as a key with the current timestamp as the value.

--- a/src/dev_blacklist.erl
+++ b/src/dev_blacklist.erl
@@ -1,0 +1,163 @@
+%%% @doc A request hook device for content moderation by blacklist.
+%%%
+%%% The node operator configures a blacklist provider via the `blacklist-provider`
+%%% key in the node message options. The provider can be a message or a path that
+%%% returns a message or binary. If a binary is returned from the provider, it is
+%%% parsed as a newline-delimited list of IDs.
+%%% 
+%%% The device is intended for use as a `~hook@1.0` `on/request` handler. It
+%%% blocks requests when any ID present in the hook payload matches the active
+%%% blacklist. The device also implements a `refresh` key that can be used to
+%%% force a reload of the blacklist cache, potentially on node startup or on a 
+%%% `~cron@1.0/every` trigger.
+%%% 
+%%% The principle of this device is the same as the content policies utilized in
+%%% the Arweave network: No central enforcement, but each node is capable of
+%%% enforcing its own content policies based on its own free choice and
+%%% configuration.
+-module(dev_blacklist).
+-export([request/3, refresh/3]).
+
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(CACHE_TABLE, ?MODULE).
+-define(DEFAULT_PROVIDER, #{ <<"body">> => [] }).
+
+%% @doc Hook handler: block requests that involve blacklisted IDs.
+request(_Base, HookReq, Opts) ->
+    ensure_cache_table(),
+    case is_match(HookReq, Opts) of
+        false -> {ok, HookReq};
+        ID -> {error, block_response(ID)}
+    end.
+
+%% @doc Check if the message contains any blacklisted IDs.
+is_match(Msg, Opts) ->
+    IDs = collect_ids(Msg, Opts),
+    case lists:filter(fun(ID) -> not ets:lookup(?CACHE_TABLE, ID) /= [] end, IDs) of
+        [] -> false;
+        [ID|_] -> ID
+    end.
+
+%% @doc Force a reload of the blacklist cache. Returns the number of newly 
+%% inserted IDs.
+refresh(_Base, _Req, Opts) ->
+    update_blacklist_cache(Opts).
+
+%%% Internal
+
+%% @doc Fetch the blacklist and store the results in the cache table.
+update_blacklist_cache(Opts) ->
+    case execute_provider(Opts) of
+        {ok, Blacklist} ->
+            {ok, IDs} = parse_blacklist(Blacklist, Opts),
+            BlacklistID = hb_message:id(Blacklist, all, Opts),
+            {ok, insert_ids(IDs, BlacklistID, Opts)};
+        {error, _} = Error ->
+            Error
+    end.
+
+%% @doc Execute the blacklist provider, returning the result.
+execute_provider(Opts) ->
+    Path = hb_opts:get(blacklist_provider, ?DEFAULT_PROVIDER, Opts),
+    Request =
+        case hb_cache:ensure_loaded(Path, Opts) of
+            Msg when is_map(Msg) -> Msg;
+            Bin when is_binary(Bin) -> #{ <<"path">> => Path }
+        end,
+    hb_ao:resolve(Request, Opts).
+
+%% @doc Parse the blacklist body, returning a list of IDs.
+parse_blacklist(Link, Opts) when ?IS_LINK(Link) ->
+    parse_blacklist(hb_cache:ensure_loaded(Link, Opts), Opts);
+parse_blacklist(Body, _Opts) when is_list(Body) ->
+    {ok, lists:filtermap(fun parse_blacklist_line/1, Body)};
+parse_blacklist(Msg, Opts) when is_map(Msg) ->
+    maybe
+        {ok, <<"content-policy">>} ?= hb_maps:find(<<"data-protocol">>, Msg, Opts),
+        {ok, Body} = hb_maps:find(<<"body">>, Msg, Opts),
+        parse_blacklist(Body, Opts)
+    end;
+parse_blacklist(Body, _Opts) when is_binary(Body) ->
+    Lines = binary:split(Body, <<"\n">>, [global]),
+    {ok, lists:filtermap(fun parse_blacklist_line/1, Lines)}.
+
+%% @doc Parse a single line of the blacklist body, returning the ID if it is valid,
+%% and `false' otherwise.
+parse_blacklist_line(Line) ->
+    Trimmed = string:trim(Line, both),
+    case Trimmed of
+        <<>> -> false;
+        <<"#", _/binary>> -> false;
+        ID when ?IS_ID(ID) -> {true, hb_util:human_id(ID)};
+        _ -> false
+    end.
+
+%% @doc Collect all IDs found as elements of a given message.
+collect_ids(Msg, Opts) -> lists:usort(collect_ids(Msg, [], Opts)).
+collect_ids(Bin, Acc, _Opts) when ?IS_ID(Bin) -> [hb_util:human_id(Bin) | Acc];
+collect_ids(Bin, Acc, _Opts) when is_binary(Bin) -> Acc;
+collect_ids(Link, Acc, Opts) when ?IS_LINK(Link) ->
+    collect_ids(hb_cache:ensure_loaded(Link, Opts), Acc, Opts);
+collect_ids(Msg, Acc, Opts) when is_map(Msg) ->
+    hb_maps:fold(
+        fun(_Key, Value, AccIn) -> collect_ids(Value, AccIn, Opts) end,
+        Acc,
+        Msg
+    );
+collect_ids(List, Acc, Opts) when is_list(List) ->
+    lists:foldl(
+        fun(Elem, AccIn) -> collect_ids(Elem, AccIn, Opts) end,
+        Acc,
+        List
+    );
+collect_ids(_Other, Acc, _Opts) -> Acc.
+
+block_response(BlockedID) ->
+    #{
+        <<"status">> => 451,
+        <<"body">> => <<"Requested message blocked by this node's content policy.">>,
+        <<"reason">> => <<"content-policy">>,
+        <<"blocked-id">> => BlockedID
+    }.
+
+%% @doc Insert a list of IDs into the cache table, returning the number of new IDs
+%% inserted. Each ID is inserted as a key with the current timestamp as the value.
+insert_ids([], _Value, _Opts) -> 0;
+insert_ids([ID | IDs], Value, Opts) when ?IS_ID(ID) ->
+    case ets:lookup(?CACHE_TABLE, ID) of
+        [] ->
+            ets:insert(?CACHE_TABLE, {ID, Value}),
+            1 + insert_ids(IDs, Value, Opts);
+        _ -> insert_ids(IDs, Value, Opts)
+    end.
+
+%% @doc Ensure the cache table exists.
+ensure_cache_table() ->
+    case ets:info(?CACHE_TABLE) of
+        undefined ->
+            try
+                ets:new(
+                    ?CACHE_TABLE,
+                    [
+                        named_table,
+                        set,
+                        public,
+                        {read_concurrency, true},
+                        {write_concurrency, true}
+                    ]
+                )
+            catch
+                error:badarg -> ok
+            end;
+        _ -> ok
+    end,
+    ?CACHE_TABLE.
+
+%% @doc Clear the entire cache table.
+clear_cache() ->
+    case ets:info(?CACHE_TABLE) of
+        undefined -> ok;
+        _ -> ets:delete_all_objects(?CACHE_TABLE)
+    end.

--- a/src/dev_blacklist.erl
+++ b/src/dev_blacklist.erl
@@ -26,6 +26,7 @@
 
 %% @doc Hook handler: block requests that involve blacklisted IDs.
 request(_Base, HookReq, Opts) ->
+    ?event({hook_req, HookReq}),
     case is_match(HookReq, Opts) of
         false -> {ok, HookReq};
         ID -> {ok, HookReq#{ <<"body">> => [block_response(ID)] }}
@@ -43,6 +44,7 @@ is_match(Msg, Opts) ->
 %% @doc Force a reload of the blacklist cache. Returns the number of newly 
 %% inserted IDs.
 refresh(_Base, _Req, Opts) ->
+    ?event({refresh_blacklist_cache, Opts}),
     update_blacklist_cache(Opts).
 
 %%% Internal
@@ -53,20 +55,22 @@ update_blacklist_cache(Opts) ->
     case execute_provider(Opts) of
         {ok, Blacklist} ->
             {ok, IDs} = parse_blacklist(Blacklist, Opts),
+            ?event({parsed_blacklist, {ids, IDs}}),
             BlacklistID = hb_message:id(Blacklist, all, Opts),
             ?event({update_blacklist_cache, {ids, IDs}, {blacklist_id, BlacklistID}}),
             {ok, insert_ids(IDs, BlacklistID, Opts)};
         {error, _} = Error ->
+            ?event({execute_provider_error, Error}),
             Error
     end.
 
 %% @doc Execute the blacklist provider, returning the result.
 execute_provider(Opts) ->
     Path = hb_opts:get(blacklist_provider, ?DEFAULT_PROVIDER, Opts),
+    ?event({execute_provider, {path, Path}}),
     Request =
         case hb_cache:ensure_loaded(Path, Opts) of
             Msg when is_map(Msg) -> Msg;
-            List when is_list(List) -> #{ <<"body">> => List };
             Bin when is_binary(Bin) -> #{ <<"path">> => Path }
         end,
     hb_ao:resolve(Request, Opts).
@@ -140,6 +144,7 @@ insert_ids([ID | IDs], Value, Opts) when ?IS_ID(ID) ->
 ensure_cache_table(Opts) ->
     case ets:info(?CACHE_TABLE) of
         undefined ->
+            ?event({creating_table, ?CACHE_TABLE}),
             ets:new(
                 ?CACHE_TABLE,
                 [
@@ -151,13 +156,15 @@ ensure_cache_table(Opts) ->
                 ]
             ),
             update_blacklist_cache(Opts);
-        _ -> ok
+        _ ->
+            ?event({table_exists, ?CACHE_TABLE}),
+            ok
     end,
     ?CACHE_TABLE.
 
 %%% Tests
 
-basic_test() ->
+setup_test_env() ->
     Opts0 = #{ store => hb_test_utils:test_store(), priv_wallet => hb:wallet() },
     Msg1 = hb_message:commit(#{ <<"body">> => <<"test-1">> }, Opts0),
     Msg2 = hb_message:commit(#{ <<"body">> => <<"test-2">> }, Opts0),
@@ -166,14 +173,42 @@ basic_test() ->
     {ok, _UnsignedID1} = hb_cache:write(Msg1, Opts0),
     {ok, UnsignedID2} = hb_cache:write(Msg2, Opts0),
     {ok, UnsignedID3} = hb_cache:write(Msg3, Opts0),
+    Blacklist =
+        #{
+            <<"data-protocol">> => <<"content-policy">>,
+            <<"body">> => <<SignedID1/binary, "\n", UnsignedID2/binary, "\n">>
+        },
+    BlacklistMsg = hb_message:commit(Blacklist, Opts0),
+    {ok, BlacklistID} = hb_cache:write(BlacklistMsg, Opts0),
+    {ok, #{
+        opts => Opts0,
+        signed1=> SignedID1,
+        unsigned2=> UnsignedID2,
+        unsigned3 => UnsignedID3,
+        blacklist => BlacklistID
+    }}.
+
+basic_test() ->
+    {ok, #{
+        opts := Opts0,
+        signed1 := SignedID1,
+        unsigned2 := UnsignedID2,
+        unsigned3 := UnsignedID3,
+        blacklist := BlacklistID
+    }} = setup_test_env(),
+    ?event(
+        {setup_test_env,
+            {opts, Opts0},
+            {signed_id1, SignedID1},
+            {unsigned_id2, UnsignedID2},
+            {unsigned_id3, UnsignedID3}
+        }
+    ),
     Opts1 =
         Opts0#{
-            blacklist_provider => [SignedID1, UnsignedID2],
+            blacklist_provider => BlacklistID,
             on => #{
-                <<"request">> => #{
-                    <<"device">> => <<"blacklist@1.0">>,
-                    <<"path">> => <<"request">>
-                }
+                <<"request">> => #{ <<"device">> => <<"blacklist@1.0">> }
             }
         },
     Node = hb_http_server:start_node(Opts1),

--- a/src/dev_blacklist.erl
+++ b/src/dev_blacklist.erl
@@ -21,8 +21,13 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--define(CACHE_TABLE, ?MODULE).
--define(DEFAULT_PROVIDER, #{ <<"body">> => [] }).
+-define(DEFAULT_PROVIDER,
+    #{
+        <<"data-protocol">> => <<"content-policy">>,
+        <<"body">> => #{ <<"body">> => <<>> }
+    }
+).
+-define(DEFAULT_MIN_WAIT, 60).
 
 %% @doc Hook handler: block requests that involve blacklisted IDs.
 request(_Base, HookReq, Opts) ->
@@ -34,23 +39,37 @@ request(_Base, HookReq, Opts) ->
 
 %% @doc Check if the message contains any blacklisted IDs.
 is_match(Msg, Opts) ->
-    ensure_cache_table(Opts),
+    maybe_refresh(Opts),
     IDs = collect_ids(Msg, Opts),
-    case lists:filter(fun(ID) -> ets:lookup(?CACHE_TABLE, ID) =/= [] end, IDs) of
+    MatchesFromIDs = fun(ID) -> ets:lookup(cache_table_name(Opts), ID) =/= [] end,
+    case lists:filter(MatchesFromIDs, IDs) of
         [] -> false;
         [ID|_] -> ID
     end.
 
 %% @doc Force a reload of the blacklist cache. Returns the number of newly 
 %% inserted IDs.
-refresh(_Base, _Req, Opts) ->
-    ?event({refresh_blacklist_cache, Opts}),
-    update_blacklist_cache(Opts).
+refresh(Base, Req, Opts) ->
+    ?event({refresh_called, {base, Base}, {req, Req}}),
+    maybe_refresh(Opts).
 
 %%% Internal
 
 %% @doc Fetch the blacklist and store the results in the cache table.
-update_blacklist_cache(Opts) ->
+maybe_refresh(Opts) ->
+    ensure_cache_table(Opts),
+    MinWait = hb_util:int(hb_opts:get(blacklist_refresh_frequency, ?DEFAULT_MIN_WAIT, Opts)),
+    Time = erlang:system_time(second),
+    case hb_opts:get(blacklist_last_refresh, 0, Opts) of
+        LastRefresh when (Time - LastRefresh) > MinWait ->
+            fetch_and_insert_ids(Opts),
+            hb_http_server:set_opts(Opts#{ blacklist_last_refresh => Time });
+        _ ->
+            skip_update
+    end.
+
+%% @doc Fetch the blacklist and insert the IDs into the cache table.
+fetch_and_insert_ids(Opts) ->
     ensure_cache_table(Opts),
     case execute_provider(Opts) of
         {ok, Blacklist} ->
@@ -58,7 +77,8 @@ update_blacklist_cache(Opts) ->
             ?event({parsed_blacklist, {ids, IDs}}),
             BlacklistID = hb_message:id(Blacklist, all, Opts),
             ?event({update_blacklist_cache, {ids, IDs}, {blacklist_id, BlacklistID}}),
-            {ok, insert_ids(IDs, BlacklistID, Opts)};
+            Table = cache_table_name(Opts),
+            {ok, insert_ids(IDs, BlacklistID, Table, Opts)};
         {error, _} = Error ->
             ?event({execute_provider_error, Error}),
             Error
@@ -131,22 +151,23 @@ block_response(BlockedID) ->
 
 %% @doc Insert a list of IDs into the cache table, returning the number of new IDs
 %% inserted. Each ID is inserted as a key with the current timestamp as the value.
-insert_ids([], _Value, _Opts) -> 0;
-insert_ids([ID | IDs], Value, Opts) when ?IS_ID(ID) ->
-    case ets:lookup(?CACHE_TABLE, ID) of
+insert_ids([], _Value, _Table, _Opts) -> 0;
+insert_ids([ID | IDs], Value, Table, Opts) when ?IS_ID(ID) ->
+    case ets:lookup(Table, ID) of
         [] ->
-            ets:insert(?CACHE_TABLE, {ID, Value}),
-            1 + insert_ids(IDs, Value, Opts);
-        _ -> insert_ids(IDs, Value, Opts)
+            ets:insert(Table, {ID, Value}),
+            1 + insert_ids(IDs, Value, Table, Opts);
+        _ -> insert_ids(IDs, Value, Table, Opts)
     end.
 
 %% @doc Ensure the cache table exists.
 ensure_cache_table(Opts) ->
-    case ets:info(?CACHE_TABLE) of
+    TableName = cache_table_name(Opts),
+    case ets:info(TableName) of
         undefined ->
-            ?event({creating_table, ?CACHE_TABLE}),
+            ?event({creating_table, TableName}),
             ets:new(
-                ?CACHE_TABLE,
+                TableName,
                 [
                     named_table,
                     set,
@@ -155,12 +176,18 @@ ensure_cache_table(Opts) ->
                     {write_concurrency, true}
                 ]
             ),
-            update_blacklist_cache(Opts);
+            fetch_and_insert_ids(Opts);
         _ ->
-            ?event({table_exists, ?CACHE_TABLE}),
+            ?event({table_exists, TableName}),
             ok
     end,
-    ?CACHE_TABLE.
+    TableName.
+
+%% @doc Calculate the name of the cache table given the `Opts`.
+cache_table_name(Opts) ->
+    Wallet = hb_opts:get(priv_wallet, hb:wallet(), Opts),
+    Address = hb_util:human_id(Wallet),
+    binary_to_atom(<<"~blacklist@1.0/cache/", Address/binary>>).
 
 %%% Tests
 
@@ -180,6 +207,15 @@ setup_test_env() ->
         },
     BlacklistMsg = hb_message:commit(Blacklist, Opts0),
     {ok, BlacklistID} = hb_cache:write(BlacklistMsg, Opts0),
+    ?event(
+        {test_env_setup,
+            {opts, Opts0},
+            {signed_id1, SignedID1},
+            {unsigned_id2, UnsignedID2},
+            {unsigned_id3, UnsignedID3},
+            {blocked, [SignedID1, UnsignedID2]}
+        }
+    ),
     {ok, #{
         opts => Opts0,
         signed1=> SignedID1,
@@ -188,22 +224,15 @@ setup_test_env() ->
         blacklist => BlacklistID
     }}.
 
+%% @doc Test the blacklist device with a static blacklist that is in the local
+%% store.
 basic_test() ->
     {ok, #{
         opts := Opts0,
         signed1 := SignedID1,
-        unsigned2 := UnsignedID2,
         unsigned3 := UnsignedID3,
         blacklist := BlacklistID
     }} = setup_test_env(),
-    ?event(
-        {setup_test_env,
-            {opts, Opts0},
-            {signed_id1, SignedID1},
-            {unsigned_id2, UnsignedID2},
-            {unsigned_id3, UnsignedID3}
-        }
-    ),
     Opts1 =
         Opts0#{
             blacklist_provider => BlacklistID,
@@ -212,12 +241,10 @@ basic_test() ->
             }
         },
     Node = hb_http_server:start_node(Opts1),
-    refresh(#{}, #{}, Opts1),
     ?assertMatch(
         {ok, <<"test-3">>},
         hb_http:get(Node, <<"/", UnsignedID3/binary, "/body">>, Opts1)
     ),
-    ?event({table, ets:tab2list(?CACHE_TABLE)}),
     ?assertMatch(
         {error,
             #{
@@ -225,4 +252,44 @@ basic_test() ->
                 <<"reason">> := <<"content-policy">>
             }},
         hb_http:get(Node, SignedID1, Opts1)
+    ),
+    ok.
+
+%% @doc Test the blacklist device with a blacklist that is provided via HTTP.
+blacklist_from_external_http_test() ->
+    {ok, #{
+        opts := RemoteOpts = #{ store := RootStore },
+        signed1 := SignedID1,
+        unsigned3 := UnsignedID3,
+        blacklist := BlacklistID
+    }} = setup_test_env(),
+    % Start a node that we will ask to provide the blacklist via HTTP.
+    BlacklistHostNode = hb_http_server:start_node(RemoteOpts),
+    % Start a node that will use the blacklist host node to provide the blacklist
+    % via HTTP.
+    NodeOpts = 
+        #{
+            store => RootStore,
+            priv_wallet => ar_wallet:new(),
+            blacklist_provider =>
+                <<
+                    "/~relay@1.0/call?relay-method=GET&relay-path=",
+                        BlacklistHostNode/binary, BlacklistID/binary
+                >>,
+            on => #{
+                <<"request">> => #{ <<"device">> => <<"blacklist@1.0">> }
+            }
+        },
+    Node = hb_http_server:start_node(NodeOpts),
+    ?assertMatch(
+        {ok, <<"test-3">>},
+        hb_http:get(Node, <<"/", UnsignedID3/binary, "/body">>, NodeOpts)
+    ),
+    ?assertMatch(
+        {error,
+            #{
+                <<"status">> := 451,
+                <<"reason">> := <<"content-policy">>
+            }},
+        hb_http:get(Node, SignedID1, NodeOpts)
     ).

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -155,6 +155,7 @@ default_message() ->
             #{<<"name">> => <<"apply@1.0">>, <<"module">> => dev_apply},
             #{<<"name">> => <<"auth-hook@1.0">>, <<"module">> => dev_auth_hook},
             #{<<"name">> => <<"ans104@1.0">>, <<"module">> => dev_codec_ans104},
+            #{<<"name">> => <<"blacklist@1.0">>, <<"module">> => dev_blacklist},
             #{<<"name">> => <<"bundler@1.0">>, <<"module">> => dev_bundler},
             #{<<"name">> => <<"compute@1.0">>, <<"module">> => dev_cu},
             #{<<"name">> => <<"cache@1.0">>, <<"module">> => dev_cache},


### PR DESCRIPTION
Introduces the `~blacklist@1.0` device, enabling decentralized content policy enforcement at the node level. This allows individual node operators to define and apply their own blacklist to incoming requests, aligning with a "no central enforcement" model -- exactly as described in the [Arweave Principles](https://arweave.net/1rL73ctmqTVv7qkqAsD4jIz5tU6WxgOAqABYuMHg5mQ).

Key changes include:

*   **Content Policy Enforcement:** A new device intercepts requests, checking for blacklisted message IDs. Requests matching a blacklisted ID are rejected with a `451 Content Policy` status, providing a clear reason and the blocked ID.
*   **Periodic Blacklist Refresh:** The blacklist cache is now periodically refreshed from a configurable provider (local or external HTTP source). This ensures the policy remains up-to-date with minimal manual intervention.
*   **Wallet-Specific Caching:** Each wallet now maintains its own unique blacklist cache table, allowing for distinct content policies across different wallets on the same node.
*   **Comprehensive Test Coverage:** Adds extensive EUnit tests to validate the device's functionality, including scenarios for local and HTTP-provided blacklists, and correct blocking behavior.