### PR TITLE
impr: addressing register/3 TODO 

### DIFF
--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -24,7 +24,7 @@
 %%% in the original process can earn their yield in the form of `child` mints.
 %%% Each mint can operate asynchronously and in real-time.
 %%% 
-%%% TODO:
+%%% TODO: ADDRESSED IN enforce_resource_config_authority & apply_resource_config
 %%% - Add `secure-set` (set guarded by address) for resource-weights and 
 %%%   supported resources.
 -module(dev_pot).
@@ -915,22 +915,33 @@ register(State, Assignment, Opts) ->
                 Opts
             ),
         true ?= dev_token:validate_address(From, ?RESERVED_KEYS),
-        
+        true ?= enforce_resource_config_authority(From, ResID, State, Req, Opts),
+        apply_resource_config(ResID, State, Req, Opts)
+    end.
+
+enforce_resource_config_authority(From, ResID, State, Req, Opts) ->
+    ?event(debug_pot, {enforce_resource_config_authority, Req}, Opts),
+    maybe
         AuthRes = case (hb_maps:get(<<"parent">>, State, no_parent, Opts) =:= From) of
             true -> true;
-            false -> case dev_security:validate(<<"mint-authority">>, State, Req, From, Opts) of
-                true -> true;
-                {error, _} -> 
-                    verify_resource_authority(ResID, State, Req, Opts)
-                end  
+            false -> 
+                case dev_security:validate(<<"mint-authority">>, State, Req, From, Opts) of
+                    true -> true;
+                    {error, _} -> 
+                        verify_resource_authority(ResID, State, Req, Opts)
+                    end  
         end,
-        true ?= AuthRes,
+        true ?= AuthRes
+    end.
 
-        State2 ?=
+apply_resource_config(ResID, State, Req, Opts) ->
+    maybe
+        State2 =
             case hb_maps:find(<<"weight">>, Req, Opts) of
                 {ok, Weight} -> register_resource(ResID, Weight, State, Opts);
                 _ -> State
             end,
+        true ?= is_map(State2) orelse State2,
         case hb_maps:find(<<"resource-authority">>, Req, Opts) of
             {ok, ResAuth} ->
                 register_resource_authority(ResID, ResAuth, State2, Opts);
@@ -941,7 +952,6 @@ register(State, Assignment, Opts) ->
             ?event(debug_pot, {error, Reason}, Opts),
             Reason
     end.
-
 %% @doc Update the authority record for a specific resource in the pot.
 register_resource_authority(ResourceID, Authority, S, Opts) ->
     maybe

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -478,6 +478,7 @@ notify(State, Assignment, Opts) ->
                 <<"No `parent` configured for notifications">>,
                 Opts
             ),
+        true ?= dev_token:validate_address(NotifyFrom, ?RESERVED_KEYS),
         true ?= (NotifyFrom =:= Parent) orelse
             {error, <<"Invalid notification source">>},
         ForwardedMsg = dev_process_outbox:original_from_forwarded(Req, Opts),
@@ -913,6 +914,7 @@ register(State, Assignment, Opts) ->
                 <<"No `from' address provided.">>, 
                 Opts
             ),
+        true ?= dev_token:validate_address(From, ?RESERVED_KEYS),
         
         AuthRes = case (hb_maps:get(<<"parent">>, State, no_parent, Opts) =:= From) of
             true -> true;

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -887,14 +887,10 @@ undelegate(_, _, _, Amount, _, _) when is_integer(Amount), Amount =:= 0 ->
 undelegate(_, _, _, Amount, _, _) when not is_integer(Amount)->
     {error, <<"Undelegate Amount must be of integer type">>}.
 
-%% @doc Set resource parameters in the pot. Authorization is evaluated against:
-%% - `State/parent`, if set and equal to `from`
-%% - `mint-authority` security policy on the pot state, if configured
-%% - `authority` security policy on the target resource, if configured
-%%
-%% N.B: `dev_security` is open-by-default when no valid/required/match policy
-%% is present, so absent authority config does not restrict this action. check
-%% `AuthRes` logic chain for better gating-understanding.
+%% @doc Resource configuration entrypoint. Validates the target resource and
+%% caller, enforces resource-config authority via
+%% `enforce_resource_config_authority/5`, then applies supported
+%% resource-scoped config mutations.
 register(State, Assignment, Opts) ->
     ?event(debug_pot, {register, Assignment}, Opts),
     maybe
@@ -918,7 +914,15 @@ register(State, Assignment, Opts) ->
         true ?= enforce_resource_config_authority(From, ResID, State, Req, Opts),
         apply_resource_config(ResID, State, Req, Opts)
     end.
-
+%% @doc Enforce authorization for resource configuration updates.
+%% Authorization is evaluated against:
+%% - `State/parent`, if set and equal to `from`
+%% - `mint-authority` security policy on the pot state, if configured
+%% - `authority` security policy on the target resource, if configured
+%%
+%% N.B: `dev_security` is open-by-default when no valid/required/match policy
+%% is present, so absent authority config does not restrict this action. check
+%% `AuthRes` logic chain for better gating-understanding.
 enforce_resource_config_authority(From, ResID, State, Req, Opts) ->
     ?event(debug_pot, {enforce_resource_config_authority, Req}, Opts),
     maybe
@@ -933,7 +937,8 @@ enforce_resource_config_authority(From, ResID, State, Req, Opts) ->
         end,
         true ?= AuthRes
     end.
-
+%% @doc Apply supported resource-scoped configuration updates. If an earlier
+%% mutation fails, later mutations in the same request are not applied.
 apply_resource_config(ResID, State, Req, Opts) ->
     maybe
         State2 =


### PR DESCRIPTION
addressed:

```erl
%%% TODO:
%%% - Add `secure-set` (set guarded by address) for resource-weights and 
%%%   supported resources.
```

self-describing changes:

```erl
%% @doc Resource configuration entrypoint. Validates the target resource and
%% caller, enforces resource-config authority via
%% `enforce_resource_config_authority/5`, then applies supported
%% resource-scoped config mutations.
register(State, Assignment, Opts) ->
    ?event(debug_pot, {register, Assignment}, Opts),
    maybe
        Req = hb_ao:get(<<"body">>, Assignment,Opts),
        {ok, ResID} ?= 
            hb_maps:find(
                <<"resource">>, 
                Req,
                <<"No `resource' provided to register.">>, 
                Opts
            ),
        true ?= dev_token:validate_address(ResID, ?RESERVED_KEYS),
        {ok, From} ?= 
            hb_maps:find(
                <<"from">>, 
                Req,
                <<"No `from' address provided.">>, 
                Opts
            ),
        true ?= dev_token:validate_address(From, ?RESERVED_KEYS),
        true ?= enforce_resource_config_authority(From, ResID, State, Req, Opts),
        apply_resource_config(ResID, State, Req, Opts)
    end.
%% @doc Enforce authorization for resource configuration updates.
%% Authorization is evaluated against:
%% - `State/parent`, if set and equal to `from`
%% - `mint-authority` security policy on the pot state, if configured
%% - `authority` security policy on the target resource, if configured
%%
%% N.B: `dev_security` is open-by-default when no valid/required/match policy
%% is present, so absent authority config does not restrict this action. check
%% `AuthRes` logic chain for better gating-understanding.
enforce_resource_config_authority(From, ResID, State, Req, Opts) ->
    ?event(debug_pot, {enforce_resource_config_authority, Req}, Opts),
    maybe
        AuthRes = case (hb_maps:get(<<"parent">>, State, no_parent, Opts) =:= From) of
            true -> true;
            false -> 
                case dev_security:validate(<<"mint-authority">>, State, Req, From, Opts) of
                    true -> true;
                    {error, _} -> 
                        verify_resource_authority(ResID, State, Req, Opts)
                    end  
        end,
        true ?= AuthRes
    end.
%% @doc Apply supported resource-scoped configuration updates. If an earlier
%% mutation fails, later mutations in the same request are not applied.
apply_resource_config(ResID, State, Req, Opts) ->
    maybe
        State2 =
            case hb_maps:find(<<"weight">>, Req, Opts) of
                {ok, Weight} -> register_resource(ResID, Weight, State, Opts);
                _ -> State
            end,
        true ?= is_map(State2) orelse State2,
        case hb_maps:find(<<"resource-authority">>, Req, Opts) of
            {ok, ResAuth} ->
                register_resource_authority(ResID, ResAuth, State2, Opts);
            _ -> State2
        end
    else
        Reason -> 
            ?event(debug_pot, {error, Reason}, Opts),
            Reason
    end.
 ```