### PR TITLE
fix: hb_store_gateway:remote_hyperbeam_node_ans104_test flaky test

### DIFF
--- a/src/dev_query_arweave.erl
+++ b/src/dev_query_arweave.erl
@@ -82,13 +82,14 @@ query(Block, <<"timestamp">>, _Args, Opts) ->
 query(Msg, <<"signature">>, _Args, Opts) ->
     % Return the signature of the transaction.
     % Other TX access methods are defined below.
-    case hb_maps:get(<<"commitments">>, Msg, not_found, Opts) of
+    case hb_message:commitments(#{ <<"committer">> => '_' }, Msg, Opts) of
         not_found -> {ok, null};
         Commitments ->
-            case maps:to_list(Commitments) of
+            case hb_maps:keys(Commitments) of
                 [] -> {ok, null};
-                [{_CommitmentID, Commitment} | _] ->
-                    {ok, hb_maps:get(<<"signature">>, Commitment, null, Opts)}
+                [CommID | _] ->
+                    {ok, Commitment} = hb_maps:find(CommID, Commitments, Opts),
+                    hb_maps:find(<<"signature">>, Commitment, Opts)
             end
     end;
 query(Msg, <<"owner">>, _Args, Opts) ->


### PR DESCRIPTION
Running the following test command can generate a flaky test when in the list of commitments, the order is different from `ans104`, `httpsig`. 

```HB_PRINT=hb_gateway_client,dev_query_graphql,http_client_short,http_server_short,warning rebar3 eunit --test hb_store_gateway:remote_hyperbeam_node_ans104_test``` 

Since we match on the first commitment of the list, if httpsig is the first item will return the HMAC signature. https://github.com/permaweb/HyperBEAM/blob/77b398f5470a95d8108d7b43a65a039b45d09654/src/ar_bundles.erl#L139 will throw because the signature will be 32 bytes (`eDAf0cyPL8svRojdP8HyCaBpvxG5ae_33xM3gfLRw9k`) and not a valid ar_bundles signature.

I've applied the same logic of the owner field below, to ensure that we select the commitment with a commiter (httpsig commitment doesn't have `commiter` field).

