### PR TITLE
fix: Avoid double read from hb_cache when returns `not_found`

### DIFF
--- a/src/dev_name.erl
+++ b/src/dev_name.erl
@@ -44,7 +44,14 @@ resolve(Key, _, Req, Opts) ->
 %% @doc Load a resolved name target if it is a cache reference, otherwise
 %% return the resolved value directly.
 maybe_load_resolved(Resolved, Opts) when ?IS_ID(Resolved) ->
-    hb_cache:read(Resolved, Opts);
+    case hb_cache:read(Resolved, Opts) of 
+        {ok, _} = Result ->
+            Result;
+        not_found -> 
+            {store, not_found};
+        failure -> 
+            {store, failure}
+    end;
 maybe_load_resolved(Resolved, Opts) when ?IS_LINK(Resolved) ->
     {ok, hb_cache:ensure_loaded(Resolved, Opts)};
 maybe_load_resolved(Resolved, _Opts) ->
@@ -103,6 +110,10 @@ request(HookMsg, HookReq, Opts) ->
         ),
         {ok, #{ <<"body">> => ModReq }}
     else
+        {cache, not_found} ->
+            {error, not_found};
+        {cache, failure} ->
+            failure;
         Reason ->
             case maps:get(<<"body">>, HookReq, []) of 
                 [] ->

--- a/src/dev_name.erl
+++ b/src/dev_name.erl
@@ -47,8 +47,13 @@ maybe_load_resolved(Resolved, Opts) when ?IS_ID(Resolved) ->
     case hb_cache:read(Resolved, Opts) of 
         {ok, _} = Result -> Result;
         not_found ->
-            %% Cache Not Found seperate from Not Found, and allow to reply 404 directly.
-            {cache, not_found};
+            case is_fail_fast_on(Opts) of 
+                true ->
+                    %% Cache Not Found seperate from Not Found, and allow to reply 404 directly.
+                    {cache, not_found};
+                false ->
+                    not_found
+            end;
         Result -> Result
     end;
 maybe_load_resolved(Resolved, Opts) when ?IS_LINK(Resolved) ->
@@ -177,6 +182,9 @@ name_from_host(ReqHost, RawNodeHost) ->
             <<>>
         ),
     name_from_host(WithoutNodeHost, no_host).
+
+is_fail_fast_on(Opts) ->
+    maps:get(dev_name_fail_fast, Opts, false).
 
 %%% Tests.
 

--- a/src/dev_name.erl
+++ b/src/dev_name.erl
@@ -45,12 +45,11 @@ resolve(Key, _, Req, Opts) ->
 %% return the resolved value directly.
 maybe_load_resolved(Resolved, Opts) when ?IS_ID(Resolved) ->
     case hb_cache:read(Resolved, Opts) of 
-        {ok, _} = Result ->
-            Result;
-        not_found -> 
-            {store, not_found};
-        failure -> 
-            {store, failure}
+        {ok, _} = Result -> Result;
+        not_found ->
+            %% Cache Not Found seperate from Not Found, and allow to reply 404 directly.
+            {cache, not_found};
+        Result -> Result
     end;
 maybe_load_resolved(Resolved, Opts) when ?IS_LINK(Resolved) ->
     {ok, hb_cache:ensure_loaded(Resolved, Opts)};
@@ -111,9 +110,7 @@ request(HookMsg, HookReq, Opts) ->
         {ok, #{ <<"body">> => ModReq }}
     else
         {cache, not_found} ->
-            {error, not_found};
-        {cache, failure} ->
-            failure;
+            {error, #{<<"status">> => 404, <<"body">> => <<"Not Found">>}};
         Reason ->
             case maps:get(<<"body">>, HookReq, []) of 
                 [] ->

--- a/src/dev_name.erl
+++ b/src/dev_name.erl
@@ -184,7 +184,7 @@ name_from_host(ReqHost, RawNodeHost) ->
     name_from_host(WithoutNodeHost, no_host).
 
 is_fail_fast_on(Opts) ->
-    maps:get(dev_name_fail_fast, Opts, false).
+    hb_util:bool(maps:get(dev_name_fail_fast, Opts, false)).
 
 %%% Tests.
 

--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -58,6 +58,7 @@ make_group(_, _) -> not_found.
 %% result, so that we don't have to read the data from the GraphQL route
 %% multiple times.
 type(#{ <<"index-store">> := IndexStore }, ID) when ?IS_ID(ID) ->
+    ?event({store_arweave, {type, ID}}),
     case hb_store:read(IndexStore, hb_store_arweave_offset:path(ID)) of
         {ok, _Offset} -> simple;
         _ -> not_found


### PR DESCRIPTION
`dev_name` does a `hb_cache:read` call that goes through all the configured stores. In a case of a `not_found`, we continue with the request and ignore the result. 

Problem:
- If we know other hooks can turn this 404 into a 200, we should close this PR.
- If we want to avoid duplicate calls to the stores, we should return as soon as possible. In the end, we can add an option to toggle this behaviour.