### PR TITLE
fix: resolve hyperbuddy paths from server root

### DIFF
--- a/src/html/hyperbuddy@1.0/index.html
+++ b/src/html/hyperbuddy@1.0/index.html
@@ -5,10 +5,10 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
 		<title>HyperBEAM</title>
-		<link rel="stylesheet" href="fonts.css">
+		<link rel="stylesheet" href="/~hyperbuddy@1.0/fonts.css">
 	</head>
 	<body>
 		<div id="root"></div>
-		<script type="module" src="bundle.js"></script>
+		<script type="module" src="/~hyperbuddy@1.0/bundle.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
Fixes asset loading when hyperbuddy is served from any hashpath by using absolute paths with the `/~hyperbuddy@1.0/` prefix instead of relative paths.