### PR TITLE
Impr/otp logger 20260320

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -104,11 +104,16 @@
 	{"(linux|darwin)", clean, "make -C \"${REBAR_ROOT_DIR}/native/lib\" secp256k1-clean"},
 	{"(linux|darwin|solaris)", clean, "rm -rf \"${REBAR_ROOT_DIR}/_build\" \"${REBAR_ROOT_DIR}/priv\""},
 	{"(linux|darwin|solaris)", compile, "echo 'Post-compile hooks executed'"},
-    { compile, "rm -f native/hb_beamr/*.o native/hb_beamr/*.d"},
-    { compile, "rm -f native/hb_keccak/*.o native/hb_keccak/*.d"},
-    { compile, "mkdir -p priv/html"},
-    { compile, "cp -R src/html/* priv/html"},
-    { compile, "cp _build/default/lib/elmdb/priv/crates/elmdb_nif/elmdb_nif.so _build/default/lib/elmdb/priv/elmdb_nif.so 2>/dev/null || true" }
+    { compile,
+        "sh -c '"
+            "rm -f native/hb_beamr/*.o native/hb_beamr/*.d; "
+            "rm -f native/hb_keccak/*.o native/hb_keccak/*.d; "
+            "mkdir -p priv/html; "
+            "cp -R src/html/* priv/html; "
+            "cp _build/default/lib/elmdb/priv/crates/elmdb_nif/elmdb_nif.so "
+                "_build/default/lib/elmdb/priv/elmdb_nif.so 2>/dev/null || true"
+        "'"
+    }
 ]}.
 
 {provider_hooks, [

--- a/src/hb.erl
+++ b/src/hb.erl
@@ -97,7 +97,7 @@
 %% @doc Initialize system-wide settings for the hyperbeam node.
 init() ->
     hb_name:start(),
-    hb_event:setup_file_logger(),
+    hb_event:setup_logger(),
     ?event({setting_debug_stack_depth, hb_opts:get(debug_stack_depth)}),
     Old = erlang:system_flag(backtrace_depth, hb_opts:get(debug_stack_depth)),
     ?event({old_system_stack_depth, Old}),

--- a/src/hb.erl
+++ b/src/hb.erl
@@ -97,6 +97,7 @@
 %% @doc Initialize system-wide settings for the hyperbeam node.
 init() ->
     hb_name:start(),
+    hb_event:setup_file_logger(),
     ?event({setting_debug_stack_depth, hb_opts:get(debug_stack_depth)}),
     Old = erlang:system_flag(backtrace_depth, hb_opts:get(debug_stack_depth)),
     ?event({old_system_stack_depth, Old}),

--- a/src/hb_event.erl
+++ b/src/hb_event.erl
@@ -1,7 +1,11 @@
 %%% @doc Wrapper for incrementing prometheus counters.
 -module(hb_event).
 -export([counters/0, diff/1, diff/2]).
+-export([debug_print/4, debug_print/5, debug_print/6]).
+-export([format_file_log/2]).
 -export([log/1, log/2, log/3, log/4, log/5, log/6]).
+-export([log_event/6]).
+-export([setup_file_logger/0]).
 -export([increment/3, increment/4, increment_callers/1]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -9,8 +13,16 @@
 -define(OVERLOAD_QUEUE_LENGTH, 10_000).
 -define(MAX_MEMORY, 50_000_000). % 50 MB
 -define(MAX_EVENT_NAME_LENGTH, 100).
+%% OTP handler for logging to disk.
+-define(FILE_LOGGER, hb_file_logger).
+%% OTP logger domain, logs sent with this domain are directed to hb_file_logger.
+-define(FILE_LOGGER_DOMAIN, [hb]).
+-define(DEFAULT_HANDLER_FILTER, hb_drop_hb_logs).
 
 -ifdef(NO_EVENTS).
+debug_print(_X, _Mod, _Func, _Line) -> ok.
+debug_print(_X, _Mod, _Func, _Line, _Opts) -> ok.
+debug_print(_Topic, _X, _Mod, _Func, _Line, _Opts) -> ok.
 log(_X) -> ok.
 log(_Topic, _X) -> ok.
 log(_Topic, _X, _Mod) -> ok.
@@ -28,34 +40,151 @@ log(Topic, X, Mod, Func, Line) -> log(Topic, X, Mod, Func, Line, #{}).
 log(Topic, X, Mod, undefined, Line, Opts) -> log(Topic, X, Mod, "", Line, Opts);
 log(Topic, X, Mod, Func, undefined, Opts) -> log(Topic, X, Mod, Func, "", Opts);
 log(Topic, X, Mod, Func, Line, Opts) ->
-    % Check if the debug_print option has the topic in it if set.
-    case should_print(Topic, Opts) orelse should_print(Mod, Opts) of
-        true -> hb_format:print(X, Mod, Func, Line, Opts);
-        false -> X
-    end,
+    debug_print(Topic, X, Mod, Func, Line, Opts),
     try increment(Topic, X, Opts) catch _:_ -> ok end,
     % Return the logged value to the caller. This allows callers to insert 
     % `?event(...)' macros into the flow of other executions, without having to
     % break functional style.
     X.
+
+debug_print(X, Mod, Func, Line) ->
+    debug_print(X, Mod, Func, Line, #{}).
+debug_print(X, Mod, Func, Line, Opts) ->
+    debug_print(debug_print, X, Mod, Func, Line, Opts).
+debug_print(Topic, X, Mod, Func, Line, Opts) ->
+    case should_print(print, Topic, Opts)
+        orelse should_print(print, Mod, Opts)
+    of
+        true -> hb_format:print(X, Mod, Func, Line, Opts);
+        false -> X
+    end,
+    case should_print(log, Topic, Opts)
+        orelse should_print(log, Mod, Opts)
+    of
+        true -> log_event(Topic, X, Mod, Func, Line, Opts);
+        false -> ok
+    end,
+    X.
 -endif.
 
-%% @doc Determine if the topic should be printed. Uses a cache in the process
-%% dictionary to avoid re-checking the same topic multiple times.
-should_print(Topic, Opts) ->
-    case erlang:get({event_print, Topic}) of
+%% @doc Determine if the topic should be printed or logged. Uses a cache in the
+%% process dictionary to avoid re-checking the same topic multiple times.
+should_print(Type, Topic, Opts) ->
+    case erlang:get({event_print, Type, Topic}) of
         {cached, X} -> X;
         undefined ->
             Result =
-                case hb_opts:get(debug_print, false, Opts) of
+                case hb_opts:get(print_opt(Type), false, Opts) of
                     EventList when is_list(EventList) ->
                         lists:member(Topic, EventList);
                     true -> true;
                     false -> false
                 end,
-            erlang:put({event_print, Topic}, {cached, Result}),
+            erlang:put({event_print, Type, Topic}, {cached, Result}),
             Result
     end.
+
+print_opt(print) -> debug_print;
+print_opt(log) -> debug_log.
+
+%% @doc Configure a rotating file logger for HyperBEAM events.
+setup_file_logger() ->
+    case hb_opts:get(debug_log) of
+        false -> ok;
+        [] -> ok;
+        _ ->
+            LogFile =
+                filename:join(
+                    hb_util:list(hb_opts:get(log_dir)),
+                    "hyperbeam.log"
+                ),
+            ok = filelib:ensure_dir(LogFile),
+            % Configure the default handler to ignore all hb_logs - this
+            % guarantees that any events logged via OTP do not go to
+            % stdout/err. io:format is used for logging to stdout/err.
+            logger:remove_handler_filter(default, ?DEFAULT_HANDLER_FILTER),
+            case logger:add_handler_filter(
+                default,
+                ?DEFAULT_HANDLER_FILTER,
+                {fun logger_filters:domain/2, {stop, sub, ?FILE_LOGGER_DOMAIN}}
+            ) of
+                ok -> ok;
+                {error, FilterReason} -> erlang:error(FilterReason)
+            end,
+            % Conigure the FILE_LOGGER handler to send all OTP logger events to
+            % the file log on disk.
+            logger:remove_handler(?FILE_LOGGER),
+            case logger:add_handler(
+                ?FILE_LOGGER,
+                logger_std_h,
+                file_logger_config(LogFile)
+            ) of
+                ok -> ok;
+                {error, HandlerReason} -> erlang:error(HandlerReason)
+            end
+    end.
+
+%% @doc Build the OTP logger configuration for the HyperBEAM file handler.
+file_logger_config(LogFile) ->
+    #{
+        level => all,
+        sync_mode_qlen => 200,
+        drop_mode_qlen => 200,
+        flush_qlen => 1000,
+        burst_limit_enable => true,
+        burst_limit_max_count => 500,
+        burst_limit_window_time => 1000,
+        filter_default => stop,
+        filters =>
+            [
+                {
+                    hb_domain,
+                    {fun logger_filters:domain/2, {log, sub, ?FILE_LOGGER_DOMAIN}}
+                }
+            ],
+        formatter =>
+            {
+                logger_formatter,
+                #{
+                    report_cb => fun ?MODULE:format_file_log/2,
+                    template => [time, " ", msg, "\n"],
+                    single_line => false
+                }
+            },
+        config =>
+            #{
+                file => LogFile,
+                max_no_bytes => hb_opts:get(log_max_bytes),
+                max_no_files => hb_opts:get(log_max_files)
+            }
+    }.
+
+%% @doc Queue an event for asynchronous file logging via OTP logger.
+log_event(Topic, X, Mod, Func, Line, Opts) ->
+    logger:log(
+        notice,
+        #{
+            event => X,
+            line => Line,
+            function => Func,
+            module => Mod,
+            opts => Opts
+        },
+        #{
+            domain => ?FILE_LOGGER_DOMAIN,
+            line => Line,
+            function => Func,
+            module => Mod,
+            topic => Topic
+        }
+    ).
+
+%% @doc Render the file log entry in the logger handler process.
+format_file_log(
+    #{event := X, line := Line, function := Func, module := Mod, opts := Opts},
+    _Config
+) ->
+    hb_format:format_debug(X, Mod, Func, Line, Opts).
 
 %% @doc Increment the counter for the given topic and message. Registers the
 %% counter if it doesn't exist. If the topic is `global', the message is ignored.
@@ -258,8 +387,8 @@ benchmark_print_lookup_test() ->
     Iterations =
         hb_test_utils:benchmark(
             fun() ->
-                should_print(test_module, DefaultOpts)
-                    orelse should_print(test_event, DefaultOpts)
+                should_print(print, test_module, DefaultOpts)
+                    orelse should_print(print, test_event, DefaultOpts)
             end,
             0.25
         ),
@@ -276,6 +405,80 @@ benchmark_increment_test() ->
         ),
     hb_test_utils:benchmark_print(<<"Incremented">>, <<"events">>, Iterations),
     ?assert(Iterations >= 1000),
+    ok.
+
+should_log_test() ->
+    ?assertEqual(true, should_print(log, topic_a, #{ debug_log => [topic_a] })),
+    ?assertEqual(false, should_print(log, topic_b, #{ debug_log => [topic_a] })),
+    ?assertEqual(true, should_print(log, topic_c, #{ debug_log => true })),
+    ?assertEqual(false, should_print(log, topic_d, #{ debug_log => false })).
+
+setup_file_logger_test() ->
+    Unique =
+        integer_to_list(erlang:unique_integer([positive, monotonic])),
+    LogDir = filename:join("test", "hb-event-logs-" ++ Unique),
+    LogFile = filename:join(LogDir, "hyperbeam.log"),
+    Env =
+        [
+            {"HB_LOG", "warning"},
+            {"HB_LOG_DIR", LogDir},
+            {"HB_LOG_MAX_FILES", "2"},
+            {"HB_LOG_MAX_BYTES", "4096"}
+        ],
+    Prev = [{Key, os:getenv(Key)} || {Key, _} <- Env],
+    try
+        lists:foreach(
+            fun({Key, Value}) ->
+                os:putenv(Key, Value),
+                clear_env_cache(Key)
+            end,
+            Env
+        ),
+        logger:remove_handler(?FILE_LOGGER),
+        ok = setup_file_logger(),
+        logger:log(notice, "should-not-appear", [], #{domain => [other]}),
+        logger:log(notice, "should-appear", [], #{domain => ?FILE_LOGGER_DOMAIN}),
+        timer:sleep(50),
+        ok = logger:remove_handler(?FILE_LOGGER),
+        {ok, Bin} = file:read_file(LogFile),
+        ?assertNotEqual(nomatch, binary:match(Bin, <<"should-appear">>)),
+        ?assertEqual(nomatch, binary:match(Bin, <<"should-not-appear">>))
+    after
+        logger:remove_handler(?FILE_LOGGER),
+        lists:foreach(
+            fun({Key, false}) ->
+                    os:unsetenv(Key);
+               ({Key, Value}) ->
+                    os:putenv(Key, Value)
+            end,
+            Prev
+        ),
+        lists:foreach(
+            fun({Key, _}) ->
+                clear_env_cache(Key)
+            end,
+            Env
+        ),
+        file:delete(LogFile),
+        file:del_dir(LogDir),
+        ok
+    end.
+
+clear_env_cache("HB_LOG") ->
+    erlang:erase({processed_env, debug_log}),
+    erlang:erase({os_env, "HB_LOG"}),
+    ok;
+clear_env_cache("HB_LOG_DIR") ->
+    erlang:erase({processed_env, log_dir}),
+    erlang:erase({os_env, "HB_LOG_DIR"}),
+    ok;
+clear_env_cache("HB_LOG_MAX_FILES") ->
+    erlang:erase({processed_env, log_max_files}),
+    erlang:erase({os_env, "HB_LOG_MAX_FILES"}),
+    ok;
+clear_env_cache("HB_LOG_MAX_BYTES") ->
+    erlang:erase({processed_env, log_max_bytes}),
+    erlang:erase({os_env, "HB_LOG_MAX_BYTES"}),
     ok.
 
 -ifdef(NO_EVENTS).

--- a/src/hb_event.erl
+++ b/src/hb_event.erl
@@ -5,7 +5,7 @@
 -export([format_file_log/2]).
 -export([log/1, log/2, log/3, log/4, log/5, log/6]).
 -export([log_event/6]).
--export([setup_file_logger/0]).
+-export([setup_logger/0]).
 -export([increment/3, increment/4, increment_callers/1]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -14,10 +14,13 @@
 -define(MAX_MEMORY, 50_000_000). % 50 MB
 -define(MAX_EVENT_NAME_LENGTH, 100).
 %% OTP handler for logging to disk.
+-define(PRINT_LOGGER, hb_print_logger).
+-define(PRINT_LOGGER_DOMAIN, [hb_print]).
 -define(FILE_LOGGER, hb_file_logger).
 %% OTP logger domain, logs sent with this domain are directed to hb_file_logger.
--define(FILE_LOGGER_DOMAIN, [hb]).
--define(DEFAULT_HANDLER_FILTER, hb_drop_hb_logs).
+-define(FILE_LOGGER_DOMAIN, [hb_log]).
+-define(DEFAULT_PRINT_HANDLER_FILTER, hb_drop_hb_print_logs).
+-define(DEFAULT_FILE_HANDLER_FILTER, hb_drop_hb_file_logs).
 
 -ifdef(NO_EVENTS).
 debug_print(_X, _Mod, _Func, _Line) -> ok.
@@ -55,7 +58,7 @@ debug_print(Topic, X, Mod, Func, Line, Opts) ->
     case should_print(print, Topic, Opts)
         orelse should_print(print, Mod, Opts)
     of
-        true -> hb_format:print(X, Mod, Func, Line, Opts);
+        true -> print_event(Topic, X, Mod, Func, Line, Opts);
         false -> X
     end,
     case should_print(log, Topic, Opts)
@@ -88,44 +91,64 @@ print_opt(print) -> debug_print;
 print_opt(log) -> debug_log.
 
 %% @doc Configure a rotating file logger for HyperBEAM events.
-setup_file_logger() ->
-    case hb_opts:get(debug_log) of
-        false -> ok;
-        [] -> ok;
-        _ ->
-            LogFile =
-                filename:join(
-                    hb_util:list(hb_opts:get(log_dir)),
-                    "hyperbeam.log"
-                ),
-            ok = filelib:ensure_dir(LogFile),
-            % Configure the default handler to ignore all hb_logs - this
-            % guarantees that any events logged via OTP do not go to
-            % stdout/err. io:format is used for logging to stdout/err.
-            logger:remove_handler_filter(default, ?DEFAULT_HANDLER_FILTER),
-            case logger:add_handler_filter(
-                default,
-                ?DEFAULT_HANDLER_FILTER,
-                {fun logger_filters:domain/2, {stop, sub, ?FILE_LOGGER_DOMAIN}}
-            ) of
-                ok -> ok;
-                {error, FilterReason} -> erlang:error(FilterReason)
-            end,
-            % Conigure the FILE_LOGGER handler to send all OTP logger events to
-            % the file log on disk.
-            logger:remove_handler(?FILE_LOGGER),
-            case logger:add_handler(
-                ?FILE_LOGGER,
-                logger_std_h,
-                file_logger_config(LogFile)
-            ) of
-                ok -> ok;
-                {error, HandlerReason} -> erlang:error(HandlerReason)
-            end
+setup_logger() ->
+    LogFile =
+        filename:join(
+            hb_util:list(hb_opts:get(log_dir)),
+            "hyperbeam.log"
+        ),
+    ok = filelib:ensure_dir(LogFile),
+    setup_handler(
+        ?PRINT_LOGGER,
+        ?DEFAULT_PRINT_HANDLER_FILTER,
+        ?PRINT_LOGGER_DOMAIN,
+        print_logger_config()
+    ),
+    setup_handler(
+        ?FILE_LOGGER,
+        ?DEFAULT_FILE_HANDLER_FILTER,
+        ?FILE_LOGGER_DOMAIN,
+        file_logger_config(LogFile)
+    ).
+
+setup_handler(Handler, DefaultFilter, Domain, Config) ->
+    ensure_default_handler_filter(DefaultFilter, Domain),
+    logger:remove_handler(Handler),
+    case logger:add_handler(Handler, logger_std_h, Config) of
+        ok -> ok;
+        {error, HandlerReason} -> erlang:error(HandlerReason)
     end.
 
 %% @doc Build the OTP logger configuration for the HyperBEAM file handler.
 file_logger_config(LogFile) ->
+    logger_handler_config(
+        ?FILE_LOGGER_DOMAIN,
+        hb_log_domain,
+        #{
+            report_cb => fun ?MODULE:format_file_log/2,
+            template => [time, " ", msg, "\n"],
+            single_line => false
+        },
+        #{
+            file => LogFile,
+            max_no_bytes => hb_opts:get(log_max_bytes),
+            max_no_files => hb_opts:get(log_max_files)
+        }
+    ).
+
+print_logger_config() ->
+    logger_handler_config(
+        ?PRINT_LOGGER_DOMAIN,
+        hb_print_domain,
+        #{
+            report_cb => fun ?MODULE:format_file_log/2,
+            template => [msg, "\n"],
+            single_line => false
+        },
+        #{type => standard_error}
+    ).
+
+logger_handler_config(Domain, FilterId, FormatterConfig, HandlerConfig) ->
     #{
         level => all,
         sync_mode_qlen => 200,
@@ -138,48 +161,62 @@ file_logger_config(LogFile) ->
         filters =>
             [
                 {
-                    hb_domain,
-                    {fun logger_filters:domain/2, {log, sub, ?FILE_LOGGER_DOMAIN}}
+                    FilterId,
+                    {fun logger_filters:domain/2, {log, sub, Domain}}
                 }
             ],
-        formatter =>
-            {
-                logger_formatter,
-                #{
-                    report_cb => fun ?MODULE:format_file_log/2,
-                    template => [time, " ", msg, "\n"],
-                    single_line => false
-                }
-            },
-        config =>
-            #{
-                file => LogFile,
-                max_no_bytes => hb_opts:get(log_max_bytes),
-                max_no_files => hb_opts:get(log_max_files)
-            }
+        formatter => {logger_formatter, FormatterConfig},
+        config => HandlerConfig
     }.
+
+ensure_default_handler_filter(FilterId, Domain) ->
+    logger:remove_handler_filter(default, FilterId),
+    case logger:add_handler_filter(
+        default,
+        FilterId,
+        {fun logger_filters:domain/2, {stop, sub, Domain}}
+    ) of
+        ok -> ok;
+        {error, FilterReason} -> erlang:error(FilterReason)
+    end.
+
+print_event(Topic, X, Mod, Func, Line, Opts) ->
+    logger:log(
+        notice,
+        event_report(X, Mod, Func, Line, Opts),
+        (event_metadata(Topic, Mod, Func, Line))#{
+            domain => ?PRINT_LOGGER_DOMAIN
+        }
+    ).
 
 %% @doc Queue an event for asynchronous file logging via OTP logger.
 log_event(Topic, X, Mod, Func, Line, Opts) ->
     logger:log(
         notice,
-        #{
-            event => X,
-            line => Line,
-            function => Func,
-            module => Mod,
-            opts => Opts
-        },
-        #{
-            domain => ?FILE_LOGGER_DOMAIN,
-            line => Line,
-            function => Func,
-            module => Mod,
-            topic => Topic
+        event_report(X, Mod, Func, Line, Opts),
+        (event_metadata(Topic, Mod, Func, Line))#{
+            domain => ?FILE_LOGGER_DOMAIN
         }
     ).
 
-%% @doc Render the file log entry in the logger handler process.
+event_report(X, Mod, Func, Line, Opts) ->
+    #{
+        event => X,
+        line => Line,
+        function => Func,
+        module => Mod,
+        opts => Opts
+    }.
+
+event_metadata(Topic, Mod, Func, Line) ->
+    #{
+        line => Line,
+        function => Func,
+        module => Mod,
+        topic => Topic
+    }.
+
+%% @doc Render the event log entry in the logger handler process.
 format_file_log(
     #{event := X, line := Line, function := Func, module := Mod, opts := Opts},
     _Config
@@ -412,74 +449,6 @@ should_log_test() ->
     ?assertEqual(false, should_print(log, topic_b, #{ debug_log => [topic_a] })),
     ?assertEqual(true, should_print(log, topic_c, #{ debug_log => true })),
     ?assertEqual(false, should_print(log, topic_d, #{ debug_log => false })).
-
-setup_file_logger_test() ->
-    Unique =
-        integer_to_list(erlang:unique_integer([positive, monotonic])),
-    LogDir = filename:join("test", "hb-event-logs-" ++ Unique),
-    LogFile = filename:join(LogDir, "hyperbeam.log"),
-    Env =
-        [
-            {"HB_LOG", "warning"},
-            {"HB_LOG_DIR", LogDir},
-            {"HB_LOG_MAX_FILES", "2"},
-            {"HB_LOG_MAX_BYTES", "4096"}
-        ],
-    Prev = [{Key, os:getenv(Key)} || {Key, _} <- Env],
-    try
-        lists:foreach(
-            fun({Key, Value}) ->
-                os:putenv(Key, Value),
-                clear_env_cache(Key)
-            end,
-            Env
-        ),
-        logger:remove_handler(?FILE_LOGGER),
-        ok = setup_file_logger(),
-        logger:log(notice, "should-not-appear", [], #{domain => [other]}),
-        logger:log(notice, "should-appear", [], #{domain => ?FILE_LOGGER_DOMAIN}),
-        timer:sleep(50),
-        ok = logger:remove_handler(?FILE_LOGGER),
-        {ok, Bin} = file:read_file(LogFile),
-        ?assertNotEqual(nomatch, binary:match(Bin, <<"should-appear">>)),
-        ?assertEqual(nomatch, binary:match(Bin, <<"should-not-appear">>))
-    after
-        logger:remove_handler(?FILE_LOGGER),
-        lists:foreach(
-            fun({Key, false}) ->
-                    os:unsetenv(Key);
-               ({Key, Value}) ->
-                    os:putenv(Key, Value)
-            end,
-            Prev
-        ),
-        lists:foreach(
-            fun({Key, _}) ->
-                clear_env_cache(Key)
-            end,
-            Env
-        ),
-        file:delete(LogFile),
-        file:del_dir(LogDir),
-        ok
-    end.
-
-clear_env_cache("HB_LOG") ->
-    erlang:erase({processed_env, debug_log}),
-    erlang:erase({os_env, "HB_LOG"}),
-    ok;
-clear_env_cache("HB_LOG_DIR") ->
-    erlang:erase({processed_env, log_dir}),
-    erlang:erase({os_env, "HB_LOG_DIR"}),
-    ok;
-clear_env_cache("HB_LOG_MAX_FILES") ->
-    erlang:erase({processed_env, log_max_files}),
-    erlang:erase({os_env, "HB_LOG_MAX_FILES"}),
-    ok;
-clear_env_cache("HB_LOG_MAX_BYTES") ->
-    erlang:erase({processed_env, log_max_bytes}),
-    erlang:erase({os_env, "HB_LOG_MAX_BYTES"}),
-    ok.
 
 -ifdef(NO_EVENTS).
 benchmark_drain_rate_test() -> ok.

--- a/src/hb_format.erl
+++ b/src/hb_format.erl
@@ -10,6 +10,7 @@
 -module(hb_format).
 %%% Public API.
 -export([term/1, term/2, term/3]).
+-export([format_debug/5]).
 -export([print/1, print/3, print/4, print/5, eunit_print/2]).
 -export([message/1, message/2, message/3]).
 -export([binary/2, error/2, trace/1, trace_short/0, trace_short/1]).
@@ -30,15 +31,16 @@
 print(X) ->
     print(X, <<>>, #{}).
 print(X, Info, Opts) ->
-    io:format(
-        standard_error,
-        "=== HB DEBUG ===~s==>~n~s~n",
-        [Info, term(X, Opts, 0)]
-    ),
+    io:format(standard_error, "~s~n", [render_debug(X, Info, Opts)]),
     X.
 print(X, Mod, Func, LineNum) ->
     print(X, debug_trace(Mod, Func, LineNum, #{}), #{}).
 print(X, Mod, Func, LineNum, Opts) ->
+    io:format(standard_error, "~s~n", [format_debug(X, Mod, Func, LineNum, Opts)]),
+    X.
+
+%% @doc Format a debug message without writing it, preserving the standard layout.
+format_debug(X, Mod, Func, LineNum, Opts) ->
     Now = erlang:system_time(millisecond),
     Last = erlang:put(last_debug_print, Now),
     TSDiff = case Last of undefined -> 0; _ -> Now - Last end,
@@ -62,7 +64,16 @@ print(X, Mod, Func, LineNum, Opts) ->
                 ]
             )
         ),
-    print(X, Info, Opts).
+    render_debug(X, Info, Opts).
+
+%% @doc Render a debug message using the standard HyperBEAM layout.
+render_debug(X, Info, Opts) ->
+    hb_util:bin(
+        io_lib:format(
+            "=== HB DEBUG ===~s==>~n~s",
+            [Info, term(X, Opts, 0)]
+        )
+    ).
 
 %% @doc Retreive the server ID of the calling process, if known.
 server_id() ->

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -81,6 +81,15 @@
                 fun topic_list_to_atoms/1,
                 {preparsed, ?DEFAULT_PRINT_OPTS}
             },
+        debug_log =>
+            {
+                "HB_LOG",
+                fun topic_list_to_atoms/1,
+                {preparsed, false}
+            },
+        log_dir => {"HB_LOG_DIR", fun hb_util:bin/1, "logs"},
+        log_max_files => {"HB_LOG_MAX_FILES", fun hb_util:int/1, "5"},
+        log_max_bytes => {"HB_LOG_MAX_BYTES", fun hb_util:int/1, "52428800"},
         lua_scripts => {"LUA_SCRIPTS", "scripts"},
         lua_tests => {"LUA_TESTS", fun dev_lua_test:parse_spec/1, tests},
         default_index =>
@@ -258,6 +267,10 @@ default_message() ->
         node_history => [],
         debug_stack_depth => 40,
         debug_print => false,
+        debug_log => false,
+        log_dir => <<"logs">>,
+        log_max_files => 5,
+        log_max_bytes => 52428800,
         debug_print_map_line_threshold => 30,
         debug_print_binary_max => 60,
         debug_print_indent => 2,
@@ -893,7 +906,11 @@ global_get_test() ->
     ?assertEqual(debug, ?MODULE:get(mode)),
     ?assertEqual(debug, ?MODULE:get(mode, production)),
     ?assertEqual(undefined, ?MODULE:get(unset_global_key)),
-    ?assertEqual(1234, ?MODULE:get(unset_global_key, 1234)).
+    ?assertEqual(1234, ?MODULE:get(unset_global_key, 1234)),
+    ?assertEqual(false, ?MODULE:get(debug_log)),
+    ?assertEqual(<<"logs">>, ?MODULE:get(log_dir)),
+    ?assertEqual(5, ?MODULE:get(log_max_files)),
+    ?assertEqual(52428800, ?MODULE:get(log_max_bytes)).
 
 local_get_test() ->
     Local = #{ only => local },

--- a/src/include/hb.hrl
+++ b/src/include/hb.hrl
@@ -32,7 +32,7 @@
 -define(event(Topic, X), hb_event:log(Topic, X, ?MODULE, ?FUNCTION_NAME, ?LINE)).
 -define(event(Topic, X, Opts), hb_event:log(maps:get(topic, Opts, Topic), X, ?MODULE, ?FUNCTION_NAME, ?LINE, Opts)).
 -define(debug_wait(T), hb:debug_wait(T, ?MODULE, ?FUNCTION_NAME, ?LINE)).
--define(debug_print(X), hb_format:print(X, ?MODULE, ?FUNCTION_NAME, ?LINE)).
+-define(debug_print(X), hb_event:debug_print(X, ?MODULE, ?FUNCTION_NAME, ?LINE)).
 -define(no_prod(X), hb:no_prod(X, ?MODULE, ?LINE)).
 
 %%% Macro shortcuts for debugging.


### PR DESCRIPTION
Add support for the asynchronous, non-blocking OTP logger.

Configured via:

- `HB_LOG` / `debug_log` (same format as `HB_PRINT` / `debug_print`) - default false
- `HB_LOG_DIR` / `log_dir` (directory to write the logs to) - default `logs`
- `HB_LOG_MAX_FILES` / `log_max_files` (max number of rotating log files) - default 5
- `HB_LOG_MAX_BYTES` / `log_max_bytes` (max size of each rotating log file) - default 50 MiB