### PR TITLE
fix: hb_maps:get/3 Default misuse

### DIFF
--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -464,7 +464,7 @@ prepare_request(Format, Method, Peer, Path, RawMessage, Opts) ->
 %% @doc Reply to the client's HTTP request with a message.
 reply(Req, TABMReq, Message, Opts) ->
     Status =
-        case hb_maps:get(<<"status">>, Message, Opts) of
+        case hb_maps:get(<<"status">>, Message, not_found, Opts) of
             not_found -> 200;
             S-> S
         end,


### PR DESCRIPTION
small fix addressing `hb_maps:get/3` Default using, after the `hb_ao:get/3` switch to hb_maps:get -- now using `hb_maps:get/4`