### PR TITLE
impr: Use boot `start` hook to call devices on node start

### DIFF
--- a/src/dev_cron.erl
+++ b/src/dev_cron.erl
@@ -56,10 +56,10 @@ once(_Base, Req, Opts) ->
 
 %% @doc Internal function for scheduling a one-time message.
 once_worker(Path, Req, Opts) ->
-	% Directly call the meta device on the newly constructed 'singleton', just
-    % as hb_http_server does.
+	% Use hb_ao:resolve directly to bypass the HTTP request pipeline (auth
+    % hooks, etc.). Cron workers are internal/trusted calls.
 	try
-		dev_meta:handle(Opts, Req#{ <<"path">> => Path})
+		hb_ao:resolve(Req#{ <<"path">> => Path}, Opts)
 	catch
 		Class:Reason:Stacktrace ->
 			?event(
@@ -170,7 +170,10 @@ every_worker_loop(CronPath, Req, Opts, IntervalMillis) ->
         }
     ),
     try
-        dev_meta:handle(Opts, Req1),
+        % Use hb_ao:resolve directly instead of dev_meta:handle to bypass the
+        % HTTP request pipeline (request hooks, auth, etc.). Cron workers are
+        % internal/trusted and should not be subject to HTTP-level auth checks.
+        hb_ao:resolve(Req1, Opts),
         ?event({cron_every_worker_executed, {path, CronPath}})
     catch
         Class:Reason:Stack ->

--- a/src/dev_hook.erl
+++ b/src/dev_hook.erl
@@ -162,13 +162,17 @@ execute_handler(HookName, Handler, Req, Opts) ->
         % handler does not affect the hashpath of a request's output. If the
         % `hook/commit` key is set to `true`, the handler request will be
         % committed before execution.
+        %
+        % NOTE: Since only path and method are allow, this aren't enough to 
+        % make it run.
+        ExtraParams = maps:get(<<"extra-params">>, Handler, #{}),
         BaseReq =
-            Req#{
+            hb_maps:merge(#{
                 <<"path">> =>
                     hb_maps:get(<<"path">>, Handler, HookName, Opts),
                 <<"method">> =>
                     hb_maps:get(<<"method">>, Handler, <<"GET">>, Opts)
-            },
+            }, ExtraParams, Opts),
         CommitReqBin = 
             hb_util:bin(
                 hb_util:deep_get(
@@ -194,6 +198,7 @@ execute_handler(HookName, Handler, Req, Opts) ->
             {resolving_handler, 
                 {name, HookName},
                 {handler, Handler},
+                {prepared_base, PreparedBase},
                 {req, {explicit, PreparedReq}}
             }
         ),

--- a/src/dev_hook.erl
+++ b/src/dev_hook.erl
@@ -162,9 +162,6 @@ execute_handler(HookName, Handler, Req, Opts) ->
         % handler does not affect the hashpath of a request's output. If the
         % `hook/commit` key is set to `true`, the handler request will be
         % committed before execution.
-        %
-        % NOTE: Since only path and method are allow, this aren't enough to 
-        % make it run.
         ExtraParams = maps:get(<<"extra-params">>, Handler, #{}),
         BaseReq =
             hb_maps:merge(#{
@@ -194,8 +191,17 @@ execute_handler(HookName, Handler, Req, Opts) ->
                     };
                 <<"false">> -> {Handler, BaseReq}
             end,
+        % Remove the current hook's handlers from Opts before resolution to
+        % prevent cross-hook interference (e.g. request handlers firing during
+        % start hook resolution).
+        ScopedOpts =
+            case maps:get(on, Opts, #{}) of
+                On when is_map(On) ->
+                    Opts#{ on => maps:remove(HookName, On) };
+                _ -> Opts
+            end,
         ?event(hook,
-            {resolving_handler, 
+            {resolving_handler,
                 {name, HookName},
                 {handler, Handler},
                 {prepared_base, PreparedBase},
@@ -207,7 +213,7 @@ execute_handler(HookName, Handler, Req, Opts) ->
             hb_ao:resolve(
                 PreparedBase,
                 PreparedReq,
-                Opts#{ hashpath => ignore }
+                ScopedOpts#{ hashpath => ignore }
             ),
         ?event(hook,
             {handler_result,

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -164,7 +164,8 @@ new_server(RawNodeMsg) ->
     NodeMsg =
         case dev_hook:on(<<"start">>, HookMsg, RawNodeMsgWithDefaults) of
             {ok, #{ <<"body">> := NodeMsgAfterHook }} when is_map(NodeMsgAfterHook) -> NodeMsgAfterHook;
-            {ok, _R} ->
+            {ok, Response} ->
+                ?event(boot, {start_hook_response, {response, Response}}),
                 %% Fire-and-forget start handlers (e.g. cron) use hook/result => ignore,
                 %% so this clause handles any remaining non-NodeMsg results gracefully.
                 maps:get(<<"body">>, HookMsg);
@@ -182,16 +183,6 @@ new_server(RawNodeMsg) ->
         end,
     % Put server ID into node message so it's possible to update current server
     hb_http:start(),
-    _ServerID =
-        hb_util:human_id(
-            ar_wallet:to_address(
-                hb_opts:get(
-                    priv_wallet,
-                    no_wallet,
-                    NodeMsg
-                )
-            )
-        ),
     % Put server ID into node message so it's possible to update current server
     % params.
     NodeMsgWithID = hb_maps:put(http_server, ServerID, NodeMsg),

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -165,9 +165,8 @@ new_server(RawNodeMsg) ->
         case dev_hook:on(<<"start">>, HookMsg, RawNodeMsgWithDefaults) of
             {ok, #{ <<"body">> := NodeMsgAfterHook }} when is_map(NodeMsgAfterHook) -> NodeMsgAfterHook;
             {ok, _R} ->
-                %% NOTE: Since cron doesn't reply with a NodeMsg, we need to handle it seperatly.
-                %% For from cron, it replies with the token.
-                %% We set opts, the same way if there is no handler to solve.
+                %% Fire-and-forget start handlers (e.g. cron) use hook/result => ignore,
+                %% so this clause handles any remaining non-NodeMsg results gracefully.
                 maps:get(<<"body">>, HookMsg);
             Unexpected ->
                 ?event(http,

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -145,15 +145,30 @@ print_greeter(Config, PrivWallet) ->
 %% before it is used to configure the server. The `start' hook expects gives and
 %% expects the node message to be in the `body' key.
 new_server(RawNodeMsg) ->
+    ServerID =
+        hb_util:human_id(
+            ar_wallet:to_address(
+                hb_opts:get(
+                    priv_wallet,
+                    no_wallet,
+                    RawNodeMsg
+                )
+            )
+        ),
     RawNodeMsgWithDefaults =
         hb_maps:merge(
             hb_opts:default_message_with_env(),
-            RawNodeMsg#{ only => local }
+            RawNodeMsg#{ only => local, http_server => ServerID }
         ),
     HookMsg = #{ <<"body">> => RawNodeMsgWithDefaults },
     NodeMsg =
         case dev_hook:on(<<"start">>, HookMsg, RawNodeMsgWithDefaults) of
-            {ok, #{ <<"body">> := NodeMsgAfterHook }} -> NodeMsgAfterHook;
+            {ok, #{ <<"body">> := NodeMsgAfterHook }} when is_map(NodeMsgAfterHook) -> NodeMsgAfterHook;
+            {ok, _R} ->
+                %% NOTE: Since cron doesn't reply with a NodeMsg, we need to handle it seperatly.
+                %% For from cron, it replies with the token.
+                %% We set opts, the same way if there is no handler to solve.
+                maps:get(<<"body">>, HookMsg);
             Unexpected ->
                 ?event(http,
                     {failed_to_start_server,
@@ -168,7 +183,7 @@ new_server(RawNodeMsg) ->
         end,
     % Put server ID into node message so it's possible to update current server
     hb_http:start(),
-    ServerID =
+    _ServerID =
         hb_util:human_id(
             ar_wallet:to_address(
                 hb_opts:get(

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -452,34 +452,45 @@ default_message() ->
             routes => []
         },
         on => #{
-            <<"request">> =>
-                [
-                    #{
-                        <<"device">> => <<"rate-limit@1.0">>
-                    },
-                    #{
-                        <<"device">> => <<"auth-hook@1.0">>,
-                        <<"path">> => <<"request">>,
-                        <<"when">> => #{
-                            <<"keys">> => [<<"authorization">>, <<"!">>]
-                        },
-                        <<"secret-provider">> =>
-                            #{
-                                <<"device">> => <<"http-auth@1.0">>,
-                                <<"access-control">> =>
-                                    #{ <<"device">> => <<"http-auth@1.0">> }
-                            }
-                    },
-                    #{
-                        <<"device">> => <<"name@1.0">>
-                    },
-                    #{
-                        <<"device">> => <<"manifest@1.0">>
-                    },
-                    #{
-                        <<"device">> => <<"blacklist@1.0">>
-                    }
-                ]
+            <<"start">> => [#{
+                <<"device">> => <<"cron@1.0">>,
+                <<"path">> => <<"every">>,
+                <<"extra-params">> => #{
+                <<"interval">> => <<"10-second">>,
+                <<"cron-path">> => <<"/~copycat@1.0/arweave&from+integer=-1&to+integer=-19">>
+                },
+                <<"target">> => <<"self">>
+            }]
+            %% NOTE: Not sure why, but requests interfer with the sucess of <<"start">> hook.
+            %% If unconmment, it will return 404 and not execute.
+%            <<"request">> =>
+%                [
+%                    #{
+%                        <<"device">> => <<"rate-limit@1.0">>
+%                    },
+%                    #{
+%                        <<"device">> => <<"auth-hook@1.0">>,
+%                        <<"path">> => <<"request">>,
+%                        <<"when">> => #{
+%                            <<"keys">> => [<<"authorization">>, <<"!">>]
+%                        },
+%                        <<"secret-provider">> =>
+%                            #{
+%                                <<"device">> => <<"http-auth@1.0">>,
+%                                <<"access-control">> =>
+%                                    #{ <<"device">> => <<"http-auth@1.0">> }
+%                            }
+%                    },
+%                    #{
+%                        <<"device">> => <<"name@1.0">>
+%                    },
+%                    #{
+%                        <<"device">> => <<"manifest@1.0">>
+%                    },
+%                    #{
+%                        <<"device">> => <<"blacklist@1.0">>
+%                    }
+%                ]
         },
         scheduler_default_commitment_spec => <<"httpsig@1.0">>,
         genesis_wasm_import_authorities =>

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -456,41 +456,42 @@ default_message() ->
                 <<"device">> => <<"cron@1.0">>,
                 <<"path">> => <<"every">>,
                 <<"extra-params">> => #{
-                <<"interval">> => <<"10-second">>,
-                <<"cron-path">> => <<"/~copycat@1.0/arweave&from+integer=-1&to+integer=-19">>
+                    <<"interval">> => <<"10-second">>,
+                    <<"cron-path">> => <<"/~copycat@1.0/arweave&from+integer=-1&to+integer=-19">>
                 },
-                <<"target">> => <<"self">>
-            }]
-            %% NOTE: Not sure why, but requests interfer with the sucess of <<"start">> hook.
-            %% If unconmment, it will return 404 and not execute.
-%            <<"request">> =>
-%                [
-%                    #{
-%                        <<"device">> => <<"rate-limit@1.0">>
-%                    },
-%                    #{
-%                        <<"device">> => <<"auth-hook@1.0">>,
-%                        <<"path">> => <<"request">>,
-%                        <<"when">> => #{
-%                            <<"keys">> => [<<"authorization">>, <<"!">>]
-%                        },
-%                        <<"secret-provider">> =>
-%                            #{
-%                                <<"device">> => <<"http-auth@1.0">>,
-%                                <<"access-control">> =>
-%                                    #{ <<"device">> => <<"http-auth@1.0">> }
-%                            }
-%                    },
-%                    #{
-%                        <<"device">> => <<"name@1.0">>
-%                    },
-%                    #{
-%                        <<"device">> => <<"manifest@1.0">>
-%                    },
-%                    #{
-%                        <<"device">> => <<"blacklist@1.0">>
-%                    }
-%                ]
+                <<"target">> => <<"self">>,
+                % Cron returns a task token, not a NodeMsg — discard the result
+                % and keep the original HookMsg so new_server gets the NodeMsg back.
+                <<"hook/result">> => <<"ignore">>
+            }],
+            <<"request">> =>
+                [
+                    #{
+                        <<"device">> => <<"rate-limit@1.0">>
+                    },
+                    #{
+                        <<"device">> => <<"auth-hook@1.0">>,
+                        <<"path">> => <<"request">>,
+                        <<"when">> => #{
+                            <<"keys">> => [<<"authorization">>, <<"!">>]
+                        },
+                        <<"secret-provider">> =>
+                            #{
+                                <<"device">> => <<"http-auth@1.0">>,
+                                <<"access-control">> =>
+                                    #{ <<"device">> => <<"http-auth@1.0">> }
+                            }
+                    },
+                    #{
+                        <<"device">> => <<"name@1.0">>
+                    },
+                    #{
+                        <<"device">> => <<"manifest@1.0">>
+                    },
+                    #{
+                        <<"device">> => <<"blacklist@1.0">>
+                    }
+                ]
         },
         scheduler_default_commitment_spec => <<"httpsig@1.0">>,
         genesis_wasm_import_authorities =>

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -452,18 +452,6 @@ default_message() ->
             routes => []
         },
         on => #{
-            <<"start">> => [#{
-                <<"device">> => <<"cron@1.0">>,
-                <<"path">> => <<"every">>,
-                <<"extra-params">> => #{
-                    <<"interval">> => <<"10-second">>,
-                    <<"cron-path">> => <<"/~copycat@1.0/arweave&from+integer=-1&to+integer=-19">>
-                },
-                <<"target">> => <<"self">>,
-                % Cron returns a task token, not a NodeMsg — discard the result
-                % and keep the original HookMsg so new_server gets the NodeMsg back.
-                <<"hook/result">> => <<"ignore">>
-            }],
             <<"request">> =>
                 [
                     #{


### PR DESCRIPTION
The use case is to start `dev_cron` to call `dev_copycat` on node start.

- `start` hook was created to modify `NodeMsg` (node config) before the node starts. So this behaviour needed to change a bit to support calling other devices.

## Config

```
{
    "on": {
        "start": [{
            "device": "cron@1.0",
            "path": "every",
            "extra-params": {
                "interval": "10-second",
                "cron-path": "/~copycat@1.0/arweave&from+integer=-1&to+integer=-19"
            },
            "target": "self",
            "hook/result": "ignore"
        }],
        "request": [
            {"device": "rate-limit@1.0"},
            {
                "device": "auth-hook@1.0",
                "path": "request",
                "when": {"keys": ["authorization", "!"]},
                "secret-provider":
                    {
                        "device": "http-auth@1.0",
                        "access-control": { "device": "http-auth@1.0" }
                    }
            },
            {"device": "name@1.0"},
            {"device": "manifest@1.0"},
            {"device": "blacklist@1.0"}
        ]
    }
}
```