### PR TITLE
fix: hb_maps:get arity misuse in genesis/delegated checkpoint flow + checkpoint data presence checks

### DIFF
--- a/src/dev_delegated_compute.erl
+++ b/src/dev_delegated_compute.erl
@@ -20,7 +20,7 @@ normalize(Base, _Req, Opts) ->
         error -> {ok, Base};
         {ok, Snapshot} ->
             Unset = hb_ao:set(Base, #{ <<"snapshot">> => unset }, Opts),
-            case hb_maps:get(<<"type">>, Snapshot, Opts) == <<"Checkpoint">> of
+            case hb_maps:get(<<"type">>, Snapshot, not_found, Opts) == <<"Checkpoint">> of
                 false -> Unset;
                 true ->
                     load_state(Snapshot, Opts),
@@ -31,7 +31,12 @@ normalize(Base, _Req, Opts) ->
 %% @doc Attempt to load a snapshot into the delegated compute server.
 load_state(Snapshot, Opts) ->
     ?event(debug_load_snapshot, {loading_snapshot, {snapshot, Snapshot}}),
-    Body = hb_maps:get(<<"data">>, Snapshot, Opts),
+    Body = hb_maps:get(<<"data">>, Snapshot, not_found, Opts),
+    case Body of
+        not_found -> throw({error, missing_checkpoint_data});
+        <<>> -> throw({error, empty_checkpoint_data});
+        _ -> ok
+    end,
     Headers = hb_maps:without([<<"data">>], Snapshot, Opts),
     Res = do_relay(
         <<"POST">>,

--- a/src/dev_delegated_compute.erl
+++ b/src/dev_delegated_compute.erl
@@ -34,7 +34,6 @@ load_state(Snapshot, Opts) ->
     Body = hb_maps:get(<<"data">>, Snapshot, not_found, Opts),
     case Body of
         not_found -> throw({error, missing_checkpoint_data});
-        <<>> -> throw({error, empty_checkpoint_data});
         _ -> ok
     end,
     Headers = hb_maps:without([<<"data">>], Snapshot, Opts),

--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -436,7 +436,10 @@ do_import(Proc, CheckpointMessage, Opts) ->
                 CheckpointSigners
             ) orelse untrusted,
         true ?= hb_message:verify(CheckpointMessage, all, Opts) orelse unverified,
-        CheckpointTargetProcID = hb_maps:get(<<"process">>, CheckpointMessage, Opts),
+        CheckpointData = hb_maps:get(<<"data">>, CheckpointMessage, not_found, Opts),
+        true ?= CheckpointData =/= not_found orelse missing_checkpoint_data,
+        true ?= CheckpointData =/= <<>> orelse empty_checkpoint_data,
+        CheckpointTargetProcID = hb_maps:get(<<"process">>, CheckpointMessage, not_found, Opts),
         ProcID = dev_process_lib:process_id(Proc, #{}, Opts),
         true ?= CheckpointTargetProcID == ProcID orelse process_mismatch,
         % Normalize the checkpoint message into a process state message with 
@@ -481,6 +484,18 @@ do_import(Proc, CheckpointMessage, Opts) ->
                 <<"body">> =>
                     <<"Checkpoint message is not signed by a trusted snapshot "
                         "authority.">>
+            }};
+        missing_checkpoint_data ->
+            {error, #{
+                <<"status">> => 400,
+                <<"body">> =>
+                    <<"Checkpoint message is missing data.">>
+            }};
+        empty_checkpoint_data ->
+            {error, #{
+                <<"status">> => 400,
+                <<"body">> =>
+                    <<"Checkpoint message data is empty.">>
             }}
     end.
 

--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -438,7 +438,6 @@ do_import(Proc, CheckpointMessage, Opts) ->
         true ?= hb_message:verify(CheckpointMessage, all, Opts) orelse unverified,
         CheckpointData = hb_maps:get(<<"data">>, CheckpointMessage, not_found, Opts),
         true ?= CheckpointData =/= not_found orelse missing_checkpoint_data,
-        true ?= CheckpointData =/= <<>> orelse empty_checkpoint_data,
         CheckpointTargetProcID = hb_maps:get(<<"process">>, CheckpointMessage, not_found, Opts),
         ProcID = dev_process_lib:process_id(Proc, #{}, Opts),
         true ?= CheckpointTargetProcID == ProcID orelse process_mismatch,
@@ -490,12 +489,6 @@ do_import(Proc, CheckpointMessage, Opts) ->
                 <<"status">> => 400,
                 <<"body">> =>
                     <<"Checkpoint message is missing data.">>
-            }};
-        empty_checkpoint_data ->
-            {error, #{
-                <<"status">> => 400,
-                <<"body">> =>
-                    <<"Checkpoint message data is empty.">>
             }}
     end.
 

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -673,7 +673,17 @@ ensure_loaded(Base, Req, Opts) ->
                             MaybeLoadedSnapshotMsg,
                             Opts
                         ),
-                    Process = hb_maps:get(<<"process">>, LoadedSnapshotMsg, Opts),
+                    Process =
+                        case hb_maps:get(
+                            <<"process">>,
+                            LoadedSnapshotMsg,
+                            not_found,
+                            Opts
+                        ) of
+                            P when is_map(P) -> P;
+                            not_found -> throw({error, missing_snapshot_process});
+                            _ -> throw({error, invalid_snapshot_process})
+                        end,
                     #{ <<"commitments">> := HmacCommits} =
                         hb_message:with_commitments(
                             #{ <<"type">> => <<"hmac-sha256">>},


### PR DESCRIPTION
## about

following the work done on https://github.com/permaweb/HyperBEAM/pull/701 i did more hb_maps:get/3 usage checks looking for default misuse. 

### dev_delegated_compute

`hb_maps:get(<<"type">>, Snapshot, Opts) == <<"Checkpoint">>` in `dev_delegated_compute` was calling get with the incorrect arity (passing Opts as default). fixed that to use get 4 arity. the same for `Body = hb_maps:get(<<"data">>, Snapshot, Opts),`

additionally for the Body patch, i added fail fast throw when the checkpoint data body isnt available

### dev_genesis_wasm

the same incorrect hb_maps:get arity was used at `CheckpointTargetProcID = hb_maps:get(<<"process">>, CheckpointMessage, Opts)` - patched that.

additionally the `import_legacy_checkpoint/0` test does:

```erlang
    ?assertMatch(
        #{ <<"data">> := Data } when byte_size(Data) > 0,
        hb_maps:get(<<"snapshot">>, ProcWithCheckpoint)
    ),
 ```

but `do_import/3` already validates signer/process/nonce, but it didnt validate checkpoint payload presence. so i added a data presence check at ingress (`not_found rejection`):
```erlang
        CheckpointData = hb_maps:get(<<"data">>, CheckpointMessage, not_found, Opts),
        true ?= CheckpointData =/= not_found orelse missing_checkpoint_data,
```

### clarity required

`~genesis-wasm@1.0` restore flow goes through `~delegated-compute@1.0` (dev_genesis_wasm:normalize/3 -> dev_delegated_compute:normalize/3 -> load_state/2), so checkpoint payload assumptions should stay aligned both at ingress (`do_import/3`) and at restore execution (`load_state/2`)

should the checkpoint point integrity policy be stricter in both dev_genesis_wasm and dev_delegated_compute to restrict 'existing but empty checkpoint' data payloads (following the import_legacy_checkpoint test)?