### PR TITLE
Add event batching to hb_event

### DIFF
--- a/src/hb_event.erl
+++ b/src/hb_event.erl
@@ -6,10 +6,9 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--define(OVERLOAD_QUEUE_LENGTH, 10000).
+-define(OVERLOAD_QUEUE_LENGTH, 10_000).
 -define(MAX_MEMORY, 50_000_000). % 50 MB
 -define(MAX_EVENT_NAME_LENGTH, 100).
--define(BATCH_MAX, 10000).
 
 -ifdef(NO_EVENTS).
 log(_X) -> ok.
@@ -180,82 +179,26 @@ handle_events() ->
     handle_events(0).
 handle_events(N) ->
     receive
-        {increment, TopicBin, EventName, Count} ->
-            {N2, Batch} =
-                drain_batch(
-                    N + 1,
-                    TopicBin,
-                    EventName,
-                    Count,
-                    {#{}, []},
-                    ?BATCH_MAX - 1
-                ),
-            hb_prometheus:ensure_started(),
-            Keys = flush_batch(Batch),
-            check_overload(Keys, N, N2),
-            handle_events(N2)
+        {increment, Topic, Event, Count} ->
+            BatchCount = 0,
+            prometheus_counter:inc(<<"event">>, [Topic, Event], Count + BatchCount),
+            check_overload({Topic, Event}, N),
+            handle_events(N + 1)
     end.
 
-drain_batch(N, LastT, LastE, Acc, Batch, 0) ->
-    {N, batch_inc({batch, LastT, LastE}, Acc, Batch)};
-drain_batch(N, LastT, LastE, Acc, Batch, Remaining) ->
-    receive
-        {increment, TopicBin, EventName, Count} ->
-            case TopicBin =:= LastT andalso EventName =:= LastE of
-                true ->
-                    drain_batch(
-                        N + 1,
-                        LastT,
-                        LastE,
-                        Acc + Count,
-                        Batch,
-                        Remaining - 1
-                    );
-                false ->
-                    drain_batch(
-                        N + 1,
-                        TopicBin,
-                        EventName,
-                        Count,
-                        batch_inc({batch, LastT, LastE}, Acc, Batch),
-                        Remaining - 1
-                    )
-            end
-    after 0 ->
-        {N, batch_inc({batch, LastT, LastE}, Acc, Batch)}
-    end.
-
-batch_inc(Key, Count, {Counts, Keys}) ->
-    case maps:get(Key, Counts, undefined) of
-        undefined ->
-            {Counts#{ Key => Count }, [Key | Keys]};
-        Old when is_integer(Old) ->
-            {Counts#{ Key => Old + Count }, Keys}
-    end.
-
-flush_batch({Counts, Keys}) ->
-    lists:foreach(
-        fun(Key = {batch, Topic, Event}) ->
-            prometheus_counter:inc(<<"event">>, [Topic, Event], maps:get(Key, Counts))
-        end,
-        Keys
-    ),
-    Keys.
-
-check_overload(Keys, Prev, N) ->
-    case N div 1000 > Prev div 1000 of
-        true ->
+check_overload(Last, N) ->
+    case N div 1000 of
+        0 ->
             case erlang:process_info(self(), message_queue_len) of
                 {message_queue_len, Len} when Len > ?OVERLOAD_QUEUE_LENGTH ->
                     {memory, MemorySize} = erlang:process_info(self(), memory),
-                    SampleKeys = lists:sublist(Keys, 5),
                     case rand:uniform(max(1000, Len - ?OVERLOAD_QUEUE_LENGTH)) of
                         1 ->
                             ?debug_print(
                                 {warning,
                                     prometheus_event_queue_overloading,
                                     {queue, Len},
-                                    {sample_keys, SampleKeys},
+                                    {last_event, Last},
                                     {memory_bytes, MemorySize}
                                 }
                             );
@@ -268,7 +211,7 @@ check_overload(Keys, Prev, N) ->
                                     prometheus_event_queue_terminating_on_memory_overload,
                                     {queue, Len},
                                     {memory_bytes, MemorySize},
-                                    {sample_keys, SampleKeys}
+                                    {last_event, Last}
                                 }
                             ),
                             exit(memory_overload);
@@ -378,7 +321,7 @@ batch_correctness_test() ->
     EventPid = hb_name:lookup(?MODULE),
     wait_drain(EventPid, 5000),
     NumKeys = 5,
-    N = 30000,
+    N = 30_000,
     Keys = [{list_to_binary("corr_topic_" ++ integer_to_list(K)),
              list_to_binary("corr_event_" ++ integer_to_list(K))}
             || K <- lists:seq(1, NumKeys)],

--- a/src/hb_event.erl
+++ b/src/hb_event.erl
@@ -7,7 +7,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(OVERLOAD_QUEUE_LENGTH, 10000).
--define(MAX_MEMORY, 1_000_000_000). % 1GB
+-define(MAX_MEMORY, 50_000_000). % 50 MB
 -define(MAX_EVENT_NAME_LENGTH, 100).
 -define(BATCH_MAX, 10000).
 
@@ -338,13 +338,23 @@ benchmark_drain_rate_test() -> ok.
 batch_correctness_test() -> ok.
 -else.
 benchmark_drain_rate_test() ->
+    NumKeys = 50,
+    NumEvents = 100000,
     log(warmup, {warmup, 0}),
     timer:sleep(100),
     EventPid = hb_name:lookup(?MODULE),
     wait_drain(EventPid, 5000),
-    N = 100000,
     erlang:suspend_process(EventPid),
-    fill_mailbox(EventPid, N),
+    Keys =
+        [
+            {
+                hb_util:bin([<<"corr-topic-">>, hb_util:int(K)]),
+                hb_util:bin([<<"corr-event-">>, hb_util:int(K)])
+            }
+        ||
+            K <- lists:seq(1, NumKeys)
+        ],
+    fill_mailbox(EventPid, NumEvents, Keys),
     erlang:resume_process(EventPid),
     {DrainTime, _} =
         timer:tc(
@@ -352,9 +362,13 @@ benchmark_drain_rate_test() ->
                 wait_drain(EventPid, 30000)
             end
         ),
-    DrainRate = round(N / (max(1, DrainTime) / 1_000_000)),
+    DrainRate = round(NumEvents / (max(1, DrainTime) / 1_000_000)),
     hb_test_utils:benchmark_print(
-        <<"Drained">>, <<"events">>, DrainRate, 1),
+        <<"Drained">>,
+        <<"events">>,
+        DrainRate,
+        1
+    ),
     ?assert(DrainRate >= 10000),
     ok.
 
@@ -363,7 +377,7 @@ batch_correctness_test() ->
     timer:sleep(100),
     EventPid = hb_name:lookup(?MODULE),
     wait_drain(EventPid, 5000),
-    NumKeys = 50,
+    NumKeys = 5,
     N = 30000,
     Keys = [{list_to_binary("corr_topic_" ++ integer_to_list(K)),
              list_to_binary("corr_event_" ++ integer_to_list(K))}
@@ -391,10 +405,13 @@ deep_get([Group, Name], Map, Default) ->
         Inner -> maps:get(Name, Inner, Default)
     end.
 
-fill_mailbox(_Pid, 0) -> ok;
-fill_mailbox(Pid, N) ->
-    Pid ! {increment, <<"bench">>, <<"drain">>, 1},
-    fill_mailbox(Pid, N - 1).
+%% @doc Fill the event server mailbox with a list of keys. Rotate the keys to
+%% ensure that we are testing the event server's ability to handle many different
+%% types of event.
+fill_mailbox(_Pid, 0, _Keys) -> ok;
+fill_mailbox(Pid, N, Keys = [{Topic, Event}|_]) ->
+    Pid ! {increment, Topic, Event, 1},
+    fill_mailbox(Pid, N - 1, hb_util:shuffle(Keys)).
 
 wait_drain(Pid, Timeout) ->
     Deadline = erlang:monotonic_time(millisecond) + Timeout,

--- a/src/hb_event.erl
+++ b/src/hb_event.erl
@@ -9,6 +9,7 @@
 -define(OVERLOAD_QUEUE_LENGTH, 10000).
 -define(MAX_MEMORY, 1_000_000_000). % 1GB
 -define(MAX_EVENT_NAME_LENGTH, 100).
+-define(BATCH_MAX, 10000).
 
 -ifdef(NO_EVENTS).
 log(_X) -> ok.
@@ -180,47 +181,87 @@ handle_events() ->
 handle_events(N) ->
     receive
         {increment, TopicBin, EventName, Count} ->
-            N2 = N + 1,
-            case N2 rem 1000 of
-                0 ->
-                    check_overload(EventName);
-                _ ->
-                    ok
-            end,
-            prometheus_counter:inc(<<"event">>, [TopicBin, EventName], Count),
+            erlang:put(batch_keys, []),
+            N2 = drain_batch(N + 1, TopicBin, EventName, Count, ?BATCH_MAX - 1),
+            hb_prometheus:ensure_started(),
+            Keys = flush_batch(),
+            check_overload(Keys, N, N2),
             handle_events(N2)
     end.
 
-check_overload(EventName) ->
-    case erlang:process_info(self(), message_queue_len) of
-        {message_queue_len, Len} when Len > ?OVERLOAD_QUEUE_LENGTH ->
-            {memory, MemorySize} = erlang:process_info(self(), memory),
-            case rand:uniform(max(1000, Len - ?OVERLOAD_QUEUE_LENGTH)) of
-                1 ->
-                    ?debug_print(
-                        {warning,
-                            prometheus_event_queue_overloading,
-                            {queue, Len},
-                            {current_message, EventName},
-                            {memory_bytes, MemorySize}
-                        }
-                    );
+drain_batch(N, LastT, LastE, Acc, 0) ->
+    pd_inc({batch, LastT, LastE}, Acc),
+    N;
+drain_batch(N, LastT, LastE, Acc, Remaining) ->
+    receive
+        {increment, TopicBin, EventName, Count} ->
+            case TopicBin =:= LastT andalso EventName =:= LastE of
+                true ->
+                    drain_batch(N + 1, LastT, LastE, Acc + Count, Remaining - 1);
+                false ->
+                    pd_inc({batch, LastT, LastE}, Acc),
+                    drain_batch(N + 1, TopicBin, EventName, Count, Remaining - 1)
+            end
+    after 0 ->
+        pd_inc({batch, LastT, LastE}, Acc),
+        N
+    end.
+
+pd_inc(Key, Count) ->
+    case erlang:get(Key) of
+        undefined ->
+            erlang:put(Key, Count),
+            erlang:put(batch_keys, [Key | erlang:get(batch_keys)]);
+        Old when is_integer(Old) ->
+            erlang:put(Key, Old + Count)
+    end.
+
+flush_batch() ->
+    Keys = erlang:get(batch_keys),
+    lists:foreach(
+        fun(Key = {batch, Topic, Event}) ->
+            prometheus_counter:inc(<<"event">>, [Topic, Event], erlang:get(Key)),
+            erlang:erase(Key)
+        end,
+        Keys),
+    erlang:put(batch_keys, []),
+    Keys.
+
+check_overload(Keys, Prev, N) ->
+    case N div 1000 > Prev div 1000 of
+        true ->
+            case erlang:process_info(self(), message_queue_len) of
+                {message_queue_len, Len} when Len > ?OVERLOAD_QUEUE_LENGTH ->
+                    {memory, MemorySize} = erlang:process_info(self(), memory),
+                    SampleKeys = lists:sublist(Keys, 5),
+                    case rand:uniform(max(1000, Len - ?OVERLOAD_QUEUE_LENGTH)) of
+                        1 ->
+                            ?debug_print(
+                                {warning,
+                                    prometheus_event_queue_overloading,
+                                    {queue, Len},
+                                    {sample_keys, SampleKeys},
+                                    {memory_bytes, MemorySize}
+                                }
+                            );
+                        _ -> ignored
+                    end,
+                    case MemorySize of
+                        MemorySize when MemorySize > ?MAX_MEMORY ->
+                            ?debug_print(
+                                {error,
+                                    prometheus_event_queue_terminating_on_memory_overload,
+                                    {queue, Len},
+                                    {memory_bytes, MemorySize},
+                                    {sample_keys, SampleKeys}
+                                }
+                            ),
+                            exit(memory_overload);
+                        _ -> no_action
+                    end;
                 _ -> ignored
-            end,
-            case MemorySize of
-                MemorySize when MemorySize > ?MAX_MEMORY ->
-                    ?debug_print(
-                        {error,
-                            prometheus_event_queue_terminating_on_memory_overload,
-                            {queue, Len},
-                            {memory_bytes, MemorySize},
-                            {current_message, EventName}
-                        }
-                    ),
-                    exit(memory_overload);
-                _ -> no_action
             end;
-        _ -> ignored
+        _ -> ok
     end.
 
 parse_name(Name) when is_tuple(Name) ->
@@ -279,6 +320,7 @@ benchmark_increment_test() ->
 
 -ifdef(NO_EVENTS).
 benchmark_drain_rate_test() -> ok.
+batch_correctness_test() -> ok.
 -else.
 benchmark_drain_rate_test() ->
     log(warmup, {warmup, 0}),
@@ -286,15 +328,50 @@ benchmark_drain_rate_test() ->
     EventPid = hb_name:lookup(?MODULE),
     wait_drain(EventPid, 5000),
     N = 100000,
+    erlang:suspend_process(EventPid),
     fill_mailbox(EventPid, N),
+    erlang:resume_process(EventPid),
     {DrainTime, _} = timer:tc(fun() ->
         wait_drain(EventPid, 30000)
     end),
-    DrainRate = round(N / (DrainTime / 1_000_000)),
+    DrainRate = round(N / (max(1, DrainTime) / 1_000_000)),
     hb_test_utils:benchmark_print(
         <<"Drained">>, <<"events">>, DrainRate, 1),
     ?assert(DrainRate >= 10000),
     ok.
+
+batch_correctness_test() ->
+    log(warmup, {warmup, 0}),
+    timer:sleep(100),
+    EventPid = hb_name:lookup(?MODULE),
+    wait_drain(EventPid, 5000),
+    NumKeys = 50,
+    N = 30000,
+    Keys = [{list_to_binary("corr_topic_" ++ integer_to_list(K)),
+             list_to_binary("corr_event_" ++ integer_to_list(K))}
+            || K <- lists:seq(1, NumKeys)],
+    Before = counters(),
+    BeforeCounts = [{T, E, deep_get([T, E], Before, 0)} || {T, E} <- Keys],
+    erlang:suspend_process(EventPid),
+    lists:foreach(fun(I) ->
+        {T, E} = lists:nth((I rem NumKeys) + 1, Keys),
+        EventPid ! {increment, T, E, 1}
+    end, lists:seq(1, N)),
+    erlang:resume_process(EventPid),
+    wait_drain(EventPid, 30000),
+    After = counters(),
+    PerKey = N div NumKeys,
+    lists:foreach(fun({T, E, BeforeVal}) ->
+        AfterVal = deep_get([T, E], After, 0),
+        ?assertEqual(PerKey, AfterVal - BeforeVal)
+    end, BeforeCounts),
+    ok.
+
+deep_get([Group, Name], Map, Default) ->
+    case maps:get(Group, Map, undefined) of
+        undefined -> Default;
+        Inner -> maps:get(Name, Inner, Default)
+    end.
 
 fill_mailbox(_Pid, 0) -> ok;
 fill_mailbox(Pid, N) ->

--- a/src/hb_event.erl
+++ b/src/hb_event.erl
@@ -181,50 +181,65 @@ handle_events() ->
 handle_events(N) ->
     receive
         {increment, TopicBin, EventName, Count} ->
-            erlang:put(batch_keys, []),
-            N2 = drain_batch(N + 1, TopicBin, EventName, Count, ?BATCH_MAX - 1),
+            {N2, Batch} =
+                drain_batch(
+                    N + 1,
+                    TopicBin,
+                    EventName,
+                    Count,
+                    {#{}, []},
+                    ?BATCH_MAX - 1
+                ),
             hb_prometheus:ensure_started(),
-            Keys = flush_batch(),
+            Keys = flush_batch(Batch),
             check_overload(Keys, N, N2),
             handle_events(N2)
     end.
 
-drain_batch(N, LastT, LastE, Acc, 0) ->
-    pd_inc({batch, LastT, LastE}, Acc),
-    N;
-drain_batch(N, LastT, LastE, Acc, Remaining) ->
+drain_batch(N, LastT, LastE, Acc, Batch, 0) ->
+    {N, batch_inc({batch, LastT, LastE}, Acc, Batch)};
+drain_batch(N, LastT, LastE, Acc, Batch, Remaining) ->
     receive
         {increment, TopicBin, EventName, Count} ->
             case TopicBin =:= LastT andalso EventName =:= LastE of
                 true ->
-                    drain_batch(N + 1, LastT, LastE, Acc + Count, Remaining - 1);
+                    drain_batch(
+                        N + 1,
+                        LastT,
+                        LastE,
+                        Acc + Count,
+                        Batch,
+                        Remaining - 1
+                    );
                 false ->
-                    pd_inc({batch, LastT, LastE}, Acc),
-                    drain_batch(N + 1, TopicBin, EventName, Count, Remaining - 1)
+                    drain_batch(
+                        N + 1,
+                        TopicBin,
+                        EventName,
+                        Count,
+                        batch_inc({batch, LastT, LastE}, Acc, Batch),
+                        Remaining - 1
+                    )
             end
     after 0 ->
-        pd_inc({batch, LastT, LastE}, Acc),
-        N
+        {N, batch_inc({batch, LastT, LastE}, Acc, Batch)}
     end.
 
-pd_inc(Key, Count) ->
-    case erlang:get(Key) of
+batch_inc(Key, Count, {Counts, Keys}) ->
+    case maps:get(Key, Counts, undefined) of
         undefined ->
-            erlang:put(Key, Count),
-            erlang:put(batch_keys, [Key | erlang:get(batch_keys)]);
+            {Counts#{ Key => Count }, [Key | Keys]};
         Old when is_integer(Old) ->
-            erlang:put(Key, Old + Count)
+            {Counts#{ Key => Old + Count }, Keys}
     end.
 
-flush_batch() ->
-    Keys = erlang:get(batch_keys),
+flush_batch({Counts, Keys}) ->
     lists:foreach(
         fun(Key = {batch, Topic, Event}) ->
-            prometheus_counter:inc(<<"event">>, [Topic, Event], erlang:get(Key)),
-            erlang:erase(Key)
+            prometheus_counter:inc(<<"event">>, [Topic, Event], maps:get(Key, Counts))
         end,
-        Keys),
-    erlang:put(batch_keys, []),
+        Keys
+    ),
     Keys.
 
 check_overload(Keys, Prev, N) ->
@@ -331,9 +346,12 @@ benchmark_drain_rate_test() ->
     erlang:suspend_process(EventPid),
     fill_mailbox(EventPid, N),
     erlang:resume_process(EventPid),
-    {DrainTime, _} = timer:tc(fun() ->
-        wait_drain(EventPid, 30000)
-    end),
+    {DrainTime, _} =
+        timer:tc(
+            fun() ->
+                wait_drain(EventPid, 30000)
+            end
+        ),
     DrainRate = round(N / (max(1, DrainTime) / 1_000_000)),
     hb_test_utils:benchmark_print(
         <<"Drained">>, <<"events">>, DrainRate, 1),

--- a/src/hb_event.erl
+++ b/src/hb_event.erl
@@ -176,44 +176,51 @@ ensure_event_counter() ->
         ]).
 
 handle_events() ->
+    handle_events(0).
+handle_events(N) ->
     receive
         {increment, TopicBin, EventName, Count} ->
-            case erlang:process_info(self(), message_queue_len) of
-                {message_queue_len, Len} when Len > ?OVERLOAD_QUEUE_LENGTH ->
-                    % Print a warning, but do so less frequently the more
-                    % overloaded the system is.
-                    {memory, MemorySize} = erlang:process_info(self(), memory),
-                    case rand:uniform(max(1000, Len - ?OVERLOAD_QUEUE_LENGTH)) of
-                        1 ->
-                            ?debug_print(
-                                {warning,
-                                    prometheus_event_queue_overloading,
-                                    {queue, Len},
-                                    {current_message, EventName},
-                                    {memory_bytes, MemorySize}
-                                }
-                            );
-                        _ -> ignored
-                    end,
-                    % If the size of this process is too large, exit such that
-                    % we can be restarted by the next caller.
-                    case MemorySize of
-                        MemorySize when MemorySize > ?MAX_MEMORY ->
-                            ?debug_print(
-                                {error,
-                                    prometheus_event_queue_terminating_on_memory_overload,
-                                    {queue, Len},
-                                    {memory_bytes, MemorySize},
-                                    {current_message, EventName}
-                                }
-                            ),
-                            exit(memory_overload);
-                        _ -> no_action
-                    end;
+            N2 = N + 1,
+            case N2 rem 1000 of
+                0 ->
+                    check_overload(EventName);
+                _ ->
+                    ok
+            end,
+            prometheus_counter:inc(<<"event">>, [TopicBin, EventName], Count),
+            handle_events(N2)
+    end.
+
+check_overload(EventName) ->
+    case erlang:process_info(self(), message_queue_len) of
+        {message_queue_len, Len} when Len > ?OVERLOAD_QUEUE_LENGTH ->
+            {memory, MemorySize} = erlang:process_info(self(), memory),
+            case rand:uniform(max(1000, Len - ?OVERLOAD_QUEUE_LENGTH)) of
+                1 ->
+                    ?debug_print(
+                        {warning,
+                            prometheus_event_queue_overloading,
+                            {queue, Len},
+                            {current_message, EventName},
+                            {memory_bytes, MemorySize}
+                        }
+                    );
                 _ -> ignored
             end,
-            hb_prometheus:inc(counter, <<"event">>, [TopicBin, EventName], Count),
-            handle_events()
+            case MemorySize of
+                MemorySize when MemorySize > ?MAX_MEMORY ->
+                    ?debug_print(
+                        {error,
+                            prometheus_event_queue_terminating_on_memory_overload,
+                            {queue, Len},
+                            {memory_bytes, MemorySize},
+                            {current_message, EventName}
+                        }
+                    ),
+                    exit(memory_overload);
+                _ -> no_action
+            end;
+        _ -> ignored
     end.
 
 parse_name(Name) when is_tuple(Name) ->
@@ -269,3 +276,46 @@ benchmark_increment_test() ->
     hb_test_utils:benchmark_print(<<"Incremented">>, <<"events">>, Iterations),
     ?assert(Iterations >= 1000),
     ok.
+
+-ifdef(NO_EVENTS).
+benchmark_drain_rate_test() -> ok.
+-else.
+benchmark_drain_rate_test() ->
+    log(warmup, {warmup, 0}),
+    timer:sleep(100),
+    EventPid = hb_name:lookup(?MODULE),
+    wait_drain(EventPid, 5000),
+    N = 100000,
+    fill_mailbox(EventPid, N),
+    {DrainTime, _} = timer:tc(fun() ->
+        wait_drain(EventPid, 30000)
+    end),
+    DrainRate = round(N / (DrainTime / 1_000_000)),
+    hb_test_utils:benchmark_print(
+        <<"Drained">>, <<"events">>, DrainRate, 1),
+    ?assert(DrainRate >= 10000),
+    ok.
+
+fill_mailbox(_Pid, 0) -> ok;
+fill_mailbox(Pid, N) ->
+    Pid ! {increment, <<"bench">>, <<"drain">>, 1},
+    fill_mailbox(Pid, N - 1).
+
+wait_drain(Pid, Timeout) ->
+    Deadline = erlang:monotonic_time(millisecond) + Timeout,
+    wait_drain_loop(Pid, Deadline).
+
+wait_drain_loop(Pid, Deadline) ->
+    case erlang:process_info(Pid, message_queue_len) of
+        {message_queue_len, 0} -> ok;
+        {message_queue_len, _} ->
+            case erlang:monotonic_time(millisecond) >= Deadline of
+                true -> error(drain_timeout);
+                false ->
+                    timer:sleep(10),
+                    wait_drain_loop(Pid, Deadline)
+            end;
+        undefined ->
+            error(event_server_dead)
+    end.
+-endif.

--- a/src/hb_util.erl
+++ b/src/hb_util.erl
@@ -20,7 +20,7 @@
 -export([maybe_throw/2]).
 -export([is_hb_module/1, is_hb_module/2, all_hb_modules/0]).
 -export([ok/1, ok/2, until/1, until/2, until/3, wait_until/2]).
--export([count/2, mean/1, stddev/1, variance/1, weighted_random/1]).
+-export([count/2, mean/1, stddev/1, variance/1, weighted_random/1, shuffle/1]).
 -export([unique/1]).
 -export([split_depth_string_aware/2, split_depth_string_aware_single/2]).
 -export([unquote/1, split_escaped_single/2]).


### PR DESCRIPTION
Process increment events in batches and reduces the amount of querying the mailbox size.

Two benchmarks included and a correctness test to check that batching did not break event counters.

Original problem (there is a benchmark/test showing it): We are unable to drain fast enough and it gets slow as the mailbox grows, up to a point where it cant keep up. That point is far from the limits we have configured, so the alternative to this PR is setting it to 5MB (currently 1GB). That is not necessary with this PR as we can drain 1GB instantly.