### PR TITLE
fix: security@1.0 security patches 

### DIFF
--- a/src/dev_security.erl
+++ b/src/dev_security.erl
@@ -80,22 +80,23 @@ validate_authority(Base, Assignment, Opts) ->
 validate(Key, Base, SubjectMsg, Opts) ->
     validate(Key, Base, SubjectMsg, hb_message:signers(SubjectMsg, Opts), Opts).
 validate(Key, Base, SubjectMsg, RawFrom, Opts) ->
-    From = as_list(RawFrom, Opts),
-    Valid = as_list(hb_ao:get(Key, Base, [], Opts), Opts),
-    Required = hb_ao:get(<<Key/binary, "-required">>, Base, [], Opts),
+    %% dedup entries for uniqueness sanity and correctness of min N threshold
+    From = lists:dedup(as_list(RawFrom, Opts)),
+    Valid = lists:dedup(as_list(hb_ao:get(Key, Base, [], Opts), Opts)),
+    RequiredList = lists:dedup(hb_ao:get(<<Key/binary, "-required">>, Base, [], Opts)),
     Match = hb_ao:get(<<Key/binary, "-match">>, Base, length(Valid), Opts),
     ?event(security_debug,
         {validate_authority,
             {subject_ids, From},
             {intent, compute},
             {valid_options, Valid},
-            {required, Required},
+            {required, RequiredList},
             {base, Base},
             {message, SubjectMsg}
         },
         Opts
     ),
-    satisfies_constraints(Key, From, Required, Valid, Match, Opts).
+    satisfies_constraints(Key, From, RequiredList, Valid, Match, Opts).
 
 %% @doc Validate that the request satisfies the given constraints.
 %% Returns true if:

--- a/src/dev_security.erl
+++ b/src/dev_security.erl
@@ -83,8 +83,14 @@ validate(Key, Base, SubjectMsg, RawFrom, Opts) ->
     %% Dedup identities so duplicate committers cannot satisfy min-N thresholds.
     From = lists:uniq(as_list(RawFrom, Opts)),
     Valid = lists:uniq(as_list(hb_ao:get(Key, Base, [], Opts), Opts)),
-    RequiredList = lists:uniq(hb_ao:get(<<Key/binary, "-required">>, Base, [], Opts)),
-    Match = hb_ao:get(<<Key/binary, "-match">>, Base, length(Valid), Opts),
+    RequiredList = lists:uniq(
+        as_list(
+            hb_ao:get(<<Key/binary, "-required">>, Base, [], Opts),
+            Opts
+        )
+    ),
+    MatchRaw = hb_ao:get(<<Key/binary, "-match">>, Base, not_found, Opts),
+    Match = safe_match(MatchRaw, length(Valid)),
     ?event(security_debug,
         {validate_authority,
             {subject_ids, From},
@@ -145,6 +151,29 @@ count_common(ListA, ListB) -> length([X || X <- ListA, lists:member(X, ListB)]).
 %% @doc Normalize value to a list.
 as_list(Value, _Opts) when is_list(Value) -> Value;
 as_list(Value, _Opts) -> [Value].
+%% @doc Normalize and validate a `*-match` threshold against the number of
+%% available valid identities. Missing thresholds fall back to `Default`.
+%% Explicit thresholds must be integer-like and within the admissible range:
+%% `0` is only allowed when `Default = 0`, otherwise the threshold must be in
+%% `1..Default`.
+safe_match(not_found, Default) when is_integer(Default), Default >= 0 ->
+    Default;
+safe_match(not_found, _Default) ->
+    {error, <<"Default must be a non-negative integer.">>};
+safe_match(Match, Default) when is_integer(Match), is_integer(Default), Default >= 0 ->
+    case {Match, Default} of
+        {0, 0} -> 0;
+        {M, D} when M > 0 andalso M =< D -> M;
+        _ -> {error, <<"Invalid Match threshold.">>}
+    end;
+safe_match(Match, Default) when is_binary(Match)->
+    try binary_to_integer(Match) of
+        IntMatch -> safe_match(IntMatch, Default)
+    catch
+        _:_ -> {error, <<"Invalid Match threshold.">>}
+    end;
+safe_match(_, _) ->
+    {error, <<"Invalid Match threshold.">>}.
 
 %% @doc Return the single element of a list if there is only one, else return
 %% the list.

--- a/src/dev_security.erl
+++ b/src/dev_security.erl
@@ -80,10 +80,10 @@ validate_authority(Base, Assignment, Opts) ->
 validate(Key, Base, SubjectMsg, Opts) ->
     validate(Key, Base, SubjectMsg, hb_message:signers(SubjectMsg, Opts), Opts).
 validate(Key, Base, SubjectMsg, RawFrom, Opts) ->
-    %% dedup entries for uniqueness sanity and correctness of min N threshold
-    From = lists:dedup(as_list(RawFrom, Opts)),
-    Valid = lists:dedup(as_list(hb_ao:get(Key, Base, [], Opts), Opts)),
-    RequiredList = lists:dedup(hb_ao:get(<<Key/binary, "-required">>, Base, [], Opts)),
+    %% Dedup identities so duplicate committers cannot satisfy min-N thresholds.
+    From = lists:uniq(as_list(RawFrom, Opts)),
+    Valid = lists:uniq(as_list(hb_ao:get(Key, Base, [], Opts), Opts)),
+    RequiredList = lists:uniq(hb_ao:get(<<Key/binary, "-required">>, Base, [], Opts)),
     Match = hb_ao:get(<<Key/binary, "-match">>, Base, length(Valid), Opts),
     ?event(security_debug,
         {validate_authority,
@@ -118,7 +118,11 @@ satisfies_constraints(Intent, MsgCommitters, Required, Valid, ValidCount, Opts) 
         (PresentRequiredCommitters == length(RequiredList)) orelse
             {error, <<"Required committers not present in message.">>},
     % Must have at least `Match' common elements AND all `Required' elements
-    Res = SatisfiesAcceptable andalso SatisfiesRequired,
+    Res =
+        case SatisfiesAcceptable of
+            true -> SatisfiesRequired;
+            Error -> Error
+        end,
     ?event(
         security_short,
         {constraint_check,
@@ -146,3 +150,18 @@ as_list(Value, _Opts) -> [Value].
 %% the list.
 maybe_single([SingleElement], _Opts) -> SingleElement;
 maybe_single(List, _Opts) -> List.
+
+duplicate_authority_match_rejected_test() ->
+    ?assertEqual(
+        {error, <<"Too few acceptable committers present.">>},
+        validate(
+            <<"authority">>,
+            #{
+                <<"authority">> => [<<"alice">>, <<"bob">>],
+                <<"authority-match">> => 2
+            },
+            #{},
+            [<<"alice">>, <<"alice">>],
+            #{}
+        )
+    ).


### PR DESCRIPTION
  ## findings

1- validate/5 was not deduping identity lists before threshold checks. this could let malformed duplicate authorities satisfy a min-N threshold incorrectly. example: 

`authority = [<<"alice">>, <<"bob">>]` with `authority-match = 2`, and a message signer list of `[<<"alice">>,
  <<"alice">>]` could be counted as meeting the threshold

2- satisfies_constraints/6 was using `andalso` on values that could be `{error, Reason}` which caused a crash when that path was reached.

3- Match handling was too loose:

  - allowed malformed raw `*-match` values to flow through without normalization
  - allowed non-binary/non-integer inputs to reach comparison logic
  - allowed invalid explicit thresholds like `Match > Default`
  - allowed Match = 0 in cases where Default > 0
  - did not safely parse binary thresholds

  ## fixes

1- dedupe identity lists with lists:uniq/1 before evaluation: `From`, `Valid` and `RequiredList`
2- replaced the unsafe andalso with explicit error propagation:

```erl
  Res =
      case SatisfiesAcceptable of
          true -> SatisfiesRequired;
          Error -> Error
      end,
```
3- added safe_match/2 to normalize and validate `*-match `thresholds:
```erl
  %% @doc Normalize and validate a `*-match` threshold against the number of
  %% available valid identities. Missing thresholds fall back to `Default`.
  %% Explicit thresholds must be integer-like and within the admissible range:
  %% `0` is only allowed when `Default = 0`, otherwise the threshold must be in
  %% `1..Default`.
  safe_match(not_found, Default) when is_integer(Default), Default >= 0 ->
      Default;
  safe_match(not_found, _Default) ->
      {error, <<"Default must be a non-negative integer.">>};
  safe_match(Match, Default) when is_integer(Match), is_integer(Default), Default >= 0 ->
      case {Match, Default} of
          {0, 0} -> 0;
          {M, D} when M > 0 andalso M =< D -> M;
          _ -> {error, <<"Invalid Match threshold.">>}
      end;
  safe_match(Match, Default) when is_binary(Match)->
      try binary_to_integer(Match) of
          IntMatch -> safe_match(IntMatch, Default)
      catch
          _:_ -> {error, <<"Invalid Match threshold.">>}
      end;
  safe_match(_, _) ->
      {error, <<"Invalid Match threshold.">>}.
```

also added `duplicate_authority_match_rejected_test` test. 

`dev_security` and `dev_lua_test_ledgers`  tests pass