### PR TITLE
impr: redirect to default hashpath after `on/request` hooks have executed

### DIFF
--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -224,6 +224,18 @@ handle_resolve(Req, Msgs, NodeMsg) ->
     ),
     LoadedMsgs = hb_cache:ensure_all_loaded(Msgs, NodeMsg),
     case resolve_hook(<<"request">>, Req, LoadedMsgs, NodeMsg) of
+        {ok, []} ->
+            {ok,
+                #{
+                    <<"status">> => 307,
+                    <<"body">> => <<"Redirecting to default request.">>,
+                    <<"location">> => hb_opts:get(
+                        default_request,
+                        <<"/~hyperbuddy@1.0/index">>,
+                        NodeMsg
+                    )
+                }
+            };
         {ok, PreProcessedMsg} ->
             ?event(http_request, {request_after_preprocessing, PreProcessedMsg}),
             AfterPreprocOpts = hb_http_server:get_opts(NodeMsg),

--- a/src/dev_name.erl
+++ b/src/dev_name.erl
@@ -46,7 +46,7 @@ match_resolver(_Key, [], _Opts) ->
 match_resolver(Key, [Resolver | Resolvers], Opts) ->
     case catch execute_resolver(Key, Resolver, Opts) of
         {ok, Value} ->
-            ?event({resolver_found, {key, Key}, {value, Value}}),
+            ?event({resolver_found, {key, Key}, {value, {string, Value}}}),
             {ok, Value};
         _ ->
             match_resolver(Key, Resolvers, Opts)
@@ -71,21 +71,25 @@ execute_resolver(Key, Resolver, Opts) when is_map(Resolver) ->
 %% @doc Implements an `on/request' compatible hook that resolves names given in
 %% the `host` key to their corresponding ID and prepends it to the execution path.
 request(HookMsg, HookReq, Opts) ->
-    ?event({request_hook, {hook_msg, HookMsg}, {hook_req, HookReq}, {opts, Opts}}),
+    ?event({request_hook, {hook_msg, HookMsg}, {hook_req, HookReq}}),
     maybe
         {ok, Req} ?= hb_maps:find(<<"request">>, HookReq, Opts),
         {ok, Host} ?= hb_maps:find(<<"host">>, Req, Opts),
         {ok, Name} ?= name_from_host(Host, hb_opts:get(host, no_host, Opts)),
         {ok, ResolvedMsg} ?= resolve(Name, HookMsg, #{}, Opts),
-        {ok, [OldBase|Rest]} ?= hb_maps:find(<<"body">>, HookReq, Opts),
-        ModReq = [overlay_loaded(OldBase, ResolvedMsg, Opts)|Rest],
+        ModReq =
+            case hb_maps:find(<<"body">>, HookReq, Opts) of
+                {ok, [OldBase|Rest]} ->
+                    [overlay_loaded(OldBase, ResolvedMsg, Opts)|Rest];
+                {ok, []} ->
+                    [ResolvedMsg]
+            end,
         ?event(
             {request_with_prepended_path,
                 {name, Name},
                 {full_host, Host},
                 {resolved_msg, ResolvedMsg},
-                {to_execute, ModReq},
-                {res, hb_ao:resolve_many(ModReq, Opts)}
+                {to_execute, ModReq}
             }
         ),
         {ok, #{ <<"body">> => ModReq }}

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -378,74 +378,55 @@ handle_request(RawReq, Body, ServerID) ->
     Req = RawReq#{ start_time => StartTime },
     NodeMsg = get_opts(#{ http_server => ServerID }),
     put(server_id, ServerID),
-    case {cowboy_req:path(RawReq), cowboy_req:qs(RawReq)} of
-        {<<"/">>, <<>>} ->
-            % If the request is for the root path, serve a redirect to the default 
-            % request of the node.
-            Req2 = cowboy_req:reply(
-                302,
-                #{
-                    <<"location">> =>
-                        hb_opts:get(
-                            default_request,
-                            <<"/~hyperbuddy@1.0/index">>,
-                            NodeMsg
-                        )
-                },
-                RawReq
-            ),
-            {ok, Req2, no_state};
-        _ ->
-            % The request is of normal AO-Core form, so we parse it and invoke
-            % the meta@1.0 device to handle it.
-            ?event(http,
-                {
-                    http_inbound,
-                    {cowboy_req, {explicit, Req}, {body, {string, Body}}}
-                }
-            ),
-            % Parse the HTTP request into HyerBEAM's message format.
-            try hb_http:req_to_tabm_singleton(Req, Body, NodeMsg) of
-                ReqSingleton ->
-                    try
-                        CommitmentCodec =
-                            hb_http:accept_to_codec(ReqSingleton, NodeMsg),
-                        ?event(http,
-                            {parsed_singleton,
-                                {req_singleton, ReqSingleton},
-                                {accept_codec, CommitmentCodec}},
-                            #{}
-                        ),
-                        % Invoke the meta@1.0 device to handle the request.
-                        {ok, Res} =
-                            dev_meta:handle(
-                                NodeMsg#{
-                                    commitment_device => CommitmentCodec
-                                },
-                                ReqSingleton
-                            ),
-                        hb_http:reply(Req, ReqSingleton, Res, NodeMsg)
-                    catch
-                        Type:Details:Stacktrace ->
-                            handle_error(
-                                Req,
-                                ReqSingleton,
-                                Type,
-                                Details,
-                                Stacktrace,
-                                NodeMsg
-                            )
-                    end
-            catch ParseError:ParseDetails:ParseStacktrace ->
-                handle_error(
-                    Req,
-                    #{},
-                    ParseError,
-                    ParseDetails,
-                    ParseStacktrace,
-                    NodeMsg
-                )
+    % The request is of normal AO-Core form, so we parse it and invoke
+    % the meta@1.0 device to handle it.
+    ?event(http,
+        {
+            http_inbound,
+            {cowboy_req, {explicit, Req}, {body, {string, Body}}}
+        }
+    ),
+    % Parse the HTTP request into HyerBEAM's message format.
+    try hb_http:req_to_tabm_singleton(Req, Body, NodeMsg) of
+        ReqSingleton ->
+            try
+                CommitmentCodec =
+                    hb_http:accept_to_codec(ReqSingleton, NodeMsg),
+                ?event(http,
+                    {parsed_singleton,
+                        {req_singleton, ReqSingleton},
+                        {accept_codec, CommitmentCodec}},
+                    #{}
+                ),
+                % Invoke the meta@1.0 device to handle the request.
+                {ok, Res} =
+                    dev_meta:handle(
+                        NodeMsg#{
+                            commitment_device => CommitmentCodec
+                        },
+                        ReqSingleton
+                    ),
+                hb_http:reply(Req, ReqSingleton, Res, NodeMsg)
+            catch
+                Type:Details:Stacktrace ->
+                    handle_error(
+                        Req,
+                        ReqSingleton,
+                        Type,
+                        Details,
+                        Stacktrace,
+                        NodeMsg
+                    )
             end
+    catch ParseError:ParseDetails:ParseStacktrace ->
+        handle_error(
+            Req,
+            #{},
+            ParseError,
+            ParseDetails,
+            ParseStacktrace,
+            NodeMsg
+        )
     end.
 
 %% @doc Return a 500 error response to the client.


### PR DESCRIPTION
Now that we have a pre-resolution hook for `~name@1.0`, we need to make sure that it can run before the default hashpath redirector (typically sending people to `~hyperbuddy@1.0/index`) executes. The effect of this is that requests for `name.domain` leads to the ID associated with `name` being returned on the root endpoint directly.
