### PR TITLE
metrics: track bytes requested per chunk load in dev_arweave

### DIFF
--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -421,6 +421,10 @@ fetch_chunk_range(Offset, Length, Opts) ->
 %% Note: we don't want to *always* query an extra chunk because if it doesn't
 %% exist, dev_arweave will consider the dataitem missing.
 fetch_post_threshold(Offset, EndOffset, Opts) ->
+    hb_prometheus:observe(
+        EndOffset - Offset,
+        arweave_chunk_load_requested_bytes,
+        []),
     Offsets = generate_offsets(Offset, EndOffset, ?DATA_CHUNK_SIZE),
     case fetch_and_collect(Offsets, Opts) of
         {ok, ChunkInfos} ->
@@ -453,6 +457,10 @@ fetch_post_threshold(Offset, EndOffset, Opts) ->
 %% DATA_CHUNK_SIZE increments plus one extra candidate chunk, then
 %% iteratively fill gaps until contiguous.
 fetch_pre_threshold(Offset, EndOffset, Opts) ->
+    hb_prometheus:observe(
+        EndOffset - Offset,
+        arweave_chunk_load_requested_bytes,
+        []),
     Offsets = generate_offsets(Offset, EndOffset, ?DATA_CHUNK_SIZE),
     case fetch_and_collect(Offsets, Opts) of
         {ok, ChunkInfos} ->

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -636,7 +636,6 @@ get_chunk(Offset, Opts) ->
     % when querying some *dataitems* does cause an error. So for now we will
     % leaeve the header out and continue to search for a case where it is
     % needed.
-    ?event(arweave_short, fetch_chunk, Opts),
     Path = <<"/chunk/", (hb_util:bin(Offset))/binary>>,
     request(<<"GET">>, Path, #{ <<"route-by">> => Offset }, Opts).
 

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -636,6 +636,7 @@ get_chunk(Offset, Opts) ->
     % when querying some *dataitems* does cause an error. So for now we will
     % leaeve the header out and continue to search for a case where it is
     % needed.
+    ?event(arweave_short, fetch_chunk, Opts),
     Path = <<"/chunk/", (hb_util:bin(Offset))/binary>>,
     request(<<"GET">>, Path, #{ <<"route-by">> => Offset }, Opts).
 

--- a/src/hb_http_client.erl
+++ b/src/hb_http_client.erl
@@ -599,6 +599,16 @@ init_prometheus() ->
 		{name, http_client_uploaded_bytes_total},
 		{help, "The total amount of bytes posted via HTTP, per remote endpoint"}
 	]),
+	hb_prometheus:declare(histogram, [
+		{name, arweave_chunk_load_requested_bytes},
+		{buckets, [
+			262144, 1048576, 10485760, 104857600,
+			524288000, 1073741824
+		]},
+		{help,
+			"Bytes requested per generate_offsets call"
+			" in dev_arweave chunk loading"}
+	]),
     ?event(started),
     ok.
 


### PR DESCRIPTION
Add arweave_chunk_load_requested_bytes histogram to observe the data size requested in each generate_offsets call. Buckets range from 256KB to 1GB to capture the full spectrum from single-chunk items to large TX downloads. Helps identify unexpectedly large load requests that could lead to memory pressure.