### PR TITLE
fix: dev_mint_index audit

### DIFF
--- a/src/dev_mint_index.erl
+++ b/src/dev_mint_index.erl
@@ -194,8 +194,14 @@ parse_signal(Base, Assignment, Opts) ->
             ),
         {ok, Quantity} ?=
             case hb_maps:find(<<"x-action">>, Msg, Opts) of
-                {ok, <<"deposit">>} -> {ok, RawQuantity};
-                {ok, <<"withdraw">>} -> {ok, -RawQuantity};
+                {ok, <<"deposit">>} when is_integer(RawQuantity), RawQuantity >= 0 -> 
+                    {ok, RawQuantity};
+                {ok, <<"deposit">>} ->
+                    {error, <<"Deposit quantity must be a non-negative integer.">>};
+                {ok, <<"withdraw">>} when is_integer(RawQuantity), RawQuantity =< 0 -> 
+                    {ok, RawQuantity};
+                {ok, <<"withdraw">>} ->
+                    {error, <<"Withdraw quantity must be a non-positive integer.">>};
                 {ok, _Unsupported} ->
                     {error, <<"Notification `action' unsupported.">>};
                 error ->

--- a/src/dev_mint_index.erl
+++ b/src/dev_mint_index.erl
@@ -240,7 +240,7 @@ update_model(Address, Quantity, Base, Opts) ->
 must_redelegate(Base, _Quantity, _Address, Opts) ->
     UpdateEvery = hb_ao:get(<<"update-every">>, Base, 0, Opts),
     ChangesSinceUpdate = hb_ao:get(<<"changes-since-update">>, Base, 0, Opts),
-    UpdateEvery >= ChangesSinceUpdate.
+    ChangesSinceUpdate >= UpdateEvery.
 
 %% @doc Send messages reflecting updated delegation preferences to the parent
 %% mint.


### PR DESCRIPTION
## findings

### dev_mint_index:parse_signal/3 double negation

in dev_mint_index:parse_signal the module was doing ` {ok, <<"withdraw">>} -> {ok, -RawQuantity};` however there is one important caveat - full pot -> outbox -> mint-index stack:

 * `dev_pot:undelegate/6` calls `dev_pot:send_delegation_notice/6` with `-Amount`
 * `dev_pot:send_delegation_notice/6` pass that -ve quantity as is to `dev_process_outbox:send/3`
  * `dev_process_outbox:notify/3` fwd the original notice fields to subscribers as `x-*` fields without changing the sign, as is
  * `dev_mint_index:notify/3` receive that forwarded withdraw notification and calls `parse_signal/3`
  * `parse_signal/3` then negated the already-negative `RawQuantity` again, turning a withdrawal delta into a +ve value
  
impact: undelegations increase the internal `indexed-deposits/<address>` model instead of decreasing it

### dev_mint_index:must_redelegate/4 inverted check

the must_redelegate/4 function was checking `UpdateEvery >= ChangesSinceUpdate.` which means the function will always return true for any positive UpdateEvery and reset ChangesSinceUpdate to 0, so it would always redelegate on every change.

there are no specific tests for this fn or doc spec, but i assumed it means "redelegate every N changes".

question: 

```erl
    UpdateEvery = hb_ao:get(<<"update-every">>, Base, 0, Opts),
    ChangesSinceUpdate = hb_ao:get(<<"changes-since-update">>, Base, 0, Opts),
```

should UpdateEvery default to 1 instead of 0, so it doesnt redelegate always at defaults?

### clarification needed

 re redelegate/3 and indexed-deposits:

* ~redelegate/3: right now redelegate/3 only emits a redelegation event and resets `changes-since-update`. what is the intended implementation of redelegate/3 here? is it currently incomplete/missing?~
 
 * ~deposit model: the current model assumes `indexed-deposits/<address>` to track indexed deposits. is the model here assuming the following stack?~ :
~1. AO: dev_pot (root pot) + dev_token~
~2. FLPs: child pots~
~3. PI: a 'special' child/index pot that mirrors AO-side delegation preference on the root AO pot~

~asking because `update_model/4` ignores resource, so it is currently assuming a single-resource parent mode~l