### PR TITLE
impr: find arweave-index-store from `store` list if not explicitly set

### DIFF
--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -156,14 +156,15 @@ raw(Base, Request, Opts) ->
         not_found -> {error, not_found};
         TXID ->
             % Read the data from the local cache.
-            IndexStore = hb_opts:get(arweave_index_store, no_store, Opts),
+            IndexStore = hb_store_arweave:store_from_opts(Opts),
             case hb_store_arweave:read_offset(IndexStore, TXID) of
                 not_found ->
                     ?event(
                         arweave,
                         {raw_read_failed, {id, TXID}},
                         Opts
-                    );
+                    ),
+                    {error, not_found};
                 {ok,
                     #{
                         <<"codec-device">> := <<"ans104@1.0">>,

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -55,8 +55,7 @@ latest_height(Opts) ->
 
 %% @doc Check if a transaction ID is indexed in the arweave index store.
 is_tx_indexed(TXID, Opts) ->
-    IndexStore = hb_opts:get(arweave_index_store, no_store, Opts),
-    case IndexStore of
+    case hb_store_arweave:store_from_opts(Opts) of
         no_store -> false;
         #{ <<"index-store">> := Store } ->
             case hb_store:read(Store, hb_store_arweave_offset:path(TXID)) of
@@ -278,7 +277,7 @@ parallel_map(Items, Fun, Opts) ->
 process_tx({{padding, _PaddingRoot}, _EndOffset}, _BlockStartOffset, _Opts) ->
     #{items_count => 0, bundle_count => 0, skipped_count => 0};
 process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
-    IndexStore = hb_opts:get(arweave_index_store, no_store, Opts),
+    IndexStore = hb_store_arweave:store_from_opts(Opts),
     TXID = hb_util:encode(TX#tx.id),
     TXEndOffset = BlockStartOffset + EndOffset,
     TXStartOffset = TXEndOffset - TX#tx.data_size,

--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -6,12 +6,31 @@
 %%% Unused Store API:
 -export([resolve/2, write/3, make_link/3, make_group/2]).
 %%% Indexing API:
--export([write_offset/5, read_offset/2, read_chunks/3]).
+-export([store_from_opts/1, write_offset/5, read_offset/2, read_chunks/3]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 -define(PARTITION_SIZE, 3_600_000_000_000).
 
+%% @doc Find the first Arweave store from the given node message. Searches first
+%% for the `arweave_index_store' option, and if not found, searches the main
+%% `store' list for the first Arweave store with an index.
+store_from_opts(Opts) ->
+    case hb_opts:get(arweave_index_store, no_store, Opts) of
+        no_store -> first_arweave_store(hb_opts:get(store, [], Opts));
+        IndexStoreOpts -> IndexStoreOpts
+    end.
+
+%% @doc Find the first Arweave store with an index from a list of stores.
+first_arweave_store(NonList) when not is_list(NonList) ->
+    first_arweave_store([NonList]);
+first_arweave_store([]) -> no_store;
+first_arweave_store(
+    [Store = #{<<"store-module">> := ?MODULE, <<"index-store">> := _ } | _]
+) -> Store;
+first_arweave_store([_ | Rest]) -> first_arweave_store(Rest).
+
+%% @doc Start the Arweave store, and the downstream associated index store.
 start(#{<<"index-store">> := IndexStore}) ->
     init_prometheus(),
     hb_store:start(IndexStore).


### PR DESCRIPTION
`hb_store_arweave` still honors `arweave_index_store` if set, but searches the `store` list if not found.