### PR TITLE
feat: allow `~scheduler@1.0` to utilize the node's local bundler

### DIFF
--- a/src/dev_scheduler_server.erl
+++ b/src/dev_scheduler_server.erl
@@ -80,6 +80,12 @@ start(ProcID, Proc, Opts) ->
                             remote_confirmation,
                             Opts
                         ),
+                    bundling_mode =>
+                        hb_util:atom(hb_opts:get(
+                            scheduler_bundling_mode,
+                            remote,
+                            Opts
+                        )),
                     opts => Opts
                 }
             )
@@ -259,8 +265,7 @@ do_assign(State, Message, ReplyPID) ->
             ),
             ?event(writes_complete),
             ?event(uploading_message),
-            hb_client:upload(Message, Opts),
-            hb_client:upload(Assignment, Opts),
+            upload(Message, Assignment, Opts),
             ?event(uploads_complete),
             maybe_inform_recipient(
                 remote_confirmation,
@@ -299,6 +304,19 @@ commit_assignment(BaseAssignment, State) ->
         BaseAssignment,
         Wallets
     ).
+
+%% @doc Determine if the assignment should be uploaded via our local bundling
+%% node, or whether we should use the `hb_client:upload/2' function to relay it
+%% to our preferred bundling peer.
+upload(Message, Assignment, Opts) ->
+    case maps:get(bundling_mode, Opts) of
+        local ->
+            dev_bundler:tx(#{}, Assignment, Opts),
+            dev_bundler:tx(#{}, Message, Opts);
+        remote ->
+            hb_client:upload(Message, Opts),
+            hb_client:upload(Assignment, Opts)
+    end.
 
 %% @doc Potentially inform the caller that the assignment has been scheduled.
 %% The main assignment loop calls this function repeatedly at different stages


### PR DESCRIPTION
This PR introduces a node message parameter that allows operators to utilize the local bundler of their machine to upload to Arweave rather than only supporting remote peers. You can enable local bundling for your scheduled processes by setting `scheduler_bundling_mode: local` in your `config.[flat|json]`.
