### PR TITLE
fix: incorrect router hb_maps:get/3 Opts-as-fallback

### DIFF
--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -566,7 +566,12 @@ choose(N, <<"Nearest">>, HashPath, Nodes, Opts) when is_binary(HashPath) ->
     NodesWithDistances =
         lists:map(
             fun(Node) ->
-                Wallet = hb_maps:get(<<"wallet">>, Node, Opts),
+                Wallet = 
+                    case hb_maps:get(<<"wallet">>, Node, not_found, Opts) of
+                        W when is_binary(W) -> W;
+                        not_found -> throw({error, wallet_not_found});
+                        _ -> throw({error, invalid_wallet})
+                    end,
                 Salt =
                     case hb_maps:find(<<"salt">>, Node, Opts) of
                         {ok, S} -> <<":", S/binary>>;
@@ -771,12 +776,21 @@ preprocess(Base, RawReq, Opts) ->
                     _ ->
                         Req
                 end,
+            UserPath =
+                case hb_maps:get(<<"path">>, Req, not_found, Opts) of
+                    P when is_binary(P), byte_size(P) > 0 ->
+                        P;
+                    not_found ->
+                        throw({error, missing_user_path});
+                    _ ->
+                        throw({error, invalid_user_path})
+                end,
             RelayReq =
                 #{
                     <<"device">> => <<"apply@1.0">>,
                     <<"path">> => <<"user-path">>,
                     <<"source">> => <<"user-message">>,
-                    <<"user-path">> => hb_maps:get(<<"path">>, Req, Opts),
+                    <<"user-path">> => UserPath,
                     <<"user-message">> => UserReqWithCommit
                 },
             ?event(debug_preprocess, {prepared_relay_req, RelayReq}),


### PR DESCRIPTION
following the `hb_maps:get/3` default misuse checks (https://github.com/permaweb/HyperBEAM/pull/701), i patched another one in dev_router (`Nearest` strategy path)

### issue

in `choose/5` for `<<"Nearest">>`, this was using `hb_maps:get(<<"wallet">>, Node, Opts)`  - which means Opts was being passed as default -> confusing errors if missing

patched to explicit handling with arity 4 + fail fast:

```erl
  Wallet =
      case hb_maps:get(<<"wallet">>, Node, not_found, Opts) of
          W when is_binary(W) -> W;
          not_found -> throw({error, wallet_not_found});
          _ -> throw({error, invalid_wallet})
      end,
```
also patched the same in `preprocess/3`, at user path extraction 

```erl
            UserPath =
                case hb_maps:get(<<"path">>, Req, not_found, Opts) of
                    P when is_binary(P), byte_size(P) > 0 ->
                        P;
                    not_found ->
                        throw({error, missing_user_path});
                    _ ->
                        throw({error, invalid_user_path})
                end,
```

^ it was `hb_maps:get(<<"path">>, Req, Opts)`

all tests pass

```bash
  [done in 17.863 s]
=======================================================
  All 30 tests passed.
  ```