### PR TITLE
fix: hb_maps:get/3 misuse - Opts as default

### DIFF
--- a/src/dev_location.erl
+++ b/src/dev_location.erl
@@ -320,13 +320,13 @@ write_foreign(Base, RawReq, Opts) ->
             )
             orelse {error, <<"Invalid location record type.">>},
         true ?=
-            (hb_maps:get(<<"url">>, MaybeLocation, Opts) =/= not_found)
+            (hb_maps:get(<<"url">>, MaybeLocation, not_found, Opts) =/= not_found)
             orelse {error, <<"Missing location record URL.">>},
         true ?=
-            (hb_maps:get(<<"nonce">>, MaybeLocation, Opts) =/= not_found)
+            (hb_maps:get(<<"nonce">>, MaybeLocation, not_found, Opts) =/= not_found)
             orelse {error, <<"Missing location record nonce.">>},
         true ?=
-            (hb_maps:get(<<"time-to-live">>, MaybeLocation, Opts) =/= not_found)
+            (hb_maps:get(<<"time-to-live">>, MaybeLocation, not_found, Opts) =/= not_found)
             orelse {error, <<"Missing location record time-to-live.">>},
         Nonce = hb_util:int(hb_ao:get(<<"nonce">>, MaybeLocation, 0, Opts)),
         SignerChecks =


### PR DESCRIPTION
fixed `hb_maps:get/3` misuse where Opts was passed as default - switched to get/4 with not_found default

previously, missing keys could incorrectly pass validation because get/3 was reutning Opts instead of not_found

i based this PR on the latest active dev_location work branch, is this the preferred base, or should i rebase to edge?