### PR TITLE
feat: id/depth nested bundles indexing

### DIFF
--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -249,26 +249,6 @@ is_ao_message(#tx{tags = Tags}) ->
     hb_util:to_lower(Value) =:= <<"ao">>;
 is_ao_message(_) ->
     false.
-%% @doc Check if a dataitem is a Redstone tx
-is_redstone_message(#tx{tags = Tags}) ->
-    Value = dev_arweave_common:tagfind(<<"Bundler-App-Name">>, Tags, <<>>),
-    hb_util:to_lower(Value) =:= <<"redstone">>;
-is_redstone_message(_) ->
-    false.
-%% @doc Get the (known) protocol type of a given dataitem
-get_ao_message_known_type(TX = #tx{}) ->
-    case is_ao_message(TX) of
-        true ->
-            ao;
-        false ->
-            case is_redstone_message(TX) of
-                true -> redstone;
-                false -> unknown
-            end
-    end;
-get_ao_message_known_type(_) ->
-    unknown.
-
 protocol_filter(Opts) ->
     hb_opts:get(arweave_filter_protocol, all, Opts).
 
@@ -310,7 +290,7 @@ is_ao_message_at_offset(ItemStartOffset, ItemSize, Opts) ->
         {ok, ChunkData} ->
             case ar_bundles:deserialize_header(ChunkData) of
                 {ok, _HeaderSize, ParsedDataitem} ->
-                    get_ao_message_known_type(ParsedDataitem) =:= ao;
+                    is_ao_message(ParsedDataitem);
                 _ ->
                     false
             end;

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -9,6 +9,8 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(ARWEAVE_DEVICE, <<"~arweave@2.9">>).
+-define(TX_CODEC, <<"tx@1.0">>).
+-define(ANS104_CODEC, <<"ans104@1.0">>).
 
 % GET /~cron@1.0/once&cron-path=~copycat@1.0/arweave
 
@@ -62,15 +64,15 @@ index_id(ID, Depth, Opts) ->
     end.
 
 payload_bounds(_ID, #{
-    <<"codec-device">> := <<"tx@1.0">>,
+    <<"codec-device">> := ?TX_CODEC,
     <<"start-offset">> := StartOffset,
     <<"length">> := Length
 }, _Opts) ->
     {ok, StartOffset, Length};
 payload_bounds(ID, #{
-    <<"codec-device">> := <<"ans104@1.0">>
+    <<"codec-device">> := ?ANS104_CODEC
 }, Opts) ->
-    Base = #{ <<"device">> => ?ARWEAVE_DEVICE, <<"raw">> => ID },
+    Base = #{ <<"device">> => <<"arweave@2.9">>, <<"raw">> => ID },
     case hb_ao:resolve(
         Base,
         #{ <<"path">> => <<"raw">>, <<"method">> => <<"HEAD">> },
@@ -95,7 +97,7 @@ index_bundle_children(BundleIndex, StartOffset, Depth, Store, Opts) ->
                 hb_store_arweave:write_offset(
                     Store,
                     EncodedID,
-                    <<"ans104@1.0">>,
+                    ?ANS104_CODEC,
                     ItemStartOffset,
                     Size
                 ),

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -11,6 +11,9 @@
 -define(ARWEAVE_DEVICE, <<"~arweave@2.9">>).
 -define(TX_CODEC, <<"tx@1.0">>).
 -define(ANS104_CODEC, <<"ans104@1.0">>).
+-define(DEPTH_L1_OFFSETS, 1).
+-define(DEPTH_IMMEDIATE_CHILDREN, 2).
+-define(DEPTH_RECURSION_CAP, 4).
 
 % GET /~cron@1.0/once&cron-path=~copycat@1.0/arweave
 
@@ -20,17 +23,28 @@
 arweave(_Base, Request, Opts) ->
     case hb_maps:find(<<"id">>, Request, Opts) of
         {ok, ID} ->
-            Depth = hb_util:int(hb_maps:get(<<"depth">>, Request, <<"1">>, Opts)),
+            Depth = request_depth(Request, <<"1">>, Opts),
             index_id(ID, Depth, Opts);
         error ->
             {From, To} = parse_range(Request, Opts),
+            Depth = request_depth(Request, hb_util:bin(?DEPTH_IMMEDIATE_CHILDREN), Opts),
+            WriteOpts = Opts#{ arweave_index_depth => Depth },
             case hb_maps:get(<<"mode">>, Request, <<"write">>, Opts) of
-                <<"write">>  -> fetch_blocks(Request, From, To, Opts);
+                <<"write">>  -> fetch_blocks(Request, From, To, WriteOpts);
                 <<"list">>   -> list_index(From, To, Opts);
                 Mode ->
                     {error, <<"Unsupported mode `", (hb_util:bin(Mode))/binary, "`. Supported modes are: write, list">>}
             end
     end.
+
+request_depth(Request, Default, Opts) ->
+    erlang:min(
+        ?DEPTH_RECURSION_CAP,
+        erlang:max(
+            ?DEPTH_L1_OFFSETS,
+            hb_util:int(hb_maps:get(<<"depth">>, Request, Default, Opts))
+        )
+    ).
 
 index_id(_ID, Depth, _Opts) when Depth =< 0 ->
     {ok, 0};
@@ -373,6 +387,7 @@ parallel_map(Items, Fun, Opts) ->
 process_tx({{padding, _PaddingRoot}, _EndOffset}, _BlockStartOffset, _Opts) ->
     #{items_count => 0, bundle_count => 0, skipped_count => 0};
 process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
+    IndexDepth = hb_opts:get(arweave_index_depth, ?DEPTH_IMMEDIATE_CHILDREN, Opts),
     IndexStore = hb_store_arweave:store_from_opts(Opts),
     TXID = hb_util:encode(TX#tx.id),
     TXEndOffset = BlockStartOffset + EndOffset,
@@ -403,19 +418,35 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
                 TXEndOffset, TX#tx.data_size, Opts
             ),
             case BundleRes of
+                {ok, {_BundleIndex, _HeaderSize}} when IndexDepth =< ?DEPTH_L1_OFFSETS ->
+                    #{items_count => 0, bundle_count => 1, skipped_count => 0};
                 {ok, {BundleIndex, HeaderSize}} ->
                     % Batch event tracking: measure total time and count for all write_offset calls
                     {TotalTime, {_, ItemsCount}} = timer:tc(fun() ->
                         lists:foldl(
                             fun({ItemID, Size}, {ItemStartOffset, ItemsCountAcc}) ->
+                                EncodedID = hb_util:encode(ItemID),
                                 hb_store_arweave:write_offset(
                                     IndexStore,
-                                    hb_util:encode(ItemID),
+                                    EncodedID,
                                     <<"ans104@1.0">>,
                                     ItemStartOffset,
                                     Size
                                 ),
-                                {ItemStartOffset + Size, ItemsCountAcc + 1}
+                                Descendants =
+                                    case IndexDepth > ?DEPTH_IMMEDIATE_CHILDREN of
+                                        true ->
+                                            case index_id(
+                                                EncodedID,
+                                                IndexDepth - ?DEPTH_IMMEDIATE_CHILDREN,
+                                                Opts
+                                            ) of
+                                                {ok, DescendantCount} -> DescendantCount;
+                                                _ -> 0
+                                            end;
+                                        false -> 0
+                                    end,
+                                {ItemStartOffset + Size, ItemsCountAcc + 1 + Descendants}
                             end,
                             {TXStartOffset + HeaderSize, 0},
                             BundleIndex

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -385,13 +385,18 @@ download_bundle_header(EndOffset, Size, Opts) ->
                 % thousands of items might require multiple chunks to fully
                 % represent the item index.
                 HeaderSize = ar_bundles:bundle_header_size(FirstChunk),
-                case header_chunk(HeaderSize, FirstChunk, StartOffset, Opts) of
-                    {ok, BundleHeader} ->
-                        {_ItemsBin, BundleIndex} =
-                            ar_bundles:decode_bundle_header(BundleHeader),
-                        {ok, {BundleIndex, HeaderSize}};
-                    Error ->
-                        Error
+                case HeaderSize =:= invalid_bundle_header orelse HeaderSize > Size of
+                    true ->
+                        {error, invalid_bundle_header};
+                    false ->
+                        case header_chunk(HeaderSize, FirstChunk, StartOffset, Opts) of
+                            {ok, BundleHeader} ->
+                                {_ItemsBin, BundleIndex} =
+                                    ar_bundles:decode_bundle_header(BundleHeader),
+                                {ok, {BundleIndex, HeaderSize}};
+                            Error ->
+                                Error
+                        end
                 end;
             Error ->
                 Error

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -195,12 +195,20 @@ index_bundle_children(BundleIndex, StartOffset, Depth, Store, Opts) ->
         ),
     {ok, Count}.
 
-should_index_item(1, ItemStartOffset, ItemSize, Opts) ->
+should_index_item(Depth, ItemStartOffset, ItemSize, Opts) ->
+    case hb_opts:get(ao_assume_authority_children, false, Opts) of
+        true ->
+            true;
+        false ->
+            should_index_item_by_depth(Depth, ItemStartOffset, ItemSize, Opts)
+    end.
+
+should_index_item_by_depth(1, ItemStartOffset, ItemSize, Opts) ->
     case protocol_filter(Opts) of
         ao -> is_ao_message_at_offset(ItemStartOffset, ItemSize, Opts);
         _ -> true
     end;
-should_index_item(_Depth, _ItemStartOffset, _ItemSize, _Opts) ->
+should_index_item_by_depth(_Depth, _ItemStartOffset, _ItemSize, _Opts) ->
     true.
 
 %% @doc Parse the range from the request.
@@ -285,18 +293,41 @@ should_index_l1_tx(TX, Opts) ->
     end.
 
 is_ao_message_at_offset(ItemStartOffset, ItemSize, Opts) ->
+    case dataitem_header_at_offset(ItemStartOffset, ItemSize, Opts) of
+        {ok, ParsedDataitem} -> is_ao_message(ParsedDataitem);
+        _ -> false
+    end.
+
+dataitem_header_at_offset(ItemStartOffset, ItemSize, Opts) ->
     ReadSize = min(ItemSize, 262144),
     case hb_store_arweave:read_chunks(ItemStartOffset, ReadSize, Opts) of
         {ok, ChunkData} ->
-            case ar_bundles:deserialize_header(ChunkData) of
+            try ar_bundles:deserialize_header(ChunkData) of
                 {ok, _HeaderSize, ParsedDataitem} ->
-                    is_ao_message(ParsedDataitem);
+                    {ok, ParsedDataitem};
                 _ ->
-                    false
+                    error
+            catch _:_ ->
+                error
             end;
         _ ->
-            false
+            error
     end.
+
+should_index_ao_immediate_child({ok, HeaderTX}, Opts) ->
+    is_ao_legacy_authority_bundle(HeaderTX, Opts) orelse is_ao_message(HeaderTX);
+should_index_ao_immediate_child(_HeaderRes, _Opts) ->
+    false.
+
+is_ao_authority_bundle({ok, HeaderTX}, Opts) ->
+    is_ao_legacy_authority_bundle(HeaderTX, Opts) andalso is_bundle_tx(HeaderTX, Opts);
+is_ao_authority_bundle(_HeaderRes, _Opts) ->
+    false.
+
+is_bundle_header({ok, HeaderTX}, Opts) ->
+    is_bundle_tx(HeaderTX, Opts);
+is_bundle_header(_HeaderRes, _Opts) ->
+    false.
 
 %% @doc Check if the TX owner is the AO
 %% bundler address. useful to optimistically
@@ -530,6 +561,7 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
             #{items_count => 0, bundle_count => 0, skipped_count => 0};
         true ->
             IndexDepth = hb_opts:get(arweave_index_depth, ?DEPTH_IMMEDIATE_CHILDREN, Opts),
+            AOPolicy = ao_policy_from_l1_tx(TX, Opts),
             IndexStore = hb_store_arweave:store_from_opts(Opts),
             TXID = hb_util:encode(TX#tx.id),
             TXEndOffset = BlockStartOffset + EndOffset,
@@ -568,27 +600,109 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
                                 lists:foldl(
                                     fun({ItemID, Size}, {ItemStartOffset, ItemsCountAcc}) ->
                                         EncodedID = hb_util:encode(ItemID),
-                                        hb_store_arweave:write_offset(
-                                            IndexStore,
-                                            EncodedID,
-                                            <<"ans104@1.0">>,
+                                        HeaderRes = dataitem_header_at_offset(
                                             ItemStartOffset,
-                                            Size
+                                            Size,
+                                            Opts
                                         ),
+                                        ShouldIndexItem =
+                                            case protocol_filter(Opts) of
+                                                ao ->
+                                                    case AOPolicy of
+                                                        legacy -> true;
+                                                        turbo -> should_index_ao_immediate_child(HeaderRes, Opts);
+                                                        _ -> false
+                                                    end;
+                                                _ ->
+                                                    true
+                                            end,
+                                        case ShouldIndexItem of
+                                            true ->
+                                                hb_store_arweave:write_offset(
+                                                    IndexStore,
+                                                    EncodedID,
+                                                    <<"ans104@1.0">>,
+                                                    ItemStartOffset,
+                                                    Size
+                                                );
+                                            false ->
+                                                ok
+                                        end,
+                                        ChildOpts =
+                                            case protocol_filter(Opts) of
+                                                ao ->
+                                                    case AOPolicy of
+                                                        legacy ->
+                                                            case is_bundle_header(HeaderRes, Opts) of
+                                                                true ->
+                                                                    Opts#{ ao_assume_authority_children => true };
+                                                                false ->
+                                                                    Opts
+                                                            end;
+                                                        turbo ->
+                                                            case is_ao_authority_bundle(HeaderRes, Opts) of
+                                                                true ->
+                                                                    Opts#{ ao_assume_authority_children => true };
+                                                                false ->
+                                                                    Opts
+                                                            end;
+                                                        _ ->
+                                                            Opts
+                                                    end;
+                                                _ ->
+                                                    Opts
+                                            end,
                                         Descendants =
                                             case IndexDepth > ?DEPTH_IMMEDIATE_CHILDREN of
                                                 true ->
-                                                    case index_id(
-                                                        EncodedID,
-                                                        IndexDepth - ?DEPTH_IMMEDIATE_CHILDREN,
-                                                        Opts
-                                                    ) of
-                                                        {ok, DescendantCount} -> DescendantCount;
-                                                        _ -> 0
+                                                    case protocol_filter(Opts) of
+                                                        ao ->
+                                                            case AOPolicy of
+                                                                legacy ->
+                                                                    case is_bundle_header(HeaderRes, Opts) of
+                                                                        true ->
+                                                                            case index_id(
+                                                                                EncodedID,
+                                                                                IndexDepth - ?DEPTH_IMMEDIATE_CHILDREN,
+                                                                                ChildOpts
+                                                                            ) of
+                                                                                {ok, DescendantCount} -> DescendantCount;
+                                                                                _ -> 0
+                                                                            end;
+                                                                        false ->
+                                                                            0
+                                                                    end;
+                                                                turbo ->
+                                                                    case is_ao_authority_bundle(HeaderRes, Opts) of
+                                                                        true ->
+                                                                            case index_id(
+                                                                                EncodedID,
+                                                                                IndexDepth - ?DEPTH_IMMEDIATE_CHILDREN,
+                                                                                ChildOpts
+                                                                            ) of
+                                                                                {ok, DescendantCount} -> DescendantCount;
+                                                                                _ -> 0
+                                                                            end;
+                                                                        false ->
+                                                                            0
+                                                                    end;
+                                                                _ ->
+                                                                    0
+                                                            end;
+                                                        _ ->
+                                                            case index_id(
+                                                                EncodedID,
+                                                                IndexDepth - ?DEPTH_IMMEDIATE_CHILDREN,
+                                                                Opts
+                                                            ) of
+                                                                {ok, DescendantCount} -> DescendantCount;
+                                                                _ -> 0
+                                                            end
                                                     end;
                                                 false -> 0
                                             end,
-                                        {ItemStartOffset + Size, ItemsCountAcc + 1 + Descendants}
+                                        IndexedItemCount = case ShouldIndexItem of true -> 1; false -> 0 end,
+                                        {ItemStartOffset + Size, ItemsCountAcc + IndexedItemCount + Descendants}
                                     end,
                                     {TXStartOffset + HeaderSize, 0},
                                     BundleIndex

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -18,6 +18,8 @@
 -define(DEPTH_L1_OFFSETS, 1).
 -define(DEPTH_IMMEDIATE_CHILDREN, 2).
 -define(DEPTH_RECURSION_CAP, 4).
+%% Filters
+-define(AO_BUNDLER_ADDR, <<"JNC6vBhjHY1EPwV3pEeNmrsgFMxH5d38_LHsZ7jful8">>).
 
 % GET /~cron@1.0/once&cron-path=~copycat@1.0/arweave
 
@@ -25,20 +27,48 @@
 %% latest known block towards the Genesis block. If no range is provided, we
 %% fetch blocks from the latest known block towards the Genesis block.
 arweave(_Base, Request, Opts) ->
-    case hb_maps:find(<<"id">>, Request, Opts) of
+    FilteredOpts = with_filter_protocol(Request, Opts),
+    case hb_maps:find(<<"id">>, Request, FilteredOpts) of
         {ok, ID} ->
-            Depth = request_depth(Request, <<"1">>, Opts),
-            index_id(ID, Depth, Opts);
+            Depth = request_depth(Request, <<"1">>, FilteredOpts),
+            index_id(ID, Depth, FilteredOpts);
         error ->
-            {From, To} = parse_range(Request, Opts),
-            Depth = request_depth(Request, hb_util:bin(?DEPTH_IMMEDIATE_CHILDREN), Opts),
-            WriteOpts = Opts#{ arweave_index_depth => Depth },
-            case hb_maps:get(<<"mode">>, Request, <<"write">>, Opts) of
+            {From, To} = parse_range(Request, FilteredOpts),
+            Depth =
+                request_depth(
+                    Request,
+                    hb_util:bin(?DEPTH_IMMEDIATE_CHILDREN),
+                    FilteredOpts
+                ),
+            WriteOpts = FilteredOpts#{ arweave_index_depth => Depth },
+            case hb_maps:get(<<"mode">>, Request, <<"write">>, FilteredOpts) of
                 <<"write">>  -> fetch_blocks(Request, From, To, WriteOpts);
-                <<"list">>   -> list_index(From, To, Opts);
+                <<"list">>   -> list_index(From, To, FilteredOpts);
                 Mode ->
                     {error, <<"Unsupported mode `", (hb_util:bin(Mode))/binary, "`. Supported modes are: write, list">>}
             end
+    end.
+
+with_filter_protocol(Request, Opts) ->
+    FilterProtocolBin =
+        hb_util:to_lower(
+            hb_util:bin(
+                hb_maps:get(<<"filter-protocol">>, Request, <<"all">>, Opts)
+            )
+        ),
+    FilterProtocol =
+        case FilterProtocolBin of
+            <<"ao">> -> ao;
+            _ -> all
+        end,
+    case FilterProtocol of
+        ao ->
+            Opts#{
+                arweave_filter_protocol => FilterProtocol,
+                arweave_ao_bundler_addr => hb_util:native_id(?AO_BUNDLER_ADDR)
+            };
+        _ ->
+            Opts#{ arweave_filter_protocol => FilterProtocol }
     end.
 
 request_depth(Request, Default, Opts) ->
@@ -112,13 +142,19 @@ index_bundle_children(BundleIndex, StartOffset, Depth, Store, Opts) ->
         lists:foldl(
             fun({ItemID, Size}, {ItemStartOffset, CountAcc}) ->
                 EncodedID = hb_util:encode(ItemID),
-                hb_store_arweave:write_offset(
-                    Store,
-                    EncodedID,
-                    ?ANS104_CODEC,
-                    ItemStartOffset,
-                    Size
-                ),
+                ShouldIndexItem = should_index_item(Depth, ItemStartOffset, Size, Opts),
+                case ShouldIndexItem of
+                    true ->
+                        hb_store_arweave:write_offset(
+                            Store,
+                            EncodedID,
+                            ?ANS104_CODEC,
+                            ItemStartOffset,
+                            Size
+                        );
+                    false ->
+                        ok
+                end,
                 Descendants =
                     case Depth > 1 of
                         true ->
@@ -128,12 +164,21 @@ index_bundle_children(BundleIndex, StartOffset, Depth, Store, Opts) ->
                             end;
                         false -> 0
                     end,
-                {ItemStartOffset + Size, CountAcc + 1 + Descendants}
+                IndexedItemCount = case ShouldIndexItem of true -> 1; false -> 0 end,
+                {ItemStartOffset + Size, CountAcc + IndexedItemCount + Descendants}
             end,
             {StartOffset, 0},
             BundleIndex
         ),
     {ok, Count}.
+
+should_index_item(1, ItemStartOffset, ItemSize, Opts) ->
+    case protocol_filter(Opts) of
+        ao -> is_ao_message_at_offset(ItemStartOffset, ItemSize, Opts);
+        _ -> true
+    end;
+should_index_item(_Depth, _ItemStartOffset, _ItemSize, _Opts) ->
+    true.
 
 %% @doc Parse the range from the request.
 parse_range(Request, Opts) ->
@@ -200,6 +245,44 @@ get_ao_message_known_type(TX = #tx{}) ->
     end;
 get_ao_message_known_type(_) ->
     unknown.
+
+protocol_filter(Opts) ->
+    hb_opts:get(arweave_filter_protocol, all, Opts).
+
+is_ao_bundler_tx(TX, Opts) ->
+    case hb_opts:get(arweave_ao_bundler_addr, undefined, Opts) of
+        undefined ->
+            is_ao_bundler_owner(TX);
+        AOAddr ->
+            ar_tx:get_owner_address(TX) =:= AOAddr
+    end.
+
+should_index_l1_tx(TX, Opts) ->
+    case protocol_filter(Opts) of
+        ao -> is_ao_bundler_tx(TX, Opts);
+        _ -> true
+    end.
+
+is_ao_message_at_offset(ItemStartOffset, ItemSize, Opts) ->
+    ReadSize = min(ItemSize, 262144),
+    case hb_store_arweave:read_chunks(ItemStartOffset, ReadSize, Opts) of
+        {ok, ChunkData} ->
+            case ar_bundles:deserialize_header(ChunkData) of
+                {ok, _HeaderSize, ParsedDataitem} ->
+                    get_ao_message_known_type(ParsedDataitem) =:= ao;
+                _ ->
+                    false
+            end;
+        _ ->
+            false
+    end.
+
+%% @doc Check if the TX owner is the AO
+%% bundler address. useful to optimistically
+%% identity ao parent bundles.
+is_ao_bundler_owner(TX) ->
+    Owner = ar_tx:get_owner_address(TX),
+    Owner =:= hb_util:native_id(?AO_BUNDLER_ADDR).
 
 %% @doc List indexed blocks and transactions in the given range.
 %% Returns JSON with block heights as keys, each containing indexed and not-indexed lists.
@@ -417,83 +500,88 @@ parallel_map(Items, Fun, Opts) ->
 process_tx({{padding, _PaddingRoot}, _EndOffset}, _BlockStartOffset, _Opts) ->
     #{items_count => 0, bundle_count => 0, skipped_count => 0};
 process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
-    IndexDepth = hb_opts:get(arweave_index_depth, ?DEPTH_IMMEDIATE_CHILDREN, Opts),
-    IndexStore = hb_store_arweave:store_from_opts(Opts),
-    TXID = hb_util:encode(TX#tx.id),
-    TXEndOffset = BlockStartOffset + EndOffset,
-    TXStartOffset = TXEndOffset - TX#tx.data_size,
-    ?event(copycat_debug, {writing_index,
-        {id, {explicit, TXID}},
-        {offset, TXStartOffset},
-        {size, TX#tx.data_size}
-    }),
-    observe_event(<<"item_indexed">>, fun() ->
-        hb_store_arweave:write_offset(
-            IndexStore,
-            TXID,
-            <<"tx@1.0">>,
-            TXStartOffset,
-            TX#tx.data_size
-        )
-    end),
-    case is_bundle_tx(TX, Opts) of
-        false -> #{items_count => 0, bundle_count => 0, skipped_count => 0};
+    case should_index_l1_tx(TX, Opts) of
+        false ->
+            #{items_count => 0, bundle_count => 0, skipped_count => 0};
         true ->
-            ?event(copycat_debug, {fetching_bundle_header, 
-                {tx_id, {explicit, TXID}},
-                {tx_end_offset, TXEndOffset},
-                {tx_data_size, TX#tx.data_size}
+            IndexDepth = hb_opts:get(arweave_index_depth, ?DEPTH_IMMEDIATE_CHILDREN, Opts),
+            IndexStore = hb_store_arweave:store_from_opts(Opts),
+            TXID = hb_util:encode(TX#tx.id),
+            TXEndOffset = BlockStartOffset + EndOffset,
+            TXStartOffset = TXEndOffset - TX#tx.data_size,
+            ?event(copycat_debug, {writing_index,
+                {id, {explicit, TXID}},
+                {offset, TXStartOffset},
+                {size, TX#tx.data_size}
             }),
-            BundleRes = download_bundle_header(
-                TXEndOffset, TX#tx.data_size, Opts
-            ),
-            case BundleRes of
-                {ok, {_BundleIndex, _HeaderSize}} when IndexDepth =< ?DEPTH_L1_OFFSETS ->
-                    #{items_count => 0, bundle_count => 1, skipped_count => 0};
-                {ok, {BundleIndex, HeaderSize}} ->
-                    % Batch event tracking: measure total time and count for all write_offset calls
-                    {TotalTime, {_, ItemsCount}} = timer:tc(fun() ->
-                        lists:foldl(
-                            fun({ItemID, Size}, {ItemStartOffset, ItemsCountAcc}) ->
-                                EncodedID = hb_util:encode(ItemID),
-                                hb_store_arweave:write_offset(
-                                    IndexStore,
-                                    EncodedID,
-                                    <<"ans104@1.0">>,
-                                    ItemStartOffset,
-                                    Size
-                                ),
-                                Descendants =
-                                    case IndexDepth > ?DEPTH_IMMEDIATE_CHILDREN of
-                                        true ->
-                                            case index_id(
-                                                EncodedID,
-                                                IndexDepth - ?DEPTH_IMMEDIATE_CHILDREN,
-                                                Opts
-                                            ) of
-                                                {ok, DescendantCount} -> DescendantCount;
-                                                _ -> 0
-                                            end;
-                                        false -> 0
-                                    end,
-                                {ItemStartOffset + Size, ItemsCountAcc + 1 + Descendants}
-                            end,
-                            {TXStartOffset + HeaderSize, 0},
-                            BundleIndex
-                        )
-                    end),
-                    % Single event increment for the batch
-                    record_event_metrics(<<"item_indexed">>, ItemsCount, TotalTime),
-                    #{items_count => ItemsCount, bundle_count => 1, skipped_count => 0};
-                {error, Reason} ->
-                    ?event(
-                        copycat_short,
-                        {arweave_bundle_skipped,
-                            {tx_id, {explicit, TXID}},
-                            {reason, Reason}
-                        }
+            observe_event(<<"item_indexed">>, fun() ->
+                hb_store_arweave:write_offset(
+                    IndexStore,
+                    TXID,
+                    <<"tx@1.0">>,
+                    TXStartOffset,
+                    TX#tx.data_size
+                )
+            end),
+            case is_bundle_tx(TX, Opts) of
+                false -> #{items_count => 0, bundle_count => 0, skipped_count => 0};
+                true ->
+                    ?event(copycat_debug, {fetching_bundle_header,
+                        {tx_id, {explicit, TXID}},
+                        {tx_end_offset, TXEndOffset},
+                        {tx_data_size, TX#tx.data_size}
+                    }),
+                    BundleRes = download_bundle_header(
+                        TXEndOffset, TX#tx.data_size, Opts
                     ),
-                    #{items_count => 0, bundle_count => 1, skipped_count => 1}
+                    case BundleRes of
+                        {ok, {_BundleIndex, _HeaderSize}} when IndexDepth =< ?DEPTH_L1_OFFSETS ->
+                            #{items_count => 0, bundle_count => 1, skipped_count => 0};
+                        {ok, {BundleIndex, HeaderSize}} ->
+                            % Batch event tracking: measure total time and count for all write_offset calls
+                            {TotalTime, {_, ItemsCount}} = timer:tc(fun() ->
+                                lists:foldl(
+                                    fun({ItemID, Size}, {ItemStartOffset, ItemsCountAcc}) ->
+                                        EncodedID = hb_util:encode(ItemID),
+                                        hb_store_arweave:write_offset(
+                                            IndexStore,
+                                            EncodedID,
+                                            <<"ans104@1.0">>,
+                                            ItemStartOffset,
+                                            Size
+                                        ),
+                                        Descendants =
+                                            case IndexDepth > ?DEPTH_IMMEDIATE_CHILDREN of
+                                                true ->
+                                                    case index_id(
+                                                        EncodedID,
+                                                        IndexDepth - ?DEPTH_IMMEDIATE_CHILDREN,
+                                                        Opts
+                                                    ) of
+                                                        {ok, DescendantCount} -> DescendantCount;
+                                                        _ -> 0
+                                                    end;
+                                                false -> 0
+                                            end,
+                                        {ItemStartOffset + Size, ItemsCountAcc + 1 + Descendants}
+                                    end,
+                                    {TXStartOffset + HeaderSize, 0},
+                                    BundleIndex
+                                )
+                            end),
+                            % Single event increment for the batch
+                            record_event_metrics(<<"item_indexed">>, ItemsCount, TotalTime),
+                            #{items_count => ItemsCount, bundle_count => 1, skipped_count => 0};
+                        {error, Reason} ->
+                            ?event(
+                                copycat_short,
+                                {arweave_bundle_skipped,
+                                    {tx_id, {explicit, TXID}},
+                                    {reason, Reason}
+                                }
+                            ),
+                            #{items_count => 0, bundle_count => 1, skipped_count => 1}
+                    end
             end
     end.
 

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -175,6 +175,32 @@ is_tx_indexed(TXID, Opts) ->
             end
     end.
 
+%% @doc Check if a dataitem is an AO protocol message
+is_ao_message(#tx{tags = Tags}) ->
+    Value = dev_arweave_common:tagfind(<<"Data-Protocol">>, Tags, <<>>),
+    hb_util:to_lower(Value) =:= <<"ao">>;
+is_ao_message(_) ->
+    false.
+%% @doc Check if a dataitem is a Redstone tx
+is_redstone_message(#tx{tags = Tags}) ->
+    Value = dev_arweave_common:tagfind(<<"Bundler-App-Name">>, Tags, <<>>),
+    hb_util:to_lower(Value) =:= <<"redstone">>;
+is_redstone_message(_) ->
+    false.
+%% @doc Get the (known) protocol type of a given dataitem
+get_ao_message_known_type(TX = #tx{}) ->
+    case is_ao_message(TX) of
+        true ->
+            ao;
+        false ->
+            case is_redstone_message(TX) of
+                true -> redstone;
+                false -> unknown
+            end
+    end;
+get_ao_message_known_type(_) ->
+    unknown.
+
 %% @doc List indexed blocks and transactions in the given range.
 %% Returns JSON with block heights as keys, each containing indexed and not-indexed lists.
 list_index(From, undefined, Opts) ->

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -16,13 +16,104 @@
 %% latest known block towards the Genesis block. If no range is provided, we
 %% fetch blocks from the latest known block towards the Genesis block.
 arweave(_Base, Request, Opts) ->
-    {From, To} = parse_range(Request, Opts),
-    case hb_maps:get(<<"mode">>, Request, <<"write">>, Opts) of
-        <<"write">>  -> fetch_blocks(Request, From, To, Opts);
-        <<"list">>   -> list_index(From, To, Opts);
-        Mode ->
-            {error, <<"Unsupported mode `", (hb_util:bin(Mode))/binary, "`. Supported modes are: write, list">>}
+    case hb_maps:find(<<"id">>, Request, Opts) of
+        {ok, ID} ->
+            Depth = hb_util:int(hb_maps:get(<<"depth">>, Request, <<"1">>, Opts)),
+            index_id(ID, Depth, Opts);
+        error ->
+            {From, To} = parse_range(Request, Opts),
+            case hb_maps:get(<<"mode">>, Request, <<"write">>, Opts) of
+                <<"write">>  -> fetch_blocks(Request, From, To, Opts);
+                <<"list">>   -> list_index(From, To, Opts);
+                Mode ->
+                    {error, <<"Unsupported mode `", (hb_util:bin(Mode))/binary, "`. Supported modes are: write, list">>}
+            end
     end.
+
+index_id(_ID, Depth, _Opts) when Depth =< 0 ->
+    {ok, 0};
+index_id(ID, Depth, Opts) ->
+    Store = hb_store_arweave:store_from_opts(Opts),
+    case hb_store_arweave:read_offset(Store, ID) of
+        not_found ->
+            {error, not_found};
+        {ok, ItemOffset} ->
+            case payload_bounds(ID, ItemOffset, Opts) of
+                {error, _} = Error ->
+                    Error;
+                {ok, PayloadStart, PayloadLength} ->
+                    case download_bundle_header(
+                        PayloadStart + PayloadLength,
+                        PayloadLength,
+                        Opts
+                    ) of
+                        {ok, {BundleIndex, HeaderSize}} ->
+                            index_bundle_children(
+                                BundleIndex,
+                                PayloadStart + HeaderSize,
+                                Depth,
+                                Store,
+                                Opts
+                            );
+                        {error, _} ->
+                            {ok, 0}
+                    end
+            end
+    end.
+
+payload_bounds(_ID, #{
+    <<"codec-device">> := <<"tx@1.0">>,
+    <<"start-offset">> := StartOffset,
+    <<"length">> := Length
+}, _Opts) ->
+    {ok, StartOffset, Length};
+payload_bounds(ID, #{
+    <<"codec-device">> := <<"ans104@1.0">>
+}, Opts) ->
+    Base = #{ <<"device">> => ?ARWEAVE_DEVICE, <<"raw">> => ID },
+    case hb_ao:resolve(
+        Base,
+        #{ <<"path">> => <<"raw">>, <<"method">> => <<"HEAD">> },
+        Opts
+    ) of
+        {ok, #{
+            <<"arweave-data-offset">> := DataOffset,
+            <<"content-length">> := ContentLength
+        }} ->
+            {ok, DataOffset, ContentLength};
+        Error ->
+            Error
+    end;
+payload_bounds(_ID, _Offset, _Opts) ->
+    {error, unsupported_codec_device}.
+
+index_bundle_children(BundleIndex, StartOffset, Depth, Store, Opts) ->
+    {_FinalOffset, Count} =
+        lists:foldl(
+            fun({ItemID, Size}, {ItemStartOffset, CountAcc}) ->
+                EncodedID = hb_util:encode(ItemID),
+                hb_store_arweave:write_offset(
+                    Store,
+                    EncodedID,
+                    <<"ans104@1.0">>,
+                    ItemStartOffset,
+                    Size
+                ),
+                Descendants =
+                    case Depth > 1 of
+                        true ->
+                            case index_id(EncodedID, Depth - 1, Opts) of
+                                {ok, DescendantCount} -> DescendantCount;
+                                _ -> 0
+                            end;
+                        false -> 0
+                    end,
+                {ItemStartOffset + Size, CountAcc + 1 + Descendants}
+            end,
+            {StartOffset, 0},
+            BundleIndex
+        ),
+    {ok, Count}.
 
 %% @doc Parse the range from the request.
 parse_range(Request, Opts) ->

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -18,8 +18,29 @@
 -define(DEPTH_L1_OFFSETS, 1).
 -define(DEPTH_IMMEDIATE_CHILDREN, 2).
 -define(DEPTH_RECURSION_CAP, 4).
-%% Filters
+%% Policies filters
+-define(AO_LEGACY_AUTHORITY, <<"fcoN_xJeisVsPXA-trzVAuIiqO3ydLQxM-L4XbrQKzY">>).
+%% policy 1: AO messages are L3 dataitems:
+%% 1- AO_BUNDLER_ADDR (Ardrive Turbo) sends bundles on Arweave (L1 txs)
+%% 2- those bundles (1) are direct parents to nested bundles (nested with AO_LEGACY_AUTHORITY as owner)
+%% 3- the (2) nested bundles are parents of L3 dataitems (ao messages)
+%% 4- full path: AO_BUNDLER_ADDR L1 TXs (bundles) -> nested bundles owner by AO_LEGACY_AUTHORITY -> ao messages
+%% example: hXztSyj_V6PXttCfzkeCWrgul7owCGcmYnz58ydgMCU
 -define(AO_BUNDLER_ADDR, <<"JNC6vBhjHY1EPwV3pEeNmrsgFMxH5d38_LHsZ7jful8">>).
+%% policy 2.1: AO messages are L2 dataitmes:
+%% 1- AO_LEGACY_BUNDLER sends bundles on Arweave (L1 txs)
+%% 2- those bundles are direct parents to ao messages (L2 messages, have AO_LEGACY_AUTHORITY as owner)
+%% 3- full path: L1 TXs (bundles) -> L2 dataitems (ao messages)
+%% example: 8DcCpFij5Dpfd2P7EjeGKZWSpOmpyT1COAM9MNc5VII
+
+%% policy 2.2: AO messages are L3 dataitems
+%% 1- AO_LEGACY_BUNDLER sends bundles on Arweave (L1 txs)
+%% 2- those bundles (1) are direct parents to nested bundles (nested with AO_LEGACY_AUTHORITY as owner)
+%% 3- the (2) nested bundles are parents of L3 dataitems (ao messages)
+%% 4- full path: AO_LEGACY_BUNDLER L1 TXs (bundles) -> nested bundles owner by AO_LEGACY_AUTHORITY -> ao messages
+%% example: -MpPRIUBCBsWaGebFj-BtD42GKmuw8Wmkw37t_f63-I
+-define(AO_LEGACY_BUNDLER, <<"FPjbN_btYKzcf8QASjs30v5C0FPv7XpwKXENBW8dqVw">>).
+
 
 % GET /~cron@1.0/once&cron-path=~copycat@1.0/arweave
 

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -11,6 +11,10 @@
 -define(ARWEAVE_DEVICE, <<"~arweave@2.9">>).
 -define(TX_CODEC, <<"tx@1.0">>).
 -define(ANS104_CODEC, <<"ans104@1.0">>).
+%% Depth semantics:
+%% 1 => index L1 TX IDs -> offsets only
+%% 2 => index immediate bundle children
+%% 3..N => recurse nested bundle children
 -define(DEPTH_L1_OFFSETS, 1).
 -define(DEPTH_IMMEDIATE_CHILDREN, 2).
 -define(DEPTH_RECURSION_CAP, 4).

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -86,7 +86,9 @@ with_filter_protocol(Request, Opts) ->
         ao ->
             Opts#{
                 arweave_filter_protocol => FilterProtocol,
-                arweave_ao_bundler_addr => hb_util:native_id(?AO_BUNDLER_ADDR)
+                ao_bundler_turbo_addr => hb_util:native_id(?AO_BUNDLER_ADDR),
+                ao_bundler_legacy_addr => hb_util:native_id(?AO_LEGACY_BUNDLER),
+                ao_legacy_authority_addr => hb_util:native_id(?AO_LEGACY_AUTHORITY)
             };
         _ ->
             Opts#{ arweave_filter_protocol => FilterProtocol }
@@ -270,17 +272,35 @@ get_ao_message_known_type(_) ->
 protocol_filter(Opts) ->
     hb_opts:get(arweave_filter_protocol, all, Opts).
 
-is_ao_bundler_tx(TX, Opts) ->
-    case hb_opts:get(arweave_ao_bundler_addr, undefined, Opts) of
-        undefined ->
-            is_ao_bundler_owner(TX);
-        AOAddr ->
-            ar_tx:get_owner_address(TX) =:= AOAddr
+ao_policy_from_l1_tx(TX, Opts) ->
+    Owner = ar_tx:get_owner_address(TX),
+    Turbo = hb_opts:get(
+        ao_bundler_turbo_addr,
+        hb_util:native_id(?AO_BUNDLER_ADDR),
+        Opts
+    ),
+    Legacy = hb_opts:get(
+        ao_bundler_legacy_addr,
+        hb_util:native_id(?AO_LEGACY_BUNDLER),
+        Opts
+    ),
+    case Owner of
+        Turbo -> turbo;
+        Legacy -> legacy;
+        _ -> none
     end.
+
+is_ao_legacy_authority_bundle(HeaderTX, Opts) ->
+    Authority = hb_opts:get(
+        ao_legacy_authority_addr,
+        hb_util:native_id(?AO_LEGACY_AUTHORITY),
+        Opts
+    ),
+    ar_tx:get_owner_address(HeaderTX) =:= Authority.
 
 should_index_l1_tx(TX, Opts) ->
     case protocol_filter(Opts) of
-        ao -> is_ao_bundler_tx(TX, Opts);
+        ao -> ao_policy_from_l1_tx(TX, Opts) =/= none;
         _ -> true
     end.
 
@@ -301,9 +321,13 @@ is_ao_message_at_offset(ItemStartOffset, ItemSize, Opts) ->
 %% @doc Check if the TX owner is the AO
 %% bundler address. useful to optimistically
 %% identity ao parent bundles.
-is_ao_bundler_owner(TX) ->
+is_ao_bundler_owner(TX, Bundler) ->
     Owner = ar_tx:get_owner_address(TX),
-    Owner =:= hb_util:native_id(?AO_BUNDLER_ADDR).
+    case Bundler of
+        ao_bundler_turbo_addr -> Owner =:= hb_util:native_id(?AO_BUNDLER_ADDR);
+        _ -> Owner =:= hb_util:native_id(?AO_LEGACY_BUNDLER)
+    end.
+    
 
 %% @doc List indexed blocks and transactions in the given range.
 %% Returns JSON with block heights as keys, each containing indexed and not-indexed lists.


### PR DESCRIPTION
 ## about

id/depth flow:

- `~copycat@1.0/arweave&id=ID&depth=N`
- depth=1 => index direct children
- depth>1 => recurse nested bundle children
- works for indexed `tx@1.0` and `ans104@1.0` items

 you might see prometheus noise like `unknown_metric hb_store_arweave_requests_partition` - the indexing works anyway, i tried disabling it manually locally in hb_store_arweave.erl (`record_partition_metric/1`), it works if disabled

how i tested it locally:

dataitem in nested bundle: https://viewblock.io/arweave/tx/81d_5S8oas728eoaIa30rKmg7xczZ68kjFFTgpfAdBI

bundle 1: https://viewblock.io/arweave/tx/hbi3lraO53m8i4bj2HGvrL7Ye0WD7bcVZ7uM4JqW5GU
bundle 2: https://viewblock.io/arweave/tx/SWFCDZeTOOVtbAvHF5t7vUev-TtEKWnh2t77ANUfwWc

```erl
  TestStore = hb_test_utils:test_store().
  StoreOpts = #{<<"index-store">> => [TestStore]}.
  Store = [
    TestStore,
    #{
      <<"store-module">> => hb_store_arweave,
      <<"name">> => <<"cache-arweave">>,
      <<"index-store">> => [TestStore],
      <<"arweave-node">> => <<"https://arweave.net">>
    }
  ].
  Opts = #{
    store => Store,
    arweave_index_ids => true,
    arweave_index_store => StoreOpts
  }.
  Node = hb_http_server:start_node(Opts).
% indexing +1 -1 range from the dataitem's blockheight: 1_866_948
  hb_http:get(
    Node,
    <<"/~copycat@1.0/arweave&from=1866949&to=1866947&mode=write">>,
    #{}
  ).

  hb_http:get(
    Node,
    <<"/~copycat@1.0/arweave&id=SWFCDZeTOOVtbAvHF5t7vUev-TtEKWnh2t77ANUfwWc&depth=2">>,
    #{}
  ).
  % hb_ao:resolve(<<"SWFCDZeTOOVtbAvHF5t7vUev-TtEKWnh2t77ANUfwWc">>, Opts).
  % hb_ao:resolve(<<"hbi3lraO53m8i4bj2HGvrL7Ye0WD7bcVZ7uM4JqW5GU">>, Opts).
  hb_ao:resolve(<<"81d_5S8oas728eoaIa30rKmg7xczZ68kjFFTgpfAdBI">>, Opts).
```

response:

```erl
8> hb_ao:resolve(<<"81d_5S8oas728eoaIa30rKmg7xczZ68kjFFTgpfAdBI">>, Opts).
=ERROR REPORT==== 2-Mar-2026::22:35:42.259154 ===
Error in process <0.2695.0> with exit value:
{{unknown_metric,default,hb_store_arweave_requests_partition},
 [{prometheus_metric,check_mf_exists,4,
                     [{file,"/home/charmful0x/Desktop/fwd-workspace/hyperbeam/_build/default/lib/prometheus/src/prometheus_metric.erl"},
                      {line,191}]},
  {prometheus_counter,insert_metric,6,
                      [{file,"/home/charmful0x/Desktop/fwd-workspace/hyperbeam/_build/default/lib/prometheus/src/metrics/prometheus_counter.erl"},
                       {line,371}]}]}

{ok,#{<<"action">> => <<"Balance">>,
      <<"commitments">> =>
          #{<<"81d_5S8oas728eoaIa30rKmg7xczZ68kjFFTgpfAdBI">> =>
                #{<<"bundle">> => <<"false">>,
                  <<"commitment-device">> => <<"ans104@1.0">>,
                  <<"committed">> =>
                      [<<"action">>,<<"target">>,<<"data-protocol">>,
                       <<"variant">>,<<"type">>,<<"sdk">>],
                  <<"committer">> =>
                      <<"D7NdL5sDGU6q3HahHg-9Un2MpjH4Kj6IFp9k2r_LzCM">>,
                  <<"field-target">> =>
                      <<"0syT13r0s0tgPmIed95bJnuSqaD29HQNN8D3ElLSrsc">>,
                  <<"keyid">> =>
                      <<"publickey:pJCd4wE71hpb0Cc5DIMIbHT_IWL-x-gkrwvmipUop4NotHc6bOJs_b2SdGCz2CeU_F8P-VvUYQN1uCAMi4QF9L"...>>,
                  <<"original-tags">> =>
                      #{<<"1">> =>
                            #{<<"name">> => <<"Action">>,<<"value">> => <<"Balance">>},
                        <<"2">> =>
                            #{<<"name">> => <<"Target">>,
                              <<"value">> =>
                                  <<"D7NdL5sDGU6q3HahHg-9Un2MpjH4Kj6IFp9k2r_LzCM">>},
                        <<"3">> =>
                            #{<<"name">> => <<"Data-Protocol">>,<<"value">> => <<"ao">>},
                        <<"4">> =>
                            #{<<"name">> => <<"Variant">>,<<"value">> => <<"ao.TN.1">>},
                        <<"5">> =>
                            #{<<"name">> => <<"Type">>,<<"value">> => <<"Message">>},
                        <<"6">> =>
                            #{<<"name">> => <<"SDK">>,<<"value">> => <<"aoconnect">>}},
                  <<"signature">> =>
                      <<"Mi_-K3hbEeS3TxcFstxe6eEzZ61-iQGbTiNzU1Ss7hOl5VWZfVu_p6T11B_Tm__r3HvbFcVP-T79F2VH9HDE82PAIIH_eSo3"...>>,
                  <<"type">> => <<"rsa-pss-sha256">>},
            <<"X_uFip3-15ZmKwVK3V7Dik2300nfBJGL7DIjifLKk44">> =>
                #{<<"commitment-device">> => <<"httpsig@1.0">>,
                  <<"committed">> =>
                      [<<"action">>,<<"data-protocol">>,<<"sdk">>,<<"target">>,
                       <<"type">>,<<"variant">>],
                  <<"keyid">> => <<"constant:ao">>,
                  <<"signature">> =>
                      <<"X_uFip3-15ZmKwVK3V7Dik2300nfBJGL7DIjifLKk44">>,
                  <<"type">> => <<"hmac-sha256">>}},
      <<"data-protocol">> => <<"ao">>,
      <<"sdk">> => <<"aoconnect">>,
      <<"target">> =>
          <<"0syT13r0s0tgPmIed95bJnuSqaD29HQNN8D3ElLSrsc">>,
      <<"type">> => <<"Message">>,<<"variant">> => <<"ao.TN.1">>}}
9> 
```
  
  
  additionally i added bundle header guard (`invalid_bundle_header orelse HeaderSize > Size of`) in `download_bundle_header/3`