### PR TITLE
fix: hb_maps:get defaults and defaults validation

### DIFF
--- a/src/dev_mint_math.erl
+++ b/src/dev_mint_math.erl
@@ -10,10 +10,10 @@
 %% @doc Determine if we should execute the next mint cycle.
 should_mint(State, Req, Opts) ->
     % Gather the current state of the mint process.
-    Cycle = required_int(hb_maps:get(<<"cycle">>, State, undefined, Opts)),
-    PeriodMs = required_int(hb_maps:get(<<"period">>, State, undefined, Opts)),
-    StartTimeMs = required_int(hb_maps:get(<<"start-time">>, State, undefined, Opts)),
-    CurrentTimeMs = required_int(hb_maps:get(<<"timestamp">>, Req, undefined, Opts)),
+    Cycle = required_int(hb_maps:get(<<"cycle">>, State, not_found, Opts)),
+    PeriodMs = required_int(hb_maps:get(<<"period">>, State, not_found, Opts)),
+    StartTimeMs = required_int(hb_maps:get(<<"start-time">>, State, not_found, Opts)),
+    CurrentTimeMs = required_int(hb_maps:get(<<"timestamp">>, Req, not_found, Opts)),
     % Calculate whether we have exceeded the timestamp of the next cycle.
     NextCycleTimeMs = StartTimeMs + (Cycle * PeriodMs),
     CurrentTimeMs >= NextCycleTimeMs.
@@ -21,8 +21,8 @@ should_mint(State, Req, Opts) ->
 %% @doc Perform a single mint cycle, returning a new state containing updated 
 %% metadata and instructions to the `Client` address.
 mint(State, _Req, Opts) ->
-    Cycle = required_int(hb_maps:get(<<"cycle">>, State, undefined, Opts)),
-    AlreadyMinted = required_int(hb_maps:get(<<"minted">>, State, undefined, Opts)),
+    Cycle = required_int(hb_maps:get(<<"cycle">>, State, not_found, Opts)),
+    AlreadyMinted = required_int(hb_maps:get(<<"minted">>, State, not_found, Opts)),
     ?event(debug,
         {starting_mint_cycle,
             {already_minted, AlreadyMinted},
@@ -89,13 +89,13 @@ mint(State, _Req, Opts) ->
 
 %% @doc Return the total number of units to distribute.
 units_to_distribute(State, Opts) ->
-    MintTotal = required_int(hb_maps:get(<<"mint-total">>, State, undefined, Opts)),
-    AlreadyMinted = required_int(hb_maps:get(<<"minted">>, State, undefined, Opts)),
+    MintTotal = required_int(hb_maps:get(<<"mint-total">>, State, not_found, Opts)),
+    AlreadyMinted = required_int(hb_maps:get(<<"minted">>, State, not_found, Opts)),
     CycleProportionNumerator =
-        required_int(hb_maps:get(<<"cycle-proportion">>, State, undefined, Opts)),
+        required_int(hb_maps:get(<<"cycle-proportion">>, State, not_found, Opts)),
     CycleProportionDenominator =
         required_int(
-            hb_maps:get(<<"cycle-proportion-denominator">>, State, undefined, Opts)
+            hb_maps:get(<<"cycle-proportion-denominator">>, State, not_found, Opts)
         ),
     Remaining = MintTotal - AlreadyMinted,
     case CycleProportionDenominator of
@@ -108,12 +108,12 @@ units_to_distribute(State, Opts) ->
 units_per_resource(TotalToDistribute, State, Opts) ->
     Resources =
         hb_private:reset(hb_message:uncommitted(
-            hb_maps:get(<<"resources">>, State, undefined, Opts)
+            hb_maps:get(<<"resources">>, State, not_found, Opts)
         )),
     ResourceWeights =
         hb_maps:map(
             fun(_ResourceID, Resource) ->
-                hb_util:int(hb_maps:get(<<"weight">>, Resource, undefined, Opts))
+                hb_util:int(hb_maps:get(<<"weight">>, Resource, not_found, Opts))
             end,
             Resources
         ),
@@ -291,7 +291,7 @@ split_suffix(Key, Suffix) ->
 distributions_to_total_units(Distributions, Opts) ->
     lists:sum(
         lists:map(
-            fun(D) -> required_int(hb_maps:get(<<"quantity">>, D, undefined, Opts)) end,
+            fun(D) -> required_int(hb_maps:get(<<"quantity">>, D, not_found, Opts)) end,
             Distributions
         )
     ).
@@ -306,7 +306,7 @@ distributions_to_results(State, Distributions, Opts) ->
                 [
                     #{
                         <<"target">> =>
-                            hb_maps:get(<<"client">>, State, undefined, Opts),
+                            hb_maps:get(<<"client">>, State, not_found, Opts),
                         <<"action">> => <<"mint-batch">>,
                         <<"content-type">> => <<"text/csv">>,
                         <<"body">> => to_csv(Distributions, Opts)
@@ -321,10 +321,10 @@ to_csv(Msgs, Opts) ->
     hb_util:bin(
         lists:map(
             fun(M) ->
-                Recpt = hb_util:human_id(hb_maps:get(<<"recipient">>, M, undefined, Opts)),
-                Quantity = hb_util:bin(hb_maps:get(<<"quantity">>, M, undefined, Opts)),
-                Minter = hb_util:human_id(hb_maps:get(<<"minter">>, M, undefined, Opts)),
-                Reason = hb_util:human_id(hb_maps:get(<<"reason">>, M, undefined, Opts)),
+                Recpt = hb_util:human_id(hb_maps:get(<<"recipient">>, M, not_found, Opts)),
+                Quantity = hb_util:bin(hb_maps:get(<<"quantity">>, M, not_found, Opts)),
+                Minter = hb_util:human_id(hb_maps:get(<<"minter">>, M, not_found, Opts)),
+                Reason = hb_util:human_id(hb_maps:get(<<"reason">>, M, not_found, Opts)),
                 <<
                     Recpt/binary, ",",
                     Quantity/binary, ",",
@@ -339,5 +339,5 @@ to_csv(Msgs, Opts) ->
 required_int(Value) ->
     case hb_util:safe_int(Value) of
         {ok, SafeInt} -> SafeInt;
-        _ -> throw({error, invalid_integer_default})
+        _ -> throw({error, required_int_parse_failure})
     end.

--- a/src/dev_mint_math.erl
+++ b/src/dev_mint_math.erl
@@ -89,12 +89,12 @@ mint(State, _Req, Opts) ->
 
 %% @doc Return the total number of units to distribute.
 units_to_distribute(State, Opts) ->
-    MintTotal = hb_util:int(hb_maps:get(<<"mint-total">>, State, undefined, Opts)),
-    AlreadyMinted = hb_util:int(hb_maps:get(<<"minted">>, State, undefined, Opts)),
+    MintTotal = required_int(hb_maps:get(<<"mint-total">>, State, undefined, Opts)),
+    AlreadyMinted = required_int(hb_maps:get(<<"minted">>, State, undefined, Opts)),
     CycleProportionNumerator =
-        hb_util:int(hb_maps:get(<<"cycle-proportion">>, State, undefined, Opts)),
+        required_int(hb_maps:get(<<"cycle-proportion">>, State, undefined, Opts)),
     CycleProportionDenominator =
-        hb_util:int(
+        required_int(
             hb_maps:get(<<"cycle-proportion-denominator">>, State, undefined, Opts)
         ),
     Remaining = MintTotal - AlreadyMinted,
@@ -291,7 +291,7 @@ split_suffix(Key, Suffix) ->
 distributions_to_total_units(Distributions, Opts) ->
     lists:sum(
         lists:map(
-            fun(D) -> hb_util:int(hb_maps:get(<<"quantity">>, D, undefined, Opts)) end,
+            fun(D) -> required_int(hb_maps:get(<<"quantity">>, D, undefined, Opts)) end,
             Distributions
         )
     ).

--- a/src/dev_mint_math.erl
+++ b/src/dev_mint_math.erl
@@ -10,10 +10,10 @@
 %% @doc Determine if we should execute the next mint cycle.
 should_mint(State, Req, Opts) ->
     % Gather the current state of the mint process.
-    Cycle = hb_util:int(hb_maps:get(<<"cycle">>, State, undefined, Opts)),
-    PeriodMs = hb_util:int(hb_maps:get(<<"period">>, State, undefined, Opts)),
-    StartTimeMs = hb_util:int(hb_maps:get(<<"start-time">>, State, undefined, Opts)),
-    CurrentTimeMs = hb_util:int(hb_maps:get(<<"timestamp">>, Req, undefined, Opts)),
+    Cycle = required_int(hb_maps:get(<<"cycle">>, State, undefined, Opts)),
+    PeriodMs = required_int(hb_maps:get(<<"period">>, State, undefined, Opts)),
+    StartTimeMs = required_int(hb_maps:get(<<"start-time">>, State, undefined, Opts)),
+    CurrentTimeMs = required_int(hb_maps:get(<<"timestamp">>, Req, undefined, Opts)),
     % Calculate whether we have exceeded the timestamp of the next cycle.
     NextCycleTimeMs = StartTimeMs + (Cycle * PeriodMs),
     CurrentTimeMs >= NextCycleTimeMs.
@@ -21,8 +21,8 @@ should_mint(State, Req, Opts) ->
 %% @doc Perform a single mint cycle, returning a new state containing updated 
 %% metadata and instructions to the `Client` address.
 mint(State, _Req, Opts) ->
-    Cycle = hb_util:int(hb_maps:get(<<"cycle">>, State, undefined, Opts)),
-    AlreadyMinted = hb_util:int(hb_maps:get(<<"minted">>, State, undefined, Opts)),
+    Cycle = required_int(hb_maps:get(<<"cycle">>, State, undefined, Opts)),
+    AlreadyMinted = required_int(hb_maps:get(<<"minted">>, State, undefined, Opts)),
     ?event(debug,
         {starting_mint_cycle,
             {already_minted, AlreadyMinted},
@@ -335,3 +335,9 @@ to_csv(Msgs, Opts) ->
             Msgs
         )
     ).
+%% @doc Fail Fast wrapper for hb_util:safe_int.
+required_int(Value) ->
+    case hb_util:safe_int(Value) of
+        {ok, SafeInt} -> SafeInt;
+        _ -> throw({error, invalid_integer_default})
+    end.

--- a/src/dev_mint_math.erl
+++ b/src/dev_mint_math.erl
@@ -10,10 +10,10 @@
 %% @doc Determine if we should execute the next mint cycle.
 should_mint(State, Req, Opts) ->
     % Gather the current state of the mint process.
-    Cycle = hb_util:int(hb_maps:get(<<"cycle">>, State, Opts)),
-    PeriodMs = hb_util:int(hb_maps:get(<<"period">>, State, Opts)),
-    StartTimeMs = hb_util:int(hb_maps:get(<<"start-time">>, State, Opts)),
-    CurrentTimeMs = hb_util:int(hb_maps:get(<<"timestamp">>, Req, Opts)),
+    Cycle = hb_util:int(hb_maps:get(<<"cycle">>, State, undefined, Opts)),
+    PeriodMs = hb_util:int(hb_maps:get(<<"period">>, State, undefined, Opts)),
+    StartTimeMs = hb_util:int(hb_maps:get(<<"start-time">>, State, undefined, Opts)),
+    CurrentTimeMs = hb_util:int(hb_maps:get(<<"timestamp">>, Req, undefined, Opts)),
     % Calculate whether we have exceeded the timestamp of the next cycle.
     NextCycleTimeMs = StartTimeMs + (Cycle * PeriodMs),
     CurrentTimeMs >= NextCycleTimeMs.
@@ -21,8 +21,8 @@ should_mint(State, Req, Opts) ->
 %% @doc Perform a single mint cycle, returning a new state containing updated 
 %% metadata and instructions to the `Client` address.
 mint(State, _Req, Opts) ->
-    Cycle = hb_util:int(hb_maps:get(<<"cycle">>, State, Opts)),
-    AlreadyMinted = hb_util:int(hb_maps:get(<<"minted">>, State, Opts)),
+    Cycle = hb_util:int(hb_maps:get(<<"cycle">>, State, undefined, Opts)),
+    AlreadyMinted = hb_util:int(hb_maps:get(<<"minted">>, State, undefined, Opts)),
     ?event(debug,
         {starting_mint_cycle,
             {already_minted, AlreadyMinted},
@@ -89,12 +89,14 @@ mint(State, _Req, Opts) ->
 
 %% @doc Return the total number of units to distribute.
 units_to_distribute(State, Opts) ->
-    MintTotal = hb_util:int(hb_maps:get(<<"mint-total">>, State, Opts)),
-    AlreadyMinted = hb_util:int(hb_maps:get(<<"minted">>, State, Opts)),
+    MintTotal = hb_util:int(hb_maps:get(<<"mint-total">>, State, undefined, Opts)),
+    AlreadyMinted = hb_util:int(hb_maps:get(<<"minted">>, State, undefined, Opts)),
     CycleProportionNumerator =
-        hb_util:int(hb_maps:get(<<"cycle-proportion">>, State, Opts)),
+        hb_util:int(hb_maps:get(<<"cycle-proportion">>, State, undefined, Opts)),
     CycleProportionDenominator =
-        hb_util:int(hb_maps:get(<<"cycle-proportion-denominator">>, State, Opts)),
+        hb_util:int(
+            hb_maps:get(<<"cycle-proportion-denominator">>, State, undefined, Opts)
+        ),
     Remaining = MintTotal - AlreadyMinted,
     case CycleProportionDenominator of
         0 -> throw({error, zero_cycle_proportion_denominator});
@@ -106,12 +108,12 @@ units_to_distribute(State, Opts) ->
 units_per_resource(TotalToDistribute, State, Opts) ->
     Resources =
         hb_private:reset(hb_message:uncommitted(
-            hb_maps:get(<<"resources">>, State, Opts)
+            hb_maps:get(<<"resources">>, State, undefined, Opts)
         )),
     ResourceWeights =
         hb_maps:map(
             fun(_ResourceID, Resource) ->
-                hb_util:int(hb_maps:get(<<"weight">>, Resource, Opts))
+                hb_util:int(hb_maps:get(<<"weight">>, Resource, undefined, Opts))
             end,
             Resources
         ),
@@ -289,7 +291,7 @@ split_suffix(Key, Suffix) ->
 distributions_to_total_units(Distributions, Opts) ->
     lists:sum(
         lists:map(
-            fun(D) -> hb_util:int(hb_maps:get(<<"quantity">>, D, Opts)) end,
+            fun(D) -> hb_util:int(hb_maps:get(<<"quantity">>, D, undefined, Opts)) end,
             Distributions
         )
     ).
@@ -304,7 +306,7 @@ distributions_to_results(State, Distributions, Opts) ->
                 [
                     #{
                         <<"target">> =>
-                            hb_maps:get(<<"client">>, State, Opts),
+                            hb_maps:get(<<"client">>, State, undefined, Opts),
                         <<"action">> => <<"mint-batch">>,
                         <<"content-type">> => <<"text/csv">>,
                         <<"body">> => to_csv(Distributions, Opts)
@@ -319,10 +321,10 @@ to_csv(Msgs, Opts) ->
     hb_util:bin(
         lists:map(
             fun(M) ->
-                Recpt = hb_util:human_id(hb_maps:get(<<"recipient">>, M, Opts)),
-                Quantity = hb_util:bin(hb_maps:get(<<"quantity">>, M, Opts)),
-                Minter = hb_util:human_id(hb_maps:get(<<"minter">>, M, Opts)),
-                Reason = hb_util:human_id(hb_maps:get(<<"reason">>, M, Opts)),
+                Recpt = hb_util:human_id(hb_maps:get(<<"recipient">>, M, undefined, Opts)),
+                Quantity = hb_util:bin(hb_maps:get(<<"quantity">>, M, undefined, Opts)),
+                Minter = hb_util:human_id(hb_maps:get(<<"minter">>, M, undefined, Opts)),
+                Reason = hb_util:human_id(hb_maps:get(<<"reason">>, M, undefined, Opts)),
                 <<
                     Recpt/binary, ",",
                     Quantity/binary, ",",

--- a/src/dev_mint_stats.erl
+++ b/src/dev_mint_stats.erl
@@ -14,9 +14,9 @@
 %% -> sum(distributions/n/quantity) == Minted supply after - Minted supply before.
 %% -> All distributions/n/quantity are positive integers.
 sanity_check(State, NewState, Opts) ->
-    MintedBefore = hb_maps:get(<<"minted">>, State, Opts),
-    MintedAfter = hb_maps:get(<<"minted">>, NewState, Opts),
-    TotalSupply = hb_maps:get(<<"total-supply">>, State, Opts),
+    MintedBefore = hb_maps:get(<<"minted">>, State, undefined, Opts),
+    MintedAfter = hb_maps:get(<<"minted">>, NewState, undefined, Opts),
+    TotalSupply = hb_maps:get(<<"total-supply">>, State, undefined, Opts),
     Quantities = get_quantities(NewState),
     SumQuantities = lists:sum(Quantities),
     NonNegativeInteger = fun(X) -> is_integer(X) andalso X >= 0 end,

--- a/src/dev_pot_test_vectors.erl
+++ b/src/dev_pot_test_vectors.erl
@@ -1198,11 +1198,11 @@ delegation_notice_message_format_test() ->
     [Notice] = Outbox,
     ?assertEqual(
         Bob, 
-        hb_maps:get(<<"target">>, Notice, Opts)
+        hb_maps:get(<<"target">>, Notice, not_found, Opts)
     ),
     ?assertEqual(
         <<"deposit">>, 
-        hb_maps:get(<<"action">>, Notice, Opts)
+        hb_maps:get(<<"action">>, Notice, not_found, Opts)
     ),
     ?assertEqual(5, hb_maps:get(<<"quantity">>, Notice, not_found, Opts)),
     ?assertEqual(ResourceOxygen, hb_maps:get(<<"resource">>, Notice, not_found, Opts)).
@@ -1221,7 +1221,8 @@ undelegate_notice_has_negative_quantity_test() ->
     ?assertEqual(2, length(Outbox)),
     % Outbox is newest first, so undelegate notice is first
     [UndelegateNotice, _] = Outbox,
-    Quantity = hb_maps:get(<<"quantity">>, UndelegateNotice, Opts),
+    Quantity = hb_maps:get(<<"quantity">>, UndelegateNotice, not_found, Opts),
+    ?assert(is_integer(Quantity)),
     ?assert(Quantity =< 0).
 
 multiple_delegations_outbox_order_test() ->


### PR DESCRIPTION
addressed https://github.com/permaweb/HyperBEAM/pull/688#issuecomment-3970940976 in a separate PR due to wider scope

## TLDR 

there was mixed `hb_maps:get/3` and `hb_maps:get/4` usage where some `get/3` calls passed `Opts` as the default value instead of using arity 4 -- patched in:

  - `dev_pot_test_vectors`
  - `dev_mint_math`
  - `dev_mint_stats`

 also added a fail fast `hb_util:safe_int/1` wrapper (`dev_mint_math:required_int/1`) to replace previous `hb_util:int/1` usage on required numeric fields, so failures now throw typed errors instead of generic crashes (as the get/4 defaults are now correctly in place)

  ```erl
  %% @doc Fail Fast wrapper for hb_util:safe_int.
  required_int(Value) ->
      case hb_util:safe_int(Value) of
          {ok, SafeInt} -> SafeInt;
          _ -> throw({error, required_int_parse_failure})
      end.
 ```

  tests run:

```bash
rebar3 eunit --module=dev_mint_test_vectors
rebar3 eunit --module=dev_pot_test_vectors
rebar3 eunit --module=dev_pot_math_props
rebar3 eunit --module=dev_pot_props
```