### PR TITLE
impr: `gun` and `volatile` store observability; Arweave node preferences

### DIFF
--- a/src/hb_http_client.erl
+++ b/src/hb_http_client.erl
@@ -162,7 +162,7 @@ httpc_req(Args, Opts) ->
 gun_req(Args, Opts) ->
     gun_req(Args, false, Opts).
 gun_req(Args, ReestablishedConnection, Opts) ->
-	StartTime = os:system_time(millisecond),
+	StartTime = os:system_time(native),
 	#{ peer := Peer, path := Path, method := Method } = Args,
 	Response =
         case catch gen_server:call(?MODULE, {get_connection, Args, Opts}, infinity) of
@@ -183,7 +183,7 @@ gun_req(Args, ReestablishedConnection, Opts) ->
             Error ->
                 Error
 	    end,
-	EndTime = os:system_time(millisecond),
+	EndTime = os:system_time(native),
 	%% Only log the metric for the top-level call to req/2 - not the recursive call
 	%% that happens when the connection is reestablished.
 	case ReestablishedConnection of
@@ -747,6 +747,7 @@ await_response(Args, Opts) ->
 			Response
 	end.
 
+%% @doc Debug `http` state logging.
 log(Type, Event, #{method := Method, peer := Peer, path := Path}, Reason, Opts) ->
     ?event(
         http,
@@ -762,6 +763,7 @@ log(Type, Event, #{method := Method, peer := Peer, path := Path}, Reason, Opts) 
     ),
     ok.
 
+%% @doc Record instances of downloaded bytes from the remote server.
 download_metric(Data) ->
 	inc_prometheus_counter(
 		http_client_downloaded_bytes_total,
@@ -769,18 +771,11 @@ download_metric(Data) ->
 		byte_size(Data)
 	).
 
-upload_metric(#{method := post, body := Body}) ->
-	inc_prometheus_counter(
-		http_client_uploaded_bytes_total,
-		[],
-		byte_size(Body)
-	);
-upload_metric(#{method := <<"POST">>, body := Body}) ->
-	inc_prometheus_counter(
-		http_client_uploaded_bytes_total,
-		[],
-		byte_size(Body)
-	);
+%% @doc Record instances of uploaded bytes to the remote server.
+upload_metric(#{method := Method, body := Body}) when is_atom(Method) ->
+    upload_metric(#{ method => hb_util:bin(Method), body => Body });
+upload_metric(#{ method := <<"POST">>, body := Body}) -> upload_metric(Body);
+upload_metric(#{ method := <<"PUT">>, body := Body}) -> upload_metric(Body);
 upload_metric(Body) when is_binary(Body) ->
 	inc_prometheus_counter(
 		http_client_uploaded_bytes_total,
@@ -797,51 +792,49 @@ get_status_class({ok, {{Status, _}, _, _, _, _}}) ->
 get_status_class({ok, Status, _RespHeaders, _Body}) ->
     get_status_class(Status);
 get_status_class({error, connection_closed}) ->
-	<<"connection_closed">>;
+	<<"connection-closed">>;
 get_status_class({error, connect_timeout}) ->
-	<<"connect_timeout">>;
+	<<"connect-timeout">>;
 get_status_class({error, timeout}) ->
 	<<"timeout">>;
 get_status_class({error,{shutdown,timeout}}) ->
-	<<"shutdown_timeout">>;
+	<<"shutdown-timeout">>;
 get_status_class({error, econnrefused}) ->
 	<<"econnrefused">>;
 get_status_class({error, {shutdown,econnrefused}}) ->
-	<<"shutdown_econnrefused">>;
+	<<"shutdown-econnrefused">>;
 get_status_class({error, {down, {shutdown, econnrefused}}}) ->
-    <<"shutdown_econnrefused">>;
+    <<"shutdown-econnrefused">>;
 get_status_class({error, {shutdown,ehostunreach}}) ->
-	<<"shutdown_ehostunreach">>;
+	<<"shutdown-ehostunreach">>;
 get_status_class({error, {shutdown,normal}}) ->
-	<<"shutdown_normal">>;
+	<<"shutdown-normal">>;
 get_status_class({error, {closed,_}}) ->
 	<<"closed">>;
 get_status_class({error, noproc}) ->
 	<<"noproc">>;
-get_status_class({error, {rate_limited, _}}) ->
-	<<"rate_limited_fast_fail">>;
 get_status_class({error, {connection_error, {stream_closed, _Message}}}) ->
-    <<"stream_closed">>;
+    <<"stream-closed">>;
 get_status_class({error, {stream_error, {stream_error, too_many_streams, _Message}}}) ->
-    <<"too_many_streams">>;
+    <<"too-many-streams">>;
 get_status_class({error, {stream_error, {stream_error, refused_stream, _Message}}}) ->
-    <<"refused_stream">>;
+    <<"refused-stream">>;
 get_status_class({error, {stream_error, {goaway, no_error, _Message}}}) ->
-    <<"goaway">>;
+    <<"go-away">>;
 get_status_class({error, {stream_error, {closed, {error, einval}}}}) ->
-    <<"closed_einval">>;
+    <<"closed-einval">>;
 get_status_class({error, {down, shutdown}}) ->
-    <<"down_shutdown">>;
+    <<"down-shutdown">>;
 get_status_class({error, {stream_error, closed}}) ->
-    <<"stream_closed">>;
+    <<"stream-closed">>;
 get_status_class({error, {stream_error, {closed, {error, closed}}}}) ->
-    <<"stream_closed">>;
+    <<"stream-closed">>;
 get_status_class(208) ->
-	<<"already_processed">>;
+	<<"already-processed">>;
 get_status_class(404) ->
-	<<"not_found">>;
+	<<"not-found">>;
 get_status_class(429) ->
-	<<"too_many_requests">>;
+	<<"too-many-requests">>;
 get_status_class(Data) when is_integer(Data), Data > 0 ->
 	hb_util:bin(prometheus_http:status_class(Data));
 get_status_class(Data) when is_binary(Data) ->
@@ -861,11 +854,11 @@ get_status_class(StatusClass) ->
 path_to_category(Path) ->
     case Path of
         <<"/graphql">> -> <<"GraphQL">>;
-        <<"/raw", _/binary>> -> <<"RAW">>;
+        <<"/raw", _/binary>> -> <<"Raw">>;
         <<"/tx", _/binary>> -> <<"TX">>;
         <<"/chunk", _/binary>> -> <<"Chunk">>;
         <<"/block/height/", _/binary>> -> <<"Block Height">>;
-        <<"/~cache@1.0/read", _/binary>> -> <<"Cache@1.0 Read">>;
+        <<"/~cache@1.0/read", _/binary>> -> <<"Remote Read">>;
         undefined -> <<"unknown">>;
         _ ->
             ?event(warning, {unknown_path_to_assign_category, {path, Path}}),

--- a/src/hb_http_client.erl
+++ b/src/hb_http_client.erl
@@ -123,6 +123,7 @@ httpc_req(Args, Opts) ->
                     HeaderKV
                 };
             _ ->
+                upload_metric(Body),
                 {
                     URL,
                     HeaderKV,
@@ -135,6 +136,7 @@ httpc_req(Args, Opts) ->
 	StartTime = os:system_time(millisecond),
     case httpc:request(Method, Request, [], HTTPCOpts) of
         {ok, {{_, Status, _}, RawRespHeaders, RespBody}} ->
+            download_metric(RespBody),
 	        EndTime = os:system_time(millisecond),
             RespHeaders =
                 [
@@ -208,7 +210,13 @@ record_duration(Details, Opts) ->
             % First, write to prometheus if it is enabled. Prometheus works
             % only with strings as lists, so we encode the data before granting
             % it.
-            GetFormat = fun(Key) -> hb_util:list(maps:get(Key, Details)) end,
+            GetFormat =
+                fun
+                    (<<"request-category">>) ->
+                        path_to_category(maps:get(<<"request-path">>, Details));
+                    (Key) ->
+                        hb_util:list(maps:get(Key, Details))
+                end,
             case application:get_application(prometheus) of
                 undefined -> ok;
                 _ ->
@@ -218,7 +226,8 @@ record_duration(Details, Opts) ->
                             GetFormat,
                             [
                                 <<"request-method">>,
-                                <<"status-class">>
+                                <<"status-class">>,
+                                <<"request-category">>
                             ]
                         ),
                         maps:get(<<"duration">>, Details)
@@ -302,7 +311,7 @@ init(Opts) ->
 init_prometheus() ->
 	hb_prometheus:declare(counter, [
 		{name, gun_requests_total},
-		{labels, [http_method, status_class]},
+		{labels, [http_method, status_class, category]},
 		{
 			help,
 			"The total number of GUN requests."
@@ -313,7 +322,7 @@ init_prometheus() ->
 	hb_prometheus:declare(histogram, [
 		{name, http_request_duration_seconds},
 		{buckets, [0.01, 0.1, 0.5, 1, 5, 10, 30, 60]},
-        {labels, [http_method, status_class]},
+        {labels, [http_method, status_class, category]},
 		{
 			help,
 			"The total duration of an hb_http_client:req call. This includes more than"
@@ -603,10 +612,13 @@ reply_error([PendingRequest | PendingRequests], Reason) ->
 	reply_error(PendingRequests, Reason).
 
 record_response_status(Method, Response) ->
+    record_response_status(Method, Response, undefined).
+record_response_status(Method, Response, Path) ->
 	inc_prometheus_counter(gun_requests_total,
         [
             hb_util:list(method_to_bin(Method)),
-			hb_util:list(get_status_class(Response))
+			hb_util:list(get_status_class(Response)),
+            hb_util:list(path_to_category(Path))
         ],
         1
     ).
@@ -629,6 +641,8 @@ method_to_bin(trace) ->
 	<<"TRACE">>;
 method_to_bin(patch) ->
 	<<"PATCH">>;
+method_to_bin(Method) when is_binary(Method) ->
+    Method;
 method_to_bin(_) ->
 	<<"unknown">>.
 
@@ -674,7 +688,7 @@ do_gun_request(PID, Args, Opts) ->
 			is_peer_request => hb_maps:get(is_peer_request, Args, true, Opts)
         },
 	Response = await_response(hb_maps:merge(Args, ResponseArgs, Opts), Opts),
-	record_response_status(Method, Response),
+	record_response_status(Method, Response, Path),
 	inet:stop_timer(Timer),
 	Response.
 
@@ -719,16 +733,16 @@ await_response(Args, Opts) ->
                 FinData
             };
 		{error, timeout} = Response ->
-			record_response_status(Method, Response),
+			record_response_status(Method, Response, Path),
 			gun:cancel(PID, Ref),
 			log(warn, gun_await_process_down, Args, Response, Opts),
 			Response;
 		{error, Reason} = Response when is_tuple(Reason) ->
-			record_response_status(Method, Response),
+			record_response_status(Method, Response, Path),
 			log(warn, gun_await_process_down, Args, Reason, Opts),
 			Response;
 		Response ->
-			record_response_status(Method, Response),
+			record_response_status(Method, Response, Path),
 			log(warn, gun_await_unknown, Args, Response, Opts),
 			Response
 	end.
@@ -761,6 +775,18 @@ upload_metric(#{method := post, body := Body}) ->
 		[],
 		byte_size(Body)
 	);
+upload_metric(#{method := <<"POST">>, body := Body}) ->
+	inc_prometheus_counter(
+		http_client_uploaded_bytes_total,
+		[],
+		byte_size(Body)
+	);
+upload_metric(Body) when is_binary(Body) ->
+	inc_prometheus_counter(
+		http_client_uploaded_bytes_total,
+		[],
+		byte_size(Body)
+	);
 upload_metric(_) ->
 	ok.
 
@@ -768,6 +794,8 @@ upload_metric(_) ->
 % gun_requests_total metrics.
 get_status_class({ok, {{Status, _}, _, _, _, _}}) ->
 	get_status_class(Status);
+get_status_class({ok, Status, _RespHeaders, _Body}) ->
+    get_status_class(Status);
 get_status_class({error, connection_closed}) ->
 	<<"connection_closed">>;
 get_status_class({error, connect_timeout}) ->
@@ -780,6 +808,8 @@ get_status_class({error, econnrefused}) ->
 	<<"econnrefused">>;
 get_status_class({error, {shutdown,econnrefused}}) ->
 	<<"shutdown_econnrefused">>;
+get_status_class({error, {down, {shutdown, econnrefused}}}) ->
+    <<"shutdown_econnrefused">>;
 get_status_class({error, {shutdown,ehostunreach}}) ->
 	<<"shutdown_ehostunreach">>;
 get_status_class({error, {shutdown,normal}}) ->
@@ -788,8 +818,30 @@ get_status_class({error, {closed,_}}) ->
 	<<"closed">>;
 get_status_class({error, noproc}) ->
 	<<"noproc">>;
+get_status_class({error, {rate_limited, _}}) ->
+	<<"rate_limited_fast_fail">>;
+get_status_class({error, {connection_error, {stream_closed, _Message}}}) ->
+    <<"stream_closed">>;
+get_status_class({error, {stream_error, {stream_error, too_many_streams, _Message}}}) ->
+    <<"too_many_streams">>;
+get_status_class({error, {stream_error, {stream_error, refused_stream, _Message}}}) ->
+    <<"refused_stream">>;
+get_status_class({error, {stream_error, {goaway, no_error, _Message}}}) ->
+    <<"goaway">>;
+get_status_class({error, {stream_error, {closed, {error, einval}}}}) ->
+    <<"closed_einval">>;
+get_status_class({error, {down, shutdown}}) ->
+    <<"down_shutdown">>;
+get_status_class({error, {stream_error, closed}}) ->
+    <<"stream_closed">>;
+get_status_class({error, {stream_error, {closed, {error, closed}}}}) ->
+    <<"stream_closed">>;
 get_status_class(208) ->
 	<<"already_processed">>;
+get_status_class(404) ->
+	<<"not_found">>;
+get_status_class(429) ->
+	<<"too_many_requests">>;
 get_status_class(Data) when is_integer(Data), Data > 0 ->
 	hb_util:bin(prometheus_http:status_class(Data));
 get_status_class(Data) when is_binary(Data) ->
@@ -798,8 +850,24 @@ get_status_class(Data) when is_binary(Data) ->
 			<<"unknown">>;
 		Status ->
 			get_status_class(Status)
-	end;
+		end;
 get_status_class(Data) when is_atom(Data) ->
 	atom_to_binary(Data);
-get_status_class(_) ->
+get_status_class(StatusClass) ->
+    ?event(warning, {unknown_status_class, {status_class, StatusClass}}),
 	<<"unknown">>.
+
+%% @doc Convert path to category for grafana labels.
+path_to_category(Path) ->
+    case Path of
+        <<"/graphql">> -> <<"GraphQL">>;
+        <<"/raw", _/binary>> -> <<"RAW">>;
+        <<"/tx", _/binary>> -> <<"TX">>;
+        <<"/chunk", _/binary>> -> <<"Chunk">>;
+        <<"/block/height/", _/binary>> -> <<"Block Height">>;
+        <<"/~cache@1.0/read", _/binary>> -> <<"Cache@1.0 Read">>;
+        undefined -> <<"unknown">>;
+        _ ->
+            ?event(warning, {unknown_path_to_assign_category, {path, Path}}),
+            <<"unknown">>
+    end.

--- a/src/hb_message_test_vectors.erl
+++ b/src/hb_message_test_vectors.erl
@@ -53,12 +53,12 @@ suite_test_opts() ->
         },
         #{
             name => ed25519,
-            desc => <<"ED25519 opts">>,
+            desc => <<"Ed25519 opts">>,
             opts => test_opts(ed25519)
         },
         #{
             name => ecdsa,
-            desc => <<"Ethereum opts">>,
+            desc => <<"Secp256k1 (Ethereum) opts">>,
             opts => test_opts(ethereum)
          }
     ].

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -313,9 +313,9 @@ default_message() ->
                         <<"path">> => <<"^/arweave/chunk">>,
                         <<"method">> => <<"GET">>
                     },
-                <<"nodes">> => ?DATA_NODES ++ ?TIP_NODES,
+                <<"nodes">> => ?ARWEAVE_BOOTSTRAP_DATA_NODES ++ ?ARWEAVE_BOOTSTRAP_TIP_NODES,
                 <<"strategy">> => <<"Shuffled-Range">>,
-                <<"choose">> => length(?DATA_NODES ++ ?TIP_NODES),
+                <<"choose">> => length(?ARWEAVE_BOOTSTRAP_DATA_NODES ++ ?ARWEAVE_BOOTSTRAP_TIP_NODES),
                 <<"parallel">> => 4,
                 <<"responses">> => 1,
                 <<"stop-after">> => true,
@@ -327,9 +327,9 @@ default_message() ->
                         <<"path">> => <<"^/arweave/chunk">>,
                         <<"method">> => <<"POST">>
                     },
-                <<"nodes">> => ?DATA_NODES ++ ?TIP_NODES,
+                <<"nodes">> => ?ARWEAVE_BOOTSTRAP_DATA_NODES ++ ?ARWEAVE_BOOTSTRAP_TIP_NODES,
                 <<"strategy">> => <<"Shuffled-Range">>,
-                <<"choose">> => length(?DATA_NODES ++ ?TIP_NODES),
+                <<"choose">> => length(?ARWEAVE_BOOTSTRAP_DATA_NODES ++ ?ARWEAVE_BOOTSTRAP_TIP_NODES),
                 <<"parallel">> => 5,
                 <<"responses">> => 3, %% keep going until we get 3x 200s
                 <<"stop-after">> => true,
@@ -341,7 +341,7 @@ default_message() ->
                         <<"path">> => <<"^/arweave/tx">>,
                         <<"method">> => <<"POST">>
                     },
-                <<"nodes">> => ?CHAIN_NODES ++ ?TIP_NODES,
+                <<"nodes">> => ?ARWEAVE_BOOTSTRAP_CHAIN_NODES ++ ?ARWEAVE_BOOTSTRAP_TIP_NODES,
                 <<"parallel">> => true,
                 <<"responses">> => 3,
                 <<"stop-after">> => false,
@@ -361,7 +361,7 @@ default_message() ->
             %% the first 200.
             #{
                 <<"template">> => <<"^/arweave">>,
-                <<"nodes">> => ?CHAIN_NODES,
+                <<"nodes">> => ?ARWEAVE_BOOTSTRAP_CHAIN_NODES,
                 <<"parallel">> => true,
                 <<"stop-after">> => 1,
                 <<"admissible-status">> => 200

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -313,9 +313,14 @@ default_message() ->
                         <<"path">> => <<"^/arweave/chunk">>,
                         <<"method">> => <<"GET">>
                     },
-                <<"nodes">> => ?ARWEAVE_BOOTSTRAP_DATA_NODES ++ ?ARWEAVE_BOOTSTRAP_TIP_NODES,
+                <<"nodes">> =>
+                    ?ARWEAVE_BOOTSTRAP_DATA_NODES ++ ?ARWEAVE_BOOTSTRAP_TIP_NODES,
                 <<"strategy">> => <<"Shuffled-Range">>,
-                <<"choose">> => length(?ARWEAVE_BOOTSTRAP_DATA_NODES ++ ?ARWEAVE_BOOTSTRAP_TIP_NODES),
+                <<"choose">> =>
+                    length(
+                        ?ARWEAVE_BOOTSTRAP_DATA_NODES
+                            ++ ?ARWEAVE_BOOTSTRAP_TIP_NODES
+                    ),
                 <<"parallel">> => 4,
                 <<"responses">> => 1,
                 <<"stop-after">> => true,
@@ -327,9 +332,14 @@ default_message() ->
                         <<"path">> => <<"^/arweave/chunk">>,
                         <<"method">> => <<"POST">>
                     },
-                <<"nodes">> => ?ARWEAVE_BOOTSTRAP_DATA_NODES ++ ?ARWEAVE_BOOTSTRAP_TIP_NODES,
+                <<"nodes">> =>
+                    ?ARWEAVE_BOOTSTRAP_DATA_NODES ++ ?ARWEAVE_BOOTSTRAP_TIP_NODES,
                 <<"strategy">> => <<"Shuffled-Range">>,
-                <<"choose">> => length(?ARWEAVE_BOOTSTRAP_DATA_NODES ++ ?ARWEAVE_BOOTSTRAP_TIP_NODES),
+                <<"choose">> =>
+                    length(
+                        ?ARWEAVE_BOOTSTRAP_DATA_NODES
+                            ++ ?ARWEAVE_BOOTSTRAP_TIP_NODES
+                    ),
                 <<"parallel">> => 5,
                 <<"responses">> => 3, %% keep going until we get 3x 200s
                 <<"stop-after">> => true,
@@ -341,7 +351,8 @@ default_message() ->
                         <<"path">> => <<"^/arweave/tx">>,
                         <<"method">> => <<"POST">>
                     },
-                <<"nodes">> => ?ARWEAVE_BOOTSTRAP_CHAIN_NODES ++ ?ARWEAVE_BOOTSTRAP_TIP_NODES,
+                <<"nodes">> =>
+                    ?ARWEAVE_BOOTSTRAP_CHAIN_NODES ++ ?ARWEAVE_BOOTSTRAP_TIP_NODES,
                 <<"parallel">> => true,
                 <<"responses">> => 3,
                 <<"stop-after">> => false,

--- a/src/hb_store_volatile.erl
+++ b/src/hb_store_volatile.erl
@@ -78,6 +78,7 @@ scope(_) -> scope().
 reset(Opts) ->
     #{ <<"ets-table">> := Table } = hb_store:find(Opts),
     ets:delete_all_objects(Table),
+    ?event(store_volatile, {volatile_reset, {table, Table}}),
     ok.
 
 %% @doc Write a value at the key path.
@@ -85,6 +86,7 @@ write(Opts, RawKey, Value) ->
     Key = hb_store:join(RawKey),
     #{ <<"ets-table">> := Table } = hb_store:find(Opts),
     ensure_parent_groups(Table, Key),
+    ?event(store_volatile, {volatile_write, {key, Key}}),
     ets:insert(Table, {Key, {raw, Value}}),
     ok.
 
@@ -97,10 +99,13 @@ read_resolved(_Opts, _Key, Depth) when Depth > ?MAX_REDIRECTS ->
 read_resolved(Opts, Key, Depth) ->
     case lookup_entry(Opts, Key) of
         {raw, Value} ->
+            ?event(store_volatile, {volatile_hit, {key, Key}}),
             {ok, Value};
         {link, Link} ->
+            ?event(store_volatile, {volatile_hit, {key, Key}}),
             read_resolved(Opts, hb_store:join(Link), Depth + 1);
         _ ->
+            ?event(store_volatile, {volatile_miss, {key, Key}}),
             not_found
     end.
 

--- a/src/include/hb_arweave_nodes.hrl
+++ b/src/include/hb_arweave_nodes.hrl
@@ -7,7 +7,7 @@
         <<"max">> => 57_600_000_000_000,
         <<"center">> => 28_800_000_000_000,
         <<"with">> => <<"http://data-1.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -15,7 +15,7 @@
         <<"max">> => 57_600_000_000_000,
         <<"center">> => 28_800_000_000_000,
         <<"with">> => <<"http://data-13.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     },
     %% Partitions 0-3
     #{
@@ -24,7 +24,7 @@
         <<"max">> => 14_400_000_000_000,
         <<"center">> => 7_200_000_000_000,
         <<"with">> => <<"http://data-2.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     },
     %% Partitions 4-7
     #{
@@ -33,7 +33,7 @@
         <<"max">> => 28_800_000_000_000,
         <<"center">> => 21_600_000_000_000,
         <<"with">> => <<"http://data-3.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     },
     %% Partitions 8-11
     #{
@@ -42,7 +42,7 @@
         <<"max">> => 43_200_000_000_000,
         <<"center">> => 36_000_000_000_000,
         <<"with">> => <<"http://data-4.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     },
     %% Partitions 12-15
     #{
@@ -51,7 +51,7 @@
         <<"max">> => 57_600_000_000_000,
         <<"center">> => 50_400_000_000_000,
         <<"with">> => <<"http://data-5.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     },
     %% Partitions 16-31
     #{
@@ -60,7 +60,7 @@
         <<"max">> => 115_200_000_000_000,
         <<"center">> => 86_400_000_000_000,
         <<"with">> => <<"http://data-2.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -68,7 +68,7 @@
         <<"max">> => 115_200_000_000_000,
         <<"center">> => 86_400_000_000_000,
         <<"with">> => <<"http://data-3.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -76,7 +76,7 @@
         <<"max">> => 115_200_000_000_000,
         <<"center">> => 86_400_000_000_000,
         <<"with">> => <<"http://data-14.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -84,7 +84,7 @@
         <<"max">> => 115_200_000_000_000,
         <<"center">> => 86_400_000_000_000,
         <<"with">> => <<"http://data-15.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     },
     %% Partitions 32-47
     #{
@@ -93,7 +93,7 @@
         <<"max">> => 172_800_000_000_000,
         <<"center">> => 144_000_000_000_000,
         <<"with">> => <<"http://data-4.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -101,7 +101,7 @@
         <<"max">> => 172_800_000_000_000,
         <<"center">> => 144_000_000_000_000,
         <<"with">> => <<"http://data-5.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -109,7 +109,7 @@
         <<"max">> => 172_800_000_000_000,
         <<"center">> => 144_000_000_000_000,
         <<"with">> => <<"http://data-16.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -117,7 +117,7 @@
         <<"max">> => 172_800_000_000_000,
         <<"center">> => 144_000_000_000_000,
         <<"with">> => <<"http://data-17.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     }
     % Exclude these data nodes for now since their partitions are covered 
     % by the tip nodes (and the tip nodes are faster to read from).
@@ -128,7 +128,7 @@
     %     <<"max">> => 230_400_000_000_000,
     %     <<"center">> => 201_600_000_000_000,
     %     <<"with">> => <<"http://data-6.arweave.xyz:1984">>,
-    %     <<"opts">> => #{ http_client => gun }
+    %     <<"opts">> => #{ http_client => gun, protocol => http2 }
     % },
     % #{
     %     <<"match">> => <<"^/arweave">>,
@@ -136,7 +136,7 @@
     %     <<"max">> => 230_400_000_000_000,
     %     <<"center">> => 201_600_000_000_000,
     %     <<"with">> => <<"http://data-7.arweave.xyz:1984">>,
-    %     <<"opts">> => #{ http_client => gun }
+    %     <<"opts">> => #{ http_client => gun, protocol => http2 }
     % },
     % %% Partitions 64-126
     % #{
@@ -145,7 +145,7 @@
     %     <<"max">> => 457_200_000_000_000,
     %     <<"center">> => 343_800_000_000_000,
     %     <<"with">> => <<"http://data-8.arweave.xyz:1984">>,
-    %     <<"opts">> => #{ http_client => gun }
+    %     <<"opts">> => #{ http_client => gun, protocol => http2 }
     % },
     % %% Partitions 75-138
     % #{
@@ -154,7 +154,7 @@
     %     <<"max">> => 500_400_000_000_000,
     %     <<"center">> => 385_200_000_000_000,
     %     <<"with">> => <<"http://data-9.arweave.xyz:1984">>,
-    %     <<"opts">> => #{ http_client => gun }
+    %     <<"opts">> => #{ http_client => gun, protocol => http2 }
     % },
     % #{
     %     <<"match">> => <<"^/arweave">>,
@@ -162,7 +162,7 @@
     %     <<"max">> => 500_400_000_000_000,
     %     <<"center">> => 385_200_000_000_000,
     %     <<"with">> => <<"http://data-10.arweave.xyz:1984">>,
-    %     <<"opts">> => #{ http_client => gun }
+    %     <<"opts">> => #{ http_client => gun, protocol => http2 }
     % },
     % #{
     %     <<"match">> => <<"^/arweave">>,
@@ -170,7 +170,7 @@
     %     <<"max">> => 500_400_000_000_000,
     %     <<"center">> => 385_200_000_000_000,
     %     <<"with">> => <<"http://data-11.arweave.xyz:1984">>,
-    %     <<"opts">> => #{ http_client => gun }
+    %     <<"opts">> => #{ http_client => gun, protocol => http2 }
     % },
     % #{
     %     <<"match">> => <<"^/arweave">>,
@@ -178,7 +178,7 @@
     %     <<"max">> => 500_400_000_000_000,
     %     <<"center">> => 385_200_000_000_000,
     %     <<"with">> => <<"http://data-12.arweave.xyz:1984">>,
-    %     <<"opts">> => #{ http_client => gun }
+    %     <<"opts">> => #{ http_client => gun, protocol => http2 }
     % }
 ]).
 
@@ -191,7 +191,7 @@
         <<"max">> => 388_800_000_000_000,
         <<"center">> => 280_800_000_000_000,
         <<"with">> => <<"http://tip-1.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -199,7 +199,7 @@
         <<"max">> => 388_800_000_000_000,
         <<"center">> => 280_800_000_000_000,
         <<"with">> => <<"http://tip-2.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -207,7 +207,7 @@
         <<"max">> => 388_800_000_000_000,
         <<"center">> => 280_800_000_000_000,
         <<"with">> => <<"http://tip-3.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -215,7 +215,7 @@
         <<"max">> => 388_800_000_000_000,
         <<"center">> => 280_800_000_000_000,
         <<"with">> => <<"http://tip-4.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -223,7 +223,7 @@
         <<"max">> => 388_800_000_000_000,
         <<"center">> => 280_800_000_000_000,
         <<"with">> => <<"http://tip-5.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     }
 ]).
 
@@ -232,11 +232,11 @@
     #{
         <<"match">> => <<"^/arweave">>,
         <<"with">> => <<"http://chain-1.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     },
     #{
         <<"match">> => <<"^/arweave">>,
         <<"with">> => <<"http://chain-2.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => gun }
+        <<"opts">> => #{ http_client => gun, protocol => http2 }
     }
 ]).

--- a/src/include/hb_arweave_nodes.hrl
+++ b/src/include/hb_arweave_nodes.hrl
@@ -1,4 +1,4 @@
--define(DATA_NODES, 
+-define(ARWEAVE_BOOTSTRAP_DATA_NODES, 
 [
     %% Partitions 0-15
     #{
@@ -7,7 +7,7 @@
         <<"max">> => 57_600_000_000_000,
         <<"center">> => 28_800_000_000_000,
         <<"with">> => <<"http://data-1.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -15,7 +15,7 @@
         <<"max">> => 57_600_000_000_000,
         <<"center">> => 28_800_000_000_000,
         <<"with">> => <<"http://data-13.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     },
     %% Partitions 0-3
     #{
@@ -24,7 +24,7 @@
         <<"max">> => 14_400_000_000_000,
         <<"center">> => 7_200_000_000_000,
         <<"with">> => <<"http://data-2.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     },
     %% Partitions 4-7
     #{
@@ -33,7 +33,7 @@
         <<"max">> => 28_800_000_000_000,
         <<"center">> => 21_600_000_000_000,
         <<"with">> => <<"http://data-3.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     },
     %% Partitions 8-11
     #{
@@ -42,7 +42,7 @@
         <<"max">> => 43_200_000_000_000,
         <<"center">> => 36_000_000_000_000,
         <<"with">> => <<"http://data-4.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     },
     %% Partitions 12-15
     #{
@@ -51,7 +51,7 @@
         <<"max">> => 57_600_000_000_000,
         <<"center">> => 50_400_000_000_000,
         <<"with">> => <<"http://data-5.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     },
     %% Partitions 16-31
     #{
@@ -60,7 +60,7 @@
         <<"max">> => 115_200_000_000_000,
         <<"center">> => 86_400_000_000_000,
         <<"with">> => <<"http://data-2.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -68,7 +68,7 @@
         <<"max">> => 115_200_000_000_000,
         <<"center">> => 86_400_000_000_000,
         <<"with">> => <<"http://data-3.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -76,7 +76,7 @@
         <<"max">> => 115_200_000_000_000,
         <<"center">> => 86_400_000_000_000,
         <<"with">> => <<"http://data-14.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -84,7 +84,7 @@
         <<"max">> => 115_200_000_000_000,
         <<"center">> => 86_400_000_000_000,
         <<"with">> => <<"http://data-15.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     },
     %% Partitions 32-47
     #{
@@ -93,7 +93,7 @@
         <<"max">> => 172_800_000_000_000,
         <<"center">> => 144_000_000_000_000,
         <<"with">> => <<"http://data-4.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -101,7 +101,7 @@
         <<"max">> => 172_800_000_000_000,
         <<"center">> => 144_000_000_000_000,
         <<"with">> => <<"http://data-5.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -109,7 +109,7 @@
         <<"max">> => 172_800_000_000_000,
         <<"center">> => 144_000_000_000_000,
         <<"with">> => <<"http://data-16.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -117,7 +117,7 @@
         <<"max">> => 172_800_000_000_000,
         <<"center">> => 144_000_000_000_000,
         <<"with">> => <<"http://data-17.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     }
     % Exclude these data nodes for now since their partitions are covered 
     % by the tip nodes (and the tip nodes are faster to read from).
@@ -128,7 +128,7 @@
     %     <<"max">> => 230_400_000_000_000,
     %     <<"center">> => 201_600_000_000_000,
     %     <<"with">> => <<"http://data-6.arweave.xyz:1984">>,
-    %     <<"opts">> => #{ http_client => httpc }
+    %     <<"opts">> => #{ http_client => gun }
     % },
     % #{
     %     <<"match">> => <<"^/arweave">>,
@@ -136,7 +136,7 @@
     %     <<"max">> => 230_400_000_000_000,
     %     <<"center">> => 201_600_000_000_000,
     %     <<"with">> => <<"http://data-7.arweave.xyz:1984">>,
-    %     <<"opts">> => #{ http_client => httpc }
+    %     <<"opts">> => #{ http_client => gun }
     % },
     % %% Partitions 64-126
     % #{
@@ -145,7 +145,7 @@
     %     <<"max">> => 457_200_000_000_000,
     %     <<"center">> => 343_800_000_000_000,
     %     <<"with">> => <<"http://data-8.arweave.xyz:1984">>,
-    %     <<"opts">> => #{ http_client => httpc }
+    %     <<"opts">> => #{ http_client => gun }
     % },
     % %% Partitions 75-138
     % #{
@@ -154,7 +154,7 @@
     %     <<"max">> => 500_400_000_000_000,
     %     <<"center">> => 385_200_000_000_000,
     %     <<"with">> => <<"http://data-9.arweave.xyz:1984">>,
-    %     <<"opts">> => #{ http_client => httpc }
+    %     <<"opts">> => #{ http_client => gun }
     % },
     % #{
     %     <<"match">> => <<"^/arweave">>,
@@ -162,7 +162,7 @@
     %     <<"max">> => 500_400_000_000_000,
     %     <<"center">> => 385_200_000_000_000,
     %     <<"with">> => <<"http://data-10.arweave.xyz:1984">>,
-    %     <<"opts">> => #{ http_client => httpc }
+    %     <<"opts">> => #{ http_client => gun }
     % },
     % #{
     %     <<"match">> => <<"^/arweave">>,
@@ -170,7 +170,7 @@
     %     <<"max">> => 500_400_000_000_000,
     %     <<"center">> => 385_200_000_000_000,
     %     <<"with">> => <<"http://data-11.arweave.xyz:1984">>,
-    %     <<"opts">> => #{ http_client => httpc }
+    %     <<"opts">> => #{ http_client => gun }
     % },
     % #{
     %     <<"match">> => <<"^/arweave">>,
@@ -178,11 +178,11 @@
     %     <<"max">> => 500_400_000_000_000,
     %     <<"center">> => 385_200_000_000_000,
     %     <<"with">> => <<"http://data-12.arweave.xyz:1984">>,
-    %     <<"opts">> => #{ http_client => httpc }
+    %     <<"opts">> => #{ http_client => gun }
     % }
 ]).
 
--define(TIP_NODES,
+-define(ARWEAVE_BOOTSTRAP_TIP_NODES,
 [
     %% Partitions 48-107
     #{
@@ -191,7 +191,7 @@
         <<"max">> => 388_800_000_000_000,
         <<"center">> => 280_800_000_000_000,
         <<"with">> => <<"http://tip-1.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -199,7 +199,7 @@
         <<"max">> => 388_800_000_000_000,
         <<"center">> => 280_800_000_000_000,
         <<"with">> => <<"http://tip-2.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -207,7 +207,7 @@
         <<"max">> => 388_800_000_000_000,
         <<"center">> => 280_800_000_000_000,
         <<"with">> => <<"http://tip-3.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -215,7 +215,7 @@
         <<"max">> => 388_800_000_000_000,
         <<"center">> => 280_800_000_000_000,
         <<"with">> => <<"http://tip-4.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     },
     #{
         <<"match">> => <<"^/arweave">>,
@@ -223,20 +223,20 @@
         <<"max">> => 388_800_000_000_000,
         <<"center">> => 280_800_000_000_000,
         <<"with">> => <<"http://tip-5.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     }
 ]).
 
--define(CHAIN_NODES,
+-define(ARWEAVE_BOOTSTRAP_CHAIN_NODES,
 [
     #{
         <<"match">> => <<"^/arweave">>,
         <<"with">> => <<"http://chain-1.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     },
     #{
         <<"match">> => <<"^/arweave">>,
         <<"with">> => <<"http://chain-2.arweave.xyz:1984">>,
-        <<"opts">> => #{ http_client => httpc }
+        <<"opts">> => #{ http_client => gun }
     }
 ]).


### PR DESCRIPTION
- Improve `gun` prometheus metrics.
- Introduce `volatile` store events.
- Switch Arweave node access to prefer `gun` over Erlang's native `httpc`.
- Clarify Arweave node macro names.