### PR TITLE
impr: add configurable raw gateway priority for hydration routes

### DIFF
--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -32,10 +32,19 @@ start() ->
                 #{}
         end,
     MergedConfig =
-        hb_maps:merge(
-            hb_opts:default_message_with_env(),
-            Loaded
-        ),
+        case maps:is_key(routes, Loaded) of
+            true ->
+                hb_maps:merge(
+                    hb_opts:default_message_with_env(),
+                    Loaded
+                );
+            false ->
+                Merged = hb_maps:merge(
+                    hb_opts:default_message_with_env(),
+                    Loaded
+                ),
+                Merged#{ routes => hb_opts:default_routes(Merged) }
+        end,
     %% Apply store defaults before starting store
     StoreOpts = hb_opts:get(store, no_store, MergedConfig),
     StoreDefaults = hb_opts:get(store_defaults, #{}, MergedConfig),

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -14,7 +14,7 @@
 %%% with a refusal to execute.
 -module(hb_opts).
 -export([get/1, get/2, get/3, as/2, identities/1, load/1, load/2, load_bin/2]).
--export([default_message/0, default_message_with_env/0, mimic_default_types/3]).
+-export([default_message/0, default_message_with_env/0, default_routes/1, mimic_default_types/3]).
 -export([ensure_node_history/2]).
 -export([check_required_opts/2]).
 -include("include/hb.hrl").
@@ -141,6 +141,7 @@ default_message() ->
         compute_mode => lazy,
         %% Choice of remote nodes for tasks that are not local to hyperbeam.
         gateway => <<"https://arweave.net">>,
+        gateway_priorities => [<<"https://arweave.net">>],
         bundler_ans104 => <<"https://up.arweave.net:443">>,
         %% Location of the wallet keyfile on disk that this node will use.
         priv_key_location => <<"hyperbeam-key.json">>,
@@ -267,7 +268,131 @@ default_message() ->
             vmm_type, guest_features
         ],
         name_resolvers => ?DEFAULT_NAME_RESOLVERS,
-        routes => [
+        routes => default_routes(#{}),
+        store =>
+            [
+                ?DEFAULT_PRIMARY_STORE,
+                #{
+                    <<"store-module">> => hb_store_fs,
+                    <<"name">> => <<"cache-mainnet">>
+                },
+                #{
+                    <<"store-module">> => hb_store_gateway,
+                    <<"subindex">> => [
+                        #{
+                            <<"name">> => <<"Data-Protocol">>,
+                            <<"value">> => <<"ao">>
+                        }
+                    ],
+                    <<"local-store">> => [?DEFAULT_PRIMARY_STORE]
+                },
+                #{
+                    <<"store-module">> => hb_store_gateway,
+                    <<"local-store">> => [?DEFAULT_PRIMARY_STORE]
+                }
+            ],
+        match_index => [?DEFAULT_PRIMARY_STORE],
+        priv_store =>
+            [
+                #{
+                    <<"store-module">> => hb_store_fs,
+                    <<"name">> => <<"cache-priv">>
+                }
+            ],
+        %default_index => #{ <<"device">> => <<"hyperbuddy@1.0">> },
+        % Should we use the latest cached state of a process when computing?
+        process_now_from_cache => false,
+        % Should we trust the GraphQL API when converting to ANS-104? Some GQL
+        % services do not provide the `anchor' or `last_tx' fields, so their
+        % responses are not verifiable.
+        ans104_trust_gql => true,
+        http_extra_opts =>
+            #{
+                force_message => true,
+                cache_control => [<<"always">>]
+            },
+        % Should the node store all signed messages?
+        store_all_signed => true,
+        % Should the node use persistent processes?
+        process_workers => false,
+        % Options for the router device
+        router_opts => #{
+            routes => []
+        },
+        on => #{
+            <<"request">> =>
+                [
+                    #{
+                        <<"device">> => <<"rate-limit@1.0">>
+                    },
+                    #{
+                        <<"device">> => <<"auth-hook@1.0">>,
+                        <<"path">> => <<"request">>,
+                        <<"when">> => #{
+                            <<"keys">> => [<<"authorization">>, <<"!">>]
+                        },
+                        <<"secret-provider">> =>
+                            #{
+                                <<"device">> => <<"http-auth@1.0">>,
+                                <<"access-control">> =>
+                                    #{ <<"device">> => <<"http-auth@1.0">> }
+                            }
+                    },
+                    #{
+                        <<"device">> => <<"name@1.0">>
+                    }
+                ]
+        },
+        scheduler_default_commitment_spec => <<"httpsig@1.0">>,
+        genesis_wasm_import_authorities =>
+            [
+                <<"WjnS-s03HWsDSdMnyTdzB1eHZB2QheUWP_FVRVYxkXk">>
+            ],
+        % Should the node track and expose prometheus metrics?
+        % We do not set this explicitly, so that the hb_features:test() value
+        % can be used to determine if we should expose metrics instead,
+        % dynamically changing the configuration based on whether we are running
+        % tests or not. To override this, set the `prometheus' option explicitly.
+        % prometheus => false
+        % Define the behaviour when accessing a file inside a manifest that 
+        % doesn't exists.
+        % Options:
+        % - fallback: Fallback to the index page
+        % - error: Return 404 Not Found
+        manifest_404 => fallback
+    }.
+
+%% @doc Build default node routes, honoring configured gateway priority for
+%% raw data fetches.
+default_routes(Opts) ->
+    DefaultGateway = maps:get(gateway, Opts, <<"https://arweave.net">>),
+    GatewayPriorities =
+        normalize_gateway_priorities(
+            maps:get(gateway_priorities, Opts, [DefaultGateway]),
+            DefaultGateway
+        ),
+    RawGatewayNodes =
+        lists:map(
+            fun(Prefix) ->
+                #{
+                    <<"prefix">> => Prefix,
+                    <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                }
+            end,
+            GatewayPriorities
+        ),
+    ArweaveRawGatewayNodes =
+        lists:map(
+            fun(Prefix) ->
+                #{
+                    <<"match">> => <<"^/arweave">>,
+                    <<"with">> => Prefix,
+                    <<"opts">> => #{ http_client => httpc, protocol => http2 }
+                }
+            end,
+            GatewayPriorities
+        ),
+    [
             %% Local CU routes.
             #{
                 <<"template">> => <<"/result/.*">>,
@@ -458,15 +583,13 @@ default_message() ->
                 <<"stop-after">> => true,
                 <<"admissible-status">> => 200
             },
-            % Raw data requests via arweave.net gateway.
+            % Raw data requests via configured gateway priority.
             #{
                 <<"template">> => <<"^/arweave/raw">>,
-                <<"node">> =>
-                    #{
-                        <<"match">> => <<"^/arweave">>,
-                        <<"with">> => <<"https://arweave.net">>,
-                        <<"opts">> => #{ http_client => httpc, protocol => http2 }
-                    }
+                <<"nodes">> => ArweaveRawGatewayNodes,
+                <<"parallel">> => true,
+                <<"stop-after">> => 1,
+                <<"admissible-status">> => 200
             },
             %% General Arweave requests: race both chain nodes, take
             %% the first 200.
@@ -489,108 +612,35 @@ default_message() ->
                 <<"stop-after">> => 1,
                 <<"admissible-status">> => 200
             },
-            %% Raw data requests via arweave.net gateway. TODO: Update later.
+            %% Raw data requests via configured gateway priority.
             #{
                 <<"template">> => <<"/raw">>,
-                <<"node">> =>
-                    #{
-                        <<"prefix">> => <<"https://arweave.net">>,
-                        <<"opts">> => #{ http_client => gun, protocol => http2 }
-                    }
+                <<"nodes">> => RawGatewayNodes,
+                <<"parallel">> => true,
+                <<"stop-after">> => 1,
+                <<"admissible-status">> => 200
             }
-        ],
-        store =>
-            [
-                ?DEFAULT_PRIMARY_STORE,
-                #{
-                    <<"store-module">> => hb_store_fs,
-                    <<"name">> => <<"cache-mainnet">>
-                },
-                #{
-                    <<"store-module">> => hb_store_gateway,
-                    <<"subindex">> => [
-                        #{
-                            <<"name">> => <<"Data-Protocol">>,
-                            <<"value">> => <<"ao">>
-                        }
-                    ],
-                    <<"local-store">> => [?DEFAULT_PRIMARY_STORE]
-                },
-                #{
-                    <<"store-module">> => hb_store_gateway,
-                    <<"local-store">> => [?DEFAULT_PRIMARY_STORE]
-                }
-            ],
-        match_index => [?DEFAULT_PRIMARY_STORE],
-        priv_store =>
-            [
-                #{
-                    <<"store-module">> => hb_store_fs,
-                    <<"name">> => <<"cache-priv">>
-                }
-            ],
-        %default_index => #{ <<"device">> => <<"hyperbuddy@1.0">> },
-        % Should we use the latest cached state of a process when computing?
-        process_now_from_cache => false,
-        % Should we trust the GraphQL API when converting to ANS-104? Some GQL
-        % services do not provide the `anchor' or `last_tx' fields, so their
-        % responses are not verifiable.
-        ans104_trust_gql => true,
-        http_extra_opts =>
-            #{
-                force_message => true,
-                cache_control => [<<"always">>]
-            },
-        % Should the node store all signed messages?
-        store_all_signed => true,
-        % Should the node use persistent processes?
-        process_workers => false,
-        % Options for the router device
-        router_opts => #{
-            routes => []
-        },
-        on => #{
-            <<"request">> =>
-                [
-                    #{
-                        <<"device">> => <<"rate-limit@1.0">>
-                    },
-                    #{
-                        <<"device">> => <<"auth-hook@1.0">>,
-                        <<"path">> => <<"request">>,
-                        <<"when">> => #{
-                            <<"keys">> => [<<"authorization">>, <<"!">>]
-                        },
-                        <<"secret-provider">> =>
-                            #{
-                                <<"device">> => <<"http-auth@1.0">>,
-                                <<"access-control">> =>
-                                    #{ <<"device">> => <<"http-auth@1.0">> }
-                            }
-                    },
-                    #{
-                        <<"device">> => <<"name@1.0">>
-                    }
-                ]
-        },
-        scheduler_default_commitment_spec => <<"httpsig@1.0">>,
-        genesis_wasm_import_authorities =>
-            [
-                <<"WjnS-s03HWsDSdMnyTdzB1eHZB2QheUWP_FVRVYxkXk">>
-            ],
-        % Should the node track and expose prometheus metrics?
-        % We do not set this explicitly, so that the hb_features:test() value
-        % can be used to determine if we should expose metrics instead,
-        % dynamically changing the configuration based on whether we are running
-        % tests or not. To override this, set the `prometheus' option explicitly.
-        % prometheus => false
-        % Define the behaviour when accessing a file inside a manifest that 
-        % doesn't exists.
-        % Options:
-        % - fallback: Fallback to the index page
-        % - error: Return 404 Not Found
-        manifest_404 => fallback
-    }.
+        ].
+
+normalize_gateway_priorities(Priorities, _DefaultGateway) when is_list(Priorities) ->
+    Priorities;
+normalize_gateway_priorities(Priorities, DefaultGateway) when is_binary(Priorities) ->
+    Trimmed =
+        hb_util:bin(
+            string:trim(binary_to_list(Priorities), both, " []")
+        ),
+    case Trimmed of
+        <<>> -> [DefaultGateway];
+        _ ->
+            lists:map(
+                fun(Entry) ->
+                    hb_util:bin(string:trim(binary_to_list(Entry), both, " "))
+                end,
+                binary:split(Trimmed, <<",">>, [global])
+            )
+    end;
+normalize_gateway_priorities(_, DefaultGateway) ->
+    [DefaultGateway].
 
 %% @doc Get an option from the global options, optionally overriding with a
 %% local `Opts' map if `prefer' or `only' is set to `local'. If the `only' 


### PR DESCRIPTION
HyperBEAM currently relies on a single default raw gateway path in its generated routes. In practice this can cause process hydration and scheduler-location resolution to fail even when the required transaction exists and is retrievable from another gateway.

Why this change is needed:
- process reads and hydration can depend on /raw fetches for scheduler-location and related process metadata
- if a transaction is missing or delayed on arweave.net, the node can fail with no_viable_gateway even though the same tx is available elsewhere
- operators currently need to override complex routing config to change this behavior, which is too heavy for a common reliability concern

What this change does:
- adds a gateway_priorities option alongside the existing gateway option
- generates /raw and /arweave/raw routes from that priority list instead of pinning them to a single gateway
- preserves existing behavior by defaulting gateway_priorities to [https://arweave.net]
- regenerates default routes after config load so operator-provided gateway settings actually affect runtime routing when a full custom route table is not supplied
- accepts both native list input and flat-config string input for gateway_priorities normalization

Why this is production-relevant:
- improves operator control over raw data source failover
- makes hydration and scheduler resolution less sensitive to single-gateway availability gaps
- keeps default behavior stable while allowing safer multi-gateway operation where needed

Scope intentionally kept narrow:
- no project-specific gateway policy is introduced
- no app-specific local-node behavior is included
- request parser changes are left out of this branch so the PR remains focused on routing reliability

Validation:
- rebar3 compile