### PR TITLE
Fix/dev token props

### DIFF
--- a/src/dev_token_props.erl
+++ b/src/dev_token_props.erl
@@ -19,6 +19,8 @@ opts() ->
 -define(USERS, 5).
 -define(MAX_INITIAL_BALANCE, 1_000_000_000_000_000_000).
 -define(MAX_TRANSFER_AMOUNT, 1_000_000_000_000_000_000 div 5).
+-define(NODE_WALLET_CACHE_KEY, {?MODULE, node_wallet}).
+-define(IDENTITIES_CACHE_KEY, {?MODULE, identities}).
 
 simulate_native_token_test() ->
     simulate(#{ <<"execution-device">> => <<"token@1.0">> }).
@@ -89,12 +91,36 @@ simulate_and_compare(Extras1, Extras2) ->
 
 generate_sim_opts(Spec = #{ users := Users }) ->
     BaseOpts = dev_token_props:opts(),
-    NodeWallet = ar_wallet:new(),
+    NodeWallet = cached_node_wallet(),
     BaseOpts#{
         priv_wallet => NodeWallet,
-        identities => generate_identities(Users),
+        identities => cached_identities(Users),
         spawn_extras => hb_opts:get(spawn_extras, #{}, Spec)
     }.
+
+cached_node_wallet() ->
+    case persistent_term:get(?NODE_WALLET_CACHE_KEY, not_found) of
+        not_found ->
+            Wallet = ar_wallet:new(),
+            persistent_term:put(?NODE_WALLET_CACHE_KEY, Wallet),
+            Wallet;
+        Wallet ->
+            Wallet
+    end.
+
+cached_identities(Users) ->
+    Cached = persistent_term:get(?IDENTITIES_CACHE_KEY, #{}),
+    case maps:get(Users, Cached, not_found) of
+        not_found ->
+            Identities = generate_identities(Users),
+            persistent_term:put(
+                ?IDENTITIES_CACHE_KEY,
+                Cached#{ Users => Identities }
+            ),
+            Identities;
+        Identities ->
+            Identities
+    end.
 
 generate_identities(Users) ->
     lists:foldl(
@@ -140,32 +166,63 @@ generate_initial_balances(Opts) ->
 
 generate_sim_request(State, Opts) ->
     ?event({generating_request_for_process, State}),
-    Ledger = dev_process_lib:process_id(State, Opts),
-    {ok, PushRes} =
-        dev_token_lib:transfer(
-            State,
-            SenderWallet = hb_invariant:pick(user_wallets(Opts)),
-            RecipientWallet = hb_invariant:pick(user_wallets(Opts)),
-            Amount = hb_invariant:int(?MAX_TRANSFER_AMOUNT),
-            Opts
-        ),
-    ?event({push_result, PushRes}),
-    Slot = hb_ao:get(<<"slot">>, PushRes, Opts),
-    {
-        ok,
-        #{
-            <<"path">> => <<"compute">>,
-            <<"slot">> => Slot,
-            <<"intent">> =>
+    SenderWallet = hb_invariant:pick(user_wallets(Opts)),
+    RecipientWallet = hb_invariant:pick(user_wallets(Opts)),
+    Amount = hb_invariant:int(?MAX_TRANSFER_AMOUNT),
+    fun(ExecState, ExecOpts) ->
+        Proc = hb_maps:get(<<"process">>, ExecState, ExecState, ExecOpts),
+        UserOpts = ExecOpts#{ priv_wallet => SenderWallet },
+        SystemOpts =
+            ExecOpts#{
+                priv_wallet => hb_opts:get(priv_wallet, hb:wallet(), ExecOpts)
+            },
+        InnerReq =
+            hb_message:commit(
                 #{
-                    <<"action">> => <<"transfer">>,
-                    <<"ledger">> => Ledger,
-                    <<"sender">> => hb_util:human_id(SenderWallet),
+                    <<"action">> => <<"Transfer">>,
                     <<"recipient">> => hb_util:human_id(RecipientWallet),
-                    <<"amount">> => Amount
-                }
-        }
-    }.
+                    <<"quantity">> => Amount,
+                    <<"target">> => dev_process_lib:process_id(Proc, SystemOpts)
+                },
+                UserOpts
+            ),
+        {ok, _} = hb_cache:write(InnerReq, ExecOpts),
+        OuterReq =
+            hb_message:commit(
+                #{
+                    <<"path">> => <<"push">>,
+                    <<"body">> => InnerReq
+                },
+                UserOpts
+            ),
+        case hb_ao:resolve(ExecState, OuterReq, SystemOpts) of
+            {ok, PushRes} ->
+                Slot = hb_ao:get(<<"slot">>, PushRes, ExecOpts),
+                hb_ao:resolve(
+                    ExecState,
+                    #{
+                        <<"path">> => <<"compute">>,
+                        <<"slot">> => Slot,
+                        <<"intent">> =>
+                            #{
+                                <<"action">> => <<"transfer">>,
+                                <<"ledger">> =>
+                                    dev_process_lib:process_id(
+                                        Proc,
+                                        ExecOpts
+                                    ),
+                                <<"sender">> => hb_util:human_id(SenderWallet),
+                                <<"recipient">> =>
+                                    hb_util:human_id(RecipientWallet),
+                                <<"amount">> => Amount
+                            }
+                    },
+                    ExecOpts
+                );
+            {error, Reason} ->
+                {error, Reason}
+        end
+    end.
 
 verify_net_balance_unchanged(OldState, _Req, NewState, Opts) ->
     dev_token_lib:supply(initial, OldState, Opts)

--- a/src/dev_token_props.erl
+++ b/src/dev_token_props.erl
@@ -151,17 +151,20 @@ generate_sim_request(State, Opts) ->
         ),
     ?event({push_result, PushRes}),
     Slot = hb_ao:get(<<"slot">>, PushRes, Opts),
-    #{
-        <<"path">> => <<"compute">>,
-        <<"slot">> => Slot,
-        <<"intent">> =>
-            #{
-                <<"action">> => <<"transfer">>,
-                <<"ledger">> => Ledger,
-                <<"sender">> => hb_util:human_id(SenderWallet),
-                <<"recipient">> => hb_util:human_id(RecipientWallet),
-                <<"amount">> => Amount
-            }
+    {
+        ok,
+        #{
+            <<"path">> => <<"compute">>,
+            <<"slot">> => Slot,
+            <<"intent">> =>
+                #{
+                    <<"action">> => <<"transfer">>,
+                    <<"ledger">> => Ledger,
+                    <<"sender">> => hb_util:human_id(SenderWallet),
+                    <<"recipient">> => hb_util:human_id(RecipientWallet),
+                    <<"amount">> => Amount
+                }
+        }
     }.
 
 verify_net_balance_unchanged(OldState, _Req, NewState, Opts) ->

--- a/src/hb_invariant.erl
+++ b/src/hb_invariant.erl
@@ -335,7 +335,7 @@ generate_request(
         }
 ) ->
     seed(Spec#{ stage => {generate, request} }),
-    execute_generator(Gen, [State, Opts]);
+    normalize_generated_request(execute_generator(Gen, [State, Opts]));
 generate_request(
         Spec = #{
             requests := Gen,
@@ -345,10 +345,15 @@ generate_request(
         }
 ) ->
     seed(Spec#{ stage => {generate, request} }),
-    StateReq = execute_generator(Gen, [State, Opts]),
+    {StateTag, StateReq} =
+        normalize_generated_request(execute_generator(Gen, [State, Opts])),
     seed(Spec#{ stage => {generate, request} }),
-    ModelReq = execute_generator(Gen, [ModelState, Opts]),
-    {StateReq, ModelReq}.
+    {ModelTag, ModelReq} =
+        normalize_generated_request(execute_generator(Gen, [ModelState, Opts])),
+    {
+        combine_generated_request_tags(StateTag, ModelTag),
+        {StateReq, ModelReq}
+    }.
 
 %% @doc Execute a generator with a given set of arguments. If a list of generators
 %% is provided, a random one is selected and executed. If a single generator is
@@ -360,6 +365,15 @@ execute_generator(Generator, Args) when is_function(Generator) ->
     apply(Generator, Args);
 execute_generator(ExplicitResult, _) ->
     ExplicitResult.
+
+normalize_generated_request({Tag, Req}) when is_atom(Tag); is_binary(Tag) ->
+    {Tag, Req};
+normalize_generated_request(Req) ->
+    {ok, Req}.
+
+combine_generated_request_tags(noop, _Tag) -> noop;
+combine_generated_request_tags(_Tag, noop) -> noop;
+combine_generated_request_tags(Tag, _OtherTag) -> Tag.
 
 %% @doc Marshall execution of a request against a given state and node message.
 %% If no model state is provided, the request is executed against the primary


### PR DESCRIPTION
## changes TLDR

  1- `dev_token_props:generate_sim_request/2` was not pure, because it was doing the real transfer / push side-effects during request generation. that was wrong for compare-mode and could desync the 2 sides before actual execution. fixed by deferring the real transfer path to execution time

2- hyper-token prop runs were  failing on missing linked inner transfer bodies during schedule/push. fixed by explicitly cache-writing the signed inner transfer message before scheduling it (codex helped here)


3- `hb_invariant` was too strict on request generator return shape. fixed by allowing both:

  - bare generated reqs
  - `{Tag, Req}` generated reqs


all tests pass (along dev_pot_props and dev_trie_pops)

```bash
  [done in 70.456 s]
=======================================================
  All 3 tests passed.
```
