### PR TITLE
impr: manifest resolution and compatibility fixes

### DIFF
--- a/src/dev_manifest.erl
+++ b/src/dev_manifest.erl
@@ -64,15 +64,10 @@ route(ID, _, _, Opts) when ?IS_ID(ID) ->
 route(Key, M1, M2, Opts) ->
     ?event(debug_manifest, {manifest_lookup, {key, Key}, {m1, M1}, {m2, {explicit, M2}}}),
     {ok, Manifest} = manifest(M1, M2, Opts),
-    Res = hb_ao:get(
-        <<"paths/", Key/binary>>,
-        {as, <<"message@1.0">>, Manifest},
-        Opts
-    ),
-    ?event({manifest_lookup_result, {res, Res}}),
-    case Res of
-        not_found ->
-            %% Support materialized view in some JavaScript frameworks
+    {ok, Res} = maps:find(<<"paths">>, Manifest),
+    case maps:get(Key, Res, no_path_match) of
+        no_path_match ->
+            % Support materialized view in some JavaScript frameworks.
             case hb_opts:get(manifest_404, fallback, Opts) of
                 error ->
                     ?event({manifest_404_error, {key, Key}}),
@@ -81,9 +76,11 @@ route(Key, M1, M2, Opts) ->
                     ?event({manifest_fallback, {key, Key}}),
                     route(<<"index">>, M1, M2, Opts)
             end;
-        _ ->
-            ?event({manifest_lookup_success, {key, Key}}),
-            {ok, Res}
+        Result ->
+            ?event({manifest_lookup_success, {key, Key}, {result, Result}}),
+            try {ok, hb_cache:ensure_loaded(Result, Opts)}
+            catch _:_:_ -> {error, not_found}
+            end
     end.
 
 %% @doc Implement the `on/request' hook for the `manifest@1.0' device, finding
@@ -174,11 +171,12 @@ maybe_cast_manifest(Msg, Opts) ->
 %% message with the `~manifest@1.0' device.
 manifest(Base, _Req, Opts) ->
     JSON =
-        hb_ao:get_first(
+        hb_maps:get_first(
             [
-                {{as, <<"message@1.0">>, Base}, [<<"data">>]},
-                {{as, <<"message@1.0">>, Base}, [<<"body">>]}
+                {Base, <<"data">>},
+                {Base, <<"body">>}
             ],
+            not_found,
             Opts
         ),
     FlatManifest = #{ <<"paths">> := FlatPaths } = hb_json:decode(JSON),

--- a/src/dev_manifest.erl
+++ b/src/dev_manifest.erl
@@ -15,7 +15,7 @@ info() ->
 
 %% @doc Return the fallback index page when the manifest itself is requested.
 index(M1, M2, Opts) ->
-    ?event(debug_manifest, {index_request, {m1, M1}, {m2, M2}}),
+    ?event(debug_manifest, {index_request, {base, M1}, {request, M2}}, Opts),
     case route(<<"index">>, M1, M2, Opts) of
         {ok, Index} ->
             ?event({manifest_index_returned, Index}),

--- a/src/dev_manifest.erl
+++ b/src/dev_manifest.erl
@@ -187,7 +187,7 @@ manifest(Base, _Req, Opts) ->
 
 %% @doc Generate a nested message of links to content from a parsed (and
 %% structured) manifest.
-linkify(#{ <<"id">> := ID }, Opts) ->
+linkify(#{ <<"id">> := ID }, Opts) when is_binary(ID) ->
     LinkOptsBase = (maps:with([store], Opts))#{ scope => [local, remote]},
     {link, ID, LinkOptsBase#{ <<"type">> => <<"link">>, <<"lazy">> => false }};
 linkify(Manifest, Opts) when is_map(Manifest) ->

--- a/src/hb_maps.erl
+++ b/src/hb_maps.erl
@@ -17,7 +17,7 @@
 %%% yourself from the inevitable issues that will arise from using this
 %%% module without understanding the full implications. You have been warned.
 -module(hb_maps).
--export([get/2, get/3, get/4, put/3, put/4, find/2, find/3]).
+-export([get/2, get/3, get/4, get_first/2, get_first/3, put/3, put/4, find/2, find/3]).
 -export([is_key/2, is_key/3, keys/1, keys/2, values/1, values/2]).
 -export([map/2, map/3, filter/2, filter/3, filtermap/2, filtermap/3]).
 -export([fold/3, fold/4, take/2, take/3, size/1, size/2]).
@@ -25,6 +25,27 @@
 -export([with/2, with/3, without/2, without/3, update_with/3, update_with/4]).
 -export([from_list/1, to_list/1, to_list/2]).
 -include_lib("eunit/include/eunit.hrl").
+
+%%% HyperBEAM-specific functions
+
+-spec get_first(
+    Paths :: [{Base :: map() | binary(), Path :: binary()}],
+    Opts :: map()
+) -> term().
+get_first(Paths, Opts) ->
+    get_first(Paths, not_found, Opts).
+
+-spec get_first(
+    Paths :: [{Base :: map() | binary(), Path :: binary()}],
+    Default :: term(),
+    Opts :: map()
+) -> term().
+get_first([], Default, _Opts) -> Default;
+get_first([{Base, Path}|Paths], Default, Opts) ->
+    case find(Path, Base, Opts) of
+        {ok, Value} -> Value;
+        error -> get_first(Paths, Default, Opts)
+    end.
 
 -spec get(Key :: term(), Map :: map()) -> term().
 get(Key, Map) ->


### PR DESCRIPTION
- Catches an edge-case bug for manifests that (as used by `cookbook.`, for example) have an `id/` subdirectory.
- Throw 404s on load errors in `~manifest@1.0`, rather than 500s.
- Add `hb_maps` corollary to `hb_ao:get_first`.