### PR TITLE
feat: add filtered L1 Bundle copycat depth-aware indexing by ID

### DIFF
--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -128,28 +128,63 @@ process_l1_request(TXID, Request, Opts) ->
     end.
 
 passes_l1_filters(TX, Filters) ->
+    l1_filter_reason(TX, Filters) =:= pass.
+
+l1_filter_reason(TX, Filters) ->
     IncludeOwner = maps:get(include_owner, Filters, undefined),
     ExcludeOwner = maps:get(exclude_owner, Filters, undefined),
     ExcludeTag = maps:get(exclude_tag, Filters, undefined),
     Owner = ar_tx:get_owner_address(TX),
-    IncludeOwnerPass =
-        case IncludeOwner of
-            undefined -> true;
-            Owner -> true;
-            _ -> false
-        end,
-    ExcludeOwnerPass =
-        case ExcludeOwner of
-            undefined -> true;
-            Owner -> false;
-            _ -> true
-        end,
-    ExcludeTagPass =
-        case ExcludeTag of
-            undefined -> true;
-            _ -> not has_tag_pair(TX, ExcludeTag)
-        end,
-    IncludeOwnerPass andalso ExcludeOwnerPass andalso ExcludeTagPass.
+    case IncludeOwner of
+        undefined ->
+            case ExcludeOwner of
+                undefined ->
+                    case ExcludeTag of
+                        undefined -> pass;
+                        _ ->
+                            case has_tag_pair(TX, ExcludeTag) of
+                                true -> exclude_tag_match;
+                                false -> pass
+                            end
+                    end;
+                Owner ->
+                    exclude_owner_match;
+                _ ->
+                    case ExcludeTag of
+                        undefined -> pass;
+                        _ ->
+                            case has_tag_pair(TX, ExcludeTag) of
+                                true -> exclude_tag_match;
+                                false -> pass
+                            end
+                    end
+            end;
+        Owner ->
+            case ExcludeOwner of
+                undefined ->
+                    case ExcludeTag of
+                        undefined -> pass;
+                        _ ->
+                            case has_tag_pair(TX, ExcludeTag) of
+                                true -> exclude_tag_match;
+                                false -> pass
+                            end
+                    end;
+                Owner ->
+                    exclude_owner_match;
+                _ ->
+                    case ExcludeTag of
+                        undefined -> pass;
+                        _ ->
+                            case has_tag_pair(TX, ExcludeTag) of
+                                true -> exclude_tag_match;
+                                false -> pass
+                            end
+                    end
+            end;
+        _ ->
+            include_owner_mismatch
+    end.
 
 has_tag_pair(#tx{tags = Tags}, #{name := Name, value := Value}) ->
     TagValue = dev_arweave_common:tagfind(Name, Tags, not_found),
@@ -529,17 +564,8 @@ process_l1_candidate(TXID, Filters, Opts) ->
             }} ->
             case resolve_tx_header(EncodedTXID, Opts) of
                 {ok, TX} ->
-                    case passes_l1_filters(TX, Filters) of
-                        false ->
-                            ?event(
-                                copycat_short,
-                                {arweave_tx_skipped,
-                                    {tx_id, {explicit, EncodedTXID}},
-                                    {reason, l1_filter}
-                                }
-                            ),
-                            Skipped;
-                        true ->
+                    case l1_filter_reason(TX, Filters) of
+                        pass ->
                             case is_bundle_tx(TX, Opts) of
                                 false ->
                                     ?event(
@@ -556,7 +582,16 @@ process_l1_candidate(TXID, Filters, Opts) ->
                                         0,
                                         Opts
                                     )
-                            end
+                            end;
+                        FilterReason ->
+                            ?event(
+                                copycat_short,
+                                {arweave_tx_skipped,
+                                    {tx_id, {explicit, EncodedTXID}},
+                                    {reason, FilterReason}
+                                }
+                            ),
+                            Skipped
                     end;
                 error ->
                     Skipped

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -29,16 +29,62 @@ normalize_owner_id(Addr) ->
 
 %% @doc Adds an address to the owners aliases cache in Opts, mapping
 %% Alias -> native address for fast lookup and once per address computation.
-add_owner_alias(Addr, Alias, Opts) -> 
+add_owner_alias(Addr, Alias, Opts) when is_binary(Alias) -> 
     ExistingAliases = maps:get(owner_aliases, Opts, #{}),
-    Opts#{ owner_aliases => ExistingAliases#{ Alias => normalize_owner_id(Addr) }}.
+    Opts#{ owner_aliases => ExistingAliases#{ Alias => normalize_owner_id(Addr) }};
+add_owner_alias(_Addr, Alias, _Opts) ->
+    throw({invalid_owner_alias, Alias}).
 
 %% @doc Retrieve the address of a given alias.
-resolve_owner_alias(Alias, Opts) ->
+resolve_owner_alias(Alias, Opts) when is_binary(Alias) ->
     Aliases = maps:get(owner_aliases, Opts, #{}),
     case maps:find(Alias, Aliases) of
         {ok, Addr} -> {ok, Addr};
         error -> {error, {owner_alias_not_found, Alias}}
+    end;
+resolve_owner_alias(Alias, _Opts) ->
+    {error, {invalid_owner_alias, Alias}}.
+
+parse_owner_filter(Request, Opts) ->
+    case resolve_owner_filter_value(
+        <<"include-owner">>,
+        <<"include-owner-alias">>,
+        Request,
+        Opts
+    ) of
+        {error, _} = Error ->
+            Error;
+        {ok, IncludeOwner} ->
+            case resolve_owner_filter_value(
+                <<"exclude-owner">>,
+                <<"exclude-owner-alias">>,
+                Request,
+                Opts
+            ) of
+                {error, _} = Error ->
+                    Error;
+                {ok, ExcludeOwner} ->
+                    {ok, #{
+                        include_owner => IncludeOwner,
+                        exclude_owner => ExcludeOwner
+                    }}
+            end
+    end.
+
+resolve_owner_filter_value(OwnerKey, AliasKey, Request, Opts) ->
+    case hb_maps:find(AliasKey, Request, Opts) of
+        {ok, Alias} ->
+            case resolve_owner_alias(Alias, Opts) of
+                {ok, Addr} -> {ok, normalize_owner_id(Addr)};
+                {error, _} = Error -> Error
+            end;
+        error ->
+            case hb_maps:find(OwnerKey, Request, Opts) of
+                {ok, Owner} ->
+                    {ok, normalize_owner_id(Owner)};
+                error ->
+                    {ok, undefined}
+            end
     end.
 %% @doc Parse the range from the request.
 parse_range(Request, Opts) ->

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -96,10 +96,7 @@ parse_owner_filter(Request, Opts) ->
 resolve_owner_filter_value(OwnerKey, AliasKey, Request, Opts) ->
     case hb_maps:find(AliasKey, Request, Opts) of
         {ok, Alias} ->
-            case resolve_owner_alias(Alias, Opts) of
-                {ok, Addr} -> {ok, normalize_owner_id(Addr)};
-                {error, _} = Error -> Error
-            end;
+            resolve_owner_aliases(Alias, Opts);
         error ->
             case hb_maps:find(OwnerKey, Request, Opts) of
                 {ok, Owner} ->
@@ -107,6 +104,32 @@ resolve_owner_filter_value(OwnerKey, AliasKey, Request, Opts) ->
                 error ->
                     {ok, undefined}
             end
+    end.
+
+resolve_owner_aliases(Alias, Opts) ->
+    case
+        lists:filter(
+            fun(Part) -> byte_size(Part) > 0 end,
+            binary:split(hb_util:bin(Alias), <<",">>, [global])
+        )
+    of
+        [SingleAlias] ->
+            case resolve_owner_alias(SingleAlias, Opts) of
+                {ok, Addr} -> {ok, normalize_owner_id(Addr)};
+                {error, _} = Error -> Error
+            end;
+        Aliases ->
+            resolve_owner_aliases(Aliases, Opts, [])
+    end.
+
+resolve_owner_aliases([], _Opts, Acc) ->
+    {ok, lists:reverse(Acc)};
+resolve_owner_aliases([Alias | Rest], Opts, Acc) ->
+    case resolve_owner_alias(Alias, Opts) of
+        {ok, Addr} ->
+            resolve_owner_aliases(Rest, Opts, [normalize_owner_id(Addr) | Acc]);
+        {error, _} = Error ->
+            Error
     end.
 
 parse_exclude_tag(Request, Opts) ->
@@ -162,56 +185,31 @@ l1_filter_reason(TX, Filters) ->
     ExcludeOwner = maps:get(exclude_owner, Filters, undefined),
     ExcludeTag = maps:get(exclude_tag, Filters, undefined),
     Owner = ar_tx:get_owner_address(TX),
-    case IncludeOwner of
-        undefined ->
-            case ExcludeOwner of
-                undefined ->
-                    case ExcludeTag of
-                        undefined -> pass;
-                        _ ->
-                            case has_tag_pair(TX, ExcludeTag) of
-                                true -> exclude_tag_match;
-                                false -> pass
-                            end
-                    end;
-                Owner ->
-                    exclude_owner_match;
-                _ ->
-                    case ExcludeTag of
-                        undefined -> pass;
-                        _ ->
-                            case has_tag_pair(TX, ExcludeTag) of
-                                true -> exclude_tag_match;
-                                false -> pass
-                            end
-                    end
-            end;
-        Owner ->
-            case ExcludeOwner of
-                undefined ->
-                    case ExcludeTag of
-                        undefined -> pass;
-                        _ ->
-                            case has_tag_pair(TX, ExcludeTag) of
-                                true -> exclude_tag_match;
-                                false -> pass
-                            end
-                    end;
-                Owner ->
-                    exclude_owner_match;
-                _ ->
-                    case ExcludeTag of
-                        undefined -> pass;
-                        _ ->
-                            case has_tag_pair(TX, ExcludeTag) of
-                                true -> exclude_tag_match;
-                                false -> pass
-                            end
-                    end
-            end;
+    case owner_matches_filter(Owner, IncludeOwner) of
+        false when IncludeOwner =/= undefined ->
+            include_owner_mismatch;
         _ ->
-            include_owner_mismatch
+            case owner_matches_filter(Owner, ExcludeOwner) of
+                true ->
+                    exclude_owner_match;
+                false ->
+                    case ExcludeTag of
+                        undefined -> pass;
+                        _ ->
+                            case has_tag_pair(TX, ExcludeTag) of
+                                true -> exclude_tag_match;
+                                false -> pass
+                            end
+                    end
+            end
     end.
+
+owner_matches_filter(_Owner, undefined) ->
+    false;
+owner_matches_filter(Owner, Owners) when is_list(Owners) ->
+    lists:member(Owner, Owners);
+owner_matches_filter(Owner, FilterOwner) ->
+    Owner =:= FilterOwner.
 
 has_tag_pair(#tx{tags = Tags}, #{name := Name, value := Value}) ->
     TagValue = dev_arweave_common:tagfind(Name, Tags, not_found),

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -215,11 +215,16 @@ l1_filter_reason(TX, Filters) ->
 
 has_tag_pair(#tx{tags = Tags}, #{name := Name, value := Value}) ->
     TagValue = dev_arweave_common:tagfind(Name, Tags, not_found),
-    LowerTagValue = hb_util:to_lower(TagValue),
-    LowerValue = hb_util:to_lower(Value),
-    case LowerTagValue of
-        LowerValue -> true;
-        _ -> false
+    case TagValue of
+        not_found ->
+            false;
+        _ ->
+            LowerTagValue = hb_util:to_lower(TagValue),
+            LowerValue = hb_util:to_lower(Value),
+            case LowerTagValue of
+                LowerValue -> true;
+                _ -> false
+            end
 end;
 has_tag_pair(_, _) ->
     false.

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -144,16 +144,16 @@ resolve_owner_aliases([Alias | Rest], Opts, Acc) ->
         {error, _} = Error ->
             Error
     end.
-%% @doc Parse an L1 exclude-tag filter from `Name:Value` form.
-parse_exclude_tag(Request, Opts) ->
-    case hb_maps:find(<<"exclude-tag">>, Request, Opts) of
+%% @doc Parse an L1 tag filter from `Name:Value` form.
+parse_tag_filter(Key, Request, Opts) ->
+    case hb_maps:find(Key, Request, Opts) of
         {ok, Tag} ->
             case binary:split(hb_util:bin(Tag), <<":">>, [global]) of
                 [Name, Value]
                         when byte_size(Name) > 0 andalso byte_size(Value) > 0 ->
                     {ok, #{name => Name, value => Value}};
                 _ ->
-                    {error, invalid_exclude_tag}
+                    {error, invalid_tag_filter}
             end;
         error ->
             {ok, undefined}
@@ -169,17 +169,25 @@ process_l1_request(TXID, Request, Opts) ->
         {error, _} = Error ->
             Error;
         {ok, OwnerFilters} ->
-            case parse_exclude_tag(Request, Opts) of
+            case parse_tag_filter(<<"include-tag">>, Request, Opts) of
                 {error, _} = Error ->
                     Error;
-                {ok, ExcludeTag} ->
-                    {ok,
-                        process_l1_candidate(
-                            TXID,
-                            OwnerFilters#{ exclude_tag => ExcludeTag },
-                            Depth,
-                            Opts
-                        )}
+                {ok, IncludeTag} ->
+                    case parse_tag_filter(<<"exclude-tag">>, Request, Opts) of
+                        {error, _} = Error ->
+                            Error;
+                        {ok, ExcludeTag} ->
+                            {ok,
+                                process_l1_candidate(
+                                    TXID,
+                                    OwnerFilters#{
+                                        include_tag => IncludeTag,
+                                        exclude_tag => ExcludeTag
+                                    },
+                                    Depth,
+                                    Opts
+                                )}
+                    end
             end
     end.
 %% @doc Parse the requested recursion depth and clamp it to the configured safe cap.
@@ -202,6 +210,7 @@ request_depth(Request, Default, Opts) ->
 l1_filter_reason(TX, Filters) ->
     IncludeOwner = maps:get(include_owner, Filters, undefined),
     ExcludeOwner = maps:get(exclude_owner, Filters, undefined),
+    IncludeTag = maps:get(include_tag, Filters, undefined),
     ExcludeTag = maps:get(exclude_tag, Filters, undefined),
     Owner = ar_tx:get_owner_address(TX),
     case owner_matches_filter(Owner, IncludeOwner) of
@@ -212,12 +221,28 @@ l1_filter_reason(TX, Filters) ->
                 true ->
                     exclude_owner_match;
                 false ->
-                    case ExcludeTag of
-                        undefined -> pass;
+                    case IncludeTag of
+                        undefined ->
+                            case ExcludeTag of
+                                undefined -> pass;
+                                _ ->
+                                    case has_tag_pair(TX, ExcludeTag) of
+                                        true -> exclude_tag_match;
+                                        false -> pass
+                                    end
+                            end;
                         _ ->
-                            case has_tag_pair(TX, ExcludeTag) of
-                                true -> exclude_tag_match;
-                                false -> pass
+                            case has_tag_pair(TX, IncludeTag) of
+                                false -> include_tag_mismatch;
+                                true ->
+                                    case ExcludeTag of
+                                        undefined -> pass;
+                                        _ ->
+                                            case has_tag_pair(TX, ExcludeTag) of
+                                                true -> exclude_tag_match;
+                                                false -> pass
+                                            end
+                                    end
                             end
                     end
             end

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -26,11 +26,28 @@ arweave(_Base, Request, Opts) ->
     case hb_maps:get(<<"mode">>, Request, <<"write">>, Opts) of
         <<"write">>  ->
             case hb_maps:find(<<"id">>, Request, Opts) of
-                {ok, TXID} -> process_l1_request(TXID, Request, Opts);
+                {ok, TXID} ->
+                    case process_l1_request(TXID, Request, Opts) of
+                        {ok, Stats} when is_map(Stats) ->
+                            ?event(
+                                copycat_short,
+                                {arweave_tx_indexed,
+                                    {id, {explicit, TXID}},
+                                    {items_indexed, maps:get(items_count, Stats, 0)},
+                                    {bundle_txs, maps:get(bundle_count, Stats, 0)},
+                                    {skipped_txs, maps:get(skipped_count, Stats, 0)}
+                                }
+                            );
+                        _ -> ok                            
+                    end,
+                    {ok, TXID};
                 error ->
                     {From, To} = parse_range(Request, Opts),
                     TargetDepth = request_depth(
                         Request, ?DEFAULT_BLOCK_DEPTH, Opts),
+                    ?event(copycat_short,
+                        {indexing_blocks, {from, From}, {to, To}, {depth, TargetDepth}}
+                    ),
                     fetch_blocks(
                         From,
                         To,
@@ -971,6 +988,12 @@ maybe_process_l1_tx(TXID, Filters, Depth, QueryL1Offset, Opts) ->
     NormalizedTXID = hb_util:native_id(TXID),
     EncodedTXID = hb_util:encode(NormalizedTXID),
     IndexStore = hb_store_arweave:store_from_opts(Opts),
+    ?event(copycat_short,
+        {indexing_l1_tx, {tx_id, {explicit, EncodedTXID}},
+        {depth, Depth},
+        {query_l1_offset, QueryL1Offset},
+        {filters, Filters}
+    }),
     maybe
         {ok,
             #{

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -5,7 +5,7 @@
 %%% provided, every block in the range is processed.
 -module(dev_copycat_arweave).
 -export([arweave/3]).
--export([add_owner_alias/3, resolve_owner_alias/2, set_memory_safe_cap/2, get_memory_safe_cap/1]).
+-export([add_owner_alias/3, resolve_owner_alias/2, set_memory_safe_cap/2, get_memory_safe_cap/1, set_depth_recursion_cap/2, get_depth_recursion_cap/1]).
 -include_lib("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -39,6 +39,15 @@ arweave(_Base, Request, Opts) ->
 %% bundle processing. in bytes.
 set_memory_safe_cap(Cap, Opts) when is_integer(Cap), Cap > 0 ->
     Opts#{copycat_memory_cap => Cap}.
+
+set_depth_recursion_cap(Cap, Opts) when is_integer(Cap), Cap > 0 ->
+    Opts#{copycat_depth_recursion_cap => Cap}.
+
+get_depth_recursion_cap(Opts) ->
+    case maps:get(copycat_depth_recursion_cap, Opts, not_found) of
+        not_found -> ?DEPTH_RECURSION_CAP;
+        Cap -> Cap
+    end.
 
 get_memory_safe_cap(Opts) ->
     case maps:get(copycat_memory_cap, Opts, not_found) of
@@ -167,13 +176,14 @@ process_l1_request(TXID, Request, Opts) ->
     end.
 
 request_depth(Request, Default, Opts) ->
+    MaxRecursionCap = get_depth_recursion_cap(Opts),
     RequestedDepth =
         case hb_maps:get(<<"depth">>, Request, Default, Opts) of
-            <<"safe_max">> -> ?DEPTH_RECURSION_CAP;
+            <<"safe_max">> -> MaxRecursionCap;
             Value -> hb_util:int(Value)
         end,
     erlang:min(
-        ?DEPTH_RECURSION_CAP,
+        MaxRecursionCap,
         erlang:max(
             ?DEPTH_L1_OFFSETS,
             RequestedDepth

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -11,9 +11,6 @@
 
 -define(ARWEAVE_DEVICE, <<"~arweave@2.9">>).
 -define(DEPTH_L1_OFFSETS, 1).
--define(DEPTH_RECURSION_CAP, 4).
-%% 6GB in bytes
--define(MEMORY_SAFE_CAP, 6 * 1024 * 1024 * 1024).
 
 % GET /~cron@1.0/once&cron-path=~copycat@1.0/arweave
 
@@ -43,19 +40,13 @@ set_memory_safe_cap(Cap, Opts) when is_integer(Cap), Cap > 0 ->
 %% in very nested bundles (very rare).
 set_depth_recursion_cap(Cap, Opts) when is_integer(Cap), Cap > 0 ->
     Opts#{copycat_depth_recursion_cap => Cap}.
-%% @doc Get the set depth recursion cap. if not set, defaults to ?DEPTH_RECURSION_CAP
+%% @doc Get the set depth recursion cap from hb_opts.
 get_depth_recursion_cap(Opts) ->
-    case maps:get(copycat_depth_recursion_cap, Opts, not_found) of
-        not_found -> ?DEPTH_RECURSION_CAP;
-        Cap -> Cap
-    end.
+    hb_opts:get(copycat_depth_recursion_cap, undefined, Opts).
 %% @doc Get the L1 TX data size that gets handled in-memory
-%% defaults to ?MEMORY_SAFE_CAP if not set.
+%% from hb_opts.
 get_memory_safe_cap(Opts) ->
-    case maps:get(copycat_memory_cap, Opts, not_found) of
-        not_found -> ?MEMORY_SAFE_CAP;
-        Cap -> Cap
-    end.
+    hb_opts:get(copycat_memory_cap, undefined, Opts).
 %% @doc Normalize an owner address into the native ID form used for comparisons.
 normalize_owner_id(Addr) ->
     hb_util:native_id(hb_util:bin(Addr)).
@@ -161,7 +152,7 @@ parse_tag_filter(Key, Request, Opts) ->
 %% @doc Process the `id=...` copycat path for an already indexed L1 TX.
 %% applies L1-level owner/tag filters on the lightweight TX header first, then,
 %% if the TX passes and is a bundle, loads the full L1 payload once and indexes
-%% descendants in-memory (under the ?MEMORY_SAFE_CAP limit) up to the requested safe depth
+%% descendants in-memory (under the configured copycat_memory_cap) up to the requested safe depth
 %% (defaults to full recursion till the set copycat_depth_recursion_cap).
 process_l1_request(TXID, Request, Opts) ->
     Depth = request_depth(Request, <<"safe_max">>, Opts),

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -5,6 +5,7 @@
 %%% provided, every block in the range is processed.
 -module(dev_copycat_arweave).
 -export([arweave/3]).
+-export([add_owner_alias/3, resolve_owner_alias/2]).
 -include_lib("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -70,7 +71,7 @@ parse_owner_filter(Request, Opts) ->
                     }}
             end
     end.
-
+%% Alias takes precedence over direct owner if both are provided
 resolve_owner_filter_value(OwnerKey, AliasKey, Request, Opts) ->
     case hb_maps:find(AliasKey, Request, Opts) of
         {ok, Alias} ->
@@ -100,6 +101,41 @@ parse_exclude_tag(Request, Opts) ->
         error ->
             {ok, undefined}
     end.
+
+passes_l1_filters(TX, Filters) ->
+    IncludeOwner = maps:get(include_owner, Filters, undefined),
+    ExcludeOwner = maps:get(exclude_owner, Filters, undefined),
+    ExcludeTag = maps:get(exclude_tag, Filters, undefined),
+    Owner = ar_tx:get_owner_address(TX),
+    IncludeOwnerPass =
+        case IncludeOwner of
+            undefined -> true;
+            Owner -> true;
+            _ -> false
+        end,
+    ExcludeOwnerPass =
+        case ExcludeOwner of
+            undefined -> true;
+            Owner -> false;
+            _ -> true
+        end,
+    ExcludeTagPass =
+        case ExcludeTag of
+            undefined -> true;
+            _ -> not has_tag_pair(TX, ExcludeTag)
+        end,
+    IncludeOwnerPass andalso ExcludeOwnerPass andalso ExcludeTagPass.
+
+has_tag_pair(#tx{tags = Tags}, #{name := Name, value := Value}) ->
+    TagValue = dev_arweave_common:tagfind(Name, Tags, not_found),
+    LowerTagValue = hb_util:to_lower(TagValue),
+    LowerValue = hb_util:to_lower(Value),
+    case LowerTagValue of
+        LowerValue -> true;
+        _ -> false
+end;
+has_tag_pair(_, _) ->
+    false.
 %% @doc Parse the range from the request.
 parse_range(Request, Opts) ->
     From =

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -83,29 +83,28 @@ resolve_owner_alias(Alias, _Opts) ->
 %% @doc Parse include/exclude owner filters from the request.
 %% Supports direct owner values and owner aliases.
 parse_owner_filter(Request, Opts) ->
-    case resolve_owner_filter_value(
-        <<"include-owner">>,
-        <<"include-owner-alias">>,
-        Request,
-        Opts
-    ) of
-        {error, _} = Error ->
-            Error;
-        {ok, IncludeOwner} ->
-            case resolve_owner_filter_value(
+    maybe
+        {ok, IncludeOwner} ?=
+            resolve_owner_filter_value(
+                <<"include-owner">>,
+                <<"include-owner-alias">>,
+                Request,
+                Opts
+            ),
+        {ok, ExcludeOwner} ?=
+            resolve_owner_filter_value(
                 <<"exclude-owner">>,
                 <<"exclude-owner-alias">>,
                 Request,
                 Opts
-            ) of
-                {error, _} = Error ->
-                    Error;
-                {ok, ExcludeOwner} ->
-                    {ok, #{
-                        include_owner => IncludeOwner,
-                        exclude_owner => ExcludeOwner
-                    }}
-            end
+            ),
+        {ok, #{
+            include_owner => IncludeOwner,
+            exclude_owner => ExcludeOwner
+        }}
+    else
+        {error, _} = Error ->
+            Error
     end.
 %% @doc Resolve one owner filter value from either a direct owner param or
 %% a comma-separated owner alias param. Alias takes precedence.
@@ -169,35 +168,28 @@ parse_tag_filter(Key, Request, Opts) ->
 %% copycat_depth_recursion_cap).
 process_l1_request(TXID, Request, Opts) ->
     Depth = request_depth(Request, <<"safe_max">>, Opts),
-    ReadL1Offset =
+    QueryL1Offset =
         hb_util:bool(
-            hb_maps:get(<<"read-l1-offset">>, Request, false, Opts)
+            hb_maps:get(<<"query-l1-offset">>, Request, false, Opts)
         ),
-    case parse_owner_filter(Request, Opts) of
+    maybe
+        {ok, OwnerFilters} ?= parse_owner_filter(Request, Opts),
+        {ok, IncludeTag} ?= parse_tag_filter(<<"include-tag">>, Request, Opts),
+        {ok, ExcludeTag} ?= parse_tag_filter(<<"exclude-tag">>, Request, Opts),
+        {ok,
+            maybe_process_l1_tx(
+                TXID,
+                OwnerFilters#{
+                    include_tag => IncludeTag,
+                    exclude_tag => ExcludeTag
+                },
+                Depth,
+                QueryL1Offset,
+                Opts
+            )}
+    else
         {error, _} = Error ->
-            Error;
-        {ok, OwnerFilters} ->
-            case parse_tag_filter(<<"include-tag">>, Request, Opts) of
-                {error, _} = Error ->
-                    Error;
-                {ok, IncludeTag} ->
-                    case parse_tag_filter(<<"exclude-tag">>, Request, Opts) of
-                        {error, _} = Error ->
-                            Error;
-                        {ok, ExcludeTag} ->
-                            {ok,
-                                process_l1_candidate(
-                                    TXID,
-                                    OwnerFilters#{
-                                        include_tag => IncludeTag,
-                                        exclude_tag => ExcludeTag
-                                    },
-                                    Depth,
-                                    ReadL1Offset,
-                                    Opts
-                                )}
-                    end
-            end
+            Error
     end.
 %% @doc Parse the requested recursion depth and clamp it to the configured
 %% safe cap. Depth is relative so depth 1 is always one level below the
@@ -222,39 +214,14 @@ l1_filter_reason(TX, Filters) ->
     IncludeTag = maps:get(include_tag, Filters, undefined),
     ExcludeTag = maps:get(exclude_tag, Filters, undefined),
     Owner = ar_tx:get_owner_address(TX),
-    case owner_matches_filter(Owner, IncludeOwner) of
-        false when IncludeOwner =/= undefined ->
-            include_owner_mismatch;
-        _ ->
-            case owner_matches_filter(Owner, ExcludeOwner) of
-                true ->
-                    exclude_owner_match;
-                false ->
-                    case IncludeTag of
-                        undefined ->
-                            case ExcludeTag of
-                                undefined -> pass;
-                                _ ->
-                                    case has_tag_pair(TX, ExcludeTag) of
-                                        true -> exclude_tag_match;
-                                        false -> pass
-                                    end
-                            end;
-                        _ ->
-                            case has_tag_pair(TX, IncludeTag) of
-                                false -> include_tag_mismatch;
-                                true ->
-                                    case ExcludeTag of
-                                        undefined -> pass;
-                                        _ ->
-                                            case has_tag_pair(TX, ExcludeTag) of
-                                                true -> exclude_tag_match;
-                                                false -> pass
-                                            end
-                                    end
-                            end
-                    end
-            end
+    maybe
+        pass ?= maybe_include_owner(Owner, IncludeOwner),
+        pass ?= maybe_exclude_owner(Owner, ExcludeOwner),
+        pass ?= maybe_include_tag(TX, IncludeTag),
+        pass ?= maybe_exclude_tag(TX, ExcludeTag),
+        pass
+    else
+        Reason -> Reason
     end.
 %% @doc Match an owner against an undefined, single-owner, or multi-owner filter.
 owner_matches_filter(_Owner, undefined) ->
@@ -263,6 +230,38 @@ owner_matches_filter(Owner, Owners) when is_list(Owners) ->
     lists:member(Owner, Owners);
 owner_matches_filter(Owner, FilterOwner) ->
     Owner =:= FilterOwner.
+
+maybe_include_owner(_Owner, undefined) ->
+    pass;
+maybe_include_owner(Owner, IncludeOwner) ->
+    case owner_matches_filter(Owner, IncludeOwner) of
+        true -> pass;
+        false -> include_owner_mismatch
+    end.
+
+maybe_exclude_owner(_Owner, undefined) ->
+    pass;
+maybe_exclude_owner(Owner, ExcludeOwner) ->
+    case owner_matches_filter(Owner, ExcludeOwner) of
+        true -> exclude_owner_match;
+        false -> pass
+    end.
+
+maybe_include_tag(_TX, undefined) ->
+    pass;
+maybe_include_tag(TX, IncludeTag) ->
+    case has_tag_pair(TX, IncludeTag) of
+        true -> pass;
+        false -> include_tag_mismatch
+    end.
+
+maybe_exclude_tag(_TX, undefined) ->
+    pass;
+maybe_exclude_tag(TX, ExcludeTag) ->
+    case has_tag_pair(TX, ExcludeTag) of
+        true -> exclude_tag_match;
+        false -> pass
+    end.
 
 has_tag_pair(#tx{tags = Tags}, #{name := Name, value := Value}) ->
     TagValue = dev_arweave_common:tagfind(Name, Tags, not_found),
@@ -452,7 +451,7 @@ process_block(BlockRes, Current, To, TargetDepth, Opts) ->
         {ok, Block} ->
             ?event(debug_copycat, {{processing_block, Current},
                 {indep_hash, hb_maps:get(<<"indep_hash">>, Block, <<>>)}}),
-            case maybe_index_ids(Block, TargetDepth, Opts) of
+            case maybe_index_block(Block, TargetDepth, Opts) of
                 {block_skipped, Results} ->
                     TotalTXs = maps:get(total_txs, Results, 0),
                     ?event(
@@ -491,7 +490,7 @@ process_block(BlockRes, Current, To, TargetDepth, Opts) ->
     end.
 
 %% @doc Index the IDs of all transactions in the block if configured to do so.
-maybe_index_ids(Block, TargetDepth, Opts) ->
+maybe_index_block(Block, TargetDepth, Opts) ->
     TotalTXs = length(hb_maps:get(<<"txs">>, Block, [], Opts)),
     case hb_opts:get(arweave_index_ids, true, Opts) of
         false -> 
@@ -522,7 +521,7 @@ maybe_index_ids(Block, TargetDepth, Opts) ->
                         fun({{padding, _}, _}) -> false; (_) -> true end,
                         TXsWithData
                     ),
-                    TXResults = process_txs(
+                    TXResults = process_block_txs(
                         ValidTXs, BlockStartOffset, TargetDepth, Opts),
                     {block_cached, TXResults#{total_txs => TotalTXs}}
             end
@@ -538,9 +537,9 @@ parallel_map(Items, Fun, Opts) ->
 
 %% @doc Process a single transaction and return its contribution to the counters.
 %% Returns a map with keys: items_count, bundle_count, skipped_count
-process_tx({{padding, _PaddingRoot}, _EndOffset}, _BlockStartOffset, _TargetDepth, _Opts) ->
+process_block_tx({{padding, _PaddingRoot}, _EndOffset}, _BlockStartOffset, _TargetDepth, _Opts) ->
     #{items_count => 0, bundle_count => 0, skipped_count => 0};
-process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, Opts) ->
+process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, Opts) ->
     IndexStore = hb_store_arweave:store_from_opts(Opts),
     TXID = hb_util:encode(TX#tx.id),
     TXEndOffset = BlockStartOffset + EndOffset,
@@ -561,10 +560,10 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, Opts) 
     end),
     case is_bundle_tx(TX, Opts) of
         false -> #{items_count => 0, bundle_count => 0, skipped_count => 0};
-        true when TargetDepth > 1 ->
-            % Indexing a block to depth 2 or greater means we need to load
+        true when TargetDepth > 2 ->
+            % Indexing a block to depth 3 or greater means we need to load
             % and recurse into each of the L1 TXs in the block.
-            process_l1_candidate(TX#tx.id, #{}, TargetDepth - 1, false, Opts);
+            maybe_process_l1_tx(TX#tx.id, #{}, TargetDepth - 1, false, Opts);
         true ->
             % Lightweight processing of block transactions to depth 2. We
             % can avoid loading the full L1 TX data into memory, and instead
@@ -876,10 +875,342 @@ index_bundle_bytes(BundleData, BundleStartOffset, Depth, Store, Opts) ->
             )
     end.
 
+%% @doc Lightweight bundle indexing. This function only loads the bundle header
+%% and writes the index based solely on the header. For a more rigorous and
+%% deeper indexing, see the index_full_bundle_xxx functions.
+index_bundle_header(TXID, TXEndOffset, TXDataSize, TXStartOffset, IndexStore, Opts) ->
+    BundleRes = download_bundle_header(TXEndOffset, TXDataSize, Opts),
+    case BundleRes of
+        {ok, {BundleIndex, HeaderSize}} ->
+            % Batch event tracking: measure total time and count for
+            % all write_offset calls
+            {TotalTime, {_, ItemsCount}} = timer:tc(fun() ->
+                lists:foldl(
+                    fun({ItemID, Size}, {ItemStartOffset, ItemsCountAcc}) ->
+                        hb_store_arweave:write_offset(
+                            IndexStore,
+                            hb_util:encode(ItemID),
+                            <<"ans104@1.0">>,
+                            ItemStartOffset,
+                            Size
+                        ),
+                        {ItemStartOffset + Size, ItemsCountAcc + 1}
+                    end,
+                    {TXStartOffset + HeaderSize, 0},
+                    BundleIndex
+                )
+            end),
+            % Single event increment for the batch
+            record_event_metrics(<<"item_indexed">>, ItemsCount, TotalTime),
+            #{items_count => ItemsCount, bundle_count => 1, skipped_count => 0};
+        {error, Reason} ->
+            ?event(
+                copycat_short,
+                {arweave_bundle_skipped,
+                    {tx_id, {explicit, TXID}},
+                    {reason, Reason}
+                }
+            ),
+            #{items_count => 0, bundle_count => 1, skipped_count => 1}
+    end.
+
+download_bundle_header(EndOffset, Size, Opts) ->
+    observe_event(<<"bundle_header">>, fun() ->
+        dev_arweave:bundle_header(EndOffset - Size, Opts)
+    end).
+
+header_chunk(invalid_bundle_header, _FirstChunk, _StartOffset, _Opts) ->
+    {error, invalid_bundle_header};
+header_chunk(HeaderSize, FirstChunk, _StartOffset, _Opts)
+        when HeaderSize =< byte_size(FirstChunk) ->
+    {ok, FirstChunk};
+header_chunk(HeaderSize, FirstChunk, StartOffset, Opts) ->
+    Res =
+        hb_ao:resolve(
+            <<
+                ?ARWEAVE_DEVICE/binary,
+                "/chunk&offset=",
+                (hb_util:bin(StartOffset + byte_size(FirstChunk)))/binary,
+                "&length=",
+                (hb_util:bin(HeaderSize - byte_size(FirstChunk)))/binary
+            >>,
+            Opts
+        ),
+    case Res of
+        {ok, OtherChunks} -> {ok, <<FirstChunk/binary, OtherChunks/binary>>};
+        Other -> Other
+    end.
+
+%% @doc Process transactions: spawn workers and manage the worker pool.
+%% This function processes transactions in parallel using parallel_map.
+%% When arweave_index_workers <= 1, processes sequentially (one worker at a time).
+%% When arweave_index_workers > 1, processes in parallel with the specified concurrency limit.
+%% Returns a map with keys: items_count, bundle_count, skipped_count.
+process_block_txs(ValidTXs, BlockStartOffset, TargetDepth, Opts) ->
+    Results = parallel_map(
+        ValidTXs,
+        fun(TXWithData) -> process_block_tx(
+            TXWithData, BlockStartOffset, TargetDepth, Opts) end,
+        Opts
+    ),
+    lists:foldl(
+        fun(Result, Acc) ->
+            #{
+                items_count => maps:get(items_count, Result, 0) + maps:get(items_count, Acc, 0),
+                bundle_count => maps:get(bundle_count, Result, 0) + maps:get(bundle_count, Acc, 0),
+                skipped_count => maps:get(skipped_count, Result, 0) + maps:get(skipped_count, Acc, 0)
+            }
+        end,
+        #{items_count => 0, bundle_count => 0, skipped_count => 0},
+        Results
+    ).
+
+%% @doc Process a single indexed L1 TX candidate after lightweight filter checks.
+maybe_process_l1_tx(TXID, Filters, Depth, QueryL1Offset, Opts) ->
+    Skipped = #{items_count => 0, bundle_count => 0, skipped_count => 1},
+    NormalizedTXID = hb_util:native_id(TXID),
+    EncodedTXID = hb_util:encode(NormalizedTXID),
+    IndexStore = hb_store_arweave:store_from_opts(Opts),
+    maybe
+        {ok,
+            #{
+                <<"codec-device">> := <<"tx@1.0">>,
+                <<"start-offset">> := StartOffset,
+                <<"length">> := Length
+            }} ?=
+            ensure_l1_tx_offset(
+                NormalizedTXID,
+                EncodedTXID,
+                IndexStore,
+                QueryL1Offset,
+                Opts
+            ),
+        {ok, TX} ?= resolve_tx_header(EncodedTXID, Opts),
+        pass ?= l1_filter_reason(TX, Filters),
+        bundle ?=
+            case is_bundle_tx(TX, Opts) of
+                true -> bundle;
+                false -> not_bundle
+            end,
+        within_memory_cap ?=
+            case Length =< get_memory_safe_cap(Opts) of
+                true -> within_memory_cap;
+                false -> memory_safe_cap_exceeded
+            end,
+        process_l1_tx(
+            StartOffset,
+            Length,
+            Depth,
+            IndexStore,
+            EncodedTXID,
+            Opts
+        )
+    else
+        {error, Reason} ->
+            ?event(
+                copycat_short,
+                {arweave_tx_skipped,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {reason, Reason}
+                }
+            ),
+            Skipped;
+        error ->
+            % event already logged in resolve_tx_header
+            Skipped;
+        not_bundle ->
+            ?event(
+                copycat_short,
+                {arweave_tx_skipped,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {reason, not_bundle}
+                }
+            ),
+            Skipped;
+        memory_safe_cap_exceeded ->
+            ?event(
+                copycat_short,
+                {arweave_bundle_skipped,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {reason, memory_safe_cap_exceeded}
+                }
+            ),
+            #{
+                items_count => 0,
+                bundle_count => 1,
+                skipped_count => 1
+            };
+        FilterReason ->
+            ?event(
+                copycat_short,
+                {arweave_tx_skipped,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {reason, FilterReason}
+                }
+            ),
+            Skipped
+    end.
+
+%% @doc Load the L1 TX data into memory and index it.
+%% 
+%% TODO: process_l1_tx and process_block_tx are very similar and can/should
+%% be merged.
+process_l1_tx(
+        StartOffset, Length, Depth, IndexStore, EncodedTXID, Opts) ->
+    case hb_store_arweave:read_chunks(StartOffset, Length, Opts) of
+        {ok, BundleData} ->
+            {TotalTime, IndexRes} = timer:tc(
+                fun() ->
+                    index_full_bundle_bytes(
+                        BundleData,
+                        StartOffset,
+                        Depth,
+                        IndexStore,
+                        Opts
+                    )
+                end
+            ),
+            case IndexRes of
+                {ok, ItemsCount} ->
+                    record_event_metrics(
+                        <<"item_indexed">>,
+                        ItemsCount,
+                        TotalTime
+                    ),
+                    #{
+                        items_count => ItemsCount,
+                        bundle_count => 1,
+                        skipped_count => 0
+                    };
+                {error, Reason} ->
+                    ?event(
+                        copycat_short,
+                        {arweave_bundle_skipped,
+                            {tx_id, {explicit, EncodedTXID}},
+                            {reason, Reason}
+                        }
+                    ),
+                    #{
+                        items_count => 0,
+                        bundle_count => 1,
+                        skipped_count => 1
+                    }
+            end;
+        {error, Reason} ->
+            ?event(
+                copycat_short,
+                {arweave_bundle_skipped,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {reason, Reason}
+                }
+            ),
+            #{
+                items_count => 0,
+                bundle_count => 1,
+                skipped_count => 1
+            };
+        not_found ->
+            ?event(
+                copycat_short,
+                {arweave_bundle_skipped,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {reason, not_found}
+                }
+            ),
+            #{
+                items_count => 0,
+                bundle_count => 1,
+                skipped_count => 1
+            }
+    end.
+%% @doc Ensure the root L1 TX offset exists locally before `id=...` indexing.
+%% if the offset is missing and `query_l1_offset` is enabled, fetches the TX
+%% offset metadata from Arweave, writes it to the local offset store, and
+%% retries the local lookup.
+ensure_l1_tx_offset(_TXID, _EncodedTXID, IndexStore, _LoadL1Offset, _Opts)
+        when is_map(IndexStore) =:= false ->
+    {error, missing_offset};
+ensure_l1_tx_offset(TXID, EncodedTXID, IndexStore, QueryL1Offset, Opts) ->
+    case hb_store_arweave:read_offset(IndexStore, TXID) of
+        {ok, _} = OffsetRes ->
+            OffsetRes;
+        not_found when QueryL1Offset ->
+            ?event(
+                copycat_short,
+                {arweave_tx_querying_offset,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {source, network}
+                }
+            ),
+            case query_l1_tx_offset(EncodedTXID, IndexStore, Opts) of
+                ok ->
+                    case hb_store_arweave:read_offset(IndexStore, TXID) of
+                        {ok, _} = OffsetRes ->
+                            OffsetRes;
+                        not_found ->
+                            {error, missing_offset}
+                    end;
+                {error, Reason} ->
+                    {error, Reason}
+            end;
+        not_found ->
+            {error, missing_offset}
+    end.
+
+query_l1_tx_offset(TXID, IndexStore, Opts) ->
+    % TODO: move this into dev_arweave - I think? Unless it's possible to
+    % query this already via one of the existing ~arweave@2.9 paths?
+    case hb_http:request(
+        #{
+            <<"path">> => <<"/arweave/tx/", TXID/binary, "/offset">>,
+            <<"method">> => <<"GET">>
+        },
+        Opts
+    ) of
+        {ok, #{ <<"body">> := OffsetBody }} ->
+            OffsetMsg = hb_json:decode(OffsetBody),
+            EndOffset = hb_util:int(maps:get(<<"offset">>, OffsetMsg)),
+            Size = hb_util:int(maps:get(<<"size">>, OffsetMsg)),
+            StartOffset = EndOffset - Size,
+            ok =
+                hb_store_arweave:write_offset(
+                    IndexStore,
+                    TXID,
+                    <<"tx@1.0">>,
+                    StartOffset,
+                    Size
+                ),
+            ok;
+        {error, Reason} ->
+            {error, Reason};
+        not_found ->
+            {error, not_found}
+    end.
+
+index_full_bundle_bytes(_BundleData, _BundleStartOffset, Depth, _Store, _Opts)
+        when Depth =< 0 ->
+    {ok, 0};
+index_full_bundle_bytes(BundleData, BundleStartOffset, Depth, Store, Opts) ->
+    case ar_bundles:decode_bundle_header(BundleData) of
+        invalid_bundle_header ->
+            {error, invalid_bundle_header};
+        {ItemsBin, BundleIndex} ->
+            HeaderSize = byte_size(BundleData) - byte_size(ItemsBin),
+            index_full_bundle_items(
+                BundleIndex,
+                ItemsBin,
+                BundleStartOffset + HeaderSize,
+                Depth,
+                Store,
+                Opts,
+                0
+            )
+    end.
+
 %% @doc Index bundle children from decoded bundle bytes and recurse descendants in-memory.
-index_bundle_items([], _ItemsBin, _ItemStartOffset, _Depth, _Store, _Opts, Count) ->
+index_full_bundle_items([], _ItemsBin, _ItemStartOffset, _Depth, _Store, _Opts, Count) ->
     {ok, Count};
-index_bundle_items(
+index_full_bundle_items(
     [{ItemID, Size} | Rest],
     ItemsBin,
     ItemStartOffset,
@@ -899,7 +1230,7 @@ index_bundle_items(
     DescendantCount =
         case Depth > 1 of
             true ->
-                index_bundle_descendants(
+                index_full_bundle_descendants(
                     ItemBinary,
                     ItemStartOffset,
                     Depth - 1,
@@ -909,7 +1240,7 @@ index_bundle_items(
             false ->
                 0
         end,
-    index_bundle_items(
+    index_full_bundle_items(
         Rest,
         binary:part(ItemsBin, Size, byte_size(ItemsBin) - Size),
         ItemStartOffset + Size,
@@ -918,19 +1249,19 @@ index_bundle_items(
         Opts,
         Count + 1 + DescendantCount
     );
-index_bundle_items(_BundleIndex, _ItemsBin, _ItemStartOffset, _Depth, _Store, _Opts, _Count) ->
+index_full_bundle_items(_BundleIndex, _ItemsBin, _ItemStartOffset, _Depth, _Store, _Opts, _Count) ->
     {error, invalid_bundle_header}.
 
 %% @doc Recurse into a nested bundle data item from in-memory bytes.
-index_bundle_descendants(_ItemBinary, _ItemStartOffset, Depth, _Store, _Opts)
+index_full_bundle_descendants(_ItemBinary, _ItemStartOffset, Depth, _Store, _Opts)
         when Depth =< 0 ->
     0;
-index_bundle_descendants(ItemBinary, ItemStartOffset, Depth, Store, Opts) ->
+index_full_bundle_descendants(ItemBinary, ItemStartOffset, Depth, Store, Opts) ->
     try ar_bundles:deserialize_header(ItemBinary) of
         {ok, HeaderSize, HeaderTX} ->
             case is_bundle_tx(HeaderTX, Opts) of
                 true ->
-                    case index_bundle_bytes(
+                    case index_full_bundle_bytes(
                         HeaderTX#tx.data,
                         ItemStartOffset + HeaderSize,
                         Depth,
@@ -952,11 +1283,6 @@ index_bundle_descendants(ItemBinary, ItemStartOffset, Depth, Store, Opts) ->
 
 is_bundle_tx(TX, _Opts) ->
     dev_arweave_common:type(TX) =/= binary.
-
-download_bundle_header(EndOffset, Size, Opts) ->
-    observe_event(<<"bundle_header">>, fun() ->
-        dev_arweave:bundle_header(EndOffset - Size, Opts)
-    end).
 
 resolve_tx_headers(TXIDs, Opts) ->
     Results = parallel_map(
@@ -1034,7 +1360,7 @@ observe_event(MetricName, Fun) ->
 
 %%% Tests
 
-index_ids_test() ->
+block_depth_2_test() ->
     %% Test block: https://viewblock.io/arweave/block/1827942
     %% Note: this block includes a data item with an Ethereum signature. This
     %% signature type is not yet (as of Jan 2026) supported by ar_bundles.erl,
@@ -1043,7 +1369,7 @@ index_ids_test() ->
     {_TestStore, StoreOpts, Opts} = setup_index_opts(),
     {ok, 1827942} =
         hb_ao:resolve(
-            <<"~copycat@1.0/arweave&from=1827942&to=1827942&depth=1">>,
+            <<"~copycat@1.0/arweave&from=1827942&to=1827942">>,
             Opts
         ),
     ?assertMatch(
@@ -1104,17 +1430,17 @@ index_ids_test() ->
     assert_item_not_read(<<"8aJrRWtHcJvJ61qsH6agGkemzrtLw3W22xFrpCGAnTM">>, Opts),
    ok.
 
-index_ids_depth_2_test() ->
+block_depth_3_test() ->
     %% Test block: https://viewblock.io/arweave/block/1827942
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     {ok, 1827942} =
         hb_ao:resolve(
-            <<"~copycat@1.0/arweave&from=1827942&to=1827942&depth=2">>,
+            <<"~copycat@1.0/arweave&from=1827942&to=1827942&depth=3">>,
             Opts
         ),
     % L3 item read when doing depth=2
     assert_item_read(
-        <<"ZQRHZhktk6dAtX9BlhO1teOtVlGHoyaWP25kAlhxrM4">>,
+        <<"8aJrRWtHcJvJ61qsH6agGkemzrtLw3W22xFrpCGAnTM">>,
         Opts),
     ok.
 
@@ -1831,7 +2157,7 @@ id_missing_offset_with_load_test() ->
                 "~copycat@1.0/arweave&"
                 "id=", TXID/binary, "&"
                 "mode=write&"
-                "read-l1-offset=true&"
+                "query-l1-offset=true&"
                 "depth=2"
             >>,
             Opts

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -24,6 +24,22 @@ arweave(_Base, Request, Opts) ->
             {error, <<"Unsupported mode `", (hb_util:bin(Mode))/binary, "`. Supported modes are: write, list">>}
     end.
 
+normalize_owner_id(Addr) ->
+    hb_util:native_id(hb_util:bin(Addr)).
+
+%% @doc Adds an address to the owners aliases cache in Opts, mapping
+%% Alias -> native address for fast lookup and once per address computation.
+add_owner_alias(Addr, Alias, Opts) -> 
+    ExistingAliases = maps:get(owner_aliases, Opts, #{}),
+    Opts#{ owner_aliases => ExistingAliases#{ Alias => normalize_owner_id(Addr) }}.
+
+%% @doc Retrieve the address of a given alias.
+resolve_owner_alias(Alias, Opts) ->
+    Aliases = maps:get(owner_aliases, Opts, #{}),
+    case maps:find(Alias, Aliases) of
+        {ok, Addr} -> {ok, Addr};
+        error -> {error, {owner_alias_not_found, Alias}}
+    end.
 %% @doc Parse the range from the request.
 parse_range(Request, Opts) ->
     From =

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -37,10 +37,11 @@ arweave(_Base, Request, Opts) ->
                                     {bundle_txs, maps:get(bundle_count, Stats, 0)},
                                     {skipped_txs, maps:get(skipped_count, Stats, 0)}
                                 }
-                            );
-                        _ -> ok                            
-                    end,
-                    {ok, TXID};
+                            ),
+                            {ok, maps:get(items_count, Stats, 0)};
+                        _ -> 
+                            {ok, 0}                         
+                    end;
                 error ->
                     {From, To} = parse_range(Request, Opts),
                     TargetDepth = request_depth(

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -158,8 +158,9 @@ parse_tag_filter(Key, Request, Opts) ->
 %% @doc Process the `id=...` copycat path for an already indexed L1 TX.
 %% applies L1-level owner/tag filters on the lightweight TX header first, then,
 %% if the TX passes and is a bundle, loads the full L1 payload once and indexes
-%% descendants in-memory (under the configured copycat_memory_cap) up to the requested safe depth
-%% (defaults to full recursion till the set copycat_depth_recursion_cap).
+%% descendants in-memory (under the configured copycat_memory_cap) up to the
+%% requested safe depth (defaults to full recursion till the set
+%% copycat_depth_recursion_cap).
 process_l1_request(TXID, Request, Opts) ->
     Depth = request_depth(Request, <<"safe_max">>, Opts),
     LoadL1Offset =
@@ -1521,6 +1522,345 @@ negative_from_index_test() ->
     ?assertNot(has_any_indexed_tx(NextBlock + 1, Opts)),
     ok.
 
+owner_alias_roundtrip_test() ->
+    Opts1 =
+        add_owner_alias(
+            <<"FPjbN7EVwP3XwQJx8qnKqJDYa4TLJ0Y8gu4AaiUuW1c">>,
+            <<"turbo">>,
+            #{}
+        ),
+    Opts2 =
+        add_owner_alias(
+            <<"JNC6vBhU4sAK5T49VL4k79vNer0tZjM8fI1gpqUQK5g">>,
+            <<"redstone">>,
+            Opts1
+        ),
+    ?assertEqual(
+        {ok, normalize_owner_id(<<"FPjbN7EVwP3XwQJx8qnKqJDYa4TLJ0Y8gu4AaiUuW1c">>)},
+        resolve_owner_alias(<<"turbo">>, Opts2)
+    ),
+    ?assertEqual(
+        {ok, normalize_owner_id(<<"JNC6vBhU4sAK5T49VL4k79vNer0tZjM8fI1gpqUQK5g">>)},
+        resolve_owner_alias(<<"redstone">>, Opts2)
+    ),
+    ?assertEqual(
+        {error, {owner_alias_not_found, <<"unknown">>}},
+        resolve_owner_alias(<<"unknown">>, Opts2)
+    ),
+    ok.
+
+parse_tag_filter_test() ->
+    ?assertEqual(
+        {ok, #{name => <<"App-Name">>, value => <<"ao">>}},
+        parse_tag_filter(<<"include-tag">>, #{<<"include-tag">> => <<"App-Name:ao">>}, #{})
+    ),
+    ?assertEqual(
+        {ok, undefined},
+        parse_tag_filter(<<"include-tag">>, #{}, #{})
+    ),
+    ?assertEqual(
+        {error, invalid_tag_filter},
+        parse_tag_filter(<<"include-tag">>, #{<<"include-tag">> => <<"App-Name">>}, #{})
+    ),
+    ?assertEqual(
+        {error, invalid_tag_filter},
+        parse_tag_filter(<<"include-tag">>, #{<<"include-tag">> => <<":ao">>}, #{})
+    ),
+    ?assertEqual(
+        {error, invalid_tag_filter},
+        parse_tag_filter(<<"include-tag">>, #{<<"include-tag">> => <<"App-Name:">>}, #{})
+    ),
+    ok.
+
+l1_filter_reason_test() ->
+    Owner = <<"owner-1">>,
+    OtherOwner = <<"owner-2">>,
+    TX = #tx{
+        owner = <<"non-default-owner">>,
+        owner_address = Owner,
+        tags = [
+            {<<"App-Name">>, <<"ao">>},
+            {<<"Bundler-App-Name">>, <<"Redstone">>}
+        ]
+    },
+    IncludeTag = #{name => <<"App-Name">>, value => <<"ao">>},
+    ExcludeTag = #{name => <<"Bundler-App-Name">>, value => <<"Redstone">>},
+    ?assertEqual(pass, l1_filter_reason(TX, #{})),
+    ?assertEqual(pass, l1_filter_reason(TX, #{include_owner => Owner})),
+    ?assertEqual(
+        include_owner_mismatch,
+        l1_filter_reason(TX, #{include_owner => OtherOwner})
+    ),
+    ?assertEqual(
+        exclude_owner_match,
+        l1_filter_reason(TX, #{exclude_owner => Owner})
+    ),
+    ?assertEqual(
+        pass,
+        l1_filter_reason(TX, #{exclude_owner => OtherOwner})
+    ),
+    ?assertEqual(pass, l1_filter_reason(TX, #{include_tag => IncludeTag})),
+    ?assertEqual(
+        include_tag_mismatch,
+        l1_filter_reason(
+            TX,
+            #{include_tag => #{name => <<"Content-Type">>, value => <<"text/plain">>}}
+        )
+    ),
+    ?assertEqual(
+        exclude_tag_match,
+        l1_filter_reason(TX, #{exclude_tag => ExcludeTag})
+    ),
+    ?assertEqual(
+        pass,
+        l1_filter_reason(
+            TX,
+            #{exclude_tag => #{name => <<"Content-Type">>, value => <<"text/plain">>}}
+        )
+    ),
+    ?assertEqual(
+        exclude_tag_match,
+        l1_filter_reason(
+            TX,
+            #{include_tag => IncludeTag, exclude_tag => ExcludeTag}
+        )
+    ),
+    ?assertEqual(
+        pass,
+        l1_filter_reason(TX, #{include_owner => [OtherOwner, Owner]})
+    ),
+    ok.
+
+request_depth_clamping_test() ->
+    {_TestStore, _StoreOpts, Opts0} = setup_index_opts(),
+    ?assertEqual(4, request_depth(#{}, <<"safe_max">>, Opts0)),
+    ?assertEqual(
+        2,
+        request_depth(#{<<"depth">> => <<"2">>}, <<"safe_max">>, Opts0)
+    ),
+    ?assertEqual(
+        ?DEPTH_L1_OFFSETS,
+        request_depth(#{<<"depth">> => <<"0">>}, <<"safe_max">>, Opts0)
+    ),
+    ?assertEqual(
+        4,
+        request_depth(#{<<"depth">> => <<"999">>}, <<"safe_max">>, Opts0)
+    ),
+    Opts1 = set_depth_recursion_cap(2, Opts0),
+    ?assertEqual(2, request_depth(#{}, <<"safe_max">>, Opts1)),
+    % no recursion cap set, use default from hb_opts
+    ?assertEqual(4, request_depth(#{}, <<"safe_max">>, #{})),
+    ok.
+
+memory_cap_setter_getter_test() ->
+    {_TestStore, _StoreOpts, Opts0} = setup_index_opts(),
+    ?assertEqual(6 * 1024 * 1024 * 1024, get_memory_safe_cap(Opts0)),
+    Opts1 = set_memory_safe_cap(1024, Opts0),
+    ?assertEqual(1024, get_memory_safe_cap(Opts1)),
+    ok.
+
+id_depth_1_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    {Block, TXID} = {1827942, <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>},
+    ok = index_l1_offsets(Block, Opts),
+    {ok, Result} =
+        hb_ao:resolve(
+            <<
+                "~copycat@1.0/arweave&"
+                "id=", TXID/binary, "&"
+                "mode=write&"
+                "depth=1"
+            >>,
+            Opts
+        ),
+    ?assertEqual(26, maps:get(items_count, Result)),
+    ?assertEqual(1, maps:get(bundle_count, Result)),
+    ?assertEqual(0, maps:get(skipped_count, Result)),
+
+    assert_bundle_read(
+        <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>,
+        [
+            {<<"54K1ehEIKZxGSusgZzgbGYaHfllwWQ09-S9-eRUJg5Y">>, <<"1">>},
+            {<<"MgatoEjlO_YtdbxFi9Q7Hxbs0YQVcChddhSS7FsdeIg">>, <<"19">>},
+            {<<"z-oKJfhMq5qoVFrljEfiBKgumaJmCWVxNJaavR5aPE8">>, <<"26">>}
+        ],
+        Opts
+    ),
+    % L3 item not read when doing L1 depth=1
+    assert_item_not_read(<<"8aJrRWtHcJvJ61qsH6agGkemzrtLw3W22xFrpCGAnTM">>, Opts),
+    ok.
+
+id_depth_2_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    {Block, TXID} = {1827942, <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>},
+    ok = index_l1_offsets(Block, Opts),
+    {ok, Result} =
+        hb_ao:resolve(
+            <<
+                "~copycat@1.0/arweave&"
+                "id=", TXID/binary, "&"
+                "mode=write&"
+                "depth=2"
+            >>,
+            Opts
+        ),
+    ?assertEqual(52, maps:get(items_count, Result)),
+    ?assertEqual(1, maps:get(bundle_count, Result)),
+    ?assertEqual(0, maps:get(skipped_count, Result)),
+
+    assert_bundle_read(
+        <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>,
+        [
+            {<<"54K1ehEIKZxGSusgZzgbGYaHfllwWQ09-S9-eRUJg5Y">>, <<"1">>},
+            {<<"MgatoEjlO_YtdbxFi9Q7Hxbs0YQVcChddhSS7FsdeIg">>, <<"19">>},
+            {<<"z-oKJfhMq5qoVFrljEfiBKgumaJmCWVxNJaavR5aPE8">>, <<"26">>}
+        ],
+        Opts
+    ),
+    % L2 bundle and L3 children should be read when doing L1 with depth=2
+    assert_bundle_read(
+        <<"54K1ehEIKZxGSusgZzgbGYaHfllwWQ09-S9-eRUJg5Y">>,
+        [
+            {<<"iS5R3iSKaCdcXG2nlKWsbdT1_uhQe54nMsgYK-ivEcE">>, <<"1">>},
+            {<<"8aJrRWtHcJvJ61qsH6agGkemzrtLw3W22xFrpCGAnTM">>, <<"2">>}
+        ],
+        Opts
+    ),
+    ok.
+
+id_exclude_tag_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    {Block, TXID} = {1827942, <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>},
+    ok = index_l1_offsets(Block, Opts),
+    {ok, Result} =
+        hb_ao:resolve(
+            <<
+                "~copycat@1.0/arweave&"
+                "id=", TXID/binary, "&"
+                "mode=write&"
+                "exclude-tag=App-Name:ArDrive%20Turbo&"
+                "depth=2"
+            >>,
+            Opts
+        ),
+    ?assertEqual(0, maps:get(items_count, Result)),
+    ?assertEqual(0, maps:get(bundle_count, Result)),
+    ?assertEqual(1, maps:get(skipped_count, Result)),
+    assert_item_not_read(<<"iS5R3iSKaCdcXG2nlKWsbdT1_uhQe54nMsgYK-ivEcE">>, Opts),
+    ok.
+
+id_include_owner_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    {Block, TXID} = {1827942, <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>},
+    ok = index_l1_offsets(Block, Opts),
+    {ok, Included} =
+        hb_ao:resolve(
+            <<
+                "~copycat@1.0/arweave&"
+                "id=", TXID/binary, "&"
+                "mode=write&"
+                "include-owner=JNC6vBhjHY1EPwV3pEeNmrsgFMxH5d38_LHsZ7jful8"
+            >>,
+            Opts
+        ),
+    ?assertEqual(52, maps:get(items_count, Included)),
+    ?assertEqual(1, maps:get(bundle_count, Included)),
+    ?assertEqual(0, maps:get(skipped_count, Included)),
+    {ok, Skipped} =
+        hb_ao:resolve(
+            <<
+                "~copycat@1.0/arweave&"
+                "id=", TXID/binary, "&"
+                "mode=write&"
+                "include-owner=FPjbN7EVwP3XwQJx8qnKqJDYa4TLJ0Y8gu4AaiUuW1c"
+            >>,
+            Opts
+        ),
+    ?assertEqual(0, maps:get(items_count, Skipped)),
+    ?assertEqual(0, maps:get(bundle_count, Skipped)),
+    ?assertEqual(1, maps:get(skipped_count, Skipped)).
+
+id_missing_offset_without_load_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    {_Block, TXID} = {1827942, <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>},
+    {ok, Result} =
+        hb_ao:resolve(
+            <<
+                "~copycat@1.0/arweave&"
+                "id=", TXID/binary, "&"
+                "mode=write"
+            >>,
+            Opts
+        ),
+    ?assertEqual(0, maps:get(items_count, Result)),
+    ?assertEqual(0, maps:get(bundle_count, Result)),
+    ?assertEqual(1, maps:get(skipped_count, Result)),
+    assert_item_not_read(<<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>, Opts),
+    ok.
+
+id_missing_offset_with_load_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    {_Block, TXID} = {1827942, <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>},
+    {ok, Result} =
+        hb_ao:resolve(
+            <<
+                "~copycat@1.0/arweave&"
+                "id=", TXID/binary, "&"
+                "mode=write&"
+                "load-l1-offset=true&"
+                "depth=2"
+            >>,
+            Opts
+        ),
+    ?assertEqual(52, maps:get(items_count, Result)),
+    ?assertEqual(1, maps:get(bundle_count, Result)),
+    ?assertEqual(0, maps:get(skipped_count, Result)),
+
+    assert_bundle_read(
+        <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>,
+        [
+            {<<"54K1ehEIKZxGSusgZzgbGYaHfllwWQ09-S9-eRUJg5Y">>, <<"1">>},
+            {<<"MgatoEjlO_YtdbxFi9Q7Hxbs0YQVcChddhSS7FsdeIg">>, <<"19">>},
+            {<<"z-oKJfhMq5qoVFrljEfiBKgumaJmCWVxNJaavR5aPE8">>, <<"26">>}
+        ],
+        Opts
+    ),
+    % L2 bundle and L3 children should be read when doing L1 with depth=2
+    assert_bundle_read(
+        <<"54K1ehEIKZxGSusgZzgbGYaHfllwWQ09-S9-eRUJg5Y">>,
+        [
+            {<<"iS5R3iSKaCdcXG2nlKWsbdT1_uhQe54nMsgYK-ivEcE">>, <<"1">>},
+            {<<"8aJrRWtHcJvJ61qsH6agGkemzrtLw3W22xFrpCGAnTM">>, <<"2">>}
+        ],
+        Opts
+    ),
+    ok.
+
+parse_owner_filter_unknown_alias_test() ->
+    ?assertEqual(
+        {error, {owner_alias_not_found, <<"nonexistent">>}},
+        parse_owner_filter(
+            #{<<"include-owner-alias">> => <<"nonexistent">>},
+            #{}
+        )
+    ),
+    ok.
+
+index_l1_offsets(Block, Opts) ->
+    BlockBin = hb_util:bin(Block),
+    {ok, Block} =
+        hb_ao:resolve(
+            <<
+                "~copycat@1.0/arweave&"
+                "from=", BlockBin/binary, "&"
+                "to=", BlockBin/binary, "&"
+                "mode=write&"
+                "depth=1"
+            >>,
+            Opts
+        ),
+    ok.
+
 setup_index_opts() ->
     TestStore = hb_test_utils:test_store(),
     StoreOpts = #{ <<"index-store">> => [TestStore] },
@@ -1570,7 +1910,9 @@ assert_bundle_read(BundleID, ExpectedItems, Opts) ->
     lists:foreach(
         fun({{_ItemID, Index}, Item}) ->
             QueriedItem = hb_ao:get(Index, Bundle, Opts),
-            ?assertEqual(hb_maps:without(?AO_CORE_KEYS, Item), hb_maps:without(?AO_CORE_KEYS, QueriedItem))
+            ?assertEqual(
+                hb_maps:without(?AO_CORE_KEYS, Item),
+                hb_maps:without(?AO_CORE_KEYS, QueriedItem))
         end,
         lists:zip(ExpectedItems, ReadItems)
     ),
@@ -1578,13 +1920,20 @@ assert_bundle_read(BundleID, ExpectedItems, Opts) ->
 
 assert_item_read(ItemID, Opts) ->
     ?event(debug_test, {resolving, {explicit, ItemID}}),
-    Resolved = hb_ao:resolve(ItemID, Opts),
-    ?assertMatch({ok, _}, Resolved, ItemID),
-    {ok, Item} = Resolved,
+    ReadResult = hb_store_arweave:read(
+        hb_store_arweave:store_from_opts(Opts), ItemID),
+    ?assertMatch({ok, _}, ReadResult, ItemID),
+    {ok, Item} = ReadResult,
     ?event(debug_test, {item, Item}),
     ?assert(hb_message:verify(Item, all, Opts)),
     ?assertEqual(ItemID, hb_message:id(Item, signed)),
     Item.
+
+assert_item_not_read(ItemID, Opts) ->
+    ReadResult = hb_store_arweave:read(
+        hb_store_arweave:store_from_opts(Opts), ItemID),
+    ?assertEqual(not_found, ReadResult),
+    ok.
 
 has_any_indexed_tx(Height, Opts) ->
     case fetch_block_header(Height, Opts) of

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -38,12 +38,15 @@ arweave(_Base, Request, Opts) ->
                                     {skipped_txs, maps:get(skipped_count, Stats, 0)}
                                 }
                             ),
-                            {ok, Stats};
+                            {ok, Stats#{
+                                <<"body">> => maps:get(items_count, Stats, 0)
+                            }};
                         _ -> 
                             {ok, #{
                                 items_count => 0,
                                 bundle_count => 0,
-                                skipped_count => 0
+                                skipped_count => 0,
+                                <<"body">> => 0
                             }}                         
                     end;
                 error ->

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -10,7 +10,12 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(ARWEAVE_DEVICE, <<"~arweave@2.9">>).
--define(DEPTH_L1_OFFSETS, 1).
+% By default we'll index blocks to depth 2 which is:
+% - depth 1: L1 TXs
+% - depth 2: L2 bundles and dataitems
+% Note: this means that the children of L2 bundles are not indexed at
+% depth 2.
+-define(DEFAULT_BLOCK_DEPTH, 2).
 
 % GET /~cron@1.0/once&cron-path=~copycat@1.0/arweave
 
@@ -23,13 +28,14 @@ arweave(_Base, Request, Opts) ->
             case hb_maps:find(<<"id">>, Request, Opts) of
                 {ok, TXID} -> process_l1_request(TXID, Request, Opts);
                 error ->
-                    BlockDepth = request_depth(Request, ?DEPTH_L1_OFFSETS, Opts),
                     {From, To} = parse_range(Request, Opts),
+                    TargetDepth = request_depth(
+                        Request, ?DEFAULT_BLOCK_DEPTH, Opts),
                     fetch_blocks(
-                        Request,
                         From,
                         To,
-                        Opts#{copycat_block_depth => BlockDepth}
+                        TargetDepth,
+                        Opts
                     )
             end;
         <<"list">>   ->
@@ -60,15 +66,15 @@ normalize_owner_id(Addr) ->
 %% @doc Adds an address to the owners aliases cache in Opts, mapping
 %% Alias -> native address for fast lookup and once per address computation.
 add_owner_alias(Addr, Alias, Opts) when is_binary(Alias) -> 
-    ExistingAliases = maps:get(owner_aliases, Opts, #{}),
+    ExistingAliases = hb_opts:get(owner_aliases, #{}, Opts),
     Opts#{ owner_aliases => ExistingAliases#{ Alias => normalize_owner_id(Addr) }};
 add_owner_alias(_Addr, Alias, _Opts) ->
     throw({invalid_owner_alias, Alias}).
 
 %% @doc Retrieve the address of a given alias.
 resolve_owner_alias(Alias, Opts) when is_binary(Alias) ->
-    Aliases = maps:get(owner_aliases, Opts, #{}),
-    case maps:find(Alias, Aliases) of
+    Aliases = hb_opts:get(owner_aliases, #{}, Opts),
+    case hb_maps:find(Alias, Aliases) of
         {ok, Addr} -> {ok, Addr};
         error -> {error, {owner_alias_not_found, Alias}}
     end;
@@ -163,9 +169,9 @@ parse_tag_filter(Key, Request, Opts) ->
 %% copycat_depth_recursion_cap).
 process_l1_request(TXID, Request, Opts) ->
     Depth = request_depth(Request, <<"safe_max">>, Opts),
-    LoadL1Offset =
+    ReadL1Offset =
         hb_util:bool(
-            hb_maps:get(<<"load-l1-offset">>, Request, false, Opts)
+            hb_maps:get(<<"read-l1-offset">>, Request, false, Opts)
         ),
     case parse_owner_filter(Request, Opts) of
         {error, _} = Error ->
@@ -183,17 +189,20 @@ process_l1_request(TXID, Request, Opts) ->
                                 process_l1_candidate(
                                     TXID,
                                     OwnerFilters#{
-                                        load_l1_offset => LoadL1Offset,
                                         include_tag => IncludeTag,
                                         exclude_tag => ExcludeTag
                                     },
                                     Depth,
+                                    ReadL1Offset,
                                     Opts
                                 )}
                     end
             end
     end.
-%% @doc Parse the requested recursion depth and clamp it to the configured safe cap.
+%% @doc Parse the requested recursion depth and clamp it to the configured
+%% safe cap. Depth is relative so depth 1 is always one level below the
+%% root specified in the request (either a block or an L1 TX ID).
+%% 
 %% `safe_max` resolves to the current copycat depth recursion cap.
 request_depth(Request, Default, Opts) ->
     MaxRecursionCap = get_depth_recursion_cap(Opts),
@@ -204,10 +213,7 @@ request_depth(Request, Default, Opts) ->
         end,
     erlang:min(
         MaxRecursionCap,
-        erlang:max(
-            ?DEPTH_L1_OFFSETS,
-            RequestedDepth
-        )
+        erlang:max(1, RequestedDepth)
     ).
 %% @doc Return the first matching L1 filter reason for a TX header, or `pass`.
 l1_filter_reason(TX, Filters) ->
@@ -395,38 +401,38 @@ classify_txs(TXIDs, Opts) ->
 %% @doc Fetch blocks from an Arweave node while moving downward from `Current'.
 %% If `To' is provided, every block in [`To', `Current'] is processed. If `To'
 %% is omitted, stop at the first block where any TX is already indexed.
-fetch_blocks(Req, Current, To, _Opts) when is_integer(To), Current < To ->
+fetch_blocks(Current, To, TargetDepth, _Opts) 
+        when is_integer(To), Current < To ->
     ?event(copycat_short,
         {arweave_block_indexing_completed,
             {reached_target, To},
-            {initial_request, Req}
+            {target_depth, TargetDepth}
         }
     ),
     {ok, To};
-fetch_blocks(_Req, Current, undefined, _Opts) when Current < 0 ->
+fetch_blocks(Current, undefined, _TargetDepth, _Opts) when Current < 0 ->
     {ok, 0};
-fetch_blocks(Req, Current, undefined, Opts) ->
+fetch_blocks(Current, undefined, TargetDepth, Opts) ->
     BlockRes = fetch_block_header(Current, Opts),
     case is_already_indexed(BlockRes, Opts) of
         true ->
             ?event(copycat_short,
                 {arweave_block_indexing_completed,
-                    {stop_at_indexed_block, Current},
-                    {initial_request, Req}
+                    {stop_at_indexed_block, Current}
                 }
             ),
             {ok, Current};
         false ->
             observe_event(<<"block_indexed">>, fun() ->
-                process_block(BlockRes, Current, undefined, Opts)
+                process_block(BlockRes, Current, undefined, TargetDepth, Opts)
             end),
-            fetch_blocks(Req, Current - 1, undefined, Opts)
+            fetch_blocks(Current - 1, undefined, TargetDepth, Opts)
     end;
-fetch_blocks(Req, Current, To, Opts) ->
+fetch_blocks(Current, To, TargetDepth, Opts) ->
     observe_event(<<"block_indexed">>, fun() ->
-        fetch_and_process_block(Current, To, Opts)
+        fetch_and_process_block(Current, To, TargetDepth, Opts)
     end),
-    fetch_blocks(Req, Current - 1, To, Opts).
+    fetch_blocks(Current - 1, To, TargetDepth, Opts).
 
 %% @doc Determine whether a fetched block is considered indexed.
 %% A block is indexed when any TX from its `txs' list is in the index.
@@ -436,17 +442,17 @@ is_already_indexed({ok, Block}, Opts) ->
 is_already_indexed({error, _}, _Opts) ->
     false.
 
-fetch_and_process_block(Current, To, Opts) ->
+fetch_and_process_block(Current, To, TargetDepth, Opts) ->
     BlockRes = fetch_block_header(Current, Opts),
-    process_block(BlockRes, Current, To, Opts).
+    process_block(BlockRes, Current, To, TargetDepth, Opts).
 
 %% @doc Process a block.
-process_block(BlockRes, Current, To, Opts) ->
+process_block(BlockRes, Current, To, TargetDepth, Opts) ->
     case BlockRes of
         {ok, Block} ->
             ?event(debug_copycat, {{processing_block, Current},
                 {indep_hash, hb_maps:get(<<"indep_hash">>, Block, <<>>)}}),
-            case maybe_index_ids(Block, Opts) of
+            case maybe_index_ids(Block, TargetDepth, Opts) of
                 {block_skipped, Results} ->
                     TotalTXs = maps:get(total_txs, Results, 0),
                     ?event(
@@ -485,7 +491,7 @@ process_block(BlockRes, Current, To, Opts) ->
     end.
 
 %% @doc Index the IDs of all transactions in the block if configured to do so.
-maybe_index_ids(Block, Opts) ->
+maybe_index_ids(Block, TargetDepth, Opts) ->
     TotalTXs = length(hb_maps:get(<<"txs">>, Block, [], Opts)),
     case hb_opts:get(arweave_index_ids, true, Opts) of
         false -> 
@@ -516,7 +522,8 @@ maybe_index_ids(Block, Opts) ->
                         fun({{padding, _}, _}) -> false; (_) -> true end,
                         TXsWithData
                     ),
-                    TXResults = process_txs(ValidTXs, BlockStartOffset, Opts),
+                    TXResults = process_txs(
+                        ValidTXs, BlockStartOffset, TargetDepth, Opts),
                     {block_cached, TXResults#{total_txs => TotalTXs}}
             end
     end.
@@ -531,10 +538,9 @@ parallel_map(Items, Fun, Opts) ->
 
 %% @doc Process a single transaction and return its contribution to the counters.
 %% Returns a map with keys: items_count, bundle_count, skipped_count
-process_tx({{padding, _PaddingRoot}, _EndOffset}, _BlockStartOffset, _Opts) ->
+process_tx({{padding, _PaddingRoot}, _EndOffset}, _BlockStartOffset, _TargetDepth, _Opts) ->
     #{items_count => 0, bundle_count => 0, skipped_count => 0};
-process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
-    Depth = get_block_depth(Opts),
+process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, Opts) ->
     IndexStore = hb_store_arweave:store_from_opts(Opts),
     TXID = hb_util:encode(TX#tx.id),
     TXEndOffset = BlockStartOffset + EndOffset,
@@ -555,8 +561,10 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
     end),
     case is_bundle_tx(TX, Opts) of
         false -> #{items_count => 0, bundle_count => 0, skipped_count => 0};
-        true when Depth > ?DEPTH_L1_OFFSETS ->
-            process_l1_candidate(TX#tx.id, #{}, Depth, Opts);
+        true when TargetDepth > 1 ->
+            % Indexing a block to depth 2 or greater means we need to load
+            % and recurse into each of the L1 TXs in the block.
+            process_l1_candidate(TX#tx.id, #{}, TargetDepth - 1, false, Opts);
         true ->
             % Lightweight processing of block transactions to depth 2. We
             % can avoid loading the full L1 TX data into memory, and instead
@@ -614,10 +622,11 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
 %% When arweave_index_workers <= 1, processes sequentially (one worker at a time).
 %% When arweave_index_workers > 1, processes in parallel with the specified concurrency limit.
 %% Returns a map with keys: items_count, bundle_count, skipped_count.
-process_txs(ValidTXs, BlockStartOffset, Opts) ->
+process_txs(ValidTXs, BlockStartOffset, TargetDepth, Opts) ->
     Results = parallel_map(
         ValidTXs,
-        fun(TXWithData) -> process_tx(TXWithData, BlockStartOffset, Opts) end,
+        fun(TXWithData) -> process_tx(
+            TXWithData, BlockStartOffset, TargetDepth, Opts) end,
         Opts
     ),
     lists:foldl(
@@ -633,17 +642,16 @@ process_txs(ValidTXs, BlockStartOffset, Opts) ->
     ).
 
 %% @doc Process a single indexed L1 TX candidate after lightweight filter checks.
-process_l1_candidate(TXID, Filters, Depth, Opts) ->
+process_l1_candidate(TXID, Filters, Depth, ReadL1Offset, Opts) ->
     Skipped = #{items_count => 0, bundle_count => 0, skipped_count => 1},
     NormalizedTXID = hb_util:native_id(TXID),
     EncodedTXID = hb_util:encode(NormalizedTXID),
     IndexStore = hb_store_arweave:store_from_opts(Opts),
-    LoadL1Offset = maps:get(load_l1_offset, Filters, false),
     case ensure_l1_tx_offset(
         NormalizedTXID,
         EncodedTXID,
         IndexStore,
-        LoadL1Offset,
+        ReadL1Offset,
         Opts
     ) of
         {ok,
@@ -793,11 +801,11 @@ process_l1_candidate(TXID, Filters, Depth, Opts) ->
 ensure_l1_tx_offset(_TXID, _EncodedTXID, IndexStore, _LoadL1Offset, _Opts)
         when is_map(IndexStore) =:= false ->
     {error, missing_offset};
-ensure_l1_tx_offset(TXID, EncodedTXID, IndexStore, LoadL1Offset, Opts) ->
+ensure_l1_tx_offset(TXID, EncodedTXID, IndexStore, ReadL1Offset, Opts) ->
     case hb_store_arweave:read_offset(IndexStore, TXID) of
         {ok, _} = OffsetRes ->
             OffsetRes;
-        not_found when LoadL1Offset ->
+        not_found when ReadL1Offset ->
             ?event(
                 copycat_short,
                 {arweave_tx_offset_loading,
@@ -1035,7 +1043,7 @@ index_ids_test() ->
     {_TestStore, StoreOpts, Opts} = setup_index_opts(),
     {ok, 1827942} =
         hb_ao:resolve(
-            <<"~copycat@1.0/arweave&from=1827942&to=1827942">>,
+            <<"~copycat@1.0/arweave&from=1827942&to=1827942&depth=1">>,
             Opts
         ),
     ?assertMatch(
@@ -1092,7 +1100,23 @@ index_ids_test() ->
         ],
         Opts
     ),
+    % L3 item not read when doing L1 depth=1
+    assert_item_not_read(<<"8aJrRWtHcJvJ61qsH6agGkemzrtLw3W22xFrpCGAnTM">>, Opts),
    ok.
+
+index_ids_depth_2_test() ->
+    %% Test block: https://viewblock.io/arweave/block/1827942
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    {ok, 1827942} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=1827942&to=1827942&depth=2">>,
+            Opts
+        ),
+    % L3 item read when doing depth=2
+    assert_item_read(
+        <<"ZQRHZhktk6dAtX9BlhO1teOtVlGHoyaWP25kAlhxrM4">>,
+        Opts),
+    ok.
 
 %% @doc Test a bundle header that fits in a single chunk.
 small_bundle_header_test() ->
@@ -1633,23 +1657,23 @@ l1_filter_reason_test() ->
 
 request_depth_clamping_test() ->
     {_TestStore, _StoreOpts, Opts0} = setup_index_opts(),
-    ?assertEqual(4, request_depth(#{}, <<"safe_max">>, Opts0)),
+    ?assertEqual(6, request_depth(#{}, <<"safe_max">>, Opts0)),
     ?assertEqual(
         2,
         request_depth(#{<<"depth">> => <<"2">>}, <<"safe_max">>, Opts0)
     ),
     ?assertEqual(
-        ?DEPTH_L1_OFFSETS,
+        1,
         request_depth(#{<<"depth">> => <<"0">>}, <<"safe_max">>, Opts0)
     ),
     ?assertEqual(
-        4,
+        6,
         request_depth(#{<<"depth">> => <<"999">>}, <<"safe_max">>, Opts0)
     ),
     Opts1 = set_depth_recursion_cap(2, Opts0),
     ?assertEqual(2, request_depth(#{}, <<"safe_max">>, Opts1)),
     % no recursion cap set, use default from hb_opts
-    ?assertEqual(4, request_depth(#{}, <<"safe_max">>, #{})),
+    ?assertEqual(6, request_depth(#{}, <<"safe_max">>, #{})),
     ok.
 
 memory_cap_setter_getter_test() ->
@@ -1807,7 +1831,7 @@ id_missing_offset_with_load_test() ->
                 "~copycat@1.0/arweave&"
                 "id=", TXID/binary, "&"
                 "mode=write&"
-                "load-l1-offset=true&"
+                "read-l1-offset=true&"
                 "depth=2"
             >>,
             Opts

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -165,6 +165,10 @@ parse_tag_filter(Key, Request, Opts) ->
 %% (defaults to full recursion till the set copycat_depth_recursion_cap).
 process_l1_request(TXID, Request, Opts) ->
     Depth = request_depth(Request, <<"safe_max">>, Opts),
+    LoadL1Offset =
+        hb_util:bool(
+            hb_maps:get(<<"load-l1-offset">>, Request, false, Opts)
+        ),
     case parse_owner_filter(Request, Opts) of
         {error, _} = Error ->
             Error;
@@ -181,6 +185,7 @@ process_l1_request(TXID, Request, Opts) ->
                                 process_l1_candidate(
                                     TXID,
                                     OwnerFilters#{
+                                        load_l1_offset => LoadL1Offset,
                                         include_tag => IncludeTag,
                                         exclude_tag => ExcludeTag
                                     },
@@ -629,7 +634,14 @@ process_l1_candidate(TXID, Filters, Depth, Opts) ->
     NormalizedTXID = hb_util:native_id(TXID),
     EncodedTXID = hb_util:encode(NormalizedTXID),
     IndexStore = hb_store_arweave:store_from_opts(Opts),
-    case hb_store_arweave:read_offset(IndexStore, NormalizedTXID) of
+    LoadL1Offset = maps:get(load_l1_offset, Filters, false),
+    case ensure_l1_tx_offset(
+        NormalizedTXID,
+        EncodedTXID,
+        IndexStore,
+        LoadL1Offset,
+        Opts
+    ) of
         {ok,
             #{
                 <<"codec-device">> := <<"tx@1.0">>,
@@ -760,15 +772,66 @@ process_l1_candidate(TXID, Filters, Depth, Opts) ->
                 }
             ),
             Skipped;
-        not_found ->
+        {error, Reason} ->
             ?event(
                 copycat_short,
                 {arweave_tx_skipped,
                     {tx_id, {explicit, EncodedTXID}},
-                    {reason, missing_offset}
+                    {reason, Reason}
                 }
             ),
             Skipped
+    end.
+
+ensure_l1_tx_offset(_TXID, _EncodedTXID, IndexStore, _LoadL1Offset, _Opts)
+        when is_map(IndexStore) =:= false ->
+    {error, missing_offset};
+ensure_l1_tx_offset(TXID, EncodedTXID, IndexStore, LoadL1Offset, Opts) ->
+    case hb_store_arweave:read_offset(IndexStore, TXID) of
+        {ok, _} = OffsetRes ->
+            OffsetRes;
+        not_found when LoadL1Offset ->
+            case load_l1_tx_offset(EncodedTXID, IndexStore, Opts) of
+                ok ->
+                    case hb_store_arweave:read_offset(IndexStore, TXID) of
+                        {ok, _} = OffsetRes ->
+                            OffsetRes;
+                        not_found ->
+                            {error, missing_offset}
+                    end;
+                {error, Reason} ->
+                    {error, Reason}
+            end;
+        not_found ->
+            {error, missing_offset}
+    end.
+
+load_l1_tx_offset(TXID, IndexStore, Opts) ->
+    case hb_http:request(
+        #{
+            <<"path">> => <<"/arweave/tx/", TXID/binary, "/offset">>,
+            <<"method">> => <<"GET">>
+        },
+        Opts
+    ) of
+        {ok, #{ <<"body">> := OffsetBody }} ->
+            OffsetMsg = hb_json:decode(OffsetBody),
+            EndOffset = hb_util:int(maps:get(<<"offset">>, OffsetMsg)),
+            Size = hb_util:int(maps:get(<<"size">>, OffsetMsg)),
+            StartOffset = EndOffset - Size,
+            ok =
+                hb_store_arweave:write_offset(
+                    IndexStore,
+                    TXID,
+                    <<"tx@1.0">>,
+                    StartOffset,
+                    Size
+                ),
+            ok;
+        {error, Reason} ->
+            {error, Reason};
+        not_found ->
+            {error, not_found}
     end.
 
 index_bundle_bytes(_BundleData, _BundleStartOffset, Depth, _Store, _Opts)

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -86,6 +86,20 @@ resolve_owner_filter_value(OwnerKey, AliasKey, Request, Opts) ->
                     {ok, undefined}
             end
     end.
+
+parse_exclude_tag(Request, Opts) ->
+    case hb_maps:find(<<"exclude-tag">>, Request, Opts) of
+        {ok, Tag} ->
+            case binary:split(hb_util:bin(Tag), <<":">>, [global]) of
+                [Name, Value]
+                        when byte_size(Name) > 0 andalso byte_size(Value) > 0 ->
+                    {ok, #{name => Name, value => Value}};
+                _ ->
+                    {error, invalid_exclude_tag}
+            end;
+        error ->
+            {ok, undefined}
+    end.
 %% @doc Parse the range from the request.
 parse_range(Request, Opts) ->
     From =

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -38,9 +38,13 @@ arweave(_Base, Request, Opts) ->
                                     {skipped_txs, maps:get(skipped_count, Stats, 0)}
                                 }
                             ),
-                            {ok, maps:get(items_count, Stats, 0)};
+                            {ok, Stats};
                         _ -> 
-                            {ok, 0}                         
+                            {ok, #{
+                                items_count => 0,
+                                bundle_count => 0,
+                                skipped_count => 0
+                            }}                         
                     end;
                 error ->
                     {From, To} = parse_range(Request, Opts),
@@ -317,9 +321,6 @@ normalize_height(Height, Opts) ->
         true -> latest_height(Opts) + RequestedHeight;
         false -> RequestedHeight
     end.
-
-get_block_depth(Opts) ->
-    maps:get(copycat_block_depth, Opts, ?DEPTH_L1_OFFSETS).
 
 latest_height(Opts) ->
     case hb_ao:resolve(
@@ -632,304 +633,6 @@ process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, 
                     ),
                     #{items_count => 0, bundle_count => 1, skipped_count => 1}
             end
-    end.
-
-%% @doc Process transactions: spawn workers and manage the worker pool.
-%% This function processes transactions in parallel using parallel_map.
-%% When arweave_index_workers <= 1, processes sequentially (one worker at a time).
-%% When arweave_index_workers > 1, processes in parallel with the specified concurrency limit.
-%% Returns a map with keys: items_count, bundle_count, skipped_count.
-process_txs(ValidTXs, BlockStartOffset, TargetDepth, Opts) ->
-    Results = parallel_map(
-        ValidTXs,
-        fun(TXWithData) -> process_tx(
-            TXWithData, BlockStartOffset, TargetDepth, Opts) end,
-        Opts
-    ),
-    lists:foldl(
-        fun(Result, Acc) ->
-            #{
-                items_count => maps:get(items_count, Result, 0) + maps:get(items_count, Acc, 0),
-                bundle_count => maps:get(bundle_count, Result, 0) + maps:get(bundle_count, Acc, 0),
-                skipped_count => maps:get(skipped_count, Result, 0) + maps:get(skipped_count, Acc, 0)
-            }
-        end,
-        #{items_count => 0, bundle_count => 0, skipped_count => 0},
-        Results
-    ).
-
-%% @doc Process a single indexed L1 TX candidate after lightweight filter checks.
-process_l1_candidate(TXID, Filters, Depth, ReadL1Offset, Opts) ->
-    Skipped = #{items_count => 0, bundle_count => 0, skipped_count => 1},
-    NormalizedTXID = hb_util:native_id(TXID),
-    EncodedTXID = hb_util:encode(NormalizedTXID),
-    IndexStore = hb_store_arweave:store_from_opts(Opts),
-    case ensure_l1_tx_offset(
-        NormalizedTXID,
-        EncodedTXID,
-        IndexStore,
-        ReadL1Offset,
-        Opts
-    ) of
-        {ok,
-            #{
-                <<"codec-device">> := <<"tx@1.0">>,
-                <<"start-offset">> := StartOffset,
-                <<"length">> := Length
-            }} ->
-            case resolve_tx_header(EncodedTXID, Opts) of
-                {ok, TX} ->
-                    case l1_filter_reason(TX, Filters) of
-                        pass ->
-                            case is_bundle_tx(TX, Opts) of
-                                false ->
-                                    ?event(
-                                        copycat_short,
-                                        {arweave_tx_skipped,
-                                            {tx_id, {explicit, EncodedTXID}},
-                                            {reason, not_bundle}
-                                }
-                                    ),
-                                    Skipped;
-                                true ->
-                                    case Length =< get_memory_safe_cap(Opts) of
-                                        false ->
-                                            ?event(
-                                                copycat_short,
-                                                {arweave_bundle_skipped,
-                                                    {tx_id, {explicit, EncodedTXID}},
-                                                    {reason, memory_safe_cap_exceeded}
-                                                }
-                                            ),
-                                            #{
-                                                items_count => 0,
-                                                bundle_count => 1,
-                                                skipped_count => 1
-                                            };
-                                        true ->
-                                            case hb_store_arweave:read_chunks(
-                                                StartOffset,
-                                                Length,
-                                                Opts
-                                            ) of
-                                                {ok, BundleData} ->
-                                                    {TotalTime, IndexRes} = timer:tc(
-                                                        fun() ->
-                                                            index_bundle_bytes(
-                                                                BundleData,
-                                                                StartOffset,
-                                                                Depth,
-                                                                IndexStore,
-                                                                Opts
-                                                            )
-                                                        end
-                                                    ),
-                                                    case IndexRes of
-                                                        {ok, ItemsCount} ->
-                                                            record_event_metrics(
-                                                                <<"item_indexed">>,
-                                                                ItemsCount,
-                                                                TotalTime
-                                                            ),
-                                                            #{
-                                                                items_count => ItemsCount,
-                                                                bundle_count => 1,
-                                                                skipped_count => 0
-                                                            };
-                                                        {error, Reason} ->
-                                                            ?event(
-                                                                copycat_short,
-                                                                {arweave_bundle_skipped,
-                                                                    {tx_id, {explicit, EncodedTXID}},
-                                                                    {reason, Reason}
-                                                                }
-                                                            ),
-                                                            #{
-                                                                items_count => 0,
-                                                                bundle_count => 1,
-                                                                skipped_count => 1
-                                                            }
-                                                    end;
-                                                {error, Reason} ->
-                                                    ?event(
-                                                        copycat_short,
-                                                        {arweave_bundle_skipped,
-                                                            {tx_id, {explicit, EncodedTXID}},
-                                                            {reason, Reason}
-                                                        }
-                                                    ),
-                                                    #{
-                                                        items_count => 0,
-                                                        bundle_count => 1,
-                                                        skipped_count => 1
-                                                    };
-                                                not_found ->
-                                                    ?event(
-                                                        copycat_short,
-                                                        {arweave_bundle_skipped,
-                                                            {tx_id, {explicit, EncodedTXID}},
-                                                            {reason, not_found}
-                                                        }
-                                                    ),
-                                                    #{
-                                                        items_count => 0,
-                                                        bundle_count => 1,
-                                                        skipped_count => 1
-                                                    }
-                                            end
-                                    end
-                            end;
-                        FilterReason ->
-                            ?event(
-                                copycat_short,
-                                {arweave_tx_skipped,
-                                    {tx_id, {explicit, EncodedTXID}},
-                                    {reason, FilterReason}
-                                }
-                            ),
-                            Skipped
-                    end;
-                error ->
-                    Skipped
-            end;
-        {ok, _OtherOffset} ->
-            ?event(
-                copycat_short,
-                {arweave_tx_skipped,
-                    {tx_id, {explicit, EncodedTXID}},
-                    {reason, not_tx}
-                }
-            ),
-            Skipped;
-        {error, Reason} ->
-            ?event(
-                copycat_short,
-                {arweave_tx_skipped,
-                    {tx_id, {explicit, EncodedTXID}},
-                    {reason, Reason}
-                }
-            ),
-            Skipped
-    end.
-%% @doc Ensure the root L1 TX offset exists locally before `id=...` indexing.
-%% if the offset is missing and `load_l1_offset` is enabled, fetches the TX
-%% offset metadata from Arweave, writes it to the local offset store, and
-%% retries the local lookup.
-ensure_l1_tx_offset(_TXID, _EncodedTXID, IndexStore, _LoadL1Offset, _Opts)
-        when is_map(IndexStore) =:= false ->
-    {error, missing_offset};
-ensure_l1_tx_offset(TXID, EncodedTXID, IndexStore, ReadL1Offset, Opts) ->
-    case hb_store_arweave:read_offset(IndexStore, TXID) of
-        {ok, _} = OffsetRes ->
-            OffsetRes;
-        not_found when ReadL1Offset ->
-            ?event(
-                copycat_short,
-                {arweave_tx_offset_loading,
-                    {tx_id, {explicit, EncodedTXID}},
-                    {source, network}
-                }
-            ),
-            case load_l1_tx_offset(EncodedTXID, IndexStore, Opts) of
-                ok ->
-                    case hb_store_arweave:read_offset(IndexStore, TXID) of
-                        {ok, _} = OffsetRes ->
-                            OffsetRes;
-                        not_found ->
-                            {error, missing_offset}
-                    end;
-                {error, Reason} ->
-                    {error, Reason}
-            end;
-        not_found ->
-            {error, missing_offset}
-    end.
-
-load_l1_tx_offset(TXID, IndexStore, Opts) ->
-    case hb_http:request(
-        #{
-            <<"path">> => <<"/arweave/tx/", TXID/binary, "/offset">>,
-            <<"method">> => <<"GET">>
-        },
-        Opts
-    ) of
-        {ok, #{ <<"body">> := OffsetBody }} ->
-            OffsetMsg = hb_json:decode(OffsetBody),
-            EndOffset = hb_util:int(maps:get(<<"offset">>, OffsetMsg)),
-            Size = hb_util:int(maps:get(<<"size">>, OffsetMsg)),
-            StartOffset = EndOffset - Size,
-            ok =
-                hb_store_arweave:write_offset(
-                    IndexStore,
-                    TXID,
-                    <<"tx@1.0">>,
-                    StartOffset,
-                    Size
-                ),
-            ok;
-        {error, Reason} ->
-            {error, Reason};
-        not_found ->
-            {error, not_found}
-    end.
-
-index_bundle_bytes(_BundleData, _BundleStartOffset, Depth, _Store, _Opts)
-        when Depth =< 0 ->
-    {ok, 0};
-index_bundle_bytes(BundleData, BundleStartOffset, Depth, Store, Opts) ->
-    case ar_bundles:decode_bundle_header(BundleData) of
-        invalid_bundle_header ->
-            {error, invalid_bundle_header};
-        {ItemsBin, BundleIndex} ->
-            HeaderSize = byte_size(BundleData) - byte_size(ItemsBin),
-            index_bundle_items(
-                BundleIndex,
-                ItemsBin,
-                BundleStartOffset + HeaderSize,
-                Depth,
-                Store,
-                Opts,
-                0
-            )
-    end.
-
-%% @doc Lightweight bundle indexing. This function only loads the bundle header
-%% and writes the index based solely on the header. For a more rigorous and
-%% deeper indexing, see the index_full_bundle_xxx functions.
-index_bundle_header(TXID, TXEndOffset, TXDataSize, TXStartOffset, IndexStore, Opts) ->
-    BundleRes = download_bundle_header(TXEndOffset, TXDataSize, Opts),
-    case BundleRes of
-        {ok, {BundleIndex, HeaderSize}} ->
-            % Batch event tracking: measure total time and count for
-            % all write_offset calls
-            {TotalTime, {_, ItemsCount}} = timer:tc(fun() ->
-                lists:foldl(
-                    fun({ItemID, Size}, {ItemStartOffset, ItemsCountAcc}) ->
-                        hb_store_arweave:write_offset(
-                            IndexStore,
-                            hb_util:encode(ItemID),
-                            <<"ans104@1.0">>,
-                            ItemStartOffset,
-                            Size
-                        ),
-                        {ItemStartOffset + Size, ItemsCountAcc + 1}
-                    end,
-                    {TXStartOffset + HeaderSize, 0},
-                    BundleIndex
-                )
-            end),
-            % Single event increment for the batch
-            record_event_metrics(<<"item_indexed">>, ItemsCount, TotalTime),
-            #{items_count => ItemsCount, bundle_count => 1, skipped_count => 0};
-        {error, Reason} ->
-            ?event(
-                copycat_short,
-                {arweave_bundle_skipped,
-                    {tx_id, {explicit, TXID}},
-                    {reason, Reason}
-                }
-            ),
-            #{items_count => 0, bundle_count => 1, skipped_count => 1}
     end.
 
 download_bundle_header(EndOffset, Size, Opts) ->
@@ -1452,7 +1155,7 @@ block_depth_2_test() ->
     ),
     % L3 item not read when doing L1 depth=1
     assert_item_not_read(<<"8aJrRWtHcJvJ61qsH6agGkemzrtLw3W22xFrpCGAnTM">>, Opts),
-   ok.
+    ok.
 
 block_depth_3_test() ->
     %% Test block: https://viewblock.io/arweave/block/1827942
@@ -2050,7 +1753,6 @@ id_depth_1_test() ->
     ?assertEqual(26, maps:get(items_count, Result)),
     ?assertEqual(1, maps:get(bundle_count, Result)),
     ?assertEqual(0, maps:get(skipped_count, Result)),
-
     assert_bundle_read(
         <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>,
         [
@@ -2081,7 +1783,6 @@ id_depth_2_test() ->
     ?assertEqual(52, maps:get(items_count, Result)),
     ?assertEqual(1, maps:get(bundle_count, Result)),
     ?assertEqual(0, maps:get(skipped_count, Result)),
-
     assert_bundle_read(
         <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>,
         [
@@ -2189,7 +1890,6 @@ id_missing_offset_with_load_test() ->
     ?assertEqual(52, maps:get(items_count, Result)),
     ?assertEqual(1, maps:get(bundle_count, Result)),
     ?assertEqual(0, maps:get(skipped_count, Result)),
-
     assert_bundle_read(
         <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>,
         [

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -13,7 +13,7 @@
 -define(DEPTH_L1_OFFSETS, 1).
 -define(DEPTH_RECURSION_CAP, 4).
 %% 1GB in bytes
--define(MEMORY_SAFE_CAP, 1024 * 1024 * 1024).
+-define(MEMORY_SAFE_CAP, 6 * 1024 * 1024 * 1024).
 
 % GET /~cron@1.0/once&cron-path=~copycat@1.0/arweave
 

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -197,25 +197,30 @@ process_l1_request(TXID, Request, Opts) ->
         hb_util:bool(
             hb_maps:get(<<"query-l1-offset">>, Request, false, Opts)
         ),
-    maybe
-        {ok, OwnerFilters} ?= parse_owner_filter(Request, Opts),
-        {ok, IncludeTag} ?= parse_tag_filter(<<"include-tag">>, Request, Opts),
-        {ok, ExcludeTag} ?= parse_tag_filter(<<"exclude-tag">>, Request, Opts),
-        {ok,
-            maybe_process_l1_tx(
-                TXID,
-                OwnerFilters#{
-                    include_tag => IncludeTag,
-                    exclude_tag => ExcludeTag
-                },
-                Depth,
-                QueryL1Offset,
-                Opts
-            )}
-    else
-        {error, _} = Error ->
-            Error
-    end.
+    observe_copycat_l1_stage(
+        <<"l1_request_total">>,
+        fun() ->
+            maybe
+                {ok, OwnerFilters} ?= parse_owner_filter(Request, Opts),
+                {ok, IncludeTag} ?= parse_tag_filter(<<"include-tag">>, Request, Opts),
+                {ok, ExcludeTag} ?= parse_tag_filter(<<"exclude-tag">>, Request, Opts),
+                {ok,
+                    maybe_process_l1_tx(
+                        TXID,
+                        OwnerFilters#{
+                            include_tag => IncludeTag,
+                            exclude_tag => ExcludeTag
+                        },
+                        Depth,
+                        QueryL1Offset,
+                        Opts
+                    )}
+            else
+                {error, _} = Error ->
+                    Error
+            end
+        end
+    ).
 %% @doc Parse the requested recursion depth and clamp it to the configured
 %% safe cap. Depth is relative so depth 1 is always one level below the
 %% root specified in the request (either a block or an L1 TX ID).
@@ -708,12 +713,17 @@ maybe_process_l1_tx(TXID, Filters, Depth, QueryL1Offset, Opts) ->
                 <<"start-offset">> := StartOffset,
                 <<"length">> := Length
             }} ?=
-            ensure_l1_tx_offset(
-                NormalizedTXID,
-                EncodedTXID,
-                IndexStore,
-                QueryL1Offset,
-                Opts
+            observe_copycat_l1_stage(
+                <<"l1_offset_lookup">>,
+                fun() ->
+                    ensure_l1_tx_offset(
+                        NormalizedTXID,
+                        EncodedTXID,
+                        IndexStore,
+                        QueryL1Offset,
+                        Opts
+                    )
+                end
             ),
         {ok, TX} ?= resolve_tx_header(EncodedTXID, Opts),
         pass ?= l1_filter_reason(TX, Filters),
@@ -787,16 +797,24 @@ maybe_process_l1_tx(TXID, Filters, Depth, QueryL1Offset, Opts) ->
 %% be merged.
 process_l1_tx(
         StartOffset, Length, Depth, IndexStore, EncodedTXID, Opts) ->
-    case hb_store_arweave:read_chunks(StartOffset, Length, Opts) of
+    case observe_copycat_l1_stage(
+        <<"l1_read_chunks">>,
+        fun() -> hb_store_arweave:read_chunks(StartOffset, Length, Opts) end
+    ) of
         {ok, BundleData} ->
             {TotalTime, IndexRes} = timer:tc(
                 fun() ->
-                    index_full_bundle_bytes(
-                        BundleData,
-                        StartOffset,
-                        Depth,
-                        IndexStore,
-                        Opts
+                    observe_copycat_l1_stage(
+                        <<"l1_full_bundle_index">>,
+                        fun() ->
+                            index_full_bundle_bytes(
+                                BundleData,
+                                StartOffset,
+                                Depth,
+                                IndexStore,
+                                Opts
+                            )
+                        end
                     )
                 end
             ),
@@ -890,26 +908,35 @@ ensure_l1_tx_offset(TXID, EncodedTXID, IndexStore, QueryL1Offset, Opts) ->
 query_l1_tx_offset(TXID, IndexStore, Opts) ->
     % TODO: move this into dev_arweave - I think? Unless it's possible to
     % query this already via one of the existing ~arweave@2.9 paths?
-    case hb_http:request(
-        #{
-            <<"path">> => <<"/arweave/tx/", TXID/binary, "/offset">>,
-            <<"method">> => <<"GET">>
-        },
-        Opts
+    case observe_copycat_l1_stage(
+        <<"l1_offset_query_http">>,
+        fun() ->
+            hb_http:request(
+                #{
+                    <<"path">> => <<"/arweave/tx/", TXID/binary, "/offset">>,
+                    <<"method">> => <<"GET">>
+                },
+                Opts
+            )
+        end
     ) of
         {ok, #{ <<"body">> := OffsetBody }} ->
             OffsetMsg = hb_json:decode(OffsetBody),
             EndOffset = hb_util:int(maps:get(<<"offset">>, OffsetMsg)),
             Size = hb_util:int(maps:get(<<"size">>, OffsetMsg)),
             StartOffset = EndOffset - Size,
-            ok =
-                hb_store_arweave:write_offset(
-                    IndexStore,
-                    TXID,
-                    <<"tx@1.0">>,
-                    StartOffset,
-                    Size
-                ),
+            ok = observe_copycat_l1_stage(
+                <<"l1_offset_query_store_write">>,
+                fun() ->
+                    hb_store_arweave:write_offset(
+                        IndexStore,
+                        TXID,
+                        <<"tx@1.0">>,
+                        StartOffset,
+                        Size
+                    )
+                end
+            ),
             ok;
         {error, Reason} ->
             {error, Reason};
@@ -1081,11 +1108,20 @@ record_event_metrics(MetricName, Count, Duration) ->
     hb_event:increment(<<"arweave_block_count">>, MetricName, #{}, Count),
     hb_event:increment(<<"arweave_block_duration">>, MetricName, #{}, Duration).
 
+record_copycat_l1_metrics(MetricName, Count, Duration) ->
+    hb_event:increment(<<"copycat_l1_count">>, MetricName, #{}, Count),
+    hb_event:increment(<<"copycat_l1_duration">>, MetricName, #{}, Duration).
+
 %% @doc Track an operation's execution time and count using hb_event:increment.
 %% Always tracks both count and duration, regardless of success/failure.
 observe_event(MetricName, Fun) ->
     {Time, Result} = timer:tc(Fun),
     record_event_metrics(MetricName, 1, Time),
+    Result.
+
+observe_copycat_l1_stage(MetricName, Fun) ->
+    {Time, Result} = timer:tc(Fun),
+    record_copycat_l1_metrics(MetricName, 1, Time),
     Result.
 
 %%% Tests

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -1104,12 +1104,12 @@ resolve_tx_header(TXID, Opts) ->
 
 %% @doc Record event metrics (count and duration) using hb_event:increment.
 record_event_metrics(MetricName, Count, Duration) ->
-    hb_event:increment(<<"arweave_block_count">>, MetricName, #{}, Count),
-    hb_event:increment(<<"arweave_block_duration">>, MetricName, #{}, Duration).
+    hb_event:increment(arweave_block_count, MetricName, #{}, Count),
+    hb_event:increment(arweave_block_duration, MetricName, #{}, Duration).
 
 record_copycat_l1_metrics(MetricName, Count, Duration) ->
-    hb_event:increment(<<"copycat_l1_count">>, MetricName, #{}, Count),
-    hb_event:increment(<<"copycat_l1_duration">>, MetricName, #{}, Duration).
+    hb_event:increment(copycat_l1_count, MetricName, #{}, Count),
+    hb_event:increment(copycat_l1_duration, MetricName, #{}, Duration).
 
 %% @doc Track an operation's execution time and count using hb_event:increment.
 %% Always tracks both count and duration, regardless of success/failure.

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -23,8 +23,14 @@ arweave(_Base, Request, Opts) ->
             case hb_maps:find(<<"id">>, Request, Opts) of
                 {ok, TXID} -> process_l1_request(TXID, Request, Opts);
                 error ->
+                    BlockDepth = request_depth(Request, ?DEPTH_L1_OFFSETS, Opts),
                     {From, To} = parse_range(Request, Opts),
-                    fetch_blocks(Request, From, To, Opts)
+                    fetch_blocks(
+                        Request,
+                        From,
+                        To,
+                        Opts#{copycat_block_depth => BlockDepth}
+                    )
             end;
         <<"list">>   ->
             {From, To} = parse_range(Request, Opts),
@@ -288,6 +294,9 @@ normalize_height(Height, Opts) ->
         false -> RequestedHeight
     end.
 
+get_block_depth(Opts) ->
+    maps:get(copycat_block_depth, Opts, ?DEPTH_L1_OFFSETS).
+
 latest_height(Opts) ->
     case hb_ao:resolve(
         <<?ARWEAVE_DEVICE/binary, "/current/height">>,
@@ -524,6 +533,7 @@ parallel_map(Items, Fun, Opts) ->
 process_tx({{padding, _PaddingRoot}, _EndOffset}, _BlockStartOffset, _Opts) ->
     #{items_count => 0, bundle_count => 0, skipped_count => 0};
 process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
+    Depth = get_block_depth(Opts),
     IndexStore = hb_store_arweave:store_from_opts(Opts),
     TXID = hb_util:encode(TX#tx.id),
     TXEndOffset = BlockStartOffset + EndOffset,
@@ -544,6 +554,8 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
     end),
     case is_bundle_tx(TX, Opts) of
         false -> #{items_count => 0, bundle_count => 0, skipped_count => 0};
+        true when Depth > ?DEPTH_L1_OFFSETS ->
+            process_l1_candidate(TX#tx.id, #{}, Depth, Opts);
         true ->
             % Lightweight processing of block transactions to depth 2. We
             % can avoid loading the full L1 TX data into memory, and instead

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -17,10 +17,17 @@
 %% latest known block towards the Genesis block. If no range is provided, we
 %% fetch blocks from the latest known block towards the Genesis block.
 arweave(_Base, Request, Opts) ->
-    {From, To} = parse_range(Request, Opts),
     case hb_maps:get(<<"mode">>, Request, <<"write">>, Opts) of
-        <<"write">>  -> fetch_blocks(Request, From, To, Opts);
-        <<"list">>   -> list_index(From, To, Opts);
+        <<"write">>  ->
+            case hb_maps:find(<<"id">>, Request, Opts) of
+                {ok, TXID} -> process_l1_request(TXID, Request, Opts);
+                error ->
+                    {From, To} = parse_range(Request, Opts),
+                    fetch_blocks(Request, From, To, Opts)
+            end;
+        <<"list">>   ->
+            {From, To} = parse_range(Request, Opts),
+            list_index(From, To, Opts);
         Mode ->
             {error, <<"Unsupported mode `", (hb_util:bin(Mode))/binary, "`. Supported modes are: write, list">>}
     end.
@@ -100,6 +107,24 @@ parse_exclude_tag(Request, Opts) ->
             end;
         error ->
             {ok, undefined}
+    end.
+
+process_l1_request(TXID, Request, Opts) ->
+    case parse_owner_filter(Request, Opts) of
+        {error, _} = Error ->
+            Error;
+        {ok, OwnerFilters} ->
+            case parse_exclude_tag(Request, Opts) of
+                {error, _} = Error ->
+                    Error;
+                {ok, ExcludeTag} ->
+                    {ok,
+                        process_l1_candidate(
+                            TXID,
+                            OwnerFilters#{ exclude_tag => ExcludeTag },
+                            Opts
+                        )}
+            end
     end.
 
 passes_l1_filters(TX, Filters) ->
@@ -488,6 +513,73 @@ process_txs(ValidTXs, BlockStartOffset, Opts) ->
         #{items_count => 0, bundle_count => 0, skipped_count => 0},
         Results
     ).
+
+%% @doc Process a single indexed L1 TX candidate after lightweight filter checks.
+process_l1_candidate(TXID, Filters, Opts) ->
+    Skipped = #{items_count => 0, bundle_count => 0, skipped_count => 1},
+    NormalizedTXID = hb_util:native_id(TXID),
+    EncodedTXID = hb_util:encode(NormalizedTXID),
+    IndexStore = hb_store_arweave:store_from_opts(Opts),
+    case hb_store_arweave:read_offset(IndexStore, NormalizedTXID) of
+        {ok,
+            #{
+                <<"codec-device">> := <<"tx@1.0">>,
+                <<"start-offset">> := StartOffset,
+                <<"length">> := Length
+            }} ->
+            case resolve_tx_header(EncodedTXID, Opts) of
+                {ok, TX} ->
+                    case passes_l1_filters(TX, Filters) of
+                        false ->
+                            ?event(
+                                copycat_short,
+                                {arweave_tx_skipped,
+                                    {tx_id, {explicit, EncodedTXID}},
+                                    {reason, l1_filter}
+                                }
+                            ),
+                            Skipped;
+                        true ->
+                            case is_bundle_tx(TX, Opts) of
+                                false ->
+                                    ?event(
+                                        copycat_short,
+                                        {arweave_tx_skipped,
+                                            {tx_id, {explicit, EncodedTXID}},
+                                            {reason, not_bundle}
+                                        }
+                                    ),
+                                    Skipped;
+                                true ->
+                                    process_tx(
+                                        {{TX, <<>>}, StartOffset + Length},
+                                        0,
+                                        Opts
+                                    )
+                            end
+                    end;
+                error ->
+                    Skipped
+            end;
+        {ok, _OtherOffset} ->
+            ?event(
+                copycat_short,
+                {arweave_tx_skipped,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {reason, not_tx}
+                }
+            ),
+            Skipped;
+        not_found ->
+            ?event(
+                copycat_short,
+                {arweave_tx_skipped,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {reason, missing_offset}
+                }
+            ),
+            Skipped
+    end.
 
 is_bundle_tx(TX, _Opts) ->
     dev_arweave_common:type(TX) =/= binary.

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -12,7 +12,7 @@
 -define(ARWEAVE_DEVICE, <<"~arweave@2.9">>).
 -define(DEPTH_L1_OFFSETS, 1).
 -define(DEPTH_RECURSION_CAP, 4).
-%% 1GB in bytes
+%% 6GB in bytes
 -define(MEMORY_SAFE_CAP, 6 * 1024 * 1024 * 1024).
 
 % GET /~cron@1.0/once&cron-path=~copycat@1.0/arweave
@@ -782,7 +782,10 @@ process_l1_candidate(TXID, Filters, Depth, Opts) ->
             ),
             Skipped
     end.
-
+%% @doc Ensure the root L1 TX offset exists locally before `id=...` indexing.
+%% if the offset is missing and `load_l1_offset` is enabled, fetches the TX
+%% offset metadata from Arweave, writes it to the local offset store, and
+%% retries the local lookup.
 ensure_l1_tx_offset(_TXID, _EncodedTXID, IndexStore, _LoadL1Offset, _Opts)
         when is_map(IndexStore) =:= false ->
     {error, missing_offset};

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -703,8 +703,7 @@ maybe_process_l1_tx(TXID, Filters, Depth, QueryL1Offset, Opts) ->
     ?event(copycat_short,
         {indexing_l1_tx, {tx_id, {explicit, EncodedTXID}},
         {depth, Depth},
-        {query_l1_offset, QueryL1Offset},
-        {filters, Filters}
+        {query_l1_offset, QueryL1Offset}
     }),
     maybe
         {ok,

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -39,22 +39,24 @@ arweave(_Base, Request, Opts) ->
 %% bundle processing. in bytes.
 set_memory_safe_cap(Cap, Opts) when is_integer(Cap), Cap > 0 ->
     Opts#{copycat_memory_cap => Cap}.
-
+%% @doc Set bundles descendant recursion cap, avoids recursion
+%% in very nested bundles (very rare).
 set_depth_recursion_cap(Cap, Opts) when is_integer(Cap), Cap > 0 ->
     Opts#{copycat_depth_recursion_cap => Cap}.
-
+%% @doc Get the set depth recursion cap. if not set, defaults to ?DEPTH_RECURSION_CAP
 get_depth_recursion_cap(Opts) ->
     case maps:get(copycat_depth_recursion_cap, Opts, not_found) of
         not_found -> ?DEPTH_RECURSION_CAP;
         Cap -> Cap
     end.
-
+%% @doc Get the L1 TX data size that gets handled in-memory
+%% defaults to ?MEMORY_SAFE_CAP if not set.
 get_memory_safe_cap(Opts) ->
     case maps:get(copycat_memory_cap, Opts, not_found) of
         not_found -> ?MEMORY_SAFE_CAP;
         Cap -> Cap
     end.
-    
+%% @doc Normalize an owner address into the native ID form used for comparisons.
 normalize_owner_id(Addr) ->
     hb_util:native_id(hb_util:bin(Addr)).
 
@@ -75,7 +77,8 @@ resolve_owner_alias(Alias, Opts) when is_binary(Alias) ->
     end;
 resolve_owner_alias(Alias, _Opts) ->
     {error, {invalid_owner_alias, Alias}}.
-
+%% @doc Parse include/exclude owner filters from the request.
+%% Supports direct owner values and owner aliases.
 parse_owner_filter(Request, Opts) ->
     case resolve_owner_filter_value(
         <<"include-owner">>,
@@ -101,7 +104,8 @@ parse_owner_filter(Request, Opts) ->
                     }}
             end
     end.
-%% Alias takes precedence over direct owner if both are provided
+%% @doc Resolve one owner filter value from either a direct owner param or
+%% a comma-separated owner alias param. Alias takes precedence.
 resolve_owner_filter_value(OwnerKey, AliasKey, Request, Opts) ->
     case hb_maps:find(AliasKey, Request, Opts) of
         {ok, Alias} ->
@@ -114,7 +118,7 @@ resolve_owner_filter_value(OwnerKey, AliasKey, Request, Opts) ->
                     {ok, undefined}
             end
     end.
-
+%% @doc Resolve one or more comma-separated owner aliases into normalized owner IDs.
 resolve_owner_aliases(Alias, Opts) ->
     case
         lists:filter(
@@ -130,7 +134,7 @@ resolve_owner_aliases(Alias, Opts) ->
         Aliases ->
             resolve_owner_aliases(Aliases, Opts, [])
     end.
-
+%% @doc Resolve a list of owner aliases into normalized owner IDs.
 resolve_owner_aliases([], _Opts, Acc) ->
     {ok, lists:reverse(Acc)};
 resolve_owner_aliases([Alias | Rest], Opts, Acc) ->
@@ -140,7 +144,7 @@ resolve_owner_aliases([Alias | Rest], Opts, Acc) ->
         {error, _} = Error ->
             Error
     end.
-
+%% @doc Parse an L1 exclude-tag filter from `Name:Value` form.
 parse_exclude_tag(Request, Opts) ->
     case hb_maps:find(<<"exclude-tag">>, Request, Opts) of
         {ok, Tag} ->
@@ -154,7 +158,11 @@ parse_exclude_tag(Request, Opts) ->
         error ->
             {ok, undefined}
     end.
-
+%% @doc Process the `id=...` copycat path for an already indexed L1 TX.
+%% applies L1-level owner/tag filters on the lightweight TX header first, then,
+%% if the TX passes and is a bundle, loads the full L1 payload once and indexes
+%% descendants in-memory (under the ?MEMORY_SAFE_CAP limit) up to the requested safe depth
+%% (defaults to full recursion till the set copycat_depth_recursion_cap).
 process_l1_request(TXID, Request, Opts) ->
     Depth = request_depth(Request, <<"safe_max">>, Opts),
     case parse_owner_filter(Request, Opts) of
@@ -174,7 +182,8 @@ process_l1_request(TXID, Request, Opts) ->
                         )}
             end
     end.
-
+%% @doc Parse the requested recursion depth and clamp it to the configured safe cap.
+%% `safe_max` resolves to the current copycat depth recursion cap.
 request_depth(Request, Default, Opts) ->
     MaxRecursionCap = get_depth_recursion_cap(Opts),
     RequestedDepth =
@@ -189,7 +198,7 @@ request_depth(Request, Default, Opts) ->
             RequestedDepth
         )
     ).
-
+%% @doc Return the first matching L1 filter reason for a TX header, or `pass`.
 l1_filter_reason(TX, Filters) ->
     IncludeOwner = maps:get(include_owner, Filters, undefined),
     ExcludeOwner = maps:get(exclude_owner, Filters, undefined),
@@ -213,7 +222,7 @@ l1_filter_reason(TX, Filters) ->
                     end
             end
     end.
-
+%% @doc Match an owner against an undefined, single-owner, or multi-owner filter.
 owner_matches_filter(_Owner, undefined) ->
     false;
 owner_matches_filter(Owner, Owners) when is_list(Owners) ->
@@ -757,6 +766,7 @@ index_bundle_bytes(BundleData, BundleStartOffset, Depth, Store, Opts) ->
             )
     end.
 
+%% @doc Index bundle children from decoded bundle bytes and recurse descendants in-memory.
 index_bundle_items([], _ItemsBin, _ItemStartOffset, _Depth, _Store, _Opts, Count) ->
     {ok, Count};
 index_bundle_items(
@@ -801,6 +811,7 @@ index_bundle_items(
 index_bundle_items(_BundleIndex, _ItemsBin, _ItemStartOffset, _Depth, _Store, _Opts, _Count) ->
     {error, invalid_bundle_header}.
 
+%% @doc Recurse into a nested bundle data item from in-memory bytes.
 index_bundle_descendants(_ItemBinary, _ItemStartOffset, Depth, _Store, _Opts)
         when Depth =< 0 ->
     0;

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -5,13 +5,15 @@
 %%% provided, every block in the range is processed.
 -module(dev_copycat_arweave).
 -export([arweave/3]).
--export([add_owner_alias/3, resolve_owner_alias/2]).
+-export([add_owner_alias/3, resolve_owner_alias/2, set_memory_safe_cap/2, get_memory_safe_cap/1]).
 -include_lib("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 -define(ARWEAVE_DEVICE, <<"~arweave@2.9">>).
 -define(DEPTH_L1_OFFSETS, 1).
 -define(DEPTH_RECURSION_CAP, 4).
+%% 1GB in bytes
+-define(MEMORY_SAFE_CAP, 1024 * 1024 * 1024).
 
 % GET /~cron@1.0/once&cron-path=~copycat@1.0/arweave
 
@@ -33,7 +35,17 @@ arweave(_Base, Request, Opts) ->
         Mode ->
             {error, <<"Unsupported mode `", (hb_util:bin(Mode))/binary, "`. Supported modes are: write, list">>}
     end.
+%% @doc Set safe memory resource allocation cap for the in-memory
+%% bundle processing. in bytes.
+set_memory_safe_cap(Cap, Opts) when is_integer(Cap), Cap > 0 ->
+    Opts#{copycat_memory_cap => Cap}.
 
+get_memory_safe_cap(Opts) ->
+    case maps:get(copycat_memory_cap, Opts, not_found) of
+        not_found -> ?MEMORY_SAFE_CAP;
+        Cap -> Cap
+    end.
+    
 normalize_owner_id(Addr) ->
     hb_util:native_id(hb_util:bin(Addr)).
 
@@ -112,7 +124,7 @@ parse_exclude_tag(Request, Opts) ->
     end.
 
 process_l1_request(TXID, Request, Opts) ->
-    Depth = request_depth(Request, <<"1">>, Opts),
+    Depth = request_depth(Request, <<"safe_max">>, Opts),
     case parse_owner_filter(Request, Opts) of
         {error, _} = Error ->
             Error;
@@ -132,16 +144,18 @@ process_l1_request(TXID, Request, Opts) ->
     end.
 
 request_depth(Request, Default, Opts) ->
+    RequestedDepth =
+        case hb_maps:get(<<"depth">>, Request, Default, Opts) of
+            <<"safe_max">> -> ?DEPTH_RECURSION_CAP;
+            Value -> hb_util:int(Value)
+        end,
     erlang:min(
         ?DEPTH_RECURSION_CAP,
         erlang:max(
             ?DEPTH_L1_OFFSETS,
-            hb_util:int(hb_maps:get(<<"depth">>, Request, Default, Opts))
+            RequestedDepth
         )
     ).
-
-passes_l1_filters(TX, Filters) ->
-    l1_filter_reason(TX, Filters) =:= pass.
 
 l1_filter_reason(TX, Filters) ->
     IncludeOwner = maps:get(include_owner, Filters, undefined),
@@ -590,35 +604,64 @@ process_l1_candidate(TXID, Filters, Depth, Opts) ->
                                     ),
                                     Skipped;
                                 true ->
-                                    case hb_store_arweave:read_chunks(
-                                        StartOffset,
-                                        Length,
-                                        Opts
-                                    ) of
-                                        {ok, BundleData} ->
-                                            {TotalTime, IndexRes} = timer:tc(
-                                                fun() ->
-                                                    index_bundle_bytes(
-                                                        BundleData,
-                                                        StartOffset,
-                                                        Depth,
-                                                        IndexStore,
-                                                        Opts
-                                                    )
-                                                end
+                                    case Length =< get_memory_safe_cap(Opts) of
+                                        false ->
+                                            ?event(
+                                                copycat_short,
+                                                {arweave_bundle_skipped,
+                                                    {tx_id, {explicit, EncodedTXID}},
+                                                    {reason, memory_safe_cap_exceeded}
+                                                }
                                             ),
-                                            case IndexRes of
-                                                {ok, ItemsCount} ->
-                                                    record_event_metrics(
-                                                        <<"item_indexed">>,
-                                                        ItemsCount,
-                                                        TotalTime
+                                            #{
+                                                items_count => 0,
+                                                bundle_count => 1,
+                                                skipped_count => 1
+                                            };
+                                        true ->
+                                            case hb_store_arweave:read_chunks(
+                                                StartOffset,
+                                                Length,
+                                                Opts
+                                            ) of
+                                                {ok, BundleData} ->
+                                                    {TotalTime, IndexRes} = timer:tc(
+                                                        fun() ->
+                                                            index_bundle_bytes(
+                                                                BundleData,
+                                                                StartOffset,
+                                                                Depth,
+                                                                IndexStore,
+                                                                Opts
+                                                            )
+                                                        end
                                                     ),
-                                                    #{
-                                                        items_count => ItemsCount,
-                                                        bundle_count => 1,
-                                                        skipped_count => 0
-                                                    };
+                                                    case IndexRes of
+                                                        {ok, ItemsCount} ->
+                                                            record_event_metrics(
+                                                                <<"item_indexed">>,
+                                                                ItemsCount,
+                                                                TotalTime
+                                                            ),
+                                                            #{
+                                                                items_count => ItemsCount,
+                                                                bundle_count => 1,
+                                                                skipped_count => 0
+                                                            };
+                                                        {error, Reason} ->
+                                                            ?event(
+                                                                copycat_short,
+                                                                {arweave_bundle_skipped,
+                                                                    {tx_id, {explicit, EncodedTXID}},
+                                                                    {reason, Reason}
+                                                                }
+                                                            ),
+                                                            #{
+                                                                items_count => 0,
+                                                                bundle_count => 1,
+                                                                skipped_count => 1
+                                                            }
+                                                    end;
                                                 {error, Reason} ->
                                                     ?event(
                                                         copycat_short,
@@ -631,34 +674,21 @@ process_l1_candidate(TXID, Filters, Depth, Opts) ->
                                                         items_count => 0,
                                                         bundle_count => 1,
                                                         skipped_count => 1
+                                                    };
+                                                not_found ->
+                                                    ?event(
+                                                        copycat_short,
+                                                        {arweave_bundle_skipped,
+                                                            {tx_id, {explicit, EncodedTXID}},
+                                                            {reason, not_found}
+                                                        }
+                                                    ),
+                                                    #{
+                                                        items_count => 0,
+                                                        bundle_count => 1,
+                                                        skipped_count => 1
                                                     }
-                                            end;
-                                        {error, Reason} ->
-                                            ?event(
-                                                copycat_short,
-                                                {arweave_bundle_skipped,
-                                                    {tx_id, {explicit, EncodedTXID}},
-                                                    {reason, Reason}
-                                                }
-                                            ),
-                                            #{
-                                                items_count => 0,
-                                                bundle_count => 1,
-                                                skipped_count => 1
-                                            };
-                                        not_found ->
-                                            ?event(
-                                                copycat_short,
-                                                {arweave_bundle_skipped,
-                                                    {tx_id, {explicit, EncodedTXID}},
-                                                    {reason, not_found}
-                                                }
-                                            ),
-                                            #{
-                                                items_count => 0,
-                                                bundle_count => 1,
-                                                skipped_count => 1
-                                            }
+                                            end
                                     end
                             end;
                         FilterReason ->

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -10,6 +10,8 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(ARWEAVE_DEVICE, <<"~arweave@2.9">>).
+-define(DEPTH_L1_OFFSETS, 1).
+-define(DEPTH_RECURSION_CAP, 4).
 
 % GET /~cron@1.0/once&cron-path=~copycat@1.0/arweave
 
@@ -110,6 +112,7 @@ parse_exclude_tag(Request, Opts) ->
     end.
 
 process_l1_request(TXID, Request, Opts) ->
+    Depth = request_depth(Request, <<"1">>, Opts),
     case parse_owner_filter(Request, Opts) of
         {error, _} = Error ->
             Error;
@@ -122,10 +125,20 @@ process_l1_request(TXID, Request, Opts) ->
                         process_l1_candidate(
                             TXID,
                             OwnerFilters#{ exclude_tag => ExcludeTag },
+                            Depth,
                             Opts
                         )}
             end
     end.
+
+request_depth(Request, Default, Opts) ->
+    erlang:min(
+        ?DEPTH_RECURSION_CAP,
+        erlang:max(
+            ?DEPTH_L1_OFFSETS,
+            hb_util:int(hb_maps:get(<<"depth">>, Request, Default, Opts))
+        )
+    ).
 
 passes_l1_filters(TX, Filters) ->
     l1_filter_reason(TX, Filters) =:= pass.
@@ -550,7 +563,7 @@ process_txs(ValidTXs, BlockStartOffset, Opts) ->
     ).
 
 %% @doc Process a single indexed L1 TX candidate after lightweight filter checks.
-process_l1_candidate(TXID, Filters, Opts) ->
+process_l1_candidate(TXID, Filters, Depth, Opts) ->
     Skipped = #{items_count => 0, bundle_count => 0, skipped_count => 1},
     NormalizedTXID = hb_util:native_id(TXID),
     EncodedTXID = hb_util:encode(NormalizedTXID),
@@ -573,15 +586,80 @@ process_l1_candidate(TXID, Filters, Opts) ->
                                         {arweave_tx_skipped,
                                             {tx_id, {explicit, EncodedTXID}},
                                             {reason, not_bundle}
-                                        }
+                                }
                                     ),
                                     Skipped;
                                 true ->
-                                    process_tx(
-                                        {{TX, <<>>}, StartOffset + Length},
-                                        0,
+                                    case hb_store_arweave:read_chunks(
+                                        StartOffset,
+                                        Length,
                                         Opts
-                                    )
+                                    ) of
+                                        {ok, BundleData} ->
+                                            {TotalTime, IndexRes} = timer:tc(
+                                                fun() ->
+                                                    index_bundle_bytes(
+                                                        BundleData,
+                                                        StartOffset,
+                                                        Depth,
+                                                        IndexStore,
+                                                        Opts
+                                                    )
+                                                end
+                                            ),
+                                            case IndexRes of
+                                                {ok, ItemsCount} ->
+                                                    record_event_metrics(
+                                                        <<"item_indexed">>,
+                                                        ItemsCount,
+                                                        TotalTime
+                                                    ),
+                                                    #{
+                                                        items_count => ItemsCount,
+                                                        bundle_count => 1,
+                                                        skipped_count => 0
+                                                    };
+                                                {error, Reason} ->
+                                                    ?event(
+                                                        copycat_short,
+                                                        {arweave_bundle_skipped,
+                                                            {tx_id, {explicit, EncodedTXID}},
+                                                            {reason, Reason}
+                                                        }
+                                                    ),
+                                                    #{
+                                                        items_count => 0,
+                                                        bundle_count => 1,
+                                                        skipped_count => 1
+                                                    }
+                                            end;
+                                        {error, Reason} ->
+                                            ?event(
+                                                copycat_short,
+                                                {arweave_bundle_skipped,
+                                                    {tx_id, {explicit, EncodedTXID}},
+                                                    {reason, Reason}
+                                                }
+                                            ),
+                                            #{
+                                                items_count => 0,
+                                                bundle_count => 1,
+                                                skipped_count => 1
+                                            };
+                                        not_found ->
+                                            ?event(
+                                                copycat_short,
+                                                {arweave_bundle_skipped,
+                                                    {tx_id, {explicit, EncodedTXID}},
+                                                    {reason, not_found}
+                                                }
+                                            ),
+                                            #{
+                                                items_count => 0,
+                                                bundle_count => 1,
+                                                skipped_count => 1
+                                            }
+                                    end
                             end;
                         FilterReason ->
                             ?event(
@@ -614,6 +692,98 @@ process_l1_candidate(TXID, Filters, Opts) ->
                 }
             ),
             Skipped
+    end.
+
+index_bundle_bytes(_BundleData, _BundleStartOffset, Depth, _Store, _Opts)
+        when Depth =< 0 ->
+    {ok, 0};
+index_bundle_bytes(BundleData, BundleStartOffset, Depth, Store, Opts) ->
+    case ar_bundles:decode_bundle_header(BundleData) of
+        invalid_bundle_header ->
+            {error, invalid_bundle_header};
+        {ItemsBin, BundleIndex} ->
+            HeaderSize = byte_size(BundleData) - byte_size(ItemsBin),
+            index_bundle_items(
+                BundleIndex,
+                ItemsBin,
+                BundleStartOffset + HeaderSize,
+                Depth,
+                Store,
+                Opts,
+                0
+            )
+    end.
+
+index_bundle_items([], _ItemsBin, _ItemStartOffset, _Depth, _Store, _Opts, Count) ->
+    {ok, Count};
+index_bundle_items(
+    [{ItemID, Size} | Rest],
+    ItemsBin,
+    ItemStartOffset,
+    Depth,
+    Store,
+    Opts,
+    Count
+) when byte_size(ItemsBin) >= Size ->
+    ItemBinary = binary:part(ItemsBin, 0, Size),
+    hb_store_arweave:write_offset(
+        Store,
+        hb_util:encode(ItemID),
+        <<"ans104@1.0">>,
+        ItemStartOffset,
+        Size
+    ),
+    DescendantCount =
+        case Depth > 1 of
+            true ->
+                index_bundle_descendants(
+                    ItemBinary,
+                    ItemStartOffset,
+                    Depth - 1,
+                    Store,
+                    Opts
+                );
+            false ->
+                0
+        end,
+    index_bundle_items(
+        Rest,
+        binary:part(ItemsBin, Size, byte_size(ItemsBin) - Size),
+        ItemStartOffset + Size,
+        Depth,
+        Store,
+        Opts,
+        Count + 1 + DescendantCount
+    );
+index_bundle_items(_BundleIndex, _ItemsBin, _ItemStartOffset, _Depth, _Store, _Opts, _Count) ->
+    {error, invalid_bundle_header}.
+
+index_bundle_descendants(_ItemBinary, _ItemStartOffset, Depth, _Store, _Opts)
+        when Depth =< 0 ->
+    0;
+index_bundle_descendants(ItemBinary, ItemStartOffset, Depth, Store, Opts) ->
+    try ar_bundles:deserialize_header(ItemBinary) of
+        {ok, HeaderSize, HeaderTX} ->
+            case is_bundle_tx(HeaderTX, Opts) of
+                true ->
+                    case index_bundle_bytes(
+                        HeaderTX#tx.data,
+                        ItemStartOffset + HeaderSize,
+                        Depth,
+                        Store,
+                        Opts
+                    ) of
+                        {ok, Count} -> Count;
+                        _ -> 0
+                    end;
+                false ->
+                    0
+            end;
+        _ ->
+            0
+    catch
+        _:_ ->
+            0
     end.
 
 is_bundle_tx(TX, _Opts) ->

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -794,6 +794,13 @@ ensure_l1_tx_offset(TXID, EncodedTXID, IndexStore, LoadL1Offset, Opts) ->
         {ok, _} = OffsetRes ->
             OffsetRes;
         not_found when LoadL1Offset ->
+            ?event(
+                copycat_short,
+                {arweave_tx_offset_loading,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {source, network}
+                }
+            ),
             case load_l1_tx_offset(EncodedTXID, IndexStore, Opts) of
                 ok ->
                     case hb_store_arweave:read_offset(IndexStore, TXID) of

--- a/src/hb_event.erl
+++ b/src/hb_event.erl
@@ -3,7 +3,6 @@
 -export([counters/0, diff/1, diff/2]).
 -export([log/1, log/2, log/3, log/4, log/5, log/6]).
 -export([increment/3, increment/4, increment_callers/1]).
--include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 -define(OVERLOAD_QUEUE_LENGTH, 10_000).
@@ -192,28 +191,10 @@ check_overload(Last, N) ->
             case erlang:process_info(self(), message_queue_len) of
                 {message_queue_len, Len} when Len > ?OVERLOAD_QUEUE_LENGTH ->
                     {memory, MemorySize} = erlang:process_info(self(), memory),
-                    case rand:uniform(max(1000, Len - ?OVERLOAD_QUEUE_LENGTH)) of
-                        1 ->
-                            ?debug_print(
-                                {warning,
-                                    prometheus_event_queue_overloading,
-                                    {queue, Len},
-                                    {last_event, Last},
-                                    {memory_bytes, MemorySize}
-                                }
-                            );
-                        _ -> ignored
-                    end,
+                    % If the size of this process is too large, exit such that
+                    % we can be restarted by the next caller.
                     case MemorySize of
                         MemorySize when MemorySize > ?MAX_MEMORY ->
-                            ?debug_print(
-                                {error,
-                                    prometheus_event_queue_terminating_on_memory_overload,
-                                    {queue, Len},
-                                    {memory_bytes, MemorySize},
-                                    {last_event, Last}
-                                }
-                            ),
                             exit(memory_overload);
                         _ -> no_action
                     end;

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -252,7 +252,7 @@ default_message() ->
         commitment_device => <<"httpsig@1.0">>,
         %% Copycat-specific options.
         copycat_memory_cap => 6 * 1024 * 1024 * 1024,
-        copycat_depth_recursion_cap => 4,
+        copycat_depth_recursion_cap => 6, % 2x the deepest we've seen to date
         %% Dev options
         mode => debug,
         profiling => true,

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -250,6 +250,9 @@ default_message() ->
         relay_http_client => httpc,
         %% The default codec to use for commitment signatures.
         commitment_device => <<"httpsig@1.0">>,
+        %% Copycat-specific options.
+        copycat_memory_cap => 6 * 1024 * 1024 * 1024,
+        copycat_depth_recursion_cap => 4,
         %% Dev options
         mode => debug,
         profiling => true,

--- a/test/arbundles.js/upload-items.js
+++ b/test/arbundles.js/upload-items.js
@@ -7,15 +7,15 @@ const BUNDLER_URL = "http://localhost:8734";
 const DEFAULT_WALLET = "../../hyperbeam-key.json";
 const CONCURRENT_UPLOADS = 100; // Number of parallel uploads
 
-async function performanceTest(walletPath, itemCount, bytesPerItem = 0) {
+async function performanceTest(walletPath, itemCount, bytesPerItem = 0, bundlerUrl = BUNDLER_URL) {
   const wallet = require(path.resolve(walletPath));
   const signer = new ArweaveSigner(wallet);
-  const endpoint = `${BUNDLER_URL}/~bundler@1.0/item?codec-device=ans104@1.0`;
+  const endpoint = `${bundlerUrl}/~bundler@1.0/item?codec-device=ans104@1.0`;
 
   console.log("\n" + "=".repeat(70));
   console.log("ANS-104 Bundle Upload Performance Test");
   console.log("=".repeat(70));
-  console.log(`Target:     ${BUNDLER_URL}`);
+  console.log(`Target:     ${bundlerUrl}`);
   console.log(`Items:      ${itemCount}`);
   console.log(`Item Size:  ${bytesPerItem > 0 ? `~${bytesPerItem} bytes` : 'default'}`);
   console.log(`Concurrent: ${CONCURRENT_UPLOADS}`);
@@ -138,23 +138,26 @@ if (require.main === module) {
   const walletPath = firstIsNumber ? DEFAULT_WALLET : (process.argv[2] || DEFAULT_WALLET);
   const itemCount   = parseInt(firstIsNumber ? process.argv[2] : process.argv[3], 10);
   const bytesPerItem = parseInt(firstIsNumber ? process.argv[3] : process.argv[4], 10) || 0;
+  const bundlerUrl = (firstIsNumber ? process.argv[4] : process.argv[5]) || BUNDLER_URL;
 
   if (!itemCount || itemCount < 1 || isNaN(itemCount)) {
-    console.error("Usage: node upload-items.js [wallet_path] <number_of_items> [bytes_per_item]");
+    console.error("Usage: node upload-items.js [wallet_path] <number_of_items> [bytes_per_item] [bundler_url]");
     console.error("");
     console.error("Arguments:");
     console.error("  wallet_path      - Path to Arweave wallet JSON (default: ../../hyperbeam-key.json)");
     console.error("  number_of_items  - Number of data items to create and upload");
     console.error("  bytes_per_item   - Minimum size of each item in bytes (optional)");
+    console.error("  bundler_url      - Bundler base URL (default: " + BUNDLER_URL + ")");
     console.error("");
     console.error("Examples:");
     console.error("  node upload-items.js 100");
     console.error("  node upload-items.js 100 1024");
     console.error("  node upload-items.js /path/to/wallet.json 100 1024");
+    console.error("  node upload-items.js 100 0 http://other-bundler:8734");
     process.exit(1);
   }
 
-  performanceTest(walletPath, itemCount, bytesPerItem)
+  performanceTest(walletPath, itemCount, bytesPerItem, bundlerUrl)
     .then(() => {
       process.exit(0);
     })


### PR DESCRIPTION
## About
performance-aware resource-minimalist filtering-aware L1 bundles copycat indexing - status: wip

## configurability

* add owner alias (reduce address computation at every query): 

```erl
Opts2 = dev_copycat_arweave:add_owner_alias(    <<"FPjbN_btYKzcf8QASjs30v5C0FPv7XpwKXENBW8dqVw">>,    <<"neo-bundler">>,    Opts1  ).
```

* set L1 bundle safe size cap (useful to configure the memory allowed usage per process, taking into accoutn arweave_workers count * MEMORY_SAFE_CAP)

```erl
dev_copycat_arweave:set_memory_safe_cap(xxxxbytes, Opts).
```

* safe max recursion depth

```
~copycat@1.0/arweave&depth=safe_max
```
in id=.. path: `&depth=safe_max` recurse every bundle till DEPTH_RECURSION_CAP. if no depth is provided (1..safe_max), it defaults to safe_max.

* defaults

```erl
-define(DEPTH_L1_OFFSETS, 1).
-define(DEPTH_RECURSION_CAP, 4).
%% 1GB in bytes
-define(MEMORY_SAFE_CAP, 1024 * 1024 * 1024).
```

## supported paths

at the moment, the new path is the &id=.. + filters. how it works:

0. it requires the L1 IDs offsets to be present in store
1. it fetch the L1 ID headers to retrieve owner and tags + validates that its a bundle
2. it applies the filters to the L1 TX, pass on it if the filters hit the guating
3. if filters passed, it downloads the L1 TX bytestream, does depth recusion in memory, index children offsets -> recurses in memory and indexes descendant offsets

to test the feature locally, and to simulate having the required local L1 tx offset index, index a block with depth=1

```erl
  application:ensure_all_started(hb).
  application:ensure_all_started(inets).
  application:ensure_all_started(ssl).
  hb_http:start().

  TestStore = hb_test_utils:test_store().
  StoreOpts = #{<<"index-store">> => [TestStore]}.
  Store = [
    TestStore,
    #{
      <<"store-module">> => hb_store_arweave,
      <<"name">> => <<"cache-arweave">>,
      <<"index-store">> => [TestStore],
      <<"arweave-node">> => <<"https://arweave.net">>
    }
  ].

  Opts = #{
    store => Store,
    arweave_index_ids => true,
    arweave_index_store => StoreOpts,
    arweave_index_workers => 4,
    prometheus => false,
    http_client => httpc,
    http_retry => 1,
    http_retry_time => 200,
    http_retry_mode => constant,
    http_retry_response => [failure]
  }.

  Opts1 = dev_copycat_arweave:add_owner_alias(
    <<"FPjbN_btYKzcf8QASjs30v5C0FPv7XpwKXENBW8dqVw">>,
    <<"neo-bundler">>,
    Opts
  ).

  %% simulate already having the L1 offset index locally
  hb_ao:resolve(
    <<"~copycat@1.0/arweave&from=1870797&to=1870797&mode=write&depth=1">>,
    Opts1
  ).
  ```
  
  for block https://aolink.ar.io/#/block/1870797
  
  now if we assume we have the required L1 TXs offsets indexed locally, we can integrate over IDs and assert filters:
  
  ```erl
hb_ao:resolve(<<"~copycat@1.0/arweave&id=6DODXspJYXcMbUvadcAQ9FoP3xh5N0dhDCiOwU7d4Q4&mode=write&depth=safe_max&include-owner-alias=neo-bundler&exclude-tag=Bundler-App-Name:Redstone">>, Opts1).
```
res:
`{ok,#{items_count => 1404,bundle_count => 1,skipped_count => 0,`

if we try a L1 TX with redstone filter enabled: must be a turbo owner L1 TX (bundle) but exclude redstone tags.

txid: https://viewblock.io/arweave/tx/5q95xvC3_BbZa5C4hypcgnIHkyLSlgGef-OpAdMjoOY

```erl
  Opts1A = dev_copycat_arweave:add_owner_alias(
    <<"JNC6vBhjHY1EPwV3pEeNmrsgFMxH5d38_LHsZ7jful8">>,
    <<"turbo">>,
    Opts1
  ).
```

```erl
42> hb_ao:resolve(    <<"~copycat@1.0/arweave&id=5q95xvC3_BbZa5C4hypcgnIHkyLSlgGef-OpAdMjoOY&mode=write&include-owner-alias=turbo&exclude-tag=Bundler-App-Name:Redstone">>,    Opts1A  ).
=== HB DEBUG ===[3273092ms in <0.1056.0> @ hb_ao:194 / hb_ao:204 / hb_ao:543 / dev_copycat_arweave:137 / dev_copycat_arweave:689]==>
arweave_tx_skipped, tx_id: [Explicit:] <<"5q95xvC3_BbZa5C4hypcgnIHkyLSlgGef-OpAdMjoOY">>, reason: exclude_tag_match
{ok,#{items_count => 0,bundle_count => 0,skipped_count => 1,
      <<"priv">> =>
          #{<<"hashpath">> =>
                <<"M8hn9wfAiAF8pQirF-j48KgJ1lXxkD02MlDX0uWhUoM/1SgyB85LEUXqwat2_18-vyaJIk2NpNKeiUKNpbrP4XA">>}}}
```

## TODOs:

  - [x] make `DEPTH_RECURSION_CAP` configurable, with getter/setter parity to `MEMORY_SAFE_CAP`
  - [x] cleanup & perf optimization