### PR TITLE
fix: observer_cli in release mode

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,12 @@
         ]
     },
     {no_events, [{erl_opts, [{d, 'NO_EVENTS', true}]}]},
-    {top, [{deps, [observer_cli]}, {erl_opts, [{d, 'AO_TOP', true}]}]},
+    {top, [
+        {deps, [{observer_cli, {git, "https://github.com/permaweb/observer_cli.git",
+            {ref, "7f90812dcd43d7954d0ba066cb94d5e934e729b5"}}}]},
+        {erl_opts, [{d, 'AO_TOP', true}]},
+        {relx, [{release, {'hb', "0.0.1"}, [hb, b64fast, cowboy, gun, luerl, prometheus, prometheus_cowboy, prometheus_ranch, elmdb, observer_cli]}]}
+    ]},
     {store_events, [{erl_opts, [{d, 'STORE_EVENTS', true}]}]},
     {ao_profiling, [{erl_opts, [{d, 'AO_PROFILING', true}]}]},
     {eflame,


### PR DESCRIPTION
While observer_cli doesn't implement the [fix](https://github.com/zhongwencool/observer_cli/pull/129), this contains a fix to access top via shell as well via release.

- Make sure you delete `_build/top/lib/observer_cli`.
- Create a release via `rebar3 as top release`.
- Start node1 with `HB_ERL_SNAME=node1 ERL_FLAGS="-setcookie test" _build/top/rel/hb/bin/hb foreground`.
- Start node2 with `HB_PORT=8001 ERL_FLAGS="-setcookie test" HB_ERL_SNAME="observer_cli" rebar3 as top shell`
- Type `observer_cli:start('node1@YOURDOMAIN', 'test')` in the rebar3 shell.