### PR TITLE
feat: token IMMUTABLE_METADATA_FIELDS policy

### DIFF
--- a/src/dev_token.erl
+++ b/src/dev_token.erl
@@ -42,6 +42,15 @@
         <<"is_reserved_key">>
     ]
 ).
+
+%% @doc Immutable token metadata fields
+-define(IMMUTABLE_METADATA_FIELDS, [
+        <<"name">>,
+        <<"ticker">>,
+        <<"denomination">>,
+        <<"logo">>
+    ]
+).
 %%% `~process@1.0' interface implementation.
 
 %% @doc No-op on process initialization.
@@ -300,8 +309,33 @@ secure_set(Base, Assignment, Opts) ->
     maybe
         {ok, Req} ?= hb_ao:resolve(Assignment, <<"body">>, Opts),
         true ?= enforce_set_authority(Base, Req, Opts),
+        % check for immutable state variable update attempts
+        true ?= enforce_immutable_fields(Base, Req, Opts),
         % Apply updates to base state
         hb_ao:resolve(Base, Req#{ <<"path">> => <<"set">> }, Opts)
+    end.
+enforce_immutable_fields(Base, Req, Opts) ->
+    lists:foldl(
+        fun
+            (_Key, {error, _} = Err) ->
+                Err;
+            (Key, true) ->
+                immutable_not_already_set(Key, Base, Req, Opts)
+        end,
+        true,
+        ?IMMUTABLE_METADATA_FIELDS
+    ).
+
+immutable_not_already_set(Key, Base, Req, Opts) ->
+    case hb_maps:find(Key, Req, Opts) of
+        {ok, _NewValue} ->
+            case hb_maps:find(Key, Base, Opts) of
+                {ok, _Existing} -> {error, <<Key/binary, " is immutable once set.">>};
+                error -> true
+            end;
+        % immutable keys not present in Req
+        _ ->
+            true
     end.
 
 %% @doc Enforce that the caller is the `set' authority.

--- a/src/dev_token_test_vectors.erl
+++ b/src/dev_token_test_vectors.erl
@@ -485,6 +485,73 @@ batch_mint_reserved_ao_recipient_rejected_test() ->
     ?assertEqual(<<"trie@1.0">>, maps:get(<<"device">>, Balances)),
     ?assertEqual(0, hb_ao:get(<<"total-supply">>, Base, Opts)).
 
+immutable_name_update_rejected_test() ->
+    Opts = opts(),
+    Setter = hb_opts:get(priv_wallet, hb:wallet(), Opts),
+    Base =
+        generate_process(
+            #{
+                extra => #{
+                    <<"set-authority">> => id(Setter)
+                }
+            },
+            Opts
+        ),
+    ?assertEqual(
+        {error, <<"name is immutable once set.">>},
+        dev_token:handle_action(
+            <<"set">>,
+            Base,
+            #{
+                <<"body">> => #{
+                    <<"from">> => id(Setter),
+                    <<"name">> => <<"New Token Name">>
+                }
+            },
+            Opts
+        )
+    ).
+
+logo_set_once_then_update_rejected_test() ->
+    Opts = opts(),
+    Setter = hb_opts:get(priv_wallet, hb:wallet(), Opts),
+    Base =
+        generate_process(
+            #{
+                extra => #{
+                    <<"set-authority">> => id(Setter)
+                }
+            },
+            Opts
+        ),
+    {ok, WithLogo} =
+        dev_token:handle_action(
+            <<"set">>,
+            Base,
+            #{
+                <<"body">> => #{
+                    <<"from">> => id(Setter),
+                    <<"logo">> => <<"logo-a">>
+                }
+            },
+            Opts
+        ),
+    ?assertEqual(<<"logo-a">>, hb_ao:get(<<"logo">>, WithLogo, Opts)),
+    ?assertEqual(
+        {error, <<"logo is immutable once set.">>},
+        dev_token:handle_action(
+            <<"set">>,
+            WithLogo,
+            #{
+                <<"body">> => #{
+                    <<"from">> => id(Setter),
+                    <<"logo">> => <<"logo-b">>
+                }
+            },
+            Opts
+        )
+    ).
+
 simple_process_test() ->
     Opts = opts(),
     Alice = ar_wallet:new(),


### PR DESCRIPTION
introduced a new policy to the `~token@1.0` device adding `IMMUTABLE_METADATA_FIELDS` list and util function that disallow setting new values for the immutable metadata fields after initialization -> aligning with ERC20 standards best practices.

all tests pass

```bash
===> Performing EUnit tests...
======================== EUnit ========================
module 'dev_token_test_vectors'
  dev_token_test_vectors: transfer_basic_test...[3.946 s] ok
  dev_token_test_vectors: mint_authority_mismatch_rejected_test...[3.399 s] ok
  dev_token_test_vectors: batch_mint_reserved_recipient_rejected_test...[4.636 s] ok
  dev_token_test_vectors: batch_mint_reserved_ao_recipient_rejected_test...[2.874 s] ok
  dev_token_test_vectors: immutable_name_update_rejected_test...[1.902 s] ok
  dev_token_test_vectors: logo_set_once_then_update_rejected_test...[2.092 s] ok
  dev_token_test_vectors: simple_process_test...[2.156 s] ok
  dev_token_test_vectors: reserved_recipient_transfer_rejected_test...[1.876 s] ok
  dev_token_test_vectors: reserved_ao_recipient_transfer_rejected_test...[1.026 s] ok
  dev_token_test_vectors: simple_pot_process_test...[3.804 s] ok
  dev_token_test_vectors: benchmark_process_transfers...
        Process transfers 100 transfers in 2,299ms (43 transfers/s)... [19.246 s] ok
  [done in 46.991 s]
=======================================================
  All 11 tests passed.
  ```