### PR TITLE
fix: add built-in ?AO_RESERVED_ADDRESS_KEYS in dev_token:validate_address/2

### DIFF
--- a/src/dev_token.erl
+++ b/src/dev_token.erl
@@ -22,7 +22,26 @@
         <<"register">>
     ]
 ).
-
+%% @doc `validate_address/2` built-in reserved keys list
+-define(AO_RESERVED_ADDRESS_KEYS,
+    [
+        <<"path">>,
+        <<"get">>,
+        <<"set">>,
+        <<"remove">>,
+        <<"verify">>,
+        <<"keys">>,
+        <<"id">>,
+        <<"commit">>,
+        <<"committed">>,
+        <<"committers">>,
+        <<"index">>,
+        <<"info">>,
+        <<"set_path">>,
+        <<"reserved_keys">>,
+        <<"is_reserved_key">>
+    ]
+).
 %%% `~process@1.0' interface implementation.
 
 %% @doc No-op on process initialization.
@@ -304,15 +323,16 @@ enforce_set_authority(Base, Req, Opts) ->
 %% allows binary addresses up to 128 bytes and prevent invalid
 %% addresses such as dev_trie reserved keys.
 validate_address(Address, CustomList) when is_binary(Address), is_list(CustomList) ->
+    ReservedKeys = ?AO_RESERVED_ADDRESS_KEYS ++ CustomList,
     case byte_size(Address) of
         0 -> {error, <<"Recipient address cannot be empty.">>};
         N when N > 128 -> {error, <<"Recipient address is too long.">>};
         _ ->
             maybe
                 true ?= (not dev_trie:is_reserved_key(Address))
-                    orelse {error, <<"Recipient address uses a reserved internal key.">>},
-                true ?= (not is_reserved_custom_key(Address, CustomList))
-                    orelse {error, <<"Address is a reserved custom key">>},
+                    orelse {error, <<"Recipient address uses a reserved trie internal key.">>},
+                true ?= (not is_reserved_custom_key(Address, ReservedKeys))
+                    orelse {error, <<"Address is a reserved ao/custom key">>},
                 % Check for path separators (security: prevent path traversal) and whitespaces.
                 case binary:match(Address, [<<"/">>, <<"\\">>, <<" ">>, <<"\n">>, <<"\r">>, <<"\t">>]) of
                     nomatch -> true;

--- a/src/dev_token_test_vectors.erl
+++ b/src/dev_token_test_vectors.erl
@@ -448,6 +448,43 @@ batch_mint_reserved_recipient_rejected_test() ->
     ?assertEqual(<<"trie@1.0">>, maps:get(<<"device">>, Balances)),
     ?assertEqual(0, hb_ao:get(<<"total-supply">>, Base, Opts)).
 
+batch_mint_reserved_ao_recipient_rejected_test() ->
+    Opts = opts(),
+    Minter = hb_opts:get(priv_wallet, hb:wallet(), Opts),
+    Recipient = id(ar_wallet:new()),
+    {Base, _} =
+        generate_base_state(
+            #{
+                total_supply => 0,
+                initial_balances => #{},
+                extra => #{
+                    <<"mint-authority">> => id(Minter)
+                }
+            },
+            Opts
+        ),
+    ?assertEqual(
+        {error, <<"Mint recipients must be valid addresses">>},
+        dev_mint_authority:mint(
+            Base,
+            #{
+                <<"body">> => #{
+                    <<"from">> => id(Minter),
+                    <<"mode">> => <<"batch">>,
+                    <<"quantities">> => #{
+                        <<"get">> => 1,
+                        Recipient => 5
+                    }
+                }
+            },
+            Opts
+        )
+    ),
+    Balances = hb_ao:get(<<"balances">>, Base, Opts),
+    ?assertEqual(0, hb_ao:get(Recipient, Balances, 0, Opts)),
+    ?assertEqual(<<"trie@1.0">>, maps:get(<<"device">>, Balances)),
+    ?assertEqual(0, hb_ao:get(<<"total-supply">>, Base, Opts)).
+
 simple_process_test() ->
     Opts = opts(),
     Alice = ar_wallet:new(),
@@ -500,6 +537,46 @@ reserved_recipient_transfer_rejected_test() ->
             #{
                 <<"from">> => AliceID,
                 <<"recipient">> => <<"device">>,
+                <<"quantity">> => 1
+            },
+            Alice,
+            Opts
+        ),
+    {ok, BalancesLink} =
+        hb_ao:resolve_many(
+            [
+                Base,
+                <<"now">>,
+                #{
+                    <<"path">> => <<"as">>,
+                    <<"as">> => <<"execution">>
+                },
+                <<"balances">>
+            ],
+            Opts
+        ),
+    ?assertEqual(1_000_000_000, get_balance(Base, AliceID, Opts)),
+    ?assertEqual(<<"trie@1.0">>, hb_maps:get(<<"device">>, BalancesLink, undefined, Opts)),
+    ?assertEqual(1_000_000_000, hb_ao:get(<<"now/total-supply">>, Base, Opts)).
+
+reserved_ao_recipient_transfer_rejected_test() ->
+    Opts = opts(),
+    Alice = ar_wallet:new(),
+    AliceID = id(Alice),
+    Base =
+        generate_process(
+            #{
+                initial_balances => #{ AliceID => 1_000_000_000 }
+            },
+            Opts
+        ),
+    _SchedRes =
+        schedule_request(
+            Base,
+            <<"transfer">>,
+            #{
+                <<"from">> => AliceID,
+                <<"recipient">> => <<"path">>,
                 <<"quantity">> => 1
             },
             Alice,


### PR DESCRIPTION
extend the AO's validate_address reserved keys and add tests - all tests pass:

```bash
  [done in 40.708 s]
=======================================================
  All 9 tests passed.
```