### PR TITLE
fix: replace Opts-as-default hb_maps:get/3 with get/4 defaults in codecs

### DIFF
--- a/src/dev_codec_ans104.erl
+++ b/src/dev_codec_ans104.erl
@@ -823,7 +823,7 @@ test_bundle_commitment(Commit, Encode, Decode) ->
     {ok, _, CommittedCommitment} = hb_message:commitment(
         #{ <<"type">> => ?RSA_SIGN_TYPE }, Committed, Opts),
     ?assertEqual(
-        [<<"list">>], hb_maps:get(<<"committed">>, CommittedCommitment, Opts),
+        [<<"list">>], hb_maps:get(<<"committed">>, CommittedCommitment, not_found, Opts),
         Label),
     ?assertEqual(ToBool(Commit),
         hb_util:atom(hb_ao:get(<<"bundle">>, CommittedCommitment, false, Opts)),
@@ -846,7 +846,7 @@ test_bundle_commitment(Commit, Encode, Decode) ->
     {ok, _, DecodedCommitment} = hb_message:commitment(
         #{ <<"type">> => ?RSA_SIGN_TYPE }, Decoded, Opts),
     ?assertEqual(
-        [<<"list">>], hb_maps:get(<<"committed">>, DecodedCommitment, Opts),
+        [<<"list">>], hb_maps:get(<<"committed">>, DecodedCommitment, not_found, Opts),
         Label),
     ?assertEqual(ToBool(Commit),
         hb_util:atom(hb_ao:get(<<"bundle">>, DecodedCommitment, false, Opts)),

--- a/src/dev_codec_flat.erl
+++ b/src/dev_codec_flat.erl
@@ -88,7 +88,7 @@ serialize(Map, Opts) when is_map(Map) ->
                         Acc,
                         hb_path:to_binary(Key),
                         <<": ">>,
-                        hb_maps:get(Key, Flattened, Opts), <<"\n">>
+                        hb_maps:get(Key, Flattened, not_found, Opts), <<"\n">>
                     ]
                 end,
                 <<>>,

--- a/src/dev_codec_tx.erl
+++ b/src/dev_codec_tx.erl
@@ -1453,7 +1453,7 @@ test_bundle_commitment(Commit, Encode, Decode) ->
     ?assert(hb_message:verify(Committed, all, Opts), Label),
     {ok, _, CommittedCommitment} = hb_message:commitment(#{}, Committed, Opts),
     ?assertEqual(
-        [<<"list">>], hb_maps:get(<<"committed">>, CommittedCommitment, Opts),
+        [<<"list">>], hb_maps:get(<<"committed">>, CommittedCommitment, not_found, Opts),
         Label),
     ?assertEqual(ToBool(Commit),
         hb_util:atom(hb_ao:get(<<"bundle">>, CommittedCommitment, false, Opts)),
@@ -1475,7 +1475,7 @@ test_bundle_commitment(Commit, Encode, Decode) ->
     ?assert(hb_message:verify(Decoded, all, Opts), Label),
     {ok, _, DecodedCommitment} = hb_message:commitment(#{}, Decoded, Opts),
     ?assertEqual(
-        [<<"list">>], hb_maps:get(<<"committed">>, DecodedCommitment, Opts),
+        [<<"list">>], hb_maps:get(<<"committed">>, DecodedCommitment, not_found, Opts),
         Label),
     ?assertEqual(ToBool(Commit),
         hb_util:atom(hb_ao:get(<<"bundle">>, DecodedCommitment, false, Opts)),


### PR DESCRIPTION
a small patch aligning `hb_maps:get` usage to get/4 defaults instead of Opts-as-default get/3 calls

* in `dev_codec_ans104` and `dev_codec_tx`: patched tests  get/3 misuse
* in `dev_codec_flat`: patched runtime code path (`serialize/2`) to use default via get/4

in dev_codec_flat, `Flattened` keys come from that same map, so get/4 fallback should never trigger in normal flow - so this patch is mostly semantics consistency