### PR TITLE
impr: Handle errors better in hb_store_arweave

### DIFF
--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -131,10 +131,24 @@ do_read(StoreOpts, ID) ->
                     ),
                     record_partition_metric(StartOffset, ok),
                     Loaded;
-                {error, Reason} ->
+                {error, not_found} ->
+                    record_partition_metric(StartOffset, not_found),
                     ?event(
                         arweave_offsets,
                         {read_chunks_not_found, 
+                            {id, {explicit, ID}},
+                            {format_version, Version},
+                            {type, CodecName},
+                            {start_offset, StartOffset},
+                            {length, Length}
+                        }
+                    ),
+                    not_found;
+                {error, Reason} ->
+                    record_partition_metric(StartOffset, failure),
+                    ?event(
+                        error,
+                        {arweave_offsets_read_chunks, 
                             {id, {explicit, ID}},
                             {format_version, Version},
                             {type, CodecName},
@@ -143,10 +157,7 @@ do_read(StoreOpts, ID) ->
                             {reason, Reason}
                         }
                     ),
-                    record_partition_metric(StartOffset, not_found),
-                    if Reason =:= not_found -> not_found;
-                    true -> {error, Reason}
-                    end
+                    failure
             end;
         not_found ->
             ?event(


### PR DESCRIPTION
When the HTTP client `hackney` exhausts the connection pool, it can return `{error, checkout_timeout}` as a response. This  is passed down the stacktrace until `hb_cache:store_read` https://github.com/permaweb/HyperBEAM/blob/impr/gun/src/hb_cache.erl#L495 which doesn't handled the error tuple case.

One possible solution is that we return a value that is handled, like `failure`.
The advantage of doing this in `hb_store_arweave` is to separate the chunk not found from chunk failure, which better represents the behaviour.