### PR TITLE
impr (policy): secure_set/3 whitelisted fields mutation only + dev_security:validate/5 additional support for set-authority

### DIFF
--- a/src/dev_token.erl
+++ b/src/dev_token.erl
@@ -369,11 +369,11 @@ enforce_whitelisted_fields(Req, Opts) ->
         false -> {error, <<"Attempted to set non-whitelisted fields.">>}
     end.
 
-%% @doc Enforce that the caller is the `set' authority. If the process
-%% Base has any of the set-authority -required or -match configured, 
-%% `enforce_set_authority/3` will switch to dev_security:validate/5 
-%% (dimensional authority - more secure if configured correctly) - if not
-%% it fallback to the single From =:= PlainSetAuthority check.
+%% @doc Enforce that the caller is the `set` authority. If `Base` configures
+%% either `set-authority-required` or `set-authority-match`, this function
+%% delegates authorization to `dev_security:validate/5` for `set-authority`.
+%% Otherwise it falls back to legacy exact-match semantics:
+%% `Req/from =:= Base/set-authority`.
 enforce_set_authority(Base, Req, Opts) ->
     maybe
         Setter = hb_ao:get(<<"from">>, Req, Opts),

--- a/src/dev_token.erl
+++ b/src/dev_token.erl
@@ -328,6 +328,7 @@ secure_set(Base, Assignment, Opts) ->
             ),
         % check for immutable state variable update attempts
         true ?= enforce_immutable_fields(Base, SetReq, Opts),
+        % check the auth is touching whitelisted fields only
         true ?= enforce_whitelisted_fields(SetReq, Opts),
         % Apply updates to base state
         hb_ao:resolve(Base, Req#{ <<"path">> => <<"set">> }, Opts)
@@ -368,23 +369,50 @@ enforce_whitelisted_fields(Req, Opts) ->
         false -> {error, <<"Attempted to set non-whitelisted fields.">>}
     end.
 
-%% @doc Enforce that the caller is the `set' authority.
+%% @doc Enforce that the caller is the `set' authority. If the process
+%% Base has any of the set-authority -required or -match configured, 
+%% `enforce_set_authority/3` will switch to dev_security:validate/5 
+%% (dimensional authority - more secure if configured correctly) - if not
+%% it fallback to the single From =:= PlainSetAuthority check.
 enforce_set_authority(Base, Req, Opts) ->
     maybe
         Setter = hb_ao:get(<<"from">>, Req, Opts),
-        SetAuthority = hb_ao:get(<<"set-authority">>, Base, Opts),
         true ?= (Setter =/= not_found) orelse
                 {error, <<"Setter not found.">>},
-        true ?= (SetAuthority =/= not_found) orelse
-                {error, <<"SetAuthority not found.">>},
         true ?= validate_address(Setter, []),
-        case {Setter, SetAuthority} of
-            {S, S} -> 
-                true;
-            _ -> 
-                {error, <<"Caller is not the `set-authority'.">>}
-        end
-end.
+        SetAuthorityRequired =
+            hb_ao:get(<<"set-authority-required">>, Base, not_found, Opts),
+        SetAuthorityMatch =
+            hb_ao:get(<<"set-authority-match">>, Base, not_found, Opts),
+        AuthRes = case
+            (SetAuthorityRequired =/= not_found)
+            orelse
+            (SetAuthorityMatch =/= not_found)
+        of
+            true ->
+                dev_security:validate(
+                    <<"set-authority">>,
+                    Base,
+                    Req,
+                    Setter,
+                    Opts
+                );
+            false ->
+                SetAuthority = hb_ao:get(<<"set-authority">>, Base, Opts),
+                case SetAuthority of
+                    not_found ->
+                        {error, <<"SetAuthority not found.">>};
+                    _ ->
+                        case {Setter, SetAuthority} of
+                            {S, S} ->
+                                true;
+                            _ ->
+                                {error, <<"Caller is not the `set-authority'.">>}
+                        end
+                end
+        end,
+        true ?= AuthRes
+	end.
 
 %%% Helper functions.
 

--- a/src/dev_token.erl
+++ b/src/dev_token.erl
@@ -51,6 +51,16 @@
         <<"logo">>
     ]
 ).
+
+%% @doc Allowed Authority base parameters mutation
+whitelisted_auth_fields() -> [
+    <<"set-authority">>, % admin rotation
+    <<"mint-authority">>, % mint governor rotation
+    <<"mint-authority-required">>, % future dev_security migration
+    <<"mint-authority-match">>
+    ]
+    ++ ?IMMUTABLE_METADATA_FIELDS.
+
 %%% `~process@1.0' interface implementation.
 
 %% @doc No-op on process initialization.
@@ -304,13 +314,21 @@ ensure_mint_device(Base, Opts) ->
 %%% Secure `set' call orchestration.
 
 %% @doc Ensure that the caller is the `set' authority, and apply changes to the
-%% base state if so.
+%% base state if so. The setter can only mutuate whitelisted fields.
 secure_set(Base, Assignment, Opts) ->
     maybe
         {ok, Req} ?= hb_ao:resolve(Assignment, <<"body">>, Opts),
         true ?= enforce_set_authority(Base, Req, Opts),
+        RawBody = hb_maps:get(<<"body">>, Assignment, #{}, Opts),
+        SetReq =
+            hb_maps:without(
+                [<<"from">>, <<"action">>, <<"path">>],
+                RawBody,
+                Opts
+            ),
         % check for immutable state variable update attempts
-        true ?= enforce_immutable_fields(Base, Req, Opts),
+        true ?= enforce_immutable_fields(Base, SetReq, Opts),
+        true ?= enforce_whitelisted_fields(SetReq, Opts),
         % Apply updates to base state
         hb_ao:resolve(Base, Req#{ <<"path">> => <<"set">> }, Opts)
     end.
@@ -336,6 +354,18 @@ immutable_not_already_set(Key, Base, Req, Opts) ->
         % immutable keys not present in Req
         _ ->
             true
+    end.
+
+enforce_whitelisted_fields(Req, Opts) ->
+    Keys = hb_maps:keys(Req, Opts),
+    case
+        lists:all(
+            fun(Key) -> lists:member(Key, whitelisted_auth_fields()) end,
+            Keys
+        )
+    of
+        true -> true;
+        false -> {error, <<"Attempted to set non-whitelisted fields.">>}
     end.
 
 %% @doc Enforce that the caller is the `set' authority.

--- a/src/dev_token.erl
+++ b/src/dev_token.erl
@@ -57,7 +57,9 @@ whitelisted_auth_fields() -> [
     <<"set-authority">>, % admin rotation
     <<"mint-authority">>, % mint governor rotation
     <<"mint-authority-required">>, % future dev_security migration
-    <<"mint-authority-match">>
+    <<"mint-authority-match">>,
+    <<"set-authority-required">>,
+    <<"set-authority-match">>
     ]
     ++ ?IMMUTABLE_METADATA_FIELDS.
 

--- a/src/dev_token_test_vectors.erl
+++ b/src/dev_token_test_vectors.erl
@@ -579,6 +579,34 @@ non_whitelisted_set_field_rejected_test() ->
         )
     ).
 
+set_authority_required_uses_dev_security_test() ->
+    Opts = opts(),
+    Setter = hb_opts:get(priv_wallet, hb:wallet(), Opts),
+    SetterID = id(Setter),
+    Base =
+        generate_process(
+            #{
+                extra => #{
+                    <<"set-authority">> => [SetterID],
+                    <<"set-authority-required">> => [SetterID]
+                }
+            },
+            Opts
+        ),
+    {ok, Updated} =
+        dev_token:handle_action(
+            <<"set">>,
+            Base,
+            #{
+                <<"body">> => #{
+                    <<"from">> => SetterID,
+                    <<"logo">> => <<"logo-a">>
+                }
+            },
+            Opts
+        ),
+    ?assertEqual(<<"logo-a">>, hb_ao:get(<<"logo">>, Updated, Opts)).
+
 simple_process_test() ->
     Opts = opts(),
     Alice = ar_wallet:new(),

--- a/src/dev_token_test_vectors.erl
+++ b/src/dev_token_test_vectors.erl
@@ -552,6 +552,33 @@ logo_set_once_then_update_rejected_test() ->
         )
     ).
 
+non_whitelisted_set_field_rejected_test() ->
+    Opts = opts(),
+    Setter = hb_opts:get(priv_wallet, hb:wallet(), Opts),
+    Base =
+        generate_process(
+            #{
+                extra => #{
+                    <<"set-authority">> => id(Setter)
+                }
+            },
+            Opts
+        ),
+    ?assertEqual(
+        {error, <<"Attempted to set non-whitelisted fields.">>},
+        dev_token:handle_action(
+            <<"set">>,
+            Base,
+            #{
+                <<"body">> => #{
+                    <<"from">> => id(Setter),
+                    <<"balances">> => #{ <<"fake">> => 1 }
+                }
+            },
+            Opts
+        )
+    ).
+
 simple_process_test() ->
     Opts = opts(),
     Alice = ar_wallet:new(),

--- a/src/dev_token_test_vectors.erl
+++ b/src/dev_token_test_vectors.erl
@@ -607,6 +607,34 @@ set_authority_required_uses_dev_security_test() ->
         ),
     ?assertEqual(<<"logo-a">>, hb_ao:get(<<"logo">>, Updated, Opts)).
 
+set_authority_match_uses_dev_security_test() ->
+    Opts = opts(),
+    Setter = hb_opts:get(priv_wallet, hb:wallet(), Opts),
+    SetterID = id(Setter),
+    Base =
+        generate_process(
+            #{
+                extra => #{
+                    <<"set-authority">> => [SetterID],
+                    <<"set-authority-match">> => 1
+                }
+            },
+            Opts
+        ),
+    {ok, Updated} =
+        dev_token:handle_action(
+            <<"set">>,
+            Base,
+            #{
+                <<"body">> => #{
+                    <<"from">> => SetterID,
+                    <<"logo">> => <<"logo-a">>
+                }
+            },
+            Opts
+        ),
+    ?assertEqual(<<"logo-a">>, hb_ao:get(<<"logo">>, Updated, Opts)).
+
 simple_process_test() ->
     Opts = opts(),
     Alice = ar_wallet:new(),


### PR DESCRIPTION
this PR touched token's authority policy - changes TLDR:

1- set-authority was too broad, allowing a single address to have absolute governance over the token state - but could be eve, in  worst case scenario, in token+pot set - the token's set-authority could have self-changed (admin rotation), resources, mint-authority, etc. to address that, added whitelisted set-authority fields, limiting what Base fields the authority can change

```erl
%% @doc Immutable token metadata fields
-define(IMMUTABLE_METADATA_FIELDS, [
        <<"name">>,
        <<"ticker">>,
        <<"denomination">>,
        <<"logo">>
    ]
).

%% @doc Allowed Authority base parameters mutation
whitelisted_auth_fields() -> [
    <<"set-authority">>, % admin rotation
    <<"mint-authority">>, % mint governor rotation
    <<"mint-authority-required">>, % future dev_security migration
    <<"mint-authority-match">>,
    <<"set-authority-required">>,
    <<"set-authority-match">>
    ]
    ++ ?IMMUTABLE_METADATA_FIELDS.
```
we can easily update the policy by updating what we whitelist

2- enforce_set_authority/3 was supporting only a plain `Req/from =:= Base/set-authority` -> which means a compromised set-authority address gets full control over the token. to fix that i added support to dev_security:validate/5 to support 'multisig' set-authority -if configured- along the legacy single address set-authority

description:

```erl
%% @doc Enforce that the caller is the `set` authority. If `Base` configures
%% either `set-authority-required` or `set-authority-match`, this function
%% delegates authorization to `dev_security:validate/5` for `set-authority`.
%% Otherwise it falls back to legacy exact-match semantics:
%% `Req/from =:= Base/set-authority`.
```

all tests pass:

```bash
======================== EUnit ========================
module 'dev_token_test_vectors'
  dev_token_test_vectors: transfer_basic_test...[3.342 s] ok
  dev_token_test_vectors: mint_authority_mismatch_rejected_test...[3.990 s] ok
  dev_token_test_vectors: batch_mint_reserved_recipient_rejected_test...[0.877 s] ok
  dev_token_test_vectors: batch_mint_reserved_ao_recipient_rejected_test...[2.497 s] ok
  dev_token_test_vectors: immutable_name_update_rejected_test...[0.861 s] ok
  dev_token_test_vectors: logo_set_once_then_update_rejected_test...[1.337 s] ok
  dev_token_test_vectors: non_whitelisted_set_field_rejected_test...[3.378 s] ok
  dev_token_test_vectors: set_authority_required_uses_dev_security_test...[1.175 s] ok
  dev_token_test_vectors: set_authority_match_uses_dev_security_test...[0.916 s] ok
  dev_token_test_vectors: simple_process_test...[3.379 s] ok
  dev_token_test_vectors: reserved_recipient_transfer_rejected_test...[1.373 s] ok
  dev_token_test_vectors: reserved_ao_recipient_transfer_rejected_test...[2.991 s] ok
  dev_token_test_vectors: simple_pot_process_test...[3.260 s] ok
  dev_token_test_vectors: benchmark_process_transfers...
        Process transfers 100 transfers in 2,714ms (37 transfers/s)... [17.631 s] ok
  [done in 47.050 s]
=======================================================
```
