### PR TITLE
fix: handle as-tuples in blacklist ID collection

### DIFF
--- a/src/dev_blacklist.erl
+++ b/src/dev_blacklist.erl
@@ -180,6 +180,7 @@ parse_blacklist_line(Line) ->
 collect_ids(Msg, Opts) -> lists:usort(collect_ids(Msg, [], Opts)).
 collect_ids(Bin, Acc, _Opts) when ?IS_ID(Bin) -> [hb_util:human_id(Bin) | Acc];
 collect_ids(Bin, Acc, _Opts) when is_binary(Bin) -> Acc;
+collect_ids({as, _, Msg}, Acc, Opts) -> collect_ids(Msg, Acc, Opts);
 collect_ids({link, ID, _}, Acc, _Opts) when ?IS_ID(ID) ->
     [hb_util:human_id(ID) | Acc];
 collect_ids(Msg, Acc, Opts) when is_map(Msg) ->


### PR DESCRIPTION
## Summary
- `collect_ids` was missing a clause for `{as, _, Msg}` tuples, which are produced when `manifest@1.0` casts legacy manifests. IDs inside these wrapped messages were silently skipped by the catch-all clause.
- Adds two tests covering the manifest+blacklist hook chain interaction: one for directly resolvable blacklisted items, one for legacy manifest content-type items.

## Test plan
- [x] All existing `dev_blacklist` tests pass
- [x] New `manifest_then_blacklist_resolvable_item_test` verifies 451 for blacklisted items that are in cache when both manifest and blacklist hooks are active
- [x] New `manifest_then_blacklist_legacy_manifest_item_test` verifies 451 for blacklisted legacy manifests after manifest casts them