### PR TITLE
fix: several inputs stricter validations

### DIFF
--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -422,14 +422,14 @@ verify_resource_authority(ResourceID, Base, Req, Opts) ->
                 <<"No `from' address provided.">>,
                 Opts
             ),
-        {ok, Resources} =
+        {ok, Resources} ?=
             hb_maps:find(
                 <<"resources">>,
                 Base,
                 <<"No resources found in mint state.">>,
                 Opts
             ),
-        {ok, Resource} = 
+        {ok, Resource} ?= 
             hb_maps:find(
                 ResourceID,
                 Resources,
@@ -856,7 +856,7 @@ end.
 %%
 %% N.B: `dev_security` is open-by-default when no valid/required/match policy
 %% is present, so absent authority config does not restrict this action. check
-%% AuthRes logic chain for better gating-understanding.
+%% `AuthRes` logic chain for better gating-understanding.
 register(State, Assignment, Opts) ->
     ?event(debug_pot, {register, Assignment}, Opts),
     maybe

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -452,8 +452,9 @@ verify_resource_authority(ResourceID, Base, Req, Opts) ->
         true ?= dev_security:validate(<<"authority">>, Resource, Req, From, Opts)
     end.
 
-%% @doc Interpret `notify' messages as if they were direct deposit/withdrawal
-%% requests, if they are sent `from' our `parent' mint process (if set).
+%% @doc Interpret forwarded `register' notifications from the configured
+%% `parent' mint process. Notifications from any other sender, or notifications
+%% forwarding a non-`register' action, are rejected.
 notify(State, Assignment, Opts) ->
     maybe
         {ok, Req} ?=

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -354,7 +354,11 @@ deposit(State, Assignment, Opts) ->
     end.
 -spec deposit(binary(), binary(), pos_integer(), map(), map()) -> map().
 deposit(Addr, ResourceID, Amount, S0, Opts) when is_integer(Amount), Amount > 0 ->
-    modify_deposit_state(Addr, ResourceID, Amount, S0, Opts).
+    modify_deposit_state(Addr, ResourceID, Amount, S0, Opts);
+deposit(_, _, Amount, _, _) when is_integer(Amount), Amount < 0 ->
+    {error, <<"Deposit amount must be positive Integer.">>};
+deposit(_, _, Amount, _, _) when not is_integer(Amount) ->
+    {error, <<"Deposit amount must be Integer.">>}.
 
 %% @doc Withdraw a quantity of a resource for a given address. If the quantity
 %% is insufficient, we'll revoke delegations until the withdrawal can be completed.
@@ -378,7 +382,12 @@ withdraw(Addr, ResourceID, Amount, S0, Opts) when is_integer(Amount), Amount > 0
         modify_deposit_state(Addr, ResourceID, -Amount, S1, Opts)
     else
         {error, _} = WithdrawErr -> WithdrawErr
-    end.
+    end;
+withdraw(_, _, Amount, _, _) when is_integer(Amount), Amount < 0 ->
+    {error,  <<"Withdraw amount must be a positive Integer.">>};
+withdraw(_, _, Amount, _, _) when not is_integer(Amount) ->
+    {error, <<"Withdraw amount must be an Integer.">>}.
+
 %% @doc Parse a request to modify a deposit and verify that it originates from
 %% the valid resource authority. Returns `{ok, {Address, ResourceID, Amount}}'
 %% if the request is valid, otherwise returns `{error, Reason}'.

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -470,6 +470,15 @@ notify(State, Assignment, Opts) ->
                 <<"No `from' address provided.">>,
                 Opts
             ),
+        {ok, Parent} ?=
+            hb_maps:find(
+                <<"parent">>,
+                State,
+                <<"No `parent` configured for notifications">>,
+                Opts
+            ),
+        true ?= (NotifyFrom =:= Parent) orelse
+            {error, <<"Invalid notification source">>},
         ForwardedMsg = dev_process_outbox:original_from_forwarded(Req, Opts),
         {ok, Action} ?=
             hb_maps:find(
@@ -477,6 +486,8 @@ notify(State, Assignment, Opts) ->
                 ForwardedMsg,
                 Opts
             ),
+        true ?= (Action =:= <<"register">>) orelse
+            {error, <<"Unsupported notification action">>},
         OriginalFrom = hb_maps:get(<<"from">>, ForwardedMsg, <<"unknown">>, Opts),
         dev_token:handle_action(
             Action, 

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -352,11 +352,13 @@ deposit(State, Assignment, Opts) ->
     else
         Reason -> {error, Reason}
     end.
--spec deposit(binary(), binary(), pos_integer(), map(), map()) -> map().
+-spec deposit(binary(), binary(), pos_integer(), map(), map()) -> map() | {error, term()}.
 deposit(Addr, ResourceID, Amount, S0, Opts) when is_integer(Amount), Amount > 0 ->
     modify_deposit_state(Addr, ResourceID, Amount, S0, Opts);
 deposit(_, _, Amount, _, _) when is_integer(Amount), Amount < 0 ->
     {error, <<"Deposit amount must be positive Integer.">>};
+deposit(_, _, Amount, _, _) when is_integer(Amount), Amount =:= 0 ->
+    {error, <<"Deposit amount must be a non-zero positive Integer.">>};
 deposit(_, _, Amount, _, _) when not is_integer(Amount) ->
     {error, <<"Deposit amount must be Integer.">>}.
 
@@ -385,6 +387,8 @@ withdraw(Addr, ResourceID, Amount, S0, Opts) when is_integer(Amount), Amount > 0
     end;
 withdraw(_, _, Amount, _, _) when is_integer(Amount), Amount < 0 ->
     {error,  <<"Withdraw amount must be a positive Integer.">>};
+withdraw(_, _, Amount, _, _) when is_integer(Amount), Amount =:= 0 ->
+    {error, <<"Withdraw amount must be a non-zero positive Integer.">>};
 withdraw(_, _, Amount, _, _) when not is_integer(Amount) ->
     {error, <<"Withdraw amount must be an Integer.">>}.
 
@@ -702,9 +706,11 @@ delegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when is_integer(Amount),
         end
 end;
 delegate(_, _, _, Amount, _, _) when is_integer(Amount), Amount < 0 ->
-    {error, <<"Delegation Amount must be a non-negative integer">>};
+    {error, <<"Delegate Amount must be a non-negative integer">>};
+delegate(_, _, _, Amount, _, _) when is_integer(Amount), Amount =:= 0 ->
+    {error, <<"Delegate amount must be a non-zero positive Integer.">>};
 delegate(_, _, _, Amount, _, _) when not is_integer(Amount)->
-    {error, <<"Delegation Amount must be of integer type">>}.
+    {error, <<"Delegate Amount must be of integer type">>}.
 
 %% @doc Undelegate some quantity of a resource from one address to another.
 -spec undelegate(map(), map(), map()) -> {ok, map()} | {error, term()}.
@@ -862,9 +868,11 @@ undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when is_integer(Amount
         end
 end;
 undelegate(_, _, _, Amount, _, _) when is_integer(Amount), Amount < 0 ->
-    {error, <<"Undelegation Amount must be a non-negative integer">>};
+    {error, <<"Undelegate Amount must be a non-negative integer">>};
+undelegate(_, _, _, Amount, _, _) when is_integer(Amount), Amount =:= 0 ->
+    {error, <<"Undelegate amount must be a non-zero positive Integer.">>};
 undelegate(_, _, _, Amount, _, _) when not is_integer(Amount)->
-    {error, <<"Undelegation Amount must be of integer type">>}.
+    {error, <<"Undelegate Amount must be of integer type">>}.
 
 %% @doc Set resource parameters in the pot. Authorization is evaluated against:
 %% - `State/parent`, if set and equal to `from`

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -572,7 +572,7 @@ delegate(State, Assignment, Opts) ->
         Reason -> {error, Reason}
     end.
 -spec delegate(binary(), binary(), binary(), pos_integer(), map(), map()) -> {ok, map()} | {error, term()}.
-delegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
+delegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when is_integer(Amount), Amount > 0 ->
     maybe
         true ?= dev_token:validate_address(FromAddr, ?RESERVED_KEYS),
         true ?= dev_token:validate_address(ToAddr, ?RESERVED_KEYS),
@@ -700,7 +700,11 @@ delegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
                             )}
                 end
         end
-end.
+end;
+delegate(_, _, _, Amount, _, _) when is_integer(Amount), Amount < 0 ->
+    {error, <<"Delegation Amount must be a non-negative integer">>};
+delegate(_, _, _, Amount, _, _) when not is_integer(Amount)->
+    {error, <<"Delegation Amount must be of integer type">>}.
 
 %% @doc Undelegate some quantity of a resource from one address to another.
 -spec undelegate(map(), map(), map()) -> {ok, map()} | {error, term()}.
@@ -724,7 +728,7 @@ undelegate(State, Assignment, Opts) ->
         Reason -> {error, Reason}
     end.
 -spec undelegate(binary(), binary(), binary(), pos_integer(), map(), map()) -> {ok, map()} | {error, term()}.
-undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
+undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when is_integer(Amount), Amount > 0 ->
     maybe
         true ?= dev_token:validate_address(FromAddr, ?RESERVED_KEYS),
         true ?= dev_token:validate_address(ToAddr, ?RESERVED_KEYS),
@@ -856,7 +860,11 @@ undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
                         end
                 end
         end
-end.
+end;
+undelegate(_, _, _, Amount, _, _) when is_integer(Amount), Amount < 0 ->
+    {error, <<"Undelegation Amount must be a non-negative integer">>};
+undelegate(_, _, _, Amount, _, _) when not is_integer(Amount)->
+    {error, <<"Undelegation Amount must be of integer type">>}.
 
 %% @doc Set resource parameters in the pot. Authorization is evaluated against:
 %% - `State/parent`, if set and equal to `from`

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -849,11 +849,14 @@ undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when Amount > 0 ->
         end
 end.
 
-%% @doc Set the weight of a specific resource in the pot. Valid requesters to
-%% change resource parameters are:
-%% - The `State/parent' address, if set.
-%% - The `mint-authority' address, if set.
-%% - The `resource-authority' address for the resource.
+%% @doc Set resource parameters in the pot. Authorization is evaluated against:
+%% - `State/parent`, if set and equal to `from`
+%% - `mint-authority` security policy on the pot state, if configured
+%% - `authority` security policy on the target resource, if configured
+%%
+%% N.B: `dev_security` is open-by-default when no valid/required/match policy
+%% is present, so absent authority config does not restrict this action. check
+%% AuthRes logic chain for better gating-understanding.
 register(State, Assignment, Opts) ->
     ?event(debug_pot, {register, Assignment}, Opts),
     maybe
@@ -873,10 +876,17 @@ register(State, Assignment, Opts) ->
                 <<"No `from' address provided.">>, 
                 Opts
             ),
-        true ?=
-            (hb_maps:get(<<"parent">>, State, no_parent, Opts) =:= From) orelse
-            dev_security:validate(<<"mint-authority">>, State, Req, From, Opts) orelse
-                verify_resource_authority(ResID, State, Req, Opts),
+        
+        AuthRes = case (hb_maps:get(<<"parent">>, State, no_parent, Opts) =:= From) of
+            true -> true;
+            false -> case dev_security:validate(<<"mint-authority">>, State, Req, From, Opts) of
+                true -> true;
+                {error, _} -> 
+                    verify_resource_authority(ResID, State, Req, Opts)
+                end  
+        end,
+        true ?= AuthRes,
+
         State2 ?=
             case hb_maps:find(<<"weight">>, Req, Opts) of
                 {ok, Weight} -> register_resource(ResID, Weight, State, Opts);

--- a/src/dev_pot_test_vectors.erl
+++ b/src/dev_pot_test_vectors.erl
@@ -672,8 +672,8 @@ deposit_zero_amount_test() ->
     % Depositing 0 should be a no-op
     S0 = pot_state(Alice, ResourceOxygen, 10),
     % deposit/5 has guard `when Amount > 0`, so calling with 0 should not match
-    ?assertError(
-        function_clause, 
+    ?assertMatch(
+        {error, _}, 
         dev_pot:deposit(Alice, ResourceOxygen, 0, S0, Opts)
     ).
 
@@ -695,8 +695,8 @@ delegate_zero_amount_test() ->
     Opts = #{},
     % Delegating 0 should not match the function guard
     S0 = pot_state_multi(ResourceOxygen, [{Alice, 10}, {Bob, 0}]),
-    ?assertError(
-        function_clause, 
+    ?assertMatch(
+        {error, _}, 
         delegate(Alice, Bob, ResourceOxygen, 0, S0, Opts)
     ).
 

--- a/src/dev_pot_test_vectors.erl
+++ b/src/dev_pot_test_vectors.erl
@@ -1125,8 +1125,8 @@ deposit_with_negative_amount_test() ->
     Opts = #{},
     % Negative deposits should be rejected
     S0 = pot_state_empty([ResourceOxygen]),
-    ?assertError(
-        function_clause, 
+    ?assertMatch(
+        {error, _},
         dev_pot:deposit(Alice, ResourceOxygen, -10, S0, Opts)
     ).
 
@@ -1136,8 +1136,8 @@ withdraw_with_negative_amount_test() ->
     Opts = #{},
     % Negative withdrawals should be rejected
     S0 = pot_state(Alice, ResourceOxygen, 10),
-    ?assertError(
-        function_clause, 
+    ?assertMatch(
+        {error, _},
         dev_pot:withdraw(Alice, ResourceOxygen, -5, S0, Opts)
     ).
 
@@ -1147,9 +1147,9 @@ deposit_non_integer_quantity_test() ->
     Opts = #{},
     % Non-integer quantities should be rejected
     S0 = pot_state_empty([ResourceOxygen]),
-    ?assertError(_, dev_pot:deposit(Alice, ResourceOxygen, 10.5, S0, Opts)),
-    ?assertError(_, dev_pot:deposit(Alice, ResourceOxygen, ten, S0, Opts)),
-    ?assertError(_, dev_pot:deposit(Alice, ResourceOxygen, "10", S0, Opts)).
+    ?assertMatch({error, _}, dev_pot:deposit(Alice, ResourceOxygen, 10.5, S0, Opts)),
+    ?assertMatch({error, _}, dev_pot:deposit(Alice, ResourceOxygen, ten, S0, Opts)),
+    ?assertMatch({error, _}, dev_pot:deposit(Alice, ResourceOxygen, "10", S0, Opts)).
 
 deposit_non_binary_address_test() ->
     ResourceOxygen = <<"oxygen">>,
@@ -1166,8 +1166,8 @@ delegate_negative_amount_test() ->
     Opts = #{},
     % Negative delegation amount should be rejected
     S0 = pot_state_multi(ResourceOxygen, [{Alice, 10}, {Bob, 0}]),
-    ?assertError(
-        function_clause, 
+    ?assertMatch(
+        {error, _},
         delegate(Alice, Bob, ResourceOxygen, -5, S0, Opts)
     ).
 

--- a/src/dev_pot_test_vectors.erl
+++ b/src/dev_pot_test_vectors.erl
@@ -1242,6 +1242,45 @@ multiple_delegations_outbox_order_test() ->
     ?assertEqual(Charlie, hb_maps:get(<<"target">>, Notice1, not_found, Opts)),
     ?assertEqual(Bob, hb_maps:get(<<"target">>, Notice2, not_found, Opts)).
 
+notify_rejects_non_parent_source_test() ->
+    Parent = <<"parent">>,
+    Mallory = <<"mallory">>,
+    ResourceOxygen = <<"oxygen">>,
+    Opts = #{},
+    State = (pot_state_empty([ResourceOxygen]))#{ <<"parent">> => Parent },
+    Assignment =
+        #{
+            <<"body">> =>
+                #{
+                    <<"from">> => Mallory,
+                    <<"x-action">> => <<"register">>,
+                    <<"x-resource">> => ResourceOxygen,
+                    <<"x-weight">> => 2
+                }
+        },
+    ?assertMatch(
+        {error, <<"Invalid notification source">>},
+        dev_pot:notify(State, Assignment, Opts)
+    ).
+
+notify_rejects_non_register_forward_action_test() ->
+    Parent = <<"parent">>,
+    ResourceOxygen = <<"oxygen">>,
+    Opts = #{},
+    State = (pot_state_empty([ResourceOxygen]))#{ <<"parent">> => Parent },
+    Assignment =
+        #{
+            <<"body">> =>
+                #{
+                    <<"from">> => Parent,
+                    <<"x-action">> => <<"deposit">>
+                }
+        },
+    ?assertMatch(
+        {error, <<"Unsupported notification action">>},
+        dev_pot:notify(State, Assignment, Opts)
+    ).
+
 %%% Empty/Zero State Tests
 
 zero_mint_cap_test() ->


### PR DESCRIPTION
-  fix: incorrect orelse chaining usage :

```erl
true ?=
            (hb_maps:get(<<"parent">>, State, no_parent, Opts) =:= From) orelse
            dev_security:validate(<<"mint-authority">>, State, Req, From, Opts) orelse
                verify_resource_authority(ResID, State, Req, Opts),
```

this orelse chaining branch was used on `true | {error, Reason}` retun shapes, where it would badarg if {error, Reason} gets returned from the upstream (dev_security:validate/5 or verify_resource_authority/4

- fix: missing ?= in maybe block:

```erl

        {ok, Resources} =
            hb_maps:find(
                <<"resources">>,
                Base,
                <<"No resources found in mint state.">>,
                Opts
            ),
        {ok, Resource} = 
            hb_maps:find(
                ResourceID,
                Resources,
  ````

- added Amount input validation at deposit/5 withdraw/5 delegate/5 and undelegate/5 paths
- hardened notify/3 to match the old `@doc`  added (Parent and Action validation)
```erl
        {ok, Parent} ?=
            hb_maps:find(
                <<"parent">>,
                State,
                <<"No `parent` configured for notifications">>,
                Opts
            ),
        true ?= (NotifyFrom =:= Parent) orelse
            {error, <<"Invalid notification source">>},
        ForwardedMsg = dev_process_outbox:original_from_forwarded(Req, Opts),
        {ok, Action} ?=
            hb_maps:find(
                <<"action">>,
                ForwardedMsg,
                Opts
            ),
        true ?= (Action =:= <<"register">>) orelse
            {error, <<"Unsupported notification action">>},
  ```
- updated stale tests and added notify/3 related tests (parent and resource verification)


all tests pass:

```bash
  [done in 2.787 s]
=======================================================
  All 66 tests passed.
  ```