### PR TITLE
fix: correctly handle inputs to dev_codec_tx when building a bundle

### DIFF
--- a/src/dev_bundler.erl
+++ b/src/dev_bundler.erl
@@ -16,6 +16,8 @@
 %%% transaction is dispatched.
 -module(dev_bundler).
 -export([tx/3, item/3, ensure_server/1, stop_server/0, get_state/0]).
+%%% Test-only exports.
+-export([start_mock_gateway/1]).
 -include("include/hb.hrl").
 -include("include/dev_bundler.hrl").
 -include_lib("eunit/include/eunit.hrl").

--- a/src/dev_bundler.erl
+++ b/src/dev_bundler.erl
@@ -803,14 +803,15 @@ recover_bundles_test() ->
         ok = dev_bundler_cache:write_item(Item1, Opts),
         ok = dev_bundler_cache:write_item(Item2, Opts),
         ok = dev_bundler_cache:write_item(Item3, Opts),
-        {ok, TX} = dev_codec_tx:to(
-            lists:reverse([Item1, Item2, Item3]), #{}, #{}),
+        TX = dev_bundler_task:data_items_to_tx(
+            lists:reverse([Item1, Item2, Item3]), Opts),
         CommittedTX = hb_message:convert(
             TX, <<"structured@1.0">>, <<"tx@1.0">>, Opts),
         ok = dev_bundler_cache:write_tx(CommittedTX, [Item1, Item2, Item3], Opts),
         Item4 = new_structured_data_item(4, 10, Opts),
         ok = dev_bundler_cache:write_item(Item4, Opts),
-        {ok, TX2} = dev_codec_tx:to(lists:reverse([Item4]), #{}, #{}),
+        TX2 = dev_bundler_task:data_items_to_tx(
+            lists:reverse([Item4]), Opts),
         CommittedTX2 = hb_message:convert(
             TX2, <<"structured@1.0">>, <<"tx@1.0">>, Opts),
         ok = dev_bundler_cache:write_tx(CommittedTX2, [Item4], Opts),

--- a/src/dev_bundler_recovery.erl
+++ b/src/dev_bundler_recovery.erl
@@ -274,5 +274,5 @@ new_data_item(Index, Size, Opts) ->
     hb_message:convert(Item, <<"structured@1.0">>, <<"ans104@1.0">>, Opts).
 
 new_bundle_tx(Items, Opts) ->
-    {ok, TX} = dev_codec_tx:to(lists:reverse(Items), #{}, #{}),
+    TX = dev_bundler_task:data_items_to_tx(lists:reverse(Items), Opts),
     hb_message:convert(TX, <<"structured@1.0">>, <<"tx@1.0">>, Opts).

--- a/src/dev_bundler_task.erl
+++ b/src/dev_bundler_task.erl
@@ -4,6 +4,8 @@
 %%% - post_proof: Seeding teh chunks to the Arweave network
 -module(dev_bundler_task).
 -export([worker_loop/0, log_task/3, format_timestamp/0]).
+%%% Test-only exports.
+-export([data_items_to_tx/2]).
 -include("include/hb.hrl").
 -include("include/dev_bundler.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -150,21 +152,40 @@ execute_task(#task{type = post_proof, data = Proof, opts = Opts} = Task) ->
 
 %% @doc Build and sign a bundle TX without posting it.
 build_signed_tx(Items, Opts) ->
-    {ok, TX} = dev_codec_tx:to(lists:reverse(Items), #{}, #{}),
+    TX = data_items_to_tx(Items, Opts),
     DataSize = TX#tx.data_size,
     PriceResult = get_price(DataSize, Opts),
     AnchorResult = get_anchor(Opts),
     case {PriceResult, AnchorResult} of
         {{ok, Price}, {ok, Anchor}} ->
             Wallet = hb_opts:get(priv_wallet, no_viable_wallet, Opts),
-            SignedTX = ar_tx:sign(
-                TX#tx{anchor = Anchor, reward = Price},
-                Wallet
-            ),
+            SignedTX = 
+                dev_arweave_common:normalize(
+                    ar_tx:sign(
+                        TX#tx{anchor = Anchor, reward = Price},
+                        Wallet
+                    )
+                ),
             {ok, SignedTX};
         {PriceErr, AnchorErr} ->
             {error, {PriceErr, AnchorErr}}
     end.
+
+data_items_to_tx(Items, Opts) ->
+    List = lists:map(
+        fun(Item) -> 
+            hb_message:convert(
+                Item,
+                #{ <<"device">> => <<"ans104@1.0">>, <<"bundle">> => true },
+                <<"structured@1.0">>,
+                Opts
+            )
+        end,
+        lists:reverse(Items)),
+    dev_arweave_common:normalize(#tx{
+        format = 2,
+        data = List
+    }).
 
 get_price(DataSize, Opts) ->
     hb_ao:resolve(
@@ -278,6 +299,79 @@ build_signed_tx_test() ->
             )
         || Item <- BundledItems],
         ?assertEqual(lists:reverse(Items), BundledStructuredItems),
+        ok
+    after
+        hb_mock_server:stop(ServerHandle)
+    end.
+
+build_signed_tx_on_arbundles_js_test() ->
+    Anchor = rand:bytes(32),
+    Price = 12345,
+    {ServerHandle, NodeOpts} = dev_bundler:start_mock_gateway(#{
+        price => {200, integer_to_binary(Price)},
+        tx_anchor => {200, hb_util:encode(Anchor)}
+    }),
+    TestOpts = NodeOpts#{
+        priv_wallet => hb:wallet(),
+        store => hb_test_utils:test_store()
+    },
+    try
+        % Load an arweave.js-created dataitem
+        Item = ar_bundles:deserialize(
+            hb_util:ok(
+                file:read_file(<<"test/arbundles.js/ans104-item.bundle">>)
+            )
+        ),
+        ?event(debug_test, {item, Item}),
+        ?assert(ar_bundles:verify_item(Item)),
+        % Load an arweave.js-created list bundle
+        {ok, Bin} = file:read_file(<<"test/arbundles.js/ans104-list-bundle.bundle">>),
+        BundledItem = ar_bundles:sign_item(#tx{
+            format = ans104,
+            data = Bin,
+            data_size = byte_size(Bin),
+            tags = [
+                {<<"Bundle-Format">>, <<"binary">>},
+                {<<"Bundle-Version">>, <<"2.0.0">>}
+            ]
+        }, hb:wallet()),
+        ?event(debug_test, {bundled_item, BundledItem}),
+        ?assert(ar_bundles:verify_item(BundledItem)),
+        % Convert both dataitems to structured messages
+        ItemStructured = hb_message:convert(Item,
+            #{ <<"device">> => <<"structured@1.0">>, <<"bundle">> => true },
+            #{ <<"device">> => <<"ans104@1.0">>, <<"bundle">> => true },
+            TestOpts),
+        ?event(debug_test, {item_structured, ItemStructured}),
+        ?assert(hb_message:verify(ItemStructured, all, TestOpts)),
+        BundledItemStructured = hb_message:convert(BundledItem,
+            #{ <<"device">> => <<"structured@1.0">>, <<"bundle">> => true },
+            #{ <<"device">> => <<"ans104@1.0">>, <<"bundle">> => true },
+            TestOpts),
+        ?event(debug_test, {bundled_item_structured, BundledItemStructured}),
+        ?assert(hb_message:verify(BundledItemStructured, all, TestOpts)),
+        % Use build_signed_tx/2 to mimic the bundler worker logic.
+        {ok, SignedTX} = build_signed_tx(
+            [ItemStructured, BundledItemStructured],
+            TestOpts
+        ),
+        ?event(debug_test, {signed_tx, SignedTX}),
+        ?assert(ar_tx:verify(SignedTX)),
+        % Convert the signed TX to a structured message
+        StructuredTX = hb_message:convert(SignedTX,
+            #{ <<"device">> => <<"structured@1.0">>, <<"bundle">> => true },
+            #{ <<"device">> => <<"tx@1.0">>, <<"bundle">> => true },
+            TestOpts),
+        % ?event(debug_test, {structured_tx, StructuredTX}),
+        ?assert(hb_message:verify(StructuredTX, all, TestOpts)),
+        % Convert back to an L1 TX
+        SignedTXRoundtrip = hb_message:convert(StructuredTX,
+            #{ <<"device">> => <<"tx@1.0">>, <<"bundle">> => true },
+            #{ <<"device">> => <<"structured@1.0">>, <<"bundle">> => true },
+            TestOpts),
+        ?event(debug_test, {signed_tx_roundtrip, SignedTXRoundtrip}),
+        ?assert(ar_tx:verify(SignedTXRoundtrip)),
+        ?assertEqual(SignedTX, SignedTXRoundtrip),
         ok
     after
         hb_mock_server:stop(ServerHandle)

--- a/src/dev_bundler_task.erl
+++ b/src/dev_bundler_task.erl
@@ -28,20 +28,8 @@ worker_loop() ->
 execute_task(#task{type = post_tx, data = Items, opts = Opts} = Task) ->
     try
         ?event(debug_bundler, log_task(executing_task, Task, [])),
-        % Get price and anchor
-        {ok, TX} = dev_codec_tx:to(lists:reverse(Items), #{}, #{}),
-        DataSize = TX#tx.data_size,
-        PriceResult = get_price(DataSize, Opts),
-        AnchorResult = get_anchor(Opts),
-        case {PriceResult, AnchorResult} of
-            {{ok, Price}, {ok, Anchor}} ->
-                % Sign the TX
-                Wallet = hb_opts:get(priv_wallet, no_viable_wallet, Opts),
-                SignedTX = ar_tx:sign(TX#tx{ anchor = Anchor, reward = Price }, Wallet),
-                % TODO: as a future improvement we should be able to recover
-                % from the TX header alone, but we have to be careful about
-                % how we rebuild the TX data to ensure it matches the already
-                % posted TX.
+        case build_signed_tx(Items, Opts) of
+            {ok, SignedTX} ->
                 Committed = hb_message:convert(
                     SignedTX,
                     #{ <<"device">> => <<"structured@1.0">>, <<"bundle">> => true },
@@ -65,7 +53,7 @@ execute_task(#task{type = post_tx, data = Items, opts = Opts} = Task) ->
                         {ok, Committed};
                     {_, ErrorReason} -> {error, ErrorReason}
                 end;
-            {PriceErr, AnchorErr} ->
+            {error, {PriceErr, AnchorErr}} ->
                 ?event(bundler_short,
                     log_task(task_failed, Task, [
                         {price, PriceErr},
@@ -160,6 +148,24 @@ execute_task(#task{type = post_proof, data = Proof, opts = Opts} = Task) ->
             {error, Err}
     end.
 
+%% @doc Build and sign a bundle TX without posting it.
+build_signed_tx(Items, Opts) ->
+    {ok, TX} = dev_codec_tx:to(lists:reverse(Items), #{}, #{}),
+    DataSize = TX#tx.data_size,
+    PriceResult = get_price(DataSize, Opts),
+    AnchorResult = get_anchor(Opts),
+    case {PriceResult, AnchorResult} of
+        {{ok, Price}, {ok, Anchor}} ->
+            Wallet = hb_opts:get(priv_wallet, no_viable_wallet, Opts),
+            SignedTX = ar_tx:sign(
+                TX#tx{anchor = Anchor, reward = Price},
+                Wallet
+            ),
+            {ok, SignedTX};
+        {PriceErr, AnchorErr} ->
+            {error, {PriceErr, AnchorErr}}
+    end.
+
 get_price(DataSize, Opts) ->
     hb_ao:resolve(
         #{ <<"device">> => <<"arweave@2.9">> },
@@ -211,3 +217,68 @@ format_timestamp() ->
     {MegaSecs, Secs, MicroSecs} = erlang:timestamp(),
     Millisecs = (MegaSecs * 1000000 + Secs) * 1000 + (MicroSecs div 1000),
     calendar:system_time_to_rfc3339(Millisecs, [{unit, millisecond}, {offset, "Z"}]).
+
+build_signed_tx_test() ->
+    Anchor = rand:bytes(32),
+    Price = 12345,
+    {ServerHandle, NodeOpts} = dev_bundler:start_mock_gateway(#{
+        price => {200, integer_to_binary(Price)},
+        tx_anchor => {200, hb_util:encode(Anchor)}
+    }),
+    TestOpts = NodeOpts#{
+        priv_wallet => ar_wallet:new(),
+        store => hb_test_utils:test_store()
+    },
+    try
+        Timestamp = 12344567,
+        ListValue = [<<"a">>, <<"b">>, <<"c">>],
+        StructuredItems = [
+            #{
+                <<"body">> => <<"body1">>,
+                <<"tag1">> => <<"value1">>,
+                <<"timestamp">> => Timestamp
+            },
+            #{
+                <<"body">> => <<"body3">>,
+                <<"tag3">> => <<"value3">>,
+                <<"list">> => ListValue
+            },
+            #{
+                <<"body">> => <<"body2">>,
+                <<"tag2">> => <<"value2">>
+            }
+        ],
+        Items = [
+            hb_message:commit(
+                Item,
+                TestOpts,
+                #{ <<"device">> => <<"ans104@1.0">>, <<"bundle">> => true }
+            )
+        || Item <- StructuredItems],
+        {ok, SignedTX} = build_signed_tx(Items, TestOpts),
+        ?assert(ar_tx:verify(SignedTX)),
+        ?assertEqual(Anchor, SignedTX#tx.anchor),
+        ?assertEqual(Price, SignedTX#tx.reward),
+        ?event(debug_test, {signed_tx, SignedTX}),
+        BundledTX = ar_bundles:deserialize(SignedTX),
+        ?event(debug_test, {bundled_tx, BundledTX}),
+        BundledItems = hb_util:numbered_keys_to_list(BundledTX#tx.data, #{}),
+        lists:foreach(
+            fun(Item) ->
+                ?assert(ar_bundles:verify_item(Item))
+            end,
+            BundledItems
+        ),
+        BundledStructuredItems = [
+            hb_message:convert(
+                Item,
+                <<"structured@1.0">>,
+                <<"ans104@1.0">>,
+                TestOpts
+            )
+        || Item <- BundledItems],
+        ?assertEqual(lists:reverse(Items), BundledStructuredItems),
+        ok
+    after
+        hb_mock_server:stop(ServerHandle)
+    end.

--- a/src/dev_codec_tx.erl
+++ b/src/dev_codec_tx.erl
@@ -147,25 +147,6 @@ to(RawTABM, Req, Opts) when is_map(RawTABM) ->
     enforce_valid_tx(FinalTX),
     ?event({to_result, FinalTX}),
     {ok, FinalTX};
-%% @doc List of ans104 items is bundled into a single L1 transaction.
-to(RawList, Req, Opts) when is_list(RawList) ->
-    List = lists:map(
-        fun(Item) -> 
-            hb_message:convert(
-                Item,
-                #{ <<"device">> => <<"ans104@1.0">>, <<"bundle">> => true },
-                #{ <<"device">> => <<"structured@1.0">>, <<"bundle">> => true },
-                Opts
-            )
-        end,
-        RawList),
-    TX = #tx{
-        format = 2,
-        data = List
-    },
-    Bundle = dev_arweave_common:normalize(TX),
-    ?event({to_result, Bundle}),
-    {ok, Bundle};
 to(Other, _Req, _Opts) ->
     throw({invalid_tx, Other}).
     
@@ -1528,61 +1509,28 @@ test_bundle_uncommitted(Encode, Decode) ->
     end,
     ok.
 
-bundle_list_test() ->
-    % Load an arweave.js-created dataitem
-    Item = ar_bundles:deserialize(
-        hb_util:ok(
-            file:read_file(<<"test/arbundles.js/ans104-item.bundle">>)
-        )
-    ),
-    ?event(debug_test, {item, Item}),
-    ?assert(ar_bundles:verify_item(Item)),
-    % Load an arweave.js-created list bundle
-    {ok, Bin} = file:read_file(<<"test/arbundles.js/ans104-list-bundle.bundle">>),
-    BundledItem = ar_bundles:sign_item(#tx{ 
-        format = ans104,
-        data = Bin,
-        data_size = byte_size(Bin),
-        tags = [
-            {<<"Bundle-Format">>, <<"binary">>},
-            {<<"Bundle-Version">>, <<"2.0.0">>}
-        ]
-    }, hb:wallet()),
-    ?event(debug_test, {bundled_item, BundledItem}),
-    ?assert(ar_bundles:verify_item(BundledItem)),
-    % Convert both dataitems to structured messages
-    ItemStructured = hb_message:convert(Item,
-        #{ <<"device">> => <<"structured@1.0">>, <<"bundle">> => true },
-        #{ <<"device">> => <<"ans104@1.0">>, <<"bundle">> => true },
-        #{}),
-    ?event(debug_test, {item_structured, ItemStructured}),
-    ?assert(hb_message:verify(ItemStructured, all, #{})),
-    BundledItemStructured = hb_message:convert(BundledItem,
-        #{ <<"device">> => <<"structured@1.0">>, <<"bundle">> => true },
-        #{ <<"device">> => <<"ans104@1.0">>, <<"bundle">> => true },
-        #{}),
-    ?event(debug_test, {bundled_item_structured, BundledItemStructured}),
-    ?assert(hb_message:verify(BundledItemStructured, all, #{})),
-    % Use dev_codec_tx:to(List) to create a L1 TX bundle. We use this
-    % interface to mimic the logic used in dev_bundler
-    {ok, BundledTX} = dev_codec_tx:to(
-        [ItemStructured, BundledItemStructured], #{}, #{}),
-    SignedTX = ar_tx:sign(BundledTX, hb:wallet()),
-    ?event(debug_test, {signed_tx, SignedTX}),
-    ?assert(ar_tx:verify(SignedTX)),
-    % Convert the signed TX to a structured message
-    StructuredTX = hb_message:convert(SignedTX,
-        #{ <<"device">> => <<"structured@1.0">>, <<"bundle">> => true },
+%% Disabled test that captures an issue we will face if we want to support
+%% ao-types on tx's.
+list_aotypes_test_disabled() ->
+    Items = [
+        #{ <<"tag1">> => <<"value1">> },
+        #{ <<"tag2">> => <<"value2">> },
+        #{ <<"tag3">> => <<"value3">> }
+    ],
+    TX = hb_message:convert(
+        Items,
         #{ <<"device">> => <<"tx@1.0">>, <<"bundle">> => true },
+        <<"structured@1.0">>,
+        #{}),
+    Anchor = crypto:strong_rand_bytes(32),
+    % SignedTX = ar_tx:sign(
+    %     TX#tx{ anchor = Anchor, reward = 100 },
+    %     hb:wallet()),
+    % ?event(debug_test, {signed_tx, SignedTX}),
+    StructuredTX = hb_message:convert(
+        TX#tx{ anchor = Anchor, reward = 100 },
+        <<"structured@1.0">>,
+        <<"tx@1.0">>,
         #{}),
     ?event(debug_test, {structured_tx, StructuredTX}),
-    ?assert(hb_message:verify(StructuredTX, all, #{})),
-    % Convert back to an L1 TX
-    SignedTXRoundtrip = hb_message:convert(StructuredTX,
-        #{ <<"device">> => <<"tx@1.0">>, <<"bundle">> => true },
-        #{ <<"device">> => <<"structured@1.0">>, <<"bundle">> => true },
-        #{}),
-    ?event(debug_test, {signed_tx_roundtrip, SignedTXRoundtrip}),
-    ?assert(ar_tx:verify(SignedTXRoundtrip)),
-    ?assertEqual(SignedTX, SignedTXRoundtrip),
     ok.

--- a/src/dev_codec_tx.erl
+++ b/src/dev_codec_tx.erl
@@ -150,7 +150,14 @@ to(RawTABM, Req, Opts) when is_map(RawTABM) ->
 %% @doc List of ans104 items is bundled into a single L1 transaction.
 to(RawList, Req, Opts) when is_list(RawList) ->
     List = lists:map(
-        fun(Item) -> hb_util:ok(dev_codec_ans104:to(Item, Req, Opts)) end,
+        fun(Item) -> 
+            hb_message:convert(
+                Item,
+                #{ <<"device">> => <<"ans104@1.0">>, <<"bundle">> => true },
+                #{ <<"device">> => <<"structured@1.0">>, <<"bundle">> => true },
+                Opts
+            )
+        end,
         RawList),
     TX = #tx{
         format = 2,


### PR DESCRIPTION
Use hb_message:convert rather than dev_codec_ans104:to to correctly handle converting to/from TABM. Previous implementation could allow structure messages to make it to the codec which were not handled correctly