### PR TITLE
feat: Arweave offsets as subdomains.

### DIFF
--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -4,12 +4,23 @@
 %%% The node(s) that are used to query data may be configured by altering the
 %%% `/arweave` route in the node's configuration message.
 -module(dev_arweave).
+-export([info/0]).
 -export([tx/3, raw/3, chunk/3, block/3, current/3, status/3, price/3, tx_anchor/3]).
 -export([post_tx_header/2, post_tx/3, post_tx/4, post_binary_ans104/2, post_json_chunk/2]).
+%%% Helper functions
+-export([get_chunk/2]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 -define(IS_BLOCK_ID(X), (is_binary(X) andalso byte_size(X) == 64)).
+
+%% @doc Route unknown keys through offset resolution first, then fall back to
+%% the message device for direct key access.
+info() ->
+    #{
+        excludes => [<<"keys">>, <<"set">>, <<"set-path">>, <<"remove">>],
+        default => fun dev_arweave_offset:get/4
+    }.
 
 %% @doc Proxy the `/info' endpoint from the Arweave node.
 status(_Base, _Request, Opts) ->

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -222,8 +222,9 @@ head_raw_tx(TXID, StartOffset, Length, Opts) ->
         ),
     {ok,
         #{
-            <<"arweave-id">> => TXID,
-            <<"arweave-data-offset">> => StartOffset,
+            <<"raw-id">> => TXID,
+            <<"offset">> => StartOffset,
+            <<"data-offset">> => StartOffset,
             <<"content-type">> => ContentType,
             <<"header-length">> => 0,
             <<"content-length">> => Length,
@@ -256,8 +257,9 @@ do_head_raw_ans104(TXID, ArweaveOffset, Length, Data, _Opts) ->
         ),
     {ok,
         #{
-            <<"arweave-id">> => TXID,
-            <<"arweave-data-offset">> => ArweaveOffset + HeaderSize,
+            <<"raw-id">> => TXID,
+            <<"offset">> => ArweaveOffset,
+            <<"data-offset">> => ArweaveOffset + HeaderSize,
             <<"content-type">> => ContentType,
             <<"header-length">> => HeaderSize,
             <<"content-length">> => Length - HeaderSize,
@@ -275,8 +277,8 @@ get_raw(Base, Request, Opts) ->
         Err = {error, _} -> Err;
         {ok,
             Header = #{
-                <<"arweave-id">> := TXID,
-                <<"arweave-data-offset">> := ArweaveDataOffset,
+                <<"raw-id">> := TXID,
+                <<"data-offset">> := ArweaveDataOffset,
                 <<"content-type">> := ContentType,
                 <<"content-length">> := FullContentLength
             }

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -8,7 +8,7 @@
 -export([tx/3, raw/3, chunk/3, block/3, current/3, status/3, price/3, tx_anchor/3]).
 -export([post_tx_header/2, post_tx/3, post_tx/4, post_binary_ans104/2, post_json_chunk/2]).
 %%% Helper functions
--export([get_chunk/2]).
+-export([get_chunk/2, bundle_header/2]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -629,6 +629,59 @@ get_chunk(Offset, Opts) ->
     % needed.
     Path = <<"/chunk/", (hb_util:bin(Offset))/binary>>,
     request(<<"GET">>, Path, #{ <<"route-by">> => Offset }, Opts).
+
+%% @doc Read and decode the bundle header index at the given global start
+%% offset, returning the header size alongside the decoded index entries.
+bundle_header(BundleStartOffset, Opts) ->
+    case hb_ao:resolve(
+        #{ <<"device">> => <<"arweave@2.9">> },
+        #{
+            <<"path">> => <<"chunk">>,
+            <<"offset">> => BundleStartOffset + 1
+        },
+        Opts
+    ) of
+        {ok, FirstChunk} ->
+            case ar_bundles:bundle_header_size(FirstChunk) of
+                invalid_bundle_header ->
+                    {error, invalid_bundle_header};
+                HeaderSize ->
+                    case read_bundle_header(BundleStartOffset, HeaderSize, FirstChunk, Opts) of
+                        {ok, HeaderBin} ->
+                            case ar_bundles:decode_bundle_header(HeaderBin) of
+                                {_Items, BundleIndex} ->
+                                    {ok, HeaderSize, BundleIndex};
+                                invalid_bundle_header ->
+                                    {error, invalid_bundle_header}
+                            end;
+                        Error ->
+                            Error
+                    end
+            end;
+        Error ->
+            Error
+    end.
+
+%% @doc Read exactly the bytes needed to decode a bundle header.
+read_bundle_header(_BundleStartOffset, HeaderSize, FirstChunk, _Opts)
+        when HeaderSize =< byte_size(FirstChunk) ->
+    {ok, binary:part(FirstChunk, 0, HeaderSize)};
+read_bundle_header(BundleStartOffset, HeaderSize, FirstChunk, Opts) ->
+    RemainingSize = HeaderSize - byte_size(FirstChunk),
+    case hb_ao:resolve(
+        #{ <<"device">> => <<"arweave@2.9">> },
+        #{
+            <<"path">> => <<"chunk">>,
+            <<"offset">> => BundleStartOffset + byte_size(FirstChunk) + 1,
+            <<"length">> => RemainingSize
+        },
+        Opts
+    ) of
+        {ok, RemainingChunk} ->
+            {ok, <<FirstChunk/binary, RemainingChunk/binary>>};
+        Error ->
+            Error
+    end.
 
 %% @doc Retrieve (and cache) block information from Arweave. If the `block' key
 %% is present, it is used to look up the associated block. If it is of Arweave

--- a/src/dev_arweave_offset.erl
+++ b/src/dev_arweave_offset.erl
@@ -105,23 +105,25 @@ read_remaining_item_data(_StartOffset, _HeaderSize, _PrefixSize, 0, _Opts) ->
 read_remaining_item_data(StartOffset, HeaderSize, PrefixSize, Length, Opts) ->
     hb_store_arweave:read_chunks(StartOffset + HeaderSize + PrefixSize, Length, Opts).
 
-%% @doc Resolve the size of the item at the given offset by locating it in the
-%% containing bundle header. We use the `note` attached to the Merkle leaf of
-%% the `tx_path` for the chunk to find the size of the bundle that contains the
-%% item. We then use the `note` attached to the Merkle leaf of the `data_path`
-%% for the chunk to find the offset of the end of the chunk inside the bundle.
+%% @doc Determine the size of the item at an offset by locating it in the parent
+%% Arweave transaction's bundle header. In order to do this we must:
+%% 1. Find the global offset of the data root of the chunk.
+%% 2. Jump to that location and read the header chunks until we find our item.
+%% 3. Extract the item's size from the bundle header and return it.
+%% We achieve objective (1) by extracting the `absolute_end_offset` from the
+%% chunk JSON and subtracting the `data_path`'s note from it. The `data_path`
+%% is the Merkle path of the chunk that contains the item, and its note is the
+%% offset of the end of the chunk inside the bundle. The `absolute_end_offset`
+%% is the global offset of the end of the chunk, so to calculate the bundle's
+%% start offset we can simply perform `absolute_end_offset - data_path_note`.
 item_size_from_offset(StartOffset, ChunkJSON, Opts) ->
     AbsEnd = hb_util:int(maps:get(<<"absolute_end_offset">>, ChunkJSON)),
-    BundleSize =
-        ar_merkle:extract_note(
-            hb_util:decode(maps:get(<<"tx_path">>, ChunkJSON))
-        ),
     ChunkEndInBundle =
         ar_merkle:extract_note(
             hb_util:decode(maps:get(<<"data_path">>, ChunkJSON))
         ),
     BundleStartOffset = AbsEnd - ChunkEndInBundle,
-    case bundle_header(BundleStartOffset, BundleSize, Opts) of
+    case dev_arweave:bundle_header(BundleStartOffset, Opts) of
         {ok, HeaderSize, BundleIndex} ->
             locate_bundle_item(
                 StartOffset,
@@ -131,44 +133,6 @@ item_size_from_offset(StartOffset, ChunkJSON, Opts) ->
         Error ->
             Error
     end.
-
-%% @doc Read and decode the containing bundle header for an item.
-bundle_header(BundleStartOffset, _BundleSize, Opts) ->
-    case hb_ao:resolve(
-        #{ <<"device">> => <<"arweave@2.9">> },
-        #{
-            <<"path">> => <<"chunk">>,
-            <<"offset">> => BundleStartOffset + 1
-        },
-        Opts
-    ) of
-        {ok, FirstChunk} ->
-            case ar_bundles:bundle_header_size(FirstChunk) of
-                invalid_bundle_header ->
-                    {error, invalid_bundle_header};
-                HeaderSize ->
-                    case read_bundle_header(BundleStartOffset, HeaderSize, FirstChunk, Opts) of
-                        {ok, HeaderBin} ->
-                            case ar_bundles:decode_bundle_header(HeaderBin) of
-                                {_Items, BundleIndex} ->
-                                    {ok, HeaderSize, BundleIndex};
-                                invalid_bundle_header ->
-                                    {error, invalid_bundle_header}
-                            end;
-                        Error ->
-                            Error
-                    end
-            end;
-        Error ->
-            Error
-    end.
-
-%% @doc Read exactly the bytes needed to decode a bundle header.
-read_bundle_header(_BundleStartOffset, HeaderSize, FirstChunk, _Opts)
-        when HeaderSize =< byte_size(FirstChunk) ->
-    {ok, binary:part(FirstChunk, 0, HeaderSize)};
-read_bundle_header(BundleStartOffset, HeaderSize, _FirstChunk, Opts) ->
-    hb_store_arweave:read_chunks(BundleStartOffset, HeaderSize, Opts).
 
 %% @doc Locate the item that starts at the given offset in a bundle header
 %% index and return its serialized size.

--- a/src/dev_arweave_offset.erl
+++ b/src/dev_arweave_offset.erl
@@ -1,0 +1,215 @@
+%%% @doc A module for the Arweave device that implements the default key 
+%%% resolution logic. The default key returns slices of bytes inside Arweave as
+%%% message representations.
+-module(dev_arweave_offset).
+-export([get/4]).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%% @doc Resolve either a message at an Arweave offset, or a direct key from the
+%% base message if the key is not an integer.
+get(Key, Base, Request, Opts) ->
+    case parse(Key) of
+        {ok, StartOffset, Length} ->
+            load_item_at_offset(StartOffset, Length, Opts);
+        error ->
+            dev_message:get(Key, Base, Request, Opts)
+    end.
+
+%% @doc Parse a path key as a global Arweave start offset.
+parse(Key) ->
+    try
+        case binary:split(Key, <<"-">>) of
+            [Start, Length] ->
+                {ok, hb_util:int(Start), hb_util:int(Length)};
+            [Start] ->
+                {ok, hb_util:int(Start), undefined}
+        end
+    catch
+        _:_ -> error
+    end.
+
+%% @doc Load an ANS-104 item whose header begins at the given global offset.
+load_item_at_offset(StartOffset, Length, Opts) ->
+    maybe
+        {ok, ChunkJSON, FirstChunk} ?= item_chunk_from_offset(StartOffset, Opts),
+        {ok, HeaderSize, HeaderTX} ?= 
+            try ar_bundles:deserialize_header(FirstChunk)
+            catch _:_ -> {error, invalid_ans104_header}
+            end,
+        {ok, ItemSize} ?=
+            if Length =:= undefined ->
+                item_size_from_offset(StartOffset, ChunkJSON, Opts);
+            true ->
+                {ok, Length}
+            end,
+        true ?= HeaderSize =< ItemSize,
+        DataSize = ItemSize - HeaderSize,
+        {HeaderData, RemainingLength} =
+            split_header_data(HeaderTX#tx.data, DataSize),
+        {ok, RemainingData} ?=
+            read_remaining_item_data(
+                StartOffset,
+                HeaderSize,
+                byte_size(HeaderData),
+                RemainingLength,
+                Opts
+            ),
+        FullTX =
+            HeaderTX#tx{
+                data = <<HeaderData/binary, RemainingData/binary>>,
+                data_size = DataSize
+            },
+        {ok,
+            hb_message:convert(
+                FullTX,
+                <<"structured@1.0">>,
+                <<"ans104@1.0">>,
+                Opts
+            )}
+    else
+        false -> {error, invalid_item_size};
+        Error -> Error
+    end.
+
+%% @doc Read the chunk containing the given offset and trim it to begin at the
+%% first byte of the requested item.
+item_chunk_from_offset(StartOffset, Opts) ->
+    case dev_arweave:get_chunk(StartOffset + 1, Opts) of
+        {ok, ChunkJSON} ->
+            ChunkSize = hb_util:int(maps:get(<<"chunk_size">>, ChunkJSON)),
+            AbsEnd = hb_util:int(maps:get(<<"absolute_end_offset">>, ChunkJSON)),
+            Chunk = hb_util:decode(maps:get(<<"chunk">>, ChunkJSON)),
+            ChunkStart = AbsEnd - ChunkSize + 1,
+            Skip = (StartOffset + 1) - ChunkStart,
+            {ok, ChunkJSON, binary:part(Chunk, Skip, byte_size(Chunk) - Skip)};
+        Error ->
+            Error
+    end.
+
+%% @doc Split the bytes already present after a decoded header from those that
+%% still need to be read from Arweave.
+split_header_data(HeaderData, DataSize) ->
+    PrefixSize = min(byte_size(HeaderData), DataSize),
+    {
+        binary:part(HeaderData, 0, PrefixSize),
+        DataSize - PrefixSize
+    }.
+
+%% @doc Read any bytes of the data segment that were not present in the first
+%% header chunk.
+read_remaining_item_data(_StartOffset, _HeaderSize, _PrefixSize, 0, _Opts) ->
+    {ok, <<>>};
+read_remaining_item_data(StartOffset, HeaderSize, PrefixSize, Length, Opts) ->
+    hb_store_arweave:read_chunks(StartOffset + HeaderSize + PrefixSize, Length, Opts).
+
+%% @doc Resolve the size of the item at the given offset by locating it in the
+%% containing bundle header. We use the `note` attached to the Merkle leaf of
+%% the `tx_path` for the chunk to find the size of the bundle that contains the
+%% item. We then use the `note` attached to the Merkle leaf of the `data_path`
+%% for the chunk to find the offset of the end of the chunk inside the bundle.
+item_size_from_offset(StartOffset, ChunkJSON, Opts) ->
+    AbsEnd = hb_util:int(maps:get(<<"absolute_end_offset">>, ChunkJSON)),
+    BundleSize =
+        ar_merkle:extract_note(
+            hb_util:decode(maps:get(<<"tx_path">>, ChunkJSON))
+        ),
+    ChunkEndInBundle =
+        ar_merkle:extract_note(
+            hb_util:decode(maps:get(<<"data_path">>, ChunkJSON))
+        ),
+    BundleStartOffset = AbsEnd - ChunkEndInBundle,
+    case bundle_header(BundleStartOffset, BundleSize, Opts) of
+        {ok, HeaderSize, BundleIndex} ->
+            locate_bundle_item(
+                StartOffset,
+                BundleStartOffset + HeaderSize,
+                BundleIndex
+            );
+        Error ->
+            Error
+    end.
+
+%% @doc Read and decode the containing bundle header for an item.
+bundle_header(BundleStartOffset, _BundleSize, Opts) ->
+    case hb_ao:resolve(
+        #{ <<"device">> => <<"arweave@2.9">> },
+        #{
+            <<"path">> => <<"chunk">>,
+            <<"offset">> => BundleStartOffset + 1
+        },
+        Opts
+    ) of
+        {ok, FirstChunk} ->
+            case ar_bundles:bundle_header_size(FirstChunk) of
+                invalid_bundle_header ->
+                    {error, invalid_bundle_header};
+                HeaderSize ->
+                    case read_bundle_header(BundleStartOffset, HeaderSize, FirstChunk, Opts) of
+                        {ok, HeaderBin} ->
+                            case ar_bundles:decode_bundle_header(HeaderBin) of
+                                {_Items, BundleIndex} ->
+                                    {ok, HeaderSize, BundleIndex};
+                                invalid_bundle_header ->
+                                    {error, invalid_bundle_header}
+                            end;
+                        Error ->
+                            Error
+                    end
+            end;
+        Error ->
+            Error
+    end.
+
+%% @doc Read exactly the bytes needed to decode a bundle header.
+read_bundle_header(_BundleStartOffset, HeaderSize, FirstChunk, _Opts)
+        when HeaderSize =< byte_size(FirstChunk) ->
+    {ok, binary:part(FirstChunk, 0, HeaderSize)};
+read_bundle_header(BundleStartOffset, HeaderSize, _FirstChunk, Opts) ->
+    hb_store_arweave:read_chunks(BundleStartOffset, HeaderSize, Opts).
+
+%% @doc Locate the item that starts at the given offset in a bundle header
+%% index and return its serialized size.
+locate_bundle_item(StartOffset, ItemStartOffset, [{_ID, Size} | _]) 
+        when StartOffset =:= ItemStartOffset ->
+    {ok, Size};
+locate_bundle_item(StartOffset, ItemStartOffset, [{_ID, Size} | Rest])
+        when StartOffset > ItemStartOffset ->
+    locate_bundle_item(StartOffset, ItemStartOffset + Size, Rest);
+locate_bundle_item(_StartOffset, _ItemStartOffset, _BundleIndex) ->
+    {error, not_found}.
+
+%%% Tests
+
+
+resolve_item_at_offset_test() ->
+    StartOffset = 384600234780716,
+    ExpectedID = <<"cTI07T1OrF0KZEqPmZji1VTdbeKJG7kMAVlLu7KQvyw">>,
+    {ok, Item} =
+        hb_ao:resolve(
+            #{ <<"device">> => <<"arweave@2.9">> },
+            hb_util:bin(StartOffset),
+            #{}
+        ),
+    ?assert(hb_message:verify(Item, all, #{})),
+    ?assertEqual(ExpectedID, hb_message:id(Item, signed, #{})).
+
+offset_as_name_resolver_lookup_test() ->
+    Opts = #{
+        name_resolvers => [#{ <<"device">> => <<"arweave@2.9">> }],
+        on =>
+            #{
+                <<"request">> => [#{ <<"device">> => <<"name@2.9">> }]
+            }
+    },
+    Node = hb_http_server:start_node(Opts),
+    {ok, Item} =
+        hb_http:get(
+            Node,
+            #{
+                <<"path">> => <<"/">>,
+                <<"host">> => <<"384600234780716.localhost">>
+            },
+            Opts
+        ),
+    ?assertEqual(<<"image/jpeg">>, hb_ao:get(<<"content-type">>, Item, Opts)).

--- a/src/dev_arweave_offset.erl
+++ b/src/dev_arweave_offset.erl
@@ -37,14 +37,16 @@ load_item_at_offset(StartOffset, Length, Opts) ->
             try ar_bundles:deserialize_header(FirstChunk)
             catch _:_ -> {error, invalid_ans104_header}
             end,
-        {ok, ItemSize} ?=
-            if Length =:= undefined ->
-                item_size_from_offset(StartOffset, ChunkJSON, Opts);
+        {ok, DataSize} ?=
+            if Length =/= undefined -> {ok, Length};
             true ->
-                {ok, Length}
+                case item_size_from_offset(StartOffset, ChunkJSON, Opts) of
+                    {ok, ItemSize} when HeaderSize =< ItemSize ->
+                        {ok, ItemSize - HeaderSize};
+                    {ok, _ItemSize} -> false;
+                    ItemSizeError -> ItemSizeError
+                end
             end,
-        true ?= HeaderSize =< ItemSize,
-        DataSize = ItemSize - HeaderSize,
         {HeaderData, RemainingLength} =
             split_header_data(HeaderTX#tx.data, DataSize),
         {ok, RemainingData} ?=
@@ -181,25 +183,48 @@ locate_bundle_item(_StartOffset, _ItemStartOffset, _BundleIndex) ->
 
 %%% Tests
 
+offset_item_cases_test() ->
+    Opts = #{},
+    assert_offset_item(
+        <<"160399272861859">>,
+        498852,
+        #{ <<"content-type">> => <<"image/png">> },
+        Opts
+    ),
+    assert_offset_item(
+        <<"160399272861859-498852">>,
+        498852,
+        #{ <<"content-type">> => <<"image/png">> },
+        Opts
+    ),
+    assert_offset_item(
+        <<"384600234780716">>,
+        856691,
+        #{ <<"content-type">> => <<"image/jpeg">> },
+        Opts
+    ),
+    ok.
 
-resolve_item_at_offset_test() ->
-    StartOffset = 384600234780716,
-    ExpectedID = <<"cTI07T1OrF0KZEqPmZji1VTdbeKJG7kMAVlLu7KQvyw">>,
-    {ok, Item} =
-        hb_ao:resolve(
-            #{ <<"device">> => <<"arweave@2.9">> },
-            hb_util:bin(StartOffset),
-            #{}
-        ),
-    ?assert(hb_message:verify(Item, all, #{})),
-    ?assertEqual(ExpectedID, hb_message:id(Item, signed, #{})).
+assert_offset_item(Path, DataSize, Tags, Opts) ->
+    {ok, Item} = hb_ao:resolve(#{ <<"device">> => <<"arweave@2.9">> }, Path, Opts),
+    TX = hb_message:convert(Item, <<"ans104@1.0">>, <<"structured@1.0">>, Opts),
+    ?assert(hb_message:verify(Item, all, Opts)),
+    ?assertEqual(DataSize, TX#tx.data_size),
+    ?assertEqual(DataSize, byte_size(TX#tx.data)),
+    maps:foreach(
+        fun(Key, Value) ->
+            ?assertEqual({ok, Value}, hb_maps:find(Key, Item, Opts))
+        end,
+        Tags
+    ),
+    ok.
 
 offset_as_name_resolver_lookup_test() ->
     Opts = #{
         name_resolvers => [#{ <<"device">> => <<"arweave@2.9">> }],
         on =>
             #{
-                <<"request">> => [#{ <<"device">> => <<"name@2.9">> }]
+                <<"request">> => [#{ <<"device">> => <<"name@1.0">> }]
             }
     },
     Node = hb_http_server:start_node(Opts),
@@ -208,8 +233,8 @@ offset_as_name_resolver_lookup_test() ->
             Node,
             #{
                 <<"path">> => <<"/">>,
-                <<"host">> => <<"384600234780716.localhost">>
+                <<"host">> => <<"152974576623958.localhost">>
             },
             Opts
         ),
-    ?assertEqual(<<"image/jpeg">>, hb_ao:get(<<"content-type">>, Item, Opts)).
+    ?assertEqual(<<"application/json">>, hb_ao:get(<<"content-type">>, Item, Opts)).

--- a/src/dev_arweave_offset.erl
+++ b/src/dev_arweave_offset.erl
@@ -16,18 +16,72 @@ get(Key, Base, Request, Opts) ->
             dev_message:get(Key, Base, Request, Opts)
     end.
 
-%% @doc Parse a path key as a global Arweave start offset.
+%% @doc Parse a path key as a global Arweave start offset. The supported syntax
+%% is as follows:
+%% ```
+%% Reference :: Offset-Length
+%% Offset :: <integer>[Unit]
+%% Length :: <integer>
+%% Unit ::
+%%     b        : The global Arweave offset in absolute bytes (default).
+%%     k[i][b]  : The global Arweave offset in absolute kilobytes or kibibytes.
+%%     m[i][b]  : The global Arweave offset in absolute megabytes or mebibytes.
+%%     g[i][b]  : The global Arweave offset in absolute gigabytes or gibibytes.
+%%     t[i][b]  : The global Arweave offset in absolute terabytes or tebibytes.
+%%     p[i][b]  : The global Arweave offset in absolute petabytes or pebibytes.
+%%     e[i][b]  : The global Arweave offset in absolute exabytes or exbibytes.
+%%     z[i][b]  : The global Arweave offset in absolute zettabytes or zebibytes.
+%%     y[i][b]  : The global Arweave offset in absolute yottabytes or yobibytes.
+%% ```
+%% In the scheme above, the `i` modifier in units indicates that the unit is in
+%% binary multiples of the base unit. For example, `kib` is 1024 bytes, `mib` is
+%% 1024 * 1024 bytes, etc. By contrast, the `kb` unit is decimal-oriented: `kb`
+%% 1000 bytes, `mb` is 1000 * 1000 bytes, etc. To aid minimization of the bytes
+%% required for the references, the `b` is always implied and need not be
+%% specified.
 parse(Key) ->
     try
-        case binary:split(Key, <<"-">>) of
-            [Start, Length] ->
-                {ok, hb_util:int(Start), hb_util:int(Length)};
-            [Start] ->
-                {ok, hb_util:int(Start), undefined}
-        end
+        {OffsetBin, Length} =
+            case binary:split(Key, <<"-">>) of
+                [Start, LengthBin] -> {Start, hb_util:int(LengthBin)};
+                [Start] -> {Start, undefined}
+            end,
+        {ok, parse_unit(OffsetBin), Length}
     catch
-        _:_ -> error
+        Class:Error:StackTrace ->
+            ?event(
+                error,
+                {error, {invalid_offset_key, Key},
+                {class, Class},
+                {error, Error},
+                {stack_trace, {trace, StackTrace}}}
+            ),
+            error
     end.
+
+%% @doc Parses and applies a unit modifier to a base value, supporting both
+%% the `kb` and `kib` unit formats.
+parse_unit(Binary) -> parse_unit(0, Binary).
+parse_unit(Complete, <<>>) -> Complete;
+parse_unit(Base, <<Int:8/integer, Rest/binary>>) when Int >= $0 andalso Int =< $9 ->
+    parse_unit(Base * 10 + (Int - $0), Rest);
+parse_unit(Base, <<"b">>) -> Base;
+parse_unit(Base, <<"ki", _/binary>>) -> parse_unit(Base * 1024, <<"b">>);
+parse_unit(Base, <<"mi", _/binary>>) -> parse_unit(Base * 1024, <<"ki">>);
+parse_unit(Base, <<"gi", _/binary>>) -> parse_unit(Base * 1024, <<"mi">>);
+parse_unit(Base, <<"ti", _/binary>>) -> parse_unit(Base * 1024, <<"gi">>);
+parse_unit(Base, <<"pi", _/binary>>) -> parse_unit(Base * 1024, <<"ti">>);
+parse_unit(Base, <<"ei", _/binary>>) -> parse_unit(Base * 1024, <<"pi">>);
+parse_unit(Base, <<"zi", _/binary>>) -> parse_unit(Base * 1024, <<"zi">>);
+parse_unit(Base, <<"yi", _/binary>>) -> parse_unit(Base * 1024, <<"zi">>);
+parse_unit(Base, <<"k", _/binary>>) -> parse_unit(Base * 1000, <<"b">>);
+parse_unit(Base, <<"m", _/binary>>) -> parse_unit(Base * 1000, <<"k">>);
+parse_unit(Base, <<"g", _/binary>>) -> parse_unit(Base * 1000, <<"m">>);
+parse_unit(Base, <<"t", _/binary>>) -> parse_unit(Base * 1000, <<"g">>);
+parse_unit(Base, <<"p", _/binary>>) -> parse_unit(Base * 1000, <<"t">>);
+parse_unit(Base, <<"e", _/binary>>) -> parse_unit(Base * 1000, <<"p">>);
+parse_unit(Base, <<"z", _/binary>>) -> parse_unit(Base * 1000, <<"e">>);
+parse_unit(Base, <<"y", _/binary>>) -> parse_unit(Base * 1000, <<"z">>).
 
 %% @doc Load an ANS-104 item whose header begins at the given global offset.
 load_item_at_offset(TargetOffset, Length, Opts) ->
@@ -193,6 +247,19 @@ find_bundle_member(_TargetOffset, _ItemStartOffset, [], _Opts) ->
 
 %%% Tests
 
+parse_offset_test() ->
+    ?assertEqual({ok, 160399272861859, undefined}, parse(<<"160399272861859">>)),
+    ?assertEqual({ok, 160399272861859, 498852}, parse(<<"160399272861859-498852">>)),
+    ?assertEqual({ok, 160399273000000, undefined}, parse(<<"160399273000000">>)),
+    ?assertEqual({ok, 160399273000000, 498852}, parse(<<"160399273000000-498852">>)),
+    ?assertEqual({ok, 160399273000000, undefined}, parse(<<"160399273m">>)),
+    ?assertEqual({ok, 160399273000000, 498852}, parse(<<"160399273m-498852">>)),
+    ?assertEqual(
+        {ok, 1337 * 1024 * 1024 * 1024 * 1024, undefined},
+        parse(<<"1337tib">>)
+    ),
+    ok.
+
 offset_item_cases_test() ->
     Opts = #{},
     % A simple message.
@@ -216,13 +283,13 @@ offset_item_cases_test() ->
         #{ <<"content-type">> => <<"image/png">> },
         Opts
     ),
-    % % A megabyte reference to the item, occurring in the middle of the item.
-    % assert_offset_item(
-    %     <<"160399273m">>,
-    %     498852,
-    %     #{ <<"content-type">> => <<"image/jpeg">> },
-    %     Opts
-    % ),
+    % A megabyte reference to the item, occurring in the middle of the item.
+    assert_offset_item(
+        <<"160399273m">>,
+        498852,
+        #{ <<"content-type">> => <<"image/png">> },
+        Opts
+    ),
     assert_offset_item(
         <<"384600234780716">>,
         856691,

--- a/src/dev_arweave_offset.erl
+++ b/src/dev_arweave_offset.erl
@@ -84,30 +84,73 @@ parse_unit(Base, <<"z", _/binary>>) -> parse_unit(Base * 1000, <<"e">>);
 parse_unit(Base, <<"y", _/binary>>) -> parse_unit(Base * 1000, <<"z">>).
 
 %% @doc Load an ANS-104 item whose header begins at the given global offset.
-load_item_at_offset(TargetOffset, Length, Opts) ->
+%% When a length is supplied it is treated as the exact ANS-104 data length, so
+%% we can skip bundle index discovery and read only the remaining payload bytes.
+load_item_at_offset(ExplicitOffset, Length, Opts) when is_integer(Length) ->
     maybe
-        {ok, StartOffset, ItemSize} ?= message_from_offset(TargetOffset, Opts),
-        {ok, _ChunkJSON, FirstChunk} ?= chunk_from_offset(StartOffset, Opts),
-        {ok, HeaderSize, HeaderTX} ?= deserialize_header(FirstChunk),
-        {ok, DataSize} ?=
-            if Length =/= undefined -> {ok, Length};
-            HeaderSize =< ItemSize -> {ok, ItemSize - HeaderSize};
-            true -> false
-            end,
-        {HeaderData, RemainingLength} =
-            split_header_data(HeaderTX#tx.data, DataSize),
+        {ok, _ChunkJSON, FirstChunk} ?= chunk_from_offset(ExplicitOffset, Opts),
         ?event(
             arweave_offset_lookup,
-            {calculating_message_from_offset,
-                {target_offset, TargetOffset},
-                {start_offset, StartOffset},
-                {header_size, HeaderSize},
-                {data_size, DataSize},
-                {header_data, HeaderData},
-                {remaining_length, RemainingLength}
+            {loaded_explicit_offset,
+                {explicit_offset, ExplicitOffset},
+                {length, Length}
             },
             Opts
         ),
+        load_item_from_data_size(ExplicitOffset, Length, FirstChunk, Opts)
+    end;
+load_item_at_offset(TargetOffset, undefined, Opts) ->
+    maybe
+        {ok, StartOffset, ItemSize, FirstChunk} ?=
+            message_from_offset(TargetOffset, Opts),
+        load_item_from_serialized_size(StartOffset, ItemSize, FirstChunk, Opts)
+    else
+        false -> {error, invalid_item_size};
+        Error -> Error
+    end.
+
+%% @doc Load an item when the exact ANS-104 data length is already known.
+load_item_from_data_size(StartOffset, DataSize, FirstChunk, Opts) ->
+    maybe
+        {ok, HeaderSize, HeaderTX} ?= deserialize_header(FirstChunk),
+        load_item_from_header(StartOffset, HeaderSize, HeaderTX, DataSize, Opts)
+    end.
+
+%% @doc Load an item when its serialized size is known from the containing
+%% bundle index.
+load_item_from_serialized_size(StartOffset, ItemSize, FirstChunk, Opts) ->
+    maybe
+        {ok, HeaderSize, HeaderTX} ?= deserialize_header(FirstChunk),
+        true ?= HeaderSize =< ItemSize,
+        load_item_from_header(
+            StartOffset,
+            HeaderSize,
+            HeaderTX,
+            ItemSize - HeaderSize,
+            Opts
+        )
+    else
+        false -> {error, invalid_item_size};
+        Error -> Error
+    end.
+
+%% @doc Complete an item load once the header has been decoded, using any data
+%% bytes that were already present after the header before reading the tail.
+load_item_from_header(StartOffset, HeaderSize, HeaderTX, DataSize, Opts) ->
+    {HeaderData, RemainingLength} =
+        split_header_data(HeaderTX#tx.data, DataSize),
+    ?event(
+        arweave_offset_lookup,
+        {calculating_message_from_offset,
+            {start_offset, StartOffset},
+            {header_size, HeaderSize},
+            {data_size, DataSize},
+            {header_data, HeaderData},
+            {remaining_length, RemainingLength}
+        },
+        Opts
+    ),
+    maybe
         {ok, RemainingData} ?=
             read_remaining_data(
                 StartOffset,
@@ -127,10 +170,8 @@ load_item_at_offset(TargetOffset, Length, Opts) ->
                 <<"structured@1.0">>,
                 <<"ans104@1.0">>,
                 Opts
-            )}
-    else
-        false -> {error, invalid_item_size};
-        Error -> Error
+            )
+        }
     end.
 
 %% @doc Read the chunk containing the given offset and trim it to begin at the
@@ -173,8 +214,14 @@ read_remaining_data(StartOffset, HeaderSize, PrefixSize, Length, Opts) ->
 %% @doc Locate the deepest bundled item that contains the given global offset.
 message_from_offset(TargetOffset, Opts) ->
     maybe
-        {ok, ChunkJSON, _Chunk} ?= chunk_from_offset(TargetOffset, Opts),
-        message_from_offset(TargetOffset, bundle_start_offset(ChunkJSON), Opts)
+        {ok, ChunkJSON, FirstChunk} ?= chunk_from_offset(TargetOffset, Opts),
+        message_from_offset(
+            TargetOffset,
+            bundle_start_offset(ChunkJSON),
+            TargetOffset,
+            FirstChunk,
+            Opts
+        )
     end.
 
 %% @doc Recover the global start offset of the containing bundle from the end
@@ -187,7 +234,7 @@ bundle_start_offset(ChunkJSON) ->
         ),
     AbsEnd - ChunkEndInBundle.
 
-message_from_offset(TargetOffset, BundleStartOffset, Opts) ->
+message_from_offset(TargetOffset, BundleStartOffset, KnownOffset, KnownChunk, Opts) ->
     maybe
         {ok, HeaderSize, BundleIndex} ?=
             dev_arweave:bundle_header(
@@ -201,21 +248,73 @@ message_from_offset(TargetOffset, BundleStartOffset, Opts) ->
                 BundleIndex,
                 Opts
             ),
-        maybe_nested_item(TargetOffset, ItemStartOffset, ItemSize, Opts)
+        maybe_nested_item(
+            TargetOffset,
+            ItemStartOffset,
+            ItemSize,
+            KnownOffset,
+            KnownChunk,
+            Opts
+        )
     end.
 
 %% @doc If the containing item is itself a bundle and the offset lies in its
 %% data payload, recurse into its bundle header. Otherwise return the item.
-maybe_nested_item(TargetOffset, ItemStartOffset, ItemSize, Opts) ->
+maybe_nested_item(
+        TargetOffset,
+        ItemStartOffset,
+        ItemSize,
+        KnownOffset,
+        KnownChunk,
+        Opts
+    ) ->
     maybe
-        {ok, _ChunkJSON, FirstChunk} ?= chunk_from_offset(ItemStartOffset, Opts),
+        {ok, FirstChunk} ?=
+            item_chunk(ItemStartOffset, KnownOffset, KnownChunk, Opts),
+        maybe_nested_item(
+            TargetOffset,
+            ItemStartOffset,
+            ItemSize,
+            FirstChunk,
+            KnownOffset,
+            KnownChunk,
+            Opts
+        )
+    end.
+
+maybe_nested_item(
+        TargetOffset,
+        ItemStartOffset,
+        ItemSize,
+        FirstChunk,
+        KnownOffset,
+        KnownChunk,
+        Opts
+    ) ->
+    maybe
         {ok, HeaderSize, HeaderTX} ?= deserialize_header(FirstChunk),
         true ?= TargetOffset >= ItemStartOffset + HeaderSize,
         true ?= dev_arweave_common:type(HeaderTX) =/= binary,
-        message_from_offset(TargetOffset, ItemStartOffset + HeaderSize, Opts)
+        message_from_offset(
+            TargetOffset,
+            ItemStartOffset + HeaderSize,
+            KnownOffset,
+            KnownChunk,
+            Opts
+        )
     else
-        false -> {ok, ItemStartOffset, ItemSize};
-        {error, not_found} -> {ok, ItemStartOffset, ItemSize};
+        false -> {ok, ItemStartOffset, ItemSize, FirstChunk};
+        {error, not_found} -> {ok, ItemStartOffset, ItemSize, FirstChunk};
+        Error -> Error
+    end.
+
+%% @doc Reuse the first chunk we already have when the located item starts at the
+%% same offset as the original request, otherwise fetch the item's first chunk.
+item_chunk(ItemStartOffset, ItemStartOffset, FirstChunk, _Opts) ->
+    {ok, FirstChunk};
+item_chunk(ItemStartOffset, _KnownOffset, _KnownChunk, Opts) ->
+    case chunk_from_offset(ItemStartOffset, Opts) of
+        {ok, _ChunkJSON, FirstChunk} -> {ok, FirstChunk};
         Error -> Error
     end.
 

--- a/src/dev_arweave_offset.erl
+++ b/src/dev_arweave_offset.erl
@@ -30,27 +30,32 @@ parse(Key) ->
     end.
 
 %% @doc Load an ANS-104 item whose header begins at the given global offset.
-load_item_at_offset(StartOffset, Length, Opts) ->
+load_item_at_offset(TargetOffset, Length, Opts) ->
     maybe
-        {ok, ChunkJSON, FirstChunk} ?= item_chunk_from_offset(StartOffset, Opts),
-        {ok, HeaderSize, HeaderTX} ?= 
-            try ar_bundles:deserialize_header(FirstChunk)
-            catch _:_ -> {error, invalid_ans104_header}
-            end,
+        {ok, StartOffset, ItemSize} ?= message_from_offset(TargetOffset, Opts),
+        {ok, _ChunkJSON, FirstChunk} ?= chunk_from_offset(StartOffset, Opts),
+        {ok, HeaderSize, HeaderTX} ?= deserialize_header(FirstChunk),
         {ok, DataSize} ?=
             if Length =/= undefined -> {ok, Length};
-            true ->
-                case item_size_from_offset(StartOffset, ChunkJSON, Opts) of
-                    {ok, ItemSize} when HeaderSize =< ItemSize ->
-                        {ok, ItemSize - HeaderSize};
-                    {ok, _ItemSize} -> false;
-                    ItemSizeError -> ItemSizeError
-                end
+            HeaderSize =< ItemSize -> {ok, ItemSize - HeaderSize};
+            true -> false
             end,
         {HeaderData, RemainingLength} =
             split_header_data(HeaderTX#tx.data, DataSize),
+        ?event(
+            arweave_offset_lookup,
+            {calculating_message_from_offset,
+                {target_offset, TargetOffset},
+                {start_offset, StartOffset},
+                {header_size, HeaderSize},
+                {data_size, DataSize},
+                {header_data, HeaderData},
+                {remaining_length, RemainingLength}
+            },
+            Opts
+        ),
         {ok, RemainingData} ?=
-            read_remaining_item_data(
+            read_remaining_data(
                 StartOffset,
                 HeaderSize,
                 byte_size(HeaderData),
@@ -59,7 +64,7 @@ load_item_at_offset(StartOffset, Length, Opts) ->
             ),
         FullTX =
             HeaderTX#tx{
-                data = <<HeaderData/binary, RemainingData/binary>>,
+                data = << HeaderData/binary, RemainingData/binary >>,
                 data_size = DataSize
             },
         {ok,
@@ -76,7 +81,7 @@ load_item_at_offset(StartOffset, Length, Opts) ->
 
 %% @doc Read the chunk containing the given offset and trim it to begin at the
 %% first byte of the requested item.
-item_chunk_from_offset(StartOffset, Opts) ->
+chunk_from_offset(StartOffset, Opts) ->
     case dev_arweave:get_chunk(StartOffset + 1, Opts) of
         {ok, ChunkJSON} ->
             ChunkSize = hb_util:int(maps:get(<<"chunk_size">>, ChunkJSON)),
@@ -87,6 +92,12 @@ item_chunk_from_offset(StartOffset, Opts) ->
             {ok, ChunkJSON, binary:part(Chunk, Skip, byte_size(Chunk) - Skip)};
         Error ->
             Error
+    end.
+
+%% @doc Safe wraper for ANS-104 header deserialization.
+deserialize_header(Binary) ->
+    try ar_bundles:deserialize_header(Binary)
+    catch _:_ -> {error, <<"Invalid message header">>}
     end.
 
 %% @doc Split the bytes already present after a decoded header from those that
@@ -100,67 +111,118 @@ split_header_data(HeaderData, DataSize) ->
 
 %% @doc Read any bytes of the data segment that were not present in the first
 %% header chunk.
-read_remaining_item_data(_StartOffset, _HeaderSize, _PrefixSize, 0, _Opts) ->
+read_remaining_data(_StartOffset, _HeaderSize, _PrefixSize, 0, _Opts) ->
     {ok, <<>>};
-read_remaining_item_data(StartOffset, HeaderSize, PrefixSize, Length, Opts) ->
+read_remaining_data(StartOffset, HeaderSize, PrefixSize, Length, Opts) ->
     hb_store_arweave:read_chunks(StartOffset + HeaderSize + PrefixSize, Length, Opts).
 
-%% @doc Determine the size of the item at an offset by locating it in the parent
-%% Arweave transaction's bundle header. In order to do this we must:
-%% 1. Find the global offset of the data root of the chunk.
-%% 2. Jump to that location and read the header chunks until we find our item.
-%% 3. Extract the item's size from the bundle header and return it.
-%% We achieve objective (1) by extracting the `absolute_end_offset` from the
-%% chunk JSON and subtracting the `data_path`'s note from it. The `data_path`
-%% is the Merkle path of the chunk that contains the item, and its note is the
-%% offset of the end of the chunk inside the bundle. The `absolute_end_offset`
-%% is the global offset of the end of the chunk, so to calculate the bundle's
-%% start offset we can simply perform `absolute_end_offset - data_path_note`.
-item_size_from_offset(StartOffset, ChunkJSON, Opts) ->
+%% @doc Locate the deepest bundled item that contains the given global offset.
+message_from_offset(TargetOffset, Opts) ->
+    maybe
+        {ok, ChunkJSON, _Chunk} ?= chunk_from_offset(TargetOffset, Opts),
+        message_from_offset(TargetOffset, bundle_start_offset(ChunkJSON), Opts)
+    end.
+
+%% @doc Recover the global start offset of the containing bundle from the end
+%% offset of the chunk in global space and its end offset inside the bundle.
+bundle_start_offset(ChunkJSON) ->
     AbsEnd = hb_util:int(maps:get(<<"absolute_end_offset">>, ChunkJSON)),
     ChunkEndInBundle =
         ar_merkle:extract_note(
             hb_util:decode(maps:get(<<"data_path">>, ChunkJSON))
         ),
-    BundleStartOffset = AbsEnd - ChunkEndInBundle,
-    case dev_arweave:bundle_header(BundleStartOffset, Opts) of
-        {ok, HeaderSize, BundleIndex} ->
-            locate_bundle_item(
-                StartOffset,
+    AbsEnd - ChunkEndInBundle.
+
+message_from_offset(TargetOffset, BundleStartOffset, Opts) ->
+    maybe
+        {ok, HeaderSize, BundleIndex} ?=
+            dev_arweave:bundle_header(
+                BundleStartOffset,
+                Opts
+            ),
+        {ok, ItemStartOffset, ItemSize} ?=
+            find_bundle_member(
+                TargetOffset,
                 BundleStartOffset + HeaderSize,
-                BundleIndex
-            );
-        Error ->
-            Error
+                BundleIndex,
+                Opts
+            ),
+        maybe_nested_item(TargetOffset, ItemStartOffset, ItemSize, Opts)
     end.
 
-%% @doc Locate the item that starts at the given offset in a bundle header
-%% index and return its serialized size.
-locate_bundle_item(StartOffset, ItemStartOffset, [{_ID, Size} | _]) 
-        when StartOffset =:= ItemStartOffset ->
-    {ok, Size};
-locate_bundle_item(StartOffset, ItemStartOffset, [{_ID, Size} | Rest])
-        when StartOffset > ItemStartOffset ->
-    locate_bundle_item(StartOffset, ItemStartOffset + Size, Rest);
-locate_bundle_item(_StartOffset, _ItemStartOffset, _BundleIndex) ->
+%% @doc If the containing item is itself a bundle and the offset lies in its
+%% data payload, recurse into its bundle header. Otherwise return the item.
+maybe_nested_item(TargetOffset, ItemStartOffset, ItemSize, Opts) ->
+    maybe
+        {ok, _ChunkJSON, FirstChunk} ?= chunk_from_offset(ItemStartOffset, Opts),
+        {ok, HeaderSize, HeaderTX} ?= deserialize_header(FirstChunk),
+        true ?= TargetOffset >= ItemStartOffset + HeaderSize,
+        true ?= dev_arweave_common:type(HeaderTX) =/= binary,
+        message_from_offset(TargetOffset, ItemStartOffset + HeaderSize, Opts)
+    else
+        false -> {ok, ItemStartOffset, ItemSize};
+        {error, not_found} -> {ok, ItemStartOffset, ItemSize};
+        Error -> Error
+    end.
+
+%% @doc Locate the bundle member containing the given offset.
+find_bundle_member(TargetOffset, ItemStartOffset, _BundleIndex, Opts)
+        when TargetOffset < ItemStartOffset ->
+    ?event(
+        arweave_offset_lookup,
+        {bundle_offset_search_exceeded_bounds,
+            {target_offset, TargetOffset},
+            {item_start_offset, ItemStartOffset}
+        },
+        Opts
+    ),
+    {error, not_found};
+find_bundle_member(TargetOffset, ItemStartOffset, [{ID, Size} | _], Opts)
+        when TargetOffset < ItemStartOffset + Size ->
+    % The target offset is within the current bundle member.
+    ?event(
+        arweave_offset_lookup,
+        {resolved_bundle_member, {id, ID}, {size, Size}},
+        Opts
+    ),
+    {ok, ItemStartOffset, Size};
+find_bundle_member(TargetOffset, ItemStartOffset, [{_ID, Size} | Rest], Opts) ->
+    find_bundle_member(TargetOffset, ItemStartOffset + Size, Rest, Opts);
+find_bundle_member(_TargetOffset, _ItemStartOffset, [], _Opts) ->
     {error, not_found}.
 
 %%% Tests
 
 offset_item_cases_test() ->
     Opts = #{},
+    % A simple message.
     assert_offset_item(
         <<"160399272861859">>,
         498852,
         #{ <<"content-type">> => <<"image/png">> },
         Opts
     ),
+    % A reference with a given length.
     assert_offset_item(
         <<"160399272861859-498852">>,
         498852,
         #{ <<"content-type">> => <<"image/png">> },
         Opts
     ),
+    % A reference to a byte in the middle of the test message.
+    assert_offset_item(
+        <<"160399273000000">>,
+        498852,
+        #{ <<"content-type">> => <<"image/png">> },
+        Opts
+    ),
+    % % A megabyte reference to the item, occurring in the middle of the item.
+    % assert_offset_item(
+    %     <<"160399273m">>,
+    %     498852,
+    %     #{ <<"content-type">> => <<"image/jpeg">> },
+    %     Opts
+    % ),
     assert_offset_item(
         <<"384600234780716">>,
         856691,
@@ -168,6 +230,20 @@ offset_item_cases_test() ->
         Opts
     ),
     ok.
+
+offset_nested_item_test() ->
+    Opts = #{},
+    TXID = <<"bndIwac23-s0K11TLC1N7z472sLGAkiOdhds87ZywoE">>,
+    Node = hb_http_server:start_node(),
+    {ok, Expected} =
+        hb_http:get(
+            Node,
+            <<"/~arweave@2.9/tx=", TXID/binary, "/1/2">>,
+            Opts
+        ),
+    {ItemStartOffset, _ItemSize} =
+        bundle_message_offset_from_tx(TXID, [1, 2], Opts),
+    assert_offset_matches(hb_util:bin(ItemStartOffset + 1), Expected, Opts).
 
 assert_offset_item(Path, DataSize, Tags, Opts) ->
     {ok, Item} = hb_ao:resolve(#{ <<"device">> => <<"arweave@2.9">> }, Path, Opts),
@@ -182,6 +258,57 @@ assert_offset_item(Path, DataSize, Tags, Opts) ->
         Tags
     ),
     ok.
+
+assert_offset_matches(Path, Expected, Opts) ->
+    {ok, Item} = hb_ao:resolve(#{ <<"device">> => <<"arweave@2.9">> }, Path, Opts),
+    ExpectedTX =
+        hb_message:convert(
+            Expected,
+            <<"ans104@1.0">>,
+            <<"structured@1.0">>,
+            Opts
+        ),
+    TX = hb_message:convert(Item, <<"ans104@1.0">>, <<"structured@1.0">>, Opts),
+    ?assert(hb_message:verify(Item, all, Opts)),
+    ?assertEqual(
+        hb_message:id(Expected, signed, Opts),
+        hb_message:id(Item, signed, Opts)
+    ),
+    ?assertEqual(ExpectedTX#tx.data_size, TX#tx.data_size),
+    ok.
+
+bundle_message_offset_from_tx(TXID, Path, Opts) ->
+    {ok, #{ <<"body">> := OffsetBody }} =
+        hb_http:request(
+            #{
+                <<"path">> => <<"/arweave/tx/", TXID/binary, "/offset">>,
+                <<"method">> => <<"GET">>
+            },
+            Opts
+        ),
+    OffsetMsg = hb_json:decode(OffsetBody),
+    EndOffset = hb_util:int(maps:get(<<"offset">>, OffsetMsg)),
+    Size = hb_util:int(maps:get(<<"size">>, OffsetMsg)),
+    bundled_index_offset(EndOffset - Size, Path, Opts).
+
+bundled_index_offset(BundleStartOffset, [Index], Opts) ->
+    {ok, HeaderSize, BundleIndex} =
+        dev_arweave:bundle_header(
+            BundleStartOffset,
+            Opts
+        ),
+    nth_bundle_item(Index, BundleStartOffset + HeaderSize, BundleIndex);
+bundled_index_offset(BundleStartOffset, [Index | Rest], Opts) ->
+    {ItemStartOffset, _ItemSize} =
+        bundled_index_offset(BundleStartOffset, [Index], Opts),
+    {ok, _ChunkJSON, FirstChunk} = chunk_from_offset(ItemStartOffset, Opts),
+    {ok, HeaderSize, _HeaderTX} = deserialize_header(FirstChunk),
+    bundled_index_offset(ItemStartOffset + HeaderSize, Rest, Opts).
+
+nth_bundle_item(1, ItemStartOffset, [{_ID, Size} | _]) ->
+    {ItemStartOffset, Size};
+nth_bundle_item(Index, ItemStartOffset, [{_ID, Size} | Rest]) when Index > 1 ->
+    nth_bundle_item(Index - 1, ItemStartOffset + Size, Rest).
 
 offset_as_name_resolver_lookup_test() ->
     Opts = #{

--- a/src/dev_arweave_offset.erl
+++ b/src/dev_arweave_offset.erl
@@ -64,7 +64,7 @@ unit(Base, <<"gi", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"mi">>);
 unit(Base, <<"ti", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"gi">>);
 unit(Base, <<"pi", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"ti">>);
 unit(Base, <<"ei", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"pi">>);
-unit(Base, <<"zi", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"zi">>);
+unit(Base, <<"zi", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"ei">>);
 unit(Base, <<"yi", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"zi">>);
 unit(Base, <<"k", _/binary>>) when Base > 0 -> unit(Base * 1000, <<"b">>);
 unit(Base, <<"m", _/binary>>) when Base > 0 -> unit(Base * 1000, <<"k">>);

--- a/src/dev_arweave_offset.erl
+++ b/src/dev_arweave_offset.erl
@@ -46,42 +46,34 @@ parse(Key) ->
                 [Start, LengthBin] -> {Start, hb_util:int(LengthBin)};
                 [Start] -> {Start, undefined}
             end,
-        {ok, parse_unit(OffsetBin), Length}
+        {ok, unit(OffsetBin), Length}
     catch
-        Class:Error:StackTrace ->
-            ?event(
-                error,
-                {error, {invalid_offset_key, Key},
-                {class, Class},
-                {error, Error},
-                {stack_trace, {trace, StackTrace}}}
-            ),
-            error
+        _Class:_Error:_StackTrace -> error
     end.
 
 %% @doc Parses and applies a unit modifier to a base value, supporting both
 %% the `kb` and `kib` unit formats.
-parse_unit(Binary) -> parse_unit(0, Binary).
-parse_unit(Complete, <<>>) -> Complete;
-parse_unit(Base, <<Int:8/integer, Rest/binary>>) when Int >= $0 andalso Int =< $9 ->
-    parse_unit(Base * 10 + (Int - $0), Rest);
-parse_unit(Base, <<"b">>) -> Base;
-parse_unit(Base, <<"ki", _/binary>>) -> parse_unit(Base * 1024, <<"b">>);
-parse_unit(Base, <<"mi", _/binary>>) -> parse_unit(Base * 1024, <<"ki">>);
-parse_unit(Base, <<"gi", _/binary>>) -> parse_unit(Base * 1024, <<"mi">>);
-parse_unit(Base, <<"ti", _/binary>>) -> parse_unit(Base * 1024, <<"gi">>);
-parse_unit(Base, <<"pi", _/binary>>) -> parse_unit(Base * 1024, <<"ti">>);
-parse_unit(Base, <<"ei", _/binary>>) -> parse_unit(Base * 1024, <<"pi">>);
-parse_unit(Base, <<"zi", _/binary>>) -> parse_unit(Base * 1024, <<"zi">>);
-parse_unit(Base, <<"yi", _/binary>>) -> parse_unit(Base * 1024, <<"zi">>);
-parse_unit(Base, <<"k", _/binary>>) -> parse_unit(Base * 1000, <<"b">>);
-parse_unit(Base, <<"m", _/binary>>) -> parse_unit(Base * 1000, <<"k">>);
-parse_unit(Base, <<"g", _/binary>>) -> parse_unit(Base * 1000, <<"m">>);
-parse_unit(Base, <<"t", _/binary>>) -> parse_unit(Base * 1000, <<"g">>);
-parse_unit(Base, <<"p", _/binary>>) -> parse_unit(Base * 1000, <<"t">>);
-parse_unit(Base, <<"e", _/binary>>) -> parse_unit(Base * 1000, <<"p">>);
-parse_unit(Base, <<"z", _/binary>>) -> parse_unit(Base * 1000, <<"e">>);
-parse_unit(Base, <<"y", _/binary>>) -> parse_unit(Base * 1000, <<"z">>).
+unit(Binary) -> unit(0, Binary).
+unit(Complete, <<>>) -> Complete;
+unit(Base, <<Int:8/integer, Rest/binary>>) when Int >= $0 andalso Int =< $9 ->
+    unit(Base * 10 + (Int - $0), Rest);
+unit(Base, <<"b">>) -> Base;
+unit(Base, <<"ki", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"b">>);
+unit(Base, <<"mi", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"ki">>);
+unit(Base, <<"gi", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"mi">>);
+unit(Base, <<"ti", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"gi">>);
+unit(Base, <<"pi", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"ti">>);
+unit(Base, <<"ei", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"pi">>);
+unit(Base, <<"zi", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"zi">>);
+unit(Base, <<"yi", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"zi">>);
+unit(Base, <<"k", _/binary>>) when Base > 0 -> unit(Base * 1000, <<"b">>);
+unit(Base, <<"m", _/binary>>) when Base > 0 -> unit(Base * 1000, <<"k">>);
+unit(Base, <<"g", _/binary>>) when Base > 0 -> unit(Base * 1000, <<"m">>);
+unit(Base, <<"t", _/binary>>) when Base > 0 -> unit(Base * 1000, <<"g">>);
+unit(Base, <<"p", _/binary>>) when Base > 0 -> unit(Base * 1000, <<"t">>);
+unit(Base, <<"e", _/binary>>) when Base > 0 -> unit(Base * 1000, <<"p">>);
+unit(Base, <<"z", _/binary>>) when Base > 0 -> unit(Base * 1000, <<"e">>);
+unit(Base, <<"y", _/binary>>) when Base > 0 -> unit(Base * 1000, <<"z">>).
 
 %% @doc Load an ANS-104 item whose header begins at the given global offset.
 %% When a length is supplied it is treated as the exact ANS-104 data length, so

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -312,7 +312,7 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
                 TXEndOffset, TX#tx.data_size, Opts
             ),
             case BundleRes of
-                {ok, {BundleIndex, HeaderSize}} ->
+                {ok, HeaderSize, BundleIndex} ->
                     % Batch event tracking: measure total time and count for all write_offset calls
                     {TotalTime, {_, ItemsCount}} = timer:tc(fun() ->
                         lists:foldl(
@@ -378,54 +378,8 @@ is_bundle_tx(TX, _Opts) ->
 
 download_bundle_header(EndOffset, Size, Opts) ->
     observe_event(<<"bundle_header">>, fun() ->
-        StartOffset = EndOffset - Size + 1,
-        case hb_ao:resolve(
-            <<
-                ?ARWEAVE_DEVICE/binary,
-                "/chunk&offset=",
-                (hb_util:bin(StartOffset))/binary
-            >>,
-            Opts
-        ) of
-            {ok, FirstChunk} ->
-                % Most bundle headers can fit in a single chunk, but those with
-                % thousands of items might require multiple chunks to fully
-                % represent the item index.
-                HeaderSize = ar_bundles:bundle_header_size(FirstChunk),
-                case header_chunk(HeaderSize, FirstChunk, StartOffset, Opts) of
-                    {ok, BundleHeader} ->
-                        {_ItemsBin, BundleIndex} =
-                            ar_bundles:decode_bundle_header(BundleHeader),
-                        {ok, {BundleIndex, HeaderSize}};
-                    Error ->
-                        Error
-                end;
-            Error ->
-                Error
-        end
+        dev_arweave:bundle_header(EndOffset - Size, Opts)
     end).
-
-header_chunk(invalid_bundle_header, _FirstChunk, _StartOffset, _Opts) ->
-    {error, invalid_bundle_header};
-header_chunk(HeaderSize, FirstChunk, _StartOffset, _Opts)
-        when HeaderSize =< byte_size(FirstChunk) ->
-    {ok, FirstChunk};
-header_chunk(HeaderSize, FirstChunk, StartOffset, Opts) ->
-    Res =
-        hb_ao:resolve(
-            <<
-                ?ARWEAVE_DEVICE/binary,
-                "/chunk&offset=",
-                (hb_util:bin(StartOffset + byte_size(FirstChunk)))/binary,
-                "&length=",
-                (hb_util:bin(HeaderSize - byte_size(FirstChunk)))/binary
-            >>,
-            Opts
-        ),
-    case Res of
-        {ok, OtherChunks} -> {ok, <<FirstChunk/binary, OtherChunks/binary>>};
-        Other -> Other
-    end.
 
 resolve_tx_headers(TXIDs, Opts) ->
     Results = parallel_map(
@@ -586,7 +540,7 @@ small_bundle_header_test() ->
     OffsetMsg = hb_json:decode(OffsetBody),
     EndOffset = hb_util:int(maps:get(<<"offset">>, OffsetMsg)),
     Size = hb_util:int(maps:get(<<"size">>, OffsetMsg)),
-    {ok, {BundleIndex, HeaderSize}} =
+    {ok, HeaderSize, BundleIndex} =
         download_bundle_header(EndOffset, Size, Opts),
     ?assertEqual(1704, length(BundleIndex)),
     ?assertEqual(109088, HeaderSize),
@@ -607,7 +561,7 @@ large_bundle_header_test() ->
     OffsetMsg = hb_json:decode(OffsetBody),
     EndOffset = hb_util:int(maps:get(<<"offset">>, OffsetMsg)),
     Size = hb_util:int(maps:get(<<"size">>, OffsetMsg)),
-    {ok, {BundleIndex, HeaderSize}} =
+    {ok, HeaderSize, BundleIndex} =
         download_bundle_header(EndOffset, Size, Opts),
     ?assertEqual(15000, length(BundleIndex)),
     ?assertEqual(960032, HeaderSize),

--- a/src/dev_name.erl
+++ b/src/dev_name.erl
@@ -33,11 +33,22 @@ resolve(Key, _, Req, Opts) ->
     case match_resolver(Key, Resolvers, Opts) of
         {ok, Resolved} ->
             case hb_util:atom(hb_ao:get(<<"load">>, Req, true, Opts)) of
-                false -> {ok, Resolved};
-                true -> hb_cache:read(Resolved, Opts)
+                false ->
+                    {ok, Resolved};
+                true ->
+                    maybe_load_resolved(Resolved, Opts)
             end;
         not_found -> not_found
     end.
+
+%% @doc Load a resolved name target if it is a cache reference, otherwise
+%% return the resolved value directly.
+maybe_load_resolved(Resolved, Opts) when ?IS_ID(Resolved) ->
+    hb_cache:read(Resolved, Opts);
+maybe_load_resolved(Resolved, Opts) when ?IS_LINK(Resolved) ->
+    {ok, hb_cache:ensure_loaded(Resolved, Opts)};
+maybe_load_resolved(Resolved, _Opts) ->
+    {ok, Resolved}.
 
 %% @doc Find the first resolver that matches the key and return its value.
 match_resolver(_Key, [], _Opts) -> 

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -43,7 +43,8 @@
 -ifndef(TEST).
 -define(DEFAULT_NAME_RESOLVERS,
     [
-        #{ <<"device">> => <<"~b32-name@1.0">> },
+        #{ <<"device">> => <<"arweave@2.9">> },
+        #{ <<"device">> => <<"b32-name@1.0">> },
         <<
             "G_gb7SAgogHMtmqycwaHaC6uC-CZ3akACdFv5PUaEE8",
                 "~json@1.0/deserialize&target=data"


### PR DESCRIPTION
This PR introduces an additional `~name@1.0` resolver, enabled by default, that interprets subdomains containing only numbers as references to byte offsets in Arweave.

This allows users to resolve subdomains like these:
`https://89269846458279.arweave.net`
`http://353022643731662.localhost:8734/`

Additionally, the syntax supports unit specifiers in the form of `kb`, `mb`, through to `yb`. The `*ibibyte` form is also supported through the addition of an `i` after the primary specifier. In either case, the `b` can be dropped at users preference:
`https://89269846460k.arweave.net`
`http://353022643732kb.localhost:8734/`
`http://160399273m.localhost:8734/`
`http://101t.localhost:8734/`
`http://100tib.localhost:8734/`

Previously, if one did not have a human-readable name for their Arweave page, visitors would have to load/share a URL that was often over 100 characters -- excluding any site-specific components (subpaths, query parameters etc). This is unnecessarily off-putting for newbies.

Because of Arweave's linear address space, every piece of data has a specific byte offset at which its content starts and ends. This PR simply makes that address space practically accessible via the URL bar on HyperBEAM nodes.

These 'names' (alternative identifiers might be more appropriate?) are not _super_ friendly to look at, but they do come with a much of neat advantages:
1. **They are short**: New data today gets at base a 15 digit identifier compared with the 43 characters of Arweave IDs plus the 52 characters used for gateway secure sandboxes. Most data crosses at least the `kb` boundary, and as such can be expressed with a `k` post-fix, dropping 2 characters. Larger data often passes a GB boundary, allowing 8 characters to be dropped. Lucky uploaders will occasionally get a `t` boundary, giving them 4 character names. The uploader of the petabyte'th byte will gain a 2 character name: `1p`.
2. They are **free**: Any data uploaded to Arweave gets an offset assigned without any additional charge.
3. They are **permanent**: Once assigned and out of Arweave's fork recovery depth (~19 blocks), an offset's content will _never_ change.
4. **Data age** is evident from the domain alone: Older data has lower byte offsets.
5. Serving requires **zero indexing**: All Arweave nodes are able to lookup the chunks and proofs associated with a given offset from their internal state. Subsequently, all that is needed to serve these addresses is a functioning Arweave node. By contrast, serving traditional 43 character domains found inside bundles requires the node to have created the (relatively heavy) indexes that relate ID->Arweave offset.

You can find the offset for any existing Arweave data with the following AO-Core hashpath: `http://localhost:8734/~arweave@2.9/raw=1rL73ctmqTVv7qkqAsD4jIz5tU6WxgOAqABYuMHg5mQ/offset`.