### PR TITLE
chore: dev_pot inputs hardening 

### DIFF
--- a/src/dev_mint_authority.erl
+++ b/src/dev_mint_authority.erl
@@ -20,8 +20,8 @@ enforce_mint_authority(Base, Req, Opts) ->
     maybe
         Minter = hb_ao:get(<<"from">>, Req, Opts),
         MintAuthority = hb_ao:get(<<"mint-authority">>, Base, Opts),
-        true ?= dev_token:validate_address(Minter),
-        true ?= dev_token:validate_address(MintAuthority),
+        true ?= dev_token:validate_address(Minter, []),
+        true ?= dev_token:validate_address(MintAuthority, []),
         case {Minter, MintAuthority} of
             {not_found, _} -> 
                 {error, <<"Minter not found.">>};
@@ -40,7 +40,7 @@ mint_single(Base, Req, Opts) ->
         {ok, Quantity} ?= hb_ao:resolve(Req, <<"quantity">>, Opts),
         true ?= (is_integer(Quantity) and (Quantity >= 0))
             orelse {error, <<"Quantity must be a non-negative integer.">>},
-        true ?= dev_token:validate_address(To),
+        true ?= dev_token:validate_address(To, []),
         ?event(debug_mint, {before_perform_mint, {to, To}, {quantity, Quantity}}),
         perform_mint(Base, #{ To => Quantity }, Opts)
     end.
@@ -62,7 +62,7 @@ perform_mint(Base, RawQuantities, Opts) ->
         % validate address
         true ?= 
             lists:all(
-                fun(Addr) -> true =:= dev_token:validate_address(Addr) end,
+                fun(Addr) -> true =:= dev_token:validate_address(Addr, []) end,
                 maps:keys(Quantities)
             )
             orelse {error, <<"Mint recipients must be valid addresses">>},

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -39,6 +39,19 @@
 -export([update_deposit_index/5]).
 -export([user/3, balance/3, balances/1, balances/2]).
 -export([get_deposit/4, get_deposits/2, get_deposits/3]).
+%%% `~pot@1.0` dev_token:validate_address custom denylist
+-define(RESERVED_KEYS, [
+    <<"balances">>,
+    <<"resources">>,
+    <<"users">>,
+    <<"total-suuply">>,
+    <<"minted">>,
+    <<"accumulator">>,
+    <<"last-drip">>,
+    <<"t">>,
+    <<"total-weighted-units">>,
+    <<"undistributed-mint">>
+]).
 
 %%% Pot Model Functions.
 
@@ -293,27 +306,30 @@ unclaimed_yield(Addr, S, Opts) ->
 
 %% @doc Return the unclaimed yield for a specific address in a specific resource.
 unclaimed_yield(Addr, ResourceID, UndrippedS, Opts) ->
-    GlobalDrippedS = drip_global(UndrippedS, Opts),
-    ?event(debug_pot,
-        {unclaimed_yield,
-            {resource_id, ResourceID},
-            {global_dripped_state, GlobalDrippedS},
-            {undripped_state, UndrippedS}
-        },
-        Opts
-    ),
-    S = drip_resource(ResourceID, GlobalDrippedS, Opts),
-    Res = hb_ao:get(<<"resources/", ResourceID/binary>>, S, #{}, Opts),
-    ResourceAcc = hb_maps:get(<<"accumulator">>, Res, 0, Opts),
-    Deposits = hb_maps:get(<<"deposits">>, Res, #{}, Opts),
-    case hb_maps:find(Addr, Deposits) of
-        error -> 0;
-        {ok, #{
-                <<"quantity">> := Qty,
-                <<"last-resource-accumulator">> := LastResourceAcc
-            }} ->
-            ?no_prod("Remove all floating point arithmetic."),
-            dev_pot_math:drip_user(ResourceAcc, LastResourceAcc, Qty)
+    maybe
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
+        GlobalDrippedS = drip_global(UndrippedS, Opts),
+        ?event(debug_pot,
+            {unclaimed_yield,
+                {resource_id, ResourceID},
+                {global_dripped_state, GlobalDrippedS},
+                {undripped_state, UndrippedS}
+            },
+            Opts
+        ),
+        S = drip_resource(ResourceID, GlobalDrippedS, Opts),
+        Res = hb_ao:get(<<"resources/", ResourceID/binary>>, S, #{}, Opts),
+        ResourceAcc = hb_maps:get(<<"accumulator">>, Res, 0, Opts),
+        Deposits = hb_maps:get(<<"deposits">>, Res, #{}, Opts),
+        case hb_maps:find(Addr, Deposits) of
+            error -> 0;
+            {ok, #{
+                    <<"quantity">> := Qty,
+                    <<"last-resource-accumulator">> := LastResourceAcc
+                }} ->
+                ?no_prod("Remove all floating point arithmetic."),
+                dev_pot_math:drip_user(ResourceAcc, LastResourceAcc, Qty)
+            end
     end.
 
 %% @doc Deposit a quantity of a resource for a given address.
@@ -367,6 +383,7 @@ parse_deposit_modification(Base, Assignment, Opts) ->
                 <<"No `address' provided.">>,
                 Opts
             ),
+        true ?= dev_token:validate_address(Address, ?RESERVED_KEYS),
         {ok, ResourceID} ?=
             hb_maps:find(
                 <<"resource">>,
@@ -374,6 +391,7 @@ parse_deposit_modification(Base, Assignment, Opts) ->
                 <<"No resource ID provided.">>,
                 Opts
             ),
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
         {ok, Amount} ?=
             hb_maps:find(
                 <<"quantity">>,
@@ -395,6 +413,7 @@ verify_resource_authority(ResourceID, Base, Req, Opts) ->
                 <<"No `from' address provided.">>,
                 Opts
             ),
+        true ?= dev_token:validate_address(From, ?RESERVED_KEYS),
         {ok, Resources} =
             hb_maps:find(
                 <<"resources">>,
@@ -502,6 +521,7 @@ delegate(State, Assignment, Opts) ->
                 <<"No `from' address provided.">>,
                 Opts
             ),
+        true ?= dev_token:validate_address(FromAddr, ?RESERVED_KEYS),
         {ok, ToAddr} ?=
             hb_maps:find(
                 <<"address">>,
@@ -509,6 +529,7 @@ delegate(State, Assignment, Opts) ->
                 <<"No recipient `address' to delegate to provided.">>,
                 Opts
             ),
+        true ?= dev_token:validate_address(ToAddr, ?RESERVED_KEYS),
         {ok, ResourceID} ?=
             hb_maps:find(
                 <<"resource">>,
@@ -516,6 +537,7 @@ delegate(State, Assignment, Opts) ->
                 <<"No `resource' ID to delegate on provided.">>,
                 Opts
             ),
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
         {ok, Amount} ?=
             hb_maps:find(
                 <<"quantity">>,
@@ -667,6 +689,9 @@ undelegate(State, Assignment, Opts) ->
         {ok, ToAddr} ?= hb_maps:find(<<"address">>, Req, Opts),
         {ok, ResourceID} ?= hb_maps:find(<<"resource">>, Req, Opts),
         {ok, Amount} ?= hb_maps:find(<<"quantity">>, Req, Opts),
+        true ?= dev_token:validate_address(FromAddr, ?RESERVED_KEYS),
+        true ?= dev_token:validate_address(ToAddr, ?RESERVED_KEYS),
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
         NewT = hb_maps:get(<<"t">>, Req, hb_maps:get(<<"t">>, State)),
         StateWithT = State#{ <<"t">> := NewT },
         {ok, NewState} ?=
@@ -822,6 +847,7 @@ register(State, Assignment, Opts) ->
                 <<"No `resource' provided to register.">>, 
                 Opts
             ),
+        true ?= dev_token:validate_address(ResID, ?RESERVED_KEYS),
         {ok, From} ?= 
             hb_maps:find(
                 <<"from">>, 
@@ -829,6 +855,7 @@ register(State, Assignment, Opts) ->
                 <<"No `from' address provided.">>, 
                 Opts
             ),
+        true ?= dev_token:validate_address(From, ?RESERVED_KEYS),
         true ?=
             (hb_maps:get(<<"parent">>, State, no_parent, Opts) =:= From) orelse
             dev_security:validate(<<"mint-authority">>, State, Req, From, Opts) orelse
@@ -851,12 +878,16 @@ register(State, Assignment, Opts) ->
 
 %% @doc Update the authority record for a specific resource in the pot.
 register_resource_authority(ResourceID, Authority, S, Opts) ->
-    hb_ao:set(
-        S,
-        <<"/resources/", ResourceID/binary, "/authority">>,
-        Authority,
-        Opts
-    ).
+    maybe
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
+        true ?= dev_token:validate_address(Authority, ?RESERVED_KEYS),
+        hb_ao:set(
+            S,
+            <<"/resources/", ResourceID/binary, "/authority">>,
+            Authority,
+            Opts
+        )
+end.
 
 %% @doc Set the weight of a specific resource in the pot, updating the pot state
 %% as necessary.

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -44,7 +44,7 @@
     <<"balances">>,
     <<"resources">>,
     <<"users">>,
-    <<"total-suuply">>,
+    <<"total-supply">>,
     <<"minted">>,
     <<"accumulator">>,
     <<"last-drip">>,
@@ -285,8 +285,11 @@ initialize_subscriptions(Base, _Req, Opts) ->
 %% @doc Get the balance of a specific address in the pot by combining the base
 %% balance with the unclaimed yield.
 balance(Addr, S, Opts) ->
-    hb_maps:get(Addr, hb_maps:get(<<"balances">>, S, #{}, Opts), 0, Opts)
-        + unclaimed_yield(Addr, S, Opts).
+    maybe
+        true ?= dev_token:validate_address(Addr, ?RESERVED_KEYS),
+        hb_maps:get(Addr, hb_maps:get(<<"balances">>, S, #{}, Opts), 0, Opts)
+            + unclaimed_yield(Addr, S, Opts)
+    end.
 
 %% @doc Return the unclaimed yield across all resources for a specific address.
 unclaimed_yield(Addr, S, Opts) ->
@@ -308,6 +311,7 @@ unclaimed_yield(Addr, S, Opts) ->
 unclaimed_yield(Addr, ResourceID, UndrippedS, Opts) ->
     maybe
         true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
+        true ?= dev_token:validate_address(Addr, ?RESERVED_KEYS),
         GlobalDrippedS = drip_global(UndrippedS, Opts),
         ?event(debug_pot,
             {unclaimed_yield,
@@ -413,7 +417,7 @@ verify_resource_authority(ResourceID, Base, Req, Opts) ->
                 <<"No `from' address provided.">>,
                 Opts
             ),
-        true ?= dev_token:validate_address(From, ?RESERVED_KEYS),
+        % true ?= dev_token:validate_address(From, ?RESERVED_KEYS),
         {ok, Resources} =
             hb_maps:find(
                 <<"resources">>,
@@ -855,7 +859,6 @@ register(State, Assignment, Opts) ->
                 <<"No `from' address provided.">>, 
                 Opts
             ),
-        true ?= dev_token:validate_address(From, ?RESERVED_KEYS),
         true ?=
             (hb_maps:get(<<"parent">>, State, no_parent, Opts) =:= From) orelse
             dev_security:validate(<<"mint-authority">>, State, Req, From, Opts) orelse
@@ -986,103 +989,111 @@ send_weight_notice(ResourceID, Weight, S, Opts) ->
 %% modify_deposit_state() includes negative numbers as well.
 modify_deposit_state(Addr, ResourceID, Amount, S0, Opts) ->
     % Drip the global state and the resource, then extract necessary components.
-    GlobalDrippedS = drip_global(S0, Opts),
-    DrippedS = #{
-        <<"balances">> := Balances,
-        <<"resources">> := Resources
-    } = drip_resource(ResourceID, GlobalDrippedS, Opts),
-    ?event(
-        debug_drip,
-        {modify_deposit_state,
-            {addr, Addr},
-            {resource_id, ResourceID},
-            {amount, Amount},
-            {resources, Resources},
-            {balances, Balances}
-        },
-        Opts
-    ),
-    ExistingDeposit = get_deposit(Addr, ResourceID, DrippedS, Opts),
-    BaseBalance = hb_ao:get(Addr, Balances, 0, Opts),
-    CurrentSupply = hb_ao:get(<<"total-supply">>, S0, 0, Opts),
-    Yield = unclaimed_yield(Addr, ResourceID, DrippedS, Opts),
-    NewBalance = BaseBalance + Yield,
-    ResourceAcc =
-        hb_ao:get(
-            <<ResourceID/binary, "/accumulator">>,
-            Resources,
-            0,
-            Opts
-        ),
-    NewResources =
-        hb_ao:set(
-            Resources,
-            #{
-                ResourceID =>
-                    #{
-                        <<"total-deposits">> =>
-                            Amount +
-                                hb_ao:get(
-                                    <<ResourceID/binary, "/total-deposits">>,
-                                    Resources,
-                                    0,
-                                    Opts
-                                ),
-                        <<"deposits">> =>
-                            #{
-                                Addr =>
-                                    #{
-                                        <<"quantity">> => ExistingDeposit + Amount,
-                                        <<"last-resource-accumulator">> =>
-                                            ResourceAcc
-                                    }
-                            }
-                    }
+    maybe
+        true ?= dev_token:validate_address(Addr, ?RESERVED_KEYS),
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
+        GlobalDrippedS = drip_global(S0, Opts),
+        DrippedS = #{
+            <<"balances">> := Balances,
+            <<"resources">> := Resources
+        } = drip_resource(ResourceID, GlobalDrippedS, Opts),
+        ?event(
+            debug_drip,
+            {modify_deposit_state,
+                {addr, Addr},
+                {resource_id, ResourceID},
+                {amount, Amount},
+                {resources, Resources},
+                {balances, Balances}
             },
             Opts
         ),
-    ?event(debug_drip, {resources_after_modify_deposit, NewResources}, Opts),
-    WeightR = hb_ao:get(<<ResourceID/binary, "/weight">>, NewResources, 0, Opts),
-    TotalWeightedUnits = hb_maps:get(<<"total-weighted-units">>, DrippedS, 0, Opts),
-    NewTotalWeightedUnits = TotalWeightedUnits + (WeightR * Amount),
-    {ok, NewBalances} =
-        hb_ao:resolve(
-            Balances,
+        ExistingDeposit = get_deposit(Addr, ResourceID, DrippedS, Opts),
+        BaseBalance = hb_ao:get(Addr, Balances, 0, Opts),
+        CurrentSupply = hb_ao:get(<<"total-supply">>, S0, 0, Opts),
+        Yield = unclaimed_yield(Addr, ResourceID, DrippedS, Opts),
+        NewBalance = BaseBalance + Yield,
+        ResourceAcc =
+            hb_ao:get(
+                <<ResourceID/binary, "/accumulator">>,
+                Resources,
+                0,
+                Opts
+            ),
+        NewResources =
+            hb_ao:set(
+                Resources,
+                #{
+                    ResourceID =>
+                        #{
+                            <<"total-deposits">> =>
+                                Amount +
+                                    hb_ao:get(
+                                        <<ResourceID/binary, "/total-deposits">>,
+                                        Resources,
+                                        0,
+                                        Opts
+                                    ),
+                            <<"deposits">> =>
+                                #{
+                                    Addr =>
+                                        #{
+                                            <<"quantity">> => ExistingDeposit + Amount,
+                                            <<"last-resource-accumulator">> =>
+                                                ResourceAcc
+                                        }
+                                }
+                        }
+                },
+                Opts
+            ),
+        ?event(debug_drip, {resources_after_modify_deposit, NewResources}, Opts),
+        WeightR = hb_ao:get(<<ResourceID/binary, "/weight">>, NewResources, 0, Opts),
+        TotalWeightedUnits = hb_maps:get(<<"total-weighted-units">>, DrippedS, 0, Opts),
+        NewTotalWeightedUnits = TotalWeightedUnits + (WeightR * Amount),
+        {ok, NewBalances} =
+            hb_ao:resolve(
+                Balances,
+                #{
+                    <<"path">> => <<"set">>,
+                    Addr => NewBalance
+                },
+                Opts
+            ),
+        UpdateValues = 
             #{
-                <<"path">> => <<"set">>,
-                Addr => NewBalance
+                <<"resources">> => NewResources,
+                <<"total-weighted-units">> => NewTotalWeightedUnits,
+                <<"balances">> => NewBalances,
+                <<"total-supply">> => CurrentSupply + Yield
             },
+        {ok, UpdatedDepositS} =
+            hb_ao:resolve(
+                DrippedS,
+                UpdateValues#{ <<"path">> => <<"set">> },
+                Opts
+            ),
+        update_deposit_index(
+            Addr,
+            ResourceID,
+            get_deposit(Addr, ResourceID, UpdatedDepositS, Opts),
+            UpdatedDepositS,
             Opts
-        ),
-    UpdateValues = 
-        #{
-            <<"resources">> => NewResources,
-            <<"total-weighted-units">> => NewTotalWeightedUnits,
-            <<"balances">> => NewBalances,
-            <<"total-supply">> => CurrentSupply + Yield
-        },
-    {ok, UpdatedDepositS} =
-        hb_ao:resolve(
-            DrippedS,
-            UpdateValues#{ <<"path">> => <<"set">> },
-            Opts
-        ),
-    update_deposit_index(
-        Addr,
-        ResourceID,
-        get_deposit(Addr, ResourceID, UpdatedDepositS, Opts),
-        UpdatedDepositS,
-        Opts
-    ).
+        )
+end.
 
 %% @doc Get the deposit quantity for a specific address in a specific resource.
 get_deposit(Addr, ResourceID, S, Opts) ->
-    hb_ao:get(
-        <<"/resources/", ResourceID/binary, "/deposits/", Addr/binary, "/quantity">>,
-        S,
-        0,
-        Opts
-    ).
+    maybe
+        true ?= dev_token:validate_address(Addr, ?RESERVED_KEYS),
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
+        hb_ao:get(
+            <<"/resources/", ResourceID/binary, "/deposits/", Addr/binary, "/quantity">>,
+            S,
+            0,
+            Opts
+        )
+    end.
 
 %% @doc Get the balances submessage from the state.
 balances(S) -> balances(S, #{}).
@@ -1097,18 +1108,24 @@ get_deposits(S = #{ <<"resources">> := Resources }, Opts) ->
         Opts
     ).
 get_deposits(ResourceID, S, Opts) ->
-    Ds = hb_ao:get(
-        <<"/resources/", ResourceID/binary, "/deposits">>,
-        S,
-        #{},
-        Opts
-    ),
-    hb_maps:map(
-        fun(Addr, _) -> get_deposit(Addr, ResourceID, S, Opts) end,
-        Ds,
-        Opts
-    ).
+    maybe
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
+        Ds = hb_ao:get(
+            <<"/resources/", ResourceID/binary, "/deposits">>,
+            S,
+            #{},
+            Opts
+        ),
+        hb_maps:map(
+            fun(Addr, _) -> get_deposit(Addr, ResourceID, S, Opts) end,
+            Ds,
+            Opts
+        )
+end.
 
 %% @doc Return the contents of the inverted index for a specific address.
 user(Addr, S, Opts) ->
-    hb_ao:get(<<"/users/", Addr/binary>>, S, #{}, Opts).
+    maybe
+        true ?= dev_token:validate_address(Addr, ?RESERVED_KEYS),
+        hb_ao:get(<<"/users/", Addr/binary>>, S, #{}, Opts)
+    end.

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -875,7 +875,7 @@ register(State, Assignment, Opts) ->
             (hb_maps:get(<<"parent">>, State, no_parent, Opts) =:= From) orelse
             dev_security:validate(<<"mint-authority">>, State, Req, From, Opts) orelse
                 verify_resource_authority(ResID, State, Req, Opts),
-        State2 =
+        State2 ?=
             case hb_maps:find(<<"weight">>, Req, Opts) of
                 {ok, Weight} -> register_resource(ResID, Weight, State, Opts);
                 _ -> State
@@ -940,7 +940,9 @@ register_resource(ResourceID, Weight, S, Opts) when is_integer(Weight), Weight >
 end;
 
 register_resource(_, Weight, _, _) when not is_integer(Weight) ->
-    {error, {<<"Inavlid Weight type.">>}}.
+    {error, <<"Invalid Weight type.">>};
+register_resource(_, Weight, _, _) when is_integer(Weight), Weight < 0 ->
+    {error, <<"Weight must be a non-negative integer.">>}.
 
 %% @doc Update the inverted index for a specific address in a specific resource.
 update_deposit_index(Addr, ResourceID, Quantity, S, Opts) ->

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -370,8 +370,10 @@ withdraw(Base, Req, Opts) ->
     end.
 -spec withdraw(binary(), binary(), pos_integer(), map(), map()) -> map() | {error, term()}.
 withdraw(Addr, ResourceID, Amount, S0, Opts) when is_integer(Amount), Amount > 0 ->
-    ExistingDeposit = get_deposit(Addr, ResourceID, S0, Opts),
     maybe
+        ExistingDepositOrError = get_deposit(Addr, ResourceID, S0, Opts),
+        true ?= is_integer(ExistingDepositOrError) orelse ExistingDepositOrError,
+        ExistingDeposit = ExistingDepositOrError,
         {ok, S1} ?= liquidate(Addr, ResourceID, Amount - ExistingDeposit, S0, Opts),
         modify_deposit_state(Addr, ResourceID, -Amount, S1, Opts)
     else
@@ -1028,7 +1030,9 @@ modify_deposit_state(Addr, ResourceID, Amount, S0, Opts) ->
             },
             Opts
         ),
-        ExistingDeposit = get_deposit(Addr, ResourceID, DrippedS, Opts),
+        ExistingDepositOrError = get_deposit(Addr, ResourceID, DrippedS, Opts),
+        true ?= is_integer(ExistingDepositOrError) orelse ExistingDepositOrError,
+        ExistingDeposit = ExistingDepositOrError,
         BaseBalance = hb_ao:get(Addr, Balances, 0, Opts),
         CurrentSupply = hb_ao:get(<<"total-supply">>, S0, 0, Opts),
         Yield = unclaimed_yield(Addr, ResourceID, DrippedS, Opts),

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -293,19 +293,22 @@ balance(Addr, S, Opts) ->
 
 %% @doc Return the unclaimed yield across all resources for a specific address.
 unclaimed_yield(Addr, S, Opts) ->
-    ResourceIDs =
-        hb_maps:keys(
-            hb_private:reset(
-                hb_ao:get(<<"users/", Addr/binary, "/deposits">>, S, #{}, Opts)
+    maybe
+        true ?= dev_token:validate_address(Addr, ?RESERVED_KEYS),
+        ResourceIDs =
+            hb_maps:keys(
+                hb_private:reset(
+                    hb_ao:get(<<"users/", Addr/binary, "/deposits">>, S, #{}, Opts)
+                ),
+                Opts
             ),
-            Opts
-        ),
-    lists:sum(
-        lists:map(
-            fun(ResID) -> unclaimed_yield(Addr, ResID, S, Opts) end,
-            ResourceIDs
+        lists:sum(
+            lists:map(
+                fun(ResID) -> unclaimed_yield(Addr, ResID, S, Opts) end,
+                ResourceIDs
+            )
         )
-    ).
+end.
 
 %% @doc Return the unclaimed yield for a specific address in a specific resource.
 unclaimed_yield(Addr, ResourceID, UndrippedS, Opts) ->
@@ -417,7 +420,6 @@ verify_resource_authority(ResourceID, Base, Req, Opts) ->
                 <<"No `from' address provided.">>,
                 Opts
             ),
-        % true ?= dev_token:validate_address(From, ?RESERVED_KEYS),
         {ok, Resources} =
             hb_maps:find(
                 <<"resources">>,
@@ -895,34 +897,37 @@ end.
 %% @doc Set the weight of a specific resource in the pot, updating the pot state
 %% as necessary.
 register_resource(ResourceID, Weight, S, Opts) ->
-    % Run the global drip to ensure the state is up to date.
-    S0 = drip_global(S, Opts),
-    S1 = drip_resource(ResourceID, S0, Opts),
-    % Calculate the new total deposited units for the weighted global counter
-    % (`/total-weighted-units').
-    Resource = hb_ao:get(<<"/resources/", ResourceID/binary>>, S1, #{}, Opts),
-    OldWeight = hb_ao:get(<<"weight">>, Resource, 0, Opts),
-    ResourceDeposits = hb_ao:get(<<"total-deposits">>, Resource, 0, Opts),
-    % Update the total weighted units counter. Subtract the deposits at the old
-    % weight first, then add the deposits at the new weight.
-    LastTotalWeightedUnits = hb_maps:get(<<"total-weighted-units">>, S1, 0, Opts),
-    NewTotalWeightedUnits =
-        LastTotalWeightedUnits
-            - (OldWeight * ResourceDeposits)
-            + (Weight * ResourceDeposits),
-    % Update the resource and the global weighted units counter.
-    AfterSet =
-        hb_ao:set(
-            S1,
-            #{
-                <<"resources">> => #{
-                    ResourceID => Resource#{ <<"weight">> => Weight }
+    maybe
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
+        % Run the global drip to ensure the state is up to date.
+        S0 = drip_global(S, Opts),
+        S1 = drip_resource(ResourceID, S0, Opts),
+        % Calculate the new total deposited units for the weighted global counter
+        % (`/total-weighted-units').
+        Resource = hb_ao:get(<<"/resources/", ResourceID/binary>>, S1, #{}, Opts),
+        OldWeight = hb_ao:get(<<"weight">>, Resource, 0, Opts),
+        ResourceDeposits = hb_ao:get(<<"total-deposits">>, Resource, 0, Opts),
+        % Update the total weighted units counter. Subtract the deposits at the old
+        % weight first, then add the deposits at the new weight.
+        LastTotalWeightedUnits = hb_maps:get(<<"total-weighted-units">>, S1, 0, Opts),
+        NewTotalWeightedUnits =
+            LastTotalWeightedUnits
+                - (OldWeight * ResourceDeposits)
+                + (Weight * ResourceDeposits),
+        % Update the resource and the global weighted units counter.
+        AfterSet =
+            hb_ao:set(
+                S1,
+                #{
+                    <<"resources">> => #{
+                        ResourceID => Resource#{ <<"weight">> => Weight }
+                    },
+                    <<"total-weighted-units">> => NewTotalWeightedUnits
                 },
-                <<"total-weighted-units">> => NewTotalWeightedUnits
-            },
-            Opts
-        ),
-    send_weight_notice(ResourceID, Weight, AfterSet, Opts).
+                Opts
+            ),
+        send_weight_notice(ResourceID, Weight, AfterSet, Opts)
+end.
 
 %% @doc Update the inverted index for a specific address in a specific resource.
 update_deposit_index(Addr, ResourceID, Quantity, S, Opts) ->

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -562,129 +562,134 @@ delegate(State, Assignment, Opts) ->
     end.
 -spec delegate(binary(), binary(), binary(), pos_integer(), map(), map()) -> {ok, map()} | {error, term()}.
 delegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
-    ?event(
-        {delegating,
-            {from_addr, FromAddr},
-            {to_addr, ToAddr},
-            {resource_id, ResourceID},
-            {amount, Amount}
-        }
-    ),
-    GlobalDrippedS = drip_global(S, Opts),
-    S0 = drip_resource(ResourceID, GlobalDrippedS, Opts),
-    S1 = drip_user(FromAddr, S0, Opts),
-    S2 = drip_user(ToAddr, S1, Opts),
-    % Self-delegation is a noop
-    case FromAddr =:= ToAddr of
-        true -> {ok, S2};
-        false ->
-            DelegatorDeposit = get_deposit(FromAddr, ResourceID, S2, Opts),
-            case DelegatorDeposit >= Amount of
-                false ->
-                    {error, <<"Delegation amount exceeds available deposit.">>};
-                true ->
-                    S3 =
-                        hb_ao:set(
-                            S2,
-                            <<
-                                "/resources/",
-                                ResourceID/binary,
-                                "/deposits/",
-                                FromAddr/binary,
-                                "/quantity"
-                            >>,
-                            DelegatorDeposit - Amount,
-                            Opts
-                        ),
-                    ExistingDelegation =
-                        hb_ao:get(
-                            <<
-                                "/resources/",
-                                ResourceID/binary,
-                                "/deposits/",
-                                FromAddr/binary,
-                                "/delegations/",
-                                ToAddr/binary
-                            >>,
-                            S3,
-                            0,
-                            Opts
-                        ),
-                    S4 =
-                        hb_ao:set(
-                            S3,
-                            <<
-                                "/resources/",
-                                ResourceID/binary,
-                                "/deposits/",
-                                FromAddr/binary,
-                                "/delegations/",
-                                ToAddr/binary
-                            >>,
-                            ExistingDelegation + Amount,
-                            Opts
-                        ),
-                    ResourceAcc =
-                        hb_ao:get(
-                            <<"resources/", ResourceID/binary, "/accumulator">>,
-                            S4,
-                            0,
-                            Opts
-                        ),
-                    RecipientDeposit = get_deposit(ToAddr, ResourceID, S4, Opts),
-                    S5 =
-                        hb_ao:set(
-                            S4,
-                            <<
-                                "/resources/", 
-                                ResourceID/binary,
-                                "/deposits/",
-                                ToAddr/binary,
-                                "/quantity"
-                            >>,
-                            RecipientDeposit + Amount,
-                            Opts
-                        ),
-                    S6 =
-                        hb_ao:set(
-                            S5,
-                            <<
-                                "/resources/", 
-                                ResourceID/binary,
-                                "/deposits/",
-                                ToAddr/binary,
-                                "/last-resource-accumulator"
-                            >>,
-                            ResourceAcc,
-                            Opts
-                        ),
-                    S7 =
-                        update_deposit_index(
-                            FromAddr,
-                            ResourceID,
-                            get_deposit(FromAddr, ResourceID, S6, Opts),
-                            S6,
-                            Opts
-                        ),
-                    S8 =
-                        update_deposit_index(
-                            ToAddr,
-                            ResourceID,
-                            get_deposit(ToAddr, ResourceID, S7, Opts),
-                            S7,
-                            Opts
-                        ),
-                    {ok,
-                        send_delegation_notice(
-                            FromAddr,
-                            ToAddr,
-                            ResourceID,
-                            Amount,
-                            S8,
-                            Opts
-                        )}
-            end
-    end.
+    maybe
+        true ?= dev_token:validate_address(FromAddr, ?RESERVED_KEYS),
+        true ?= dev_token:validate_address(ToAddr, ?RESERVED_KEYS),
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
+        ?event(
+            {delegating,
+                {from_addr, FromAddr},
+                {to_addr, ToAddr},
+                {resource_id, ResourceID},
+                {amount, Amount}
+            }
+        ),
+        GlobalDrippedS = drip_global(S, Opts),
+        S0 = drip_resource(ResourceID, GlobalDrippedS, Opts),
+        S1 = drip_user(FromAddr, S0, Opts),
+        S2 = drip_user(ToAddr, S1, Opts),
+        % Self-delegation is a noop
+        case FromAddr =:= ToAddr of
+            true -> {ok, S2};
+            false ->
+                DelegatorDeposit = get_deposit(FromAddr, ResourceID, S2, Opts),
+                case DelegatorDeposit >= Amount of
+                    false ->
+                        {error, <<"Delegation amount exceeds available deposit.">>};
+                    true ->
+                        S3 =
+                            hb_ao:set(
+                                S2,
+                                <<
+                                    "/resources/",
+                                    ResourceID/binary,
+                                    "/deposits/",
+                                    FromAddr/binary,
+                                    "/quantity"
+                                >>,
+                                DelegatorDeposit - Amount,
+                                Opts
+                            ),
+                        ExistingDelegation =
+                            hb_ao:get(
+                                <<
+                                    "/resources/",
+                                    ResourceID/binary,
+                                    "/deposits/",
+                                    FromAddr/binary,
+                                    "/delegations/",
+                                    ToAddr/binary
+                                >>,
+                                S3,
+                                0,
+                                Opts
+                            ),
+                        S4 =
+                            hb_ao:set(
+                                S3,
+                                <<
+                                    "/resources/",
+                                    ResourceID/binary,
+                                    "/deposits/",
+                                    FromAddr/binary,
+                                    "/delegations/",
+                                    ToAddr/binary
+                                >>,
+                                ExistingDelegation + Amount,
+                                Opts
+                            ),
+                        ResourceAcc =
+                            hb_ao:get(
+                                <<"resources/", ResourceID/binary, "/accumulator">>,
+                                S4,
+                                0,
+                                Opts
+                            ),
+                        RecipientDeposit = get_deposit(ToAddr, ResourceID, S4, Opts),
+                        S5 =
+                            hb_ao:set(
+                                S4,
+                                <<
+                                    "/resources/", 
+                                    ResourceID/binary,
+                                    "/deposits/",
+                                    ToAddr/binary,
+                                    "/quantity"
+                                >>,
+                                RecipientDeposit + Amount,
+                                Opts
+                            ),
+                        S6 =
+                            hb_ao:set(
+                                S5,
+                                <<
+                                    "/resources/", 
+                                    ResourceID/binary,
+                                    "/deposits/",
+                                    ToAddr/binary,
+                                    "/last-resource-accumulator"
+                                >>,
+                                ResourceAcc,
+                                Opts
+                            ),
+                        S7 =
+                            update_deposit_index(
+                                FromAddr,
+                                ResourceID,
+                                get_deposit(FromAddr, ResourceID, S6, Opts),
+                                S6,
+                                Opts
+                            ),
+                        S8 =
+                            update_deposit_index(
+                                ToAddr,
+                                ResourceID,
+                                get_deposit(ToAddr, ResourceID, S7, Opts),
+                                S7,
+                                Opts
+                            ),
+                        {ok,
+                            send_delegation_notice(
+                                FromAddr,
+                                ToAddr,
+                                ResourceID,
+                                Amount,
+                                S8,
+                                Opts
+                            )}
+                end
+        end
+end.
 
 %% @doc Undelegate some quantity of a resource from one address to another.
 -spec undelegate(map(), map(), map()) -> {ok, map()} | {error, term()}.
@@ -709,133 +714,138 @@ undelegate(State, Assignment, Opts) ->
     end.
 -spec undelegate(binary(), binary(), binary(), pos_integer(), map(), map()) -> {ok, map()} | {error, term()}.
 undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
-    ExistingDelegationBefore =
-        case FromAddr =:= ToAddr of
-            true -> 0;
-            false ->
-                hb_ao:get(
-                    <<
-                        "/resources/",
-                        ResourceID/binary,
-                        "/deposits/",
-                        FromAddr/binary,
-                        "/delegations/",
-                        ToAddr/binary
-                    >>,
-                    S,
-                    0,
-                    Opts
-                )
-        end,
-    Validation =
-        case FromAddr =:= ToAddr of
-            true -> ok;
-            false ->
-                case ExistingDelegationBefore >= Amount of
-                    true -> ok;
-                    false ->
-                        {error, <<"Undelegation amount exceeds existing delegation.">>}
-                end
-        end,
-    case Validation of
-        {error, _} = Err -> Err;
-        ok ->
-            RecipientDeposit = get_deposit(ToAddr, ResourceID, S, Opts),
-            case liquidate(ToAddr, ResourceID, Amount - RecipientDeposit, S, Opts) of
-                {error, _} = Err -> Err;
-                {ok, Liquidated} ->
-                    GlobalDrippedS = drip_global(Liquidated, Opts),
-                    DrippedS = drip_resource(ResourceID, GlobalDrippedS, Opts),
-                    S0 = drip_user(FromAddr, DrippedS, Opts),
-                    S1 = drip_user(ToAddr, S0, Opts),
-                    % Self-undelegation is a noop
-                    case FromAddr =:= ToAddr of
-                        true -> {ok, S1};
+    maybe
+        true ?= dev_token:validate_address(FromAddr, ?RESERVED_KEYS),
+        true ?= dev_token:validate_address(ToAddr, ?RESERVED_KEYS),
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
+        ExistingDelegationBefore =
+            case FromAddr =:= ToAddr of
+                true -> 0;
+                false ->
+                    hb_ao:get(
+                        <<
+                            "/resources/",
+                            ResourceID/binary,
+                            "/deposits/",
+                            FromAddr/binary,
+                            "/delegations/",
+                            ToAddr/binary
+                        >>,
+                        S,
+                        0,
+                        Opts
+                    )
+            end,
+        Validation =
+            case FromAddr =:= ToAddr of
+                true -> ok;
+                false ->
+                    case ExistingDelegationBefore >= Amount of
+                        true -> ok;
                         false ->
-                            NewRecipientDeposit = get_deposit(ToAddr, ResourceID, S1, Opts),
-                            S2 =
-                                hb_ao:set(
-                                    S1,
-                                    <<
-                                        "/resources/",
-                                        ResourceID/binary,
-                                        "/deposits/",
-                                        ToAddr/binary,
-                                        "/quantity"
-                                    >>,
-                                    NewRecipientDeposit - Amount,
-                                    Opts
-                                ),
-                            DelegatorDeposit = get_deposit(FromAddr, ResourceID, S1, Opts),
-                            S3 =
-                                hb_ao:set(
-                                    S2,
-                                    <<
-                                        "/resources/",
-                                        ResourceID/binary,
-                                        "/deposits/",
-                                        FromAddr/binary,
-                                        "/quantity"
-                                    >>,
-                                    DelegatorDeposit + Amount,
-                                    Opts
-                                ),
-                            ExistingDelegation =
-                                hb_ao:get(
-                                    <<
-                                        "/resources/",
-                                        ResourceID/binary,
-                                        "/deposits/",
-                                        FromAddr/binary,
-                                        "/delegations/",
-                                        ToAddr/binary
-                                    >>,
-                                    S1,
-                                    0,
-                                    Opts
-                                ),
-                            S4 =
-                                hb_ao:set(
-                                    S3,
-                                    <<
-                                        "/resources/",
-                                        ResourceID/binary,
-                                        "/deposits/",
-                                        FromAddr/binary,
-                                        "/delegations/",
-                                        ToAddr/binary
-                                    >>,
-                                    ExistingDelegation - Amount,
-                                    Opts
-                                ),
-                            S5 =
-                                update_deposit_index(
-                                    FromAddr,
-                                    ResourceID,
-                                    get_deposit(FromAddr, ResourceID, S3, Opts),
-                                    S4,
-                                    Opts
-                                ),
-                            S6 =
-                                update_deposit_index(
-                                    ToAddr,
-                                    ResourceID,
-                                    get_deposit(ToAddr, ResourceID, S4, Opts),
-                                    S5,
-                                    Opts
-                                ),
-                            {ok,
-                                send_delegation_notice(
-                                    FromAddr,
-                                    ToAddr,
-                                    ResourceID,
-                                    -Amount,
-                                    S6,
-                                    Opts
-                                )}
+                            {error, <<"Undelegation amount exceeds existing delegation.">>}
                     end
-            end
-    end.
+            end,
+        case Validation of
+            {error, _} = Err -> Err;
+            ok ->
+                RecipientDeposit = get_deposit(ToAddr, ResourceID, S, Opts),
+                case liquidate(ToAddr, ResourceID, Amount - RecipientDeposit, S, Opts) of
+                    {error, _} = Err -> Err;
+                    {ok, Liquidated} ->
+                        GlobalDrippedS = drip_global(Liquidated, Opts),
+                        DrippedS = drip_resource(ResourceID, GlobalDrippedS, Opts),
+                        S0 = drip_user(FromAddr, DrippedS, Opts),
+                        S1 = drip_user(ToAddr, S0, Opts),
+                        % Self-undelegation is a noop
+                        case FromAddr =:= ToAddr of
+                            true -> {ok, S1};
+                            false ->
+                                NewRecipientDeposit = get_deposit(ToAddr, ResourceID, S1, Opts),
+                                S2 =
+                                    hb_ao:set(
+                                        S1,
+                                        <<
+                                            "/resources/",
+                                            ResourceID/binary,
+                                            "/deposits/",
+                                            ToAddr/binary,
+                                            "/quantity"
+                                        >>,
+                                        NewRecipientDeposit - Amount,
+                                        Opts
+                                    ),
+                                DelegatorDeposit = get_deposit(FromAddr, ResourceID, S1, Opts),
+                                S3 =
+                                    hb_ao:set(
+                                        S2,
+                                        <<
+                                            "/resources/",
+                                            ResourceID/binary,
+                                            "/deposits/",
+                                            FromAddr/binary,
+                                            "/quantity"
+                                        >>,
+                                        DelegatorDeposit + Amount,
+                                        Opts
+                                    ),
+                                ExistingDelegation =
+                                    hb_ao:get(
+                                        <<
+                                            "/resources/",
+                                            ResourceID/binary,
+                                            "/deposits/",
+                                            FromAddr/binary,
+                                            "/delegations/",
+                                            ToAddr/binary
+                                        >>,
+                                        S1,
+                                        0,
+                                        Opts
+                                    ),
+                                S4 =
+                                    hb_ao:set(
+                                        S3,
+                                        <<
+                                            "/resources/",
+                                            ResourceID/binary,
+                                            "/deposits/",
+                                            FromAddr/binary,
+                                            "/delegations/",
+                                            ToAddr/binary
+                                        >>,
+                                        ExistingDelegation - Amount,
+                                        Opts
+                                    ),
+                                S5 =
+                                    update_deposit_index(
+                                        FromAddr,
+                                        ResourceID,
+                                        get_deposit(FromAddr, ResourceID, S3, Opts),
+                                        S4,
+                                        Opts
+                                    ),
+                                S6 =
+                                    update_deposit_index(
+                                        ToAddr,
+                                        ResourceID,
+                                        get_deposit(ToAddr, ResourceID, S4, Opts),
+                                        S5,
+                                        Opts
+                                    ),
+                                {ok,
+                                    send_delegation_notice(
+                                        FromAddr,
+                                        ToAddr,
+                                        ResourceID,
+                                        -Amount,
+                                        S6,
+                                        Opts
+                                    )}
+                        end
+                end
+        end
+end.
 
 %% @doc Set the weight of a specific resource in the pot. Valid requesters to
 %% change resource parameters are:
@@ -896,7 +906,7 @@ end.
 
 %% @doc Set the weight of a specific resource in the pot, updating the pot state
 %% as necessary.
-register_resource(ResourceID, Weight, S, Opts) ->
+register_resource(ResourceID, Weight, S, Opts) when is_integer(Weight), Weight >= 0 ->
     maybe
         true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
         % Run the global drip to ensure the state is up to date.
@@ -927,7 +937,10 @@ register_resource(ResourceID, Weight, S, Opts) ->
                 Opts
             ),
         send_weight_notice(ResourceID, Weight, AfterSet, Opts)
-end.
+end;
+
+register_resource(_, Weight, _, _) when not is_integer(Weight) ->
+    {error, {<<"Inavlid Weight type.">>}}.
 
 %% @doc Update the inverted index for a specific address in a specific resource.
 update_deposit_index(Addr, ResourceID, Quantity, S, Opts) ->

--- a/src/dev_pot_test_vectors.erl
+++ b/src/dev_pot_test_vectors.erl
@@ -1156,8 +1156,8 @@ deposit_non_binary_address_test() ->
     Opts = #{},
     % Non-binary addresses should fail
     S0 = pot_state_empty([ResourceOxygen]),
-    ?assertError(_, dev_pot:deposit(12345, ResourceOxygen, 10, S0, Opts)),
-    ?assertError(_, dev_pot:deposit(alice, ResourceOxygen, 10, S0, Opts)).
+    ?assertMatch({error, _}, dev_pot:deposit(12345, ResourceOxygen, 10, S0, Opts)),
+    ?assertMatch({error, _}, dev_pot:deposit(alice, ResourceOxygen, 10, S0, Opts)).
 
 delegate_negative_amount_test() ->
     Alice = <<"alice">>,

--- a/src/dev_token.erl
+++ b/src/dev_token.erl
@@ -7,7 +7,7 @@
 %%% excluding in an `info/1` response.
 -export([handle_action/4]).
 %%% Public helpers.
--export([validate_address/1]).
+-export([validate_address/2]).
 -include_lib("include/hb.hrl").
 
 %% @doc `Action' values that should be handled by the `mint-device'.
@@ -81,7 +81,7 @@ handle_action(Action, Base, Req, Opts) ->
 balance(Base, Req, Opts) ->
     maybe
         {ok, Account} ?= hb_ao:resolve(Req, <<"balance">>, Opts),
-        true ?= validate_address(Account),
+        true ?= validate_address(Account, []),
         ?event(
             debug_token,
             {balance_request,
@@ -158,7 +158,7 @@ transfer(Base, Assignment, Opts) ->
             orelse {error, <<"Quantity must be a non-negative integer.">>},
         true ?= (SenderBalance >= Quantity) 
             orelse {error, <<"Insufficient balance.">>},
-        true ?= validate_address(Recipient),
+        true ?= validate_address(Recipient, []),
         % Handle self-transfer: skip balance updates
         NewBaseAfterTransfer =
             case From =:= Recipient of
@@ -303,7 +303,7 @@ enforce_set_authority(Base, Req, Opts) ->
 %% @doc Validate address format for security. the validation
 %% allows binary addresses up to 128 bytes and prevent invalid
 %% addresses such as dev_trie reserved keys.
-validate_address(Address) when is_binary(Address) ->
+validate_address(Address, CustomList) when is_binary(Address), is_list(CustomList) ->
     case byte_size(Address) of
         0 -> {error, <<"Recipient address cannot be empty.">>};
         N when N > 128 -> {error, <<"Recipient address is too long.">>};
@@ -311,6 +311,8 @@ validate_address(Address) when is_binary(Address) ->
             maybe
                 true ?= (not dev_trie:is_reserved_key(Address))
                     orelse {error, <<"Recipient address uses a reserved internal key.">>},
+                true ?= (not is_reserved_custom_key(Address, CustomList))
+                    orelse {error, <<"Address is a reserved custom key">>},
                 % Check for path separators (security: prevent path traversal) and whitespaces.
                 case binary:match(Address, [<<"/">>, <<"\\">>, <<" ">>, <<"\n">>, <<"\r">>, <<"\t">>]) of
                     nomatch -> true;
@@ -318,9 +320,13 @@ validate_address(Address) when is_binary(Address) ->
                 end
             end
     end;
-validate_address(_) ->
+validate_address(_, _) ->
     {error, <<"Recipient address must be a binary.">>}.
-
+%% @doc Check if the given Key exists in the passed List
+is_reserved_custom_key(Key, List) when is_binary(Key), is_list(List) ->
+    lists:member(Key, List);
+is_reserved_custom_key(_, _) -> 
+    false.
 send_error(Base, Assignment, Reason, Opts) when is_atom(Reason) ->
     send_error(Base, Assignment, atom_to_binary(Reason), Opts);
 send_error(Base, Assignment, Reason, Opts) when not is_binary(Reason) ->


### PR DESCRIPTION
* modular dev_token:validated_address function that accepts a custom prohibited keys list
* used dev_token:validated_address across dev_pot functions
* patched some unhandled error propagation