### PR TITLE
feat: Adds range query support for raw Arweave data requests

### DIFF
--- a/src/ar_bundles.erl
+++ b/src/ar_bundles.erl
@@ -3,7 +3,8 @@
 -export([id/1, id/2, hd/1, member/2, find/2]).
 -export([new_item/4, sign_item/2, verify_item/1]).
 -export([encode_tags/1, decode_tags/1]).
--export([serialize/1, deserialize/1, deserialize_item_wrapper/1, serialize_bundle/3]).
+-export([serialize/1, deserialize/1, serialize_bundle/3]).
+-export([deserialize_header/1, deserialize_item_wrapper/1]).
 -export([data_item_signature_data/1]).
 -export([bundle_header_size/1, decode_bundle_header/1]).
 -include("include/hb.hrl").
@@ -433,21 +434,31 @@ deserialize_item(Binary) ->
 %% in the case that it is a bundle. It may be unbundled by calling `maybe_unbundle/1'
 %% at any later point.
 deserialize_item_wrapper(Binary) ->
+    {ok, _HeaderSize, Header} = deserialize_header(Binary),
+    dev_arweave_common:reset_ids(Header).
+
+%% @doc Deserialize the header of an item, returning a #tx record with the 
+%% remaining unprocessed data in the #tx.data field.
+deserialize_header(Binary) ->
     {SignatureType, Signature, Owner, Rest} = decode_signature(Binary),
     {Target, Rest2} = decode_optional_field(Rest),
     {Anchor, Rest3} = decode_optional_field(Rest2),
-    {Tags, Data} = decode_tags(Rest3),
-    dev_arweave_common:reset_ids(#tx{
-        format = ans104,
-        signature_type = SignatureType,
-        signature = Signature,
-        owner = Owner,
-        target = Target,
-        anchor = Anchor,
-        tags = Tags,
-        data = Data,
-        data_size = byte_size(Data)
-    }).
+    {Tags, RemainingData} = decode_tags(Rest3),
+    HeaderSize = byte_size(Binary) - byte_size(RemainingData),
+    {
+        ok,
+        HeaderSize,
+        #tx{
+            format = ans104,
+            signature_type = SignatureType,
+            signature = Signature,
+            owner = Owner,
+            target = Target,
+            anchor = Anchor,
+            tags = Tags,
+            data = RemainingData
+        }
+    }.
 
 maybe_unbundle(Item) ->
     case dev_arweave_common:type(Item) of

--- a/src/ar_bundles.erl
+++ b/src/ar_bundles.erl
@@ -456,7 +456,8 @@ deserialize_header(Binary) ->
             target = Target,
             anchor = Anchor,
             tags = Tags,
-            data = RemainingData
+            data = RemainingData,
+            data_size = byte_size(RemainingData)
         }
     }.
 

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -163,25 +163,26 @@ head_raw(Base, Request, Opts) ->
             % Read the data from the local cache.
             IndexStore = hb_store_arweave:store_from_opts(Opts),
             case hb_store_arweave:read_offset(IndexStore, TXID) of
-                not_found ->
-                    ?event(
-                        arweave,
-                        {raw_read_failed, {id, TXID}},
-                        Opts
-                    ),
-                    {error, not_found};
                 {ok,
                     #{
                         <<"codec-device">> := <<"ans104@1.0">>,
-                        <<"start-offset">> := StartOffset
+                        <<"start-offset">> := StartOffset,
+                        <<"length">> := Length
                     }} ->
-                        do_head_raw(StartOffset, Opts)
+                        do_head_raw(StartOffset, Length, Opts);
+                not_found ->
+                    ?event(
+                        arweave,
+                        {raw_head_offset_failed, {id, TXID}},
+                        Opts
+                    ),
+                    {error, not_found}
             end
     end.
 
 %% @doc Handle `HEAD /raw=ID` requests by reading the header chunk and
 %% returning the `content-type` of the item, if found.
-do_head_raw(ArweaveOffset, Opts) ->
+do_head_raw(ArweaveOffset, Length, Opts) ->
     HeaderReq =
         #{
             <<"path">> => <<"chunk">>,
@@ -189,10 +190,11 @@ do_head_raw(ArweaveOffset, Opts) ->
             <<"length">> => ?DATA_CHUNK_SIZE
         },
     case hb_ao:resolve(#{ <<"device">> => <<"arweave@2.9">> }, HeaderReq, Opts) of
-        {ok, HeaderChunk} -> do_head_raw(ArweaveOffset, HeaderChunk, Opts);
+        {ok, HeaderChunk} ->
+            do_head_raw(ArweaveOffset, Length, HeaderChunk, Opts);
         {error, Error} -> Error
     end.
-do_head_raw(_ArweaveOffset, Data, _Opts) ->
+do_head_raw(_ArweaveOffset, Length, Data, _Opts) ->
     {ok, HeaderSize, HeaderTX} = ar_bundles:deserialize_header(Data),
     ContentType =
         list_find(
@@ -200,7 +202,13 @@ do_head_raw(_ArweaveOffset, Data, _Opts) ->
             HeaderTX#tx.tags,
             <<"application/octet-stream">>
         ),
-    {ok, #{ <<"content-type">> => ContentType, <<"header-length">> => HeaderSize }}.
+    {ok,
+        #{
+            <<"content-type">> => ContentType,
+            <<"header-length">> => HeaderSize,
+            <<"content-length">> => Length - HeaderSize
+        }
+    }.
 
 %% @doc Get raw transaction *data* and `content-type` of an Arweave message.
 %% Does not deserialize the message, nor return signature information. Included
@@ -251,7 +259,7 @@ get_raw(Base, Request, Opts) ->
                                     <<"content-type">> := ContentType,
                                     <<"header-length">> := HeaderLength
                                 }
-                            } = do_head_raw(StartOffset, Opts),
+                            } = do_head_raw(StartOffset, Length, Opts),
                             ArweaveOffset = StartOffset + HeaderLength + StartRange,
                             RangeLength = (EndRange - StartRange) + 1,
                             {ok, Data} =
@@ -263,6 +271,7 @@ get_raw(Base, Request, Opts) ->
                             {
                                 ok,
                                 #{
+                                    <<"status">> => 306,
                                     <<"content-type">> => ContentType,
                                     <<"data">> => Data
                                 }
@@ -1398,6 +1407,10 @@ head_raw_test() ->
     ?assertEqual(
         {ok, <<"application/json">>},
         hb_maps:find(<<"content-type">>, RawData, Opts)
+    ),
+    ?assertEqual(
+        {ok, 575},
+        hb_maps:find(<<"content-length">>, RawData, Opts)
     ).
 
 get_raw_range_test() ->

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -147,10 +147,65 @@ get_tx(Base, Request, Opts) ->
             )
     end.
 
+%% @doc A router for range requests by method. Both `HEAD` and `GET` requests
+%% are supported.
+raw(Base, Request, Opts) ->
+    case hb_maps:get(<<"method">>, Request, <<"GET">>, Opts) of
+        <<"HEAD">> -> head_raw(Base, Request, Opts);
+        <<"GET">> -> get_raw(Base, Request, Opts)
+    end.
+
+head_raw(Base, Request, Opts) ->
+    ?event(debug_raw, {raw, {base, Base}, {request, Request}}),
+    case find_key(<<"raw">>, Base, Request, Opts) of
+        not_found -> {error, not_found};
+        TXID ->
+            % Read the data from the local cache.
+            IndexStore = hb_store_arweave:store_from_opts(Opts),
+            case hb_store_arweave:read_offset(IndexStore, TXID) of
+                not_found ->
+                    ?event(
+                        arweave,
+                        {raw_read_failed, {id, TXID}},
+                        Opts
+                    ),
+                    {error, not_found};
+                {ok,
+                    #{
+                        <<"codec-device">> := <<"ans104@1.0">>,
+                        <<"start-offset">> := StartOffset
+                    }} ->
+                        do_head_raw(StartOffset, Opts)
+            end
+    end.
+
+%% @doc Handle `HEAD /raw=ID` requests by reading the header chunk and
+%% returning the `content-type` of the item, if found.
+do_head_raw(ArweaveOffset, Opts) ->
+    HeaderReq =
+        #{
+            <<"path">> => <<"chunk">>,
+            <<"offset">> => ArweaveOffset + 1,
+            <<"length">> => ?DATA_CHUNK_SIZE
+        },
+    case hb_ao:resolve(#{ <<"device">> => <<"arweave@2.9">> }, HeaderReq, Opts) of
+        {ok, HeaderChunk} -> do_head_raw(ArweaveOffset, HeaderChunk, Opts);
+        {error, Error} -> Error
+    end.
+do_head_raw(_ArweaveOffset, Data, _Opts) ->
+    {ok, HeaderSize, HeaderTX} = ar_bundles:deserialize_header(Data),
+    ContentType =
+        list_find(
+            <<"content-type">>,
+            HeaderTX#tx.tags,
+            <<"application/octet-stream">>
+        ),
+    {ok, #{ <<"content-type">> => ContentType, <<"header-length">> => HeaderSize }}.
+
 %% @doc Get raw transaction *data* and `content-type` of an Arweave message.
 %% Does not deserialize the message, nor return signature information. Included
 %% only for compatibility with the legacy Arweave gateway `/raw` endpoint.
-raw(Base, Request, Opts) ->
+get_raw(Base, Request, Opts) ->
     ?event(debug_raw, {raw, {base, Base}, {request, Request}}),
     case find_key(<<"raw">>, Base, Request, Opts) of
         not_found -> {error, not_found};
@@ -184,31 +239,61 @@ raw(Base, Request, Opts) ->
                             {length, Length}
                         }
                     ),
-                    case hb_store_arweave:read_chunks(StartOffset, Length, Opts) of
-                        {ok, Data} ->
-                            TX = ar_bundles:deserialize_item_wrapper(Data),
-                            ?event(
-                                debug_raw,
-                                {deserialized_raw, {id, TXID}, {tx, TX}}
-                            ),
-                            ContentType =
-                                list_find(
-                                    <<"content-type">>,
-                                    TX#tx.tags,
-                                    <<"application/octet-stream">>
+                    case parse_range_params(Request, Opts) of
+                        {ok, StartRange, EndRange} ->
+                            % The user request is a range request. To calculate
+                            % the Arweave offset to read, we add the start range
+                            % to the item start offset (past the item header)
+                            % and read only the range end minus start bytes
+                            % from that position.
+                            {ok,
+                                #{
+                                    <<"content-type">> := ContentType,
+                                    <<"header-length">> := HeaderLength
+                                }
+                            } = do_head_raw(StartOffset, Opts),
+                            ArweaveOffset = StartOffset + HeaderLength + StartRange,
+                            RangeLength = (EndRange - StartRange) + 1,
+                            {ok, Data} =
+                                hb_store_arweave:read_chunks(
+                                    ArweaveOffset,
+                                    RangeLength,
+                                    Opts
                                 ),
-                            {ok, #{
-                                <<"content-type">> => ContentType,
-                                <<"data">> => Data
-                            }};
-                        Error ->
-                            ?event(
-                                arweave,
-                                {raw_read_chunks_failed, {id, TXID}, {error, Error}},
-                                Opts
-                            ),
-                            Error
-                    end;
+                            {
+                                ok,
+                                #{
+                                    <<"content-type">> => ContentType,
+                                    <<"data">> => Data
+                                }
+                            };
+                        false ->
+                            case hb_store_arweave:read_chunks(StartOffset, Length, Opts) of
+                                {ok, Data} ->
+                                    TX = ar_bundles:deserialize_item_wrapper(Data),
+                                    ?event(
+                                        debug_raw,
+                                        {deserialized_raw, {id, TXID}, {tx, TX}}
+                                    ),
+                                    ContentType =
+                                        list_find(
+                                            <<"content-type">>,
+                                            TX#tx.tags,
+                                            <<"application/octet-stream">>
+                                        ),
+                                    {ok, #{
+                                        <<"content-type">> => ContentType,
+                                        <<"data">> => Data
+                                    }};
+                                Error ->
+                                    ?event(
+                                        arweave,
+                                        {raw_read_chunks_failed, {id, TXID}, {error, Error}},
+                                        Opts
+                                    ),
+                                    Error
+                            end
+                        end;
                 {ok,
                     #{
                         <<"codec-device">> := <<"tx@1.0">>,
@@ -273,6 +358,18 @@ raw(Base, Request, Opts) ->
                             Error
                     end
             end
+    end.
+
+%% @doc Extract the start and end range from a request.
+parse_range_params(Req, Opts) ->
+    case hb_maps:get(<<"range">>, Req, Opts) of
+        <<"bytes *", _>> -> false;
+        <<"bytes ", ByteDescriptor/binary>> ->
+            [ByteRange|_] = binary:split(ByteDescriptor, <<"/">>),
+            [Start, End] = binary:split(ByteRange, <<"-">>),
+            {ok, hb_util:int(Start), hb_util:int(End)};
+        _ ->
+            false
     end.
 
 %% @doc Case-insensitively find a key in a list and return its value.
@@ -1279,6 +1376,72 @@ get_tx_data_tag_exclude_data_test() ->
     DataHash = hb_util:encode(crypto:hash(sha256, Data)),
     ?assertEqual(<<"IHyJ9BlQaHLWVwwklMwV1XEYXGjwx2B6HXNJZ4yJXeQ">>, DataHash),
     ok.
+
+head_raw_test() ->
+    Opts = setup_arweave_index_opts([]),
+    DataItemID = <<"0vy2Ey8bWkSDcRIvWQJjxDeVGYOrTSmYIIhBILJntY8">>,
+    BlockBin = hb_util:bin(1_827_942),
+    hb_ao:resolve(
+        <<"~copycat@1.0/arweave&from=", BlockBin/binary, "&to=", BlockBin/binary>>,
+        Opts
+    ),
+    {ok, RawData} =
+        hb_ao:resolve(
+            #{ <<"device">> => <<"arweave@2.9">> },
+            #{
+                <<"path">> => <<"raw">>,
+                <<"raw">> => DataItemID,
+                <<"method">> => <<"HEAD">>
+            },
+            Opts
+        ),
+    ?assertEqual(
+        {ok, <<"application/json">>},
+        hb_maps:find(<<"content-type">>, RawData, Opts)
+    ).
+
+get_raw_range_test() ->
+    Opts = setup_arweave_index_opts([]),
+    DataItemID = <<"0vy2Ey8bWkSDcRIvWQJjxDeVGYOrTSmYIIhBILJntY8">>,
+    BlockBin = hb_util:bin(1_827_942),
+    hb_ao:resolve(
+        <<"~copycat@1.0/arweave&from=", BlockBin/binary, "&to=", BlockBin/binary>>,
+        Opts
+    ),
+    {ok, Result} =
+        hb_ao:resolve(
+            #{ <<"device">> => <<"arweave@2.9">> },
+            #{
+                <<"path">> => <<"raw">>,
+                <<"raw">> => DataItemID,
+                <<"method">> => <<"GET">>,
+                <<"range">> => <<"bytes 0-1/575">>
+            },
+            Opts
+        ),
+    ?assertEqual(
+        {ok, <<"{\n">>},
+        hb_maps:find(<<"data">>, Result, Opts)
+    ),
+    {ok, Result2} =
+        hb_ao:resolve(
+            #{ <<"device">> => <<"arweave@2.9">> },
+            #{
+                <<"path">> => <<"raw">>,
+                <<"raw">> => DataItemID,
+                <<"method">> => <<"GET">>,
+                <<"range">> => <<"bytes 100-105/575">>
+            },
+            Opts
+        ),
+    ?assertEqual(
+        {ok, <<"application/json">>},
+        hb_maps:find(<<"content-type">>, Result2, Opts)
+    ),
+    ?assertEqual(
+        {ok, <<"t #972">>},
+        hb_maps:find(<<"data">>, Result2, Opts)
+    ).
 
 get_tx_rsa_nested_bundle_test() ->
     Node = hb_http_server:start_node(),

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -206,7 +206,8 @@ do_head_raw(_ArweaveOffset, Length, Data, _Opts) ->
         #{
             <<"content-type">> => ContentType,
             <<"header-length">> => HeaderSize,
-            <<"content-length">> => Length - HeaderSize
+            <<"content-length">> => Length - HeaderSize,
+            <<"accept-ranges">> => <<"bytes">>
         }
     }.
 
@@ -257,7 +258,8 @@ get_raw(Base, Request, Opts) ->
                             {ok,
                                 #{
                                     <<"content-type">> := ContentType,
-                                    <<"header-length">> := HeaderLength
+                                    <<"header-length">> := HeaderLength,
+                                    <<"content-length">> := FullContentLength
                                 }
                             } = do_head_raw(StartOffset, Length, Opts),
                             ArweaveOffset = StartOffset + HeaderLength + StartRange,
@@ -271,8 +273,17 @@ get_raw(Base, Request, Opts) ->
                             {
                                 ok,
                                 #{
-                                    <<"status">> => 306,
+                                    <<"status">> => 206,
                                     <<"content-type">> => ContentType,
+                                    <<"content-range">> =>
+                                        <<
+                                            "bytes ",
+                                            (hb_util:bin(StartRange))/binary,
+                                            "-",
+                                            (hb_util:bin(EndRange))/binary,
+                                            "/",
+                                            (hb_util:bin(FullContentLength))/binary
+                                        >>,
                                     <<"data">> => Data
                                 }
                             };


### PR DESCRIPTION
Enables HTTP range requests for the `~arweave@2.9/raw` endpoint, allowing clients to efficiently retrieve partial content of Arweave data items. This significantly improves handling of large data items and facilitates streaming use cases.

Key changes include:
- Adds support for `HEAD /raw` requests, returning essential metadata such as `content-type`, `content-length`, `header-length`, and the `accept-ranges` header, without transferring the full data.
- Implements processing of the `Range` header for `GET /raw` requests, delivering only the requested byte range with a `206 Partial Content` status and `content-range` header.
- Refactors transaction deserialization to introduce `deserialize_header`, enabling efficient extraction of metadata and calculation of data offsets without needing to process the entire item data.
- Ensures the `#tx` record accurately reflects the size of the actual data content.