### PR TITLE
impr: ~token@1.0 robust whitelisted fields policy

### DIFF
--- a/src/dev_token.erl
+++ b/src/dev_token.erl
@@ -46,12 +46,25 @@
 %% @doc Return the configured `set` field whitelist. Defaults to open policy
 %% via wildcard unless `whitelisted-fields` is explicitly restricted.
 whitelisted_auth_fields(Base, Opts) ->
-    hb_ao:get(
-        <<"whitelisted-fields">>,
-        Base,
-        [<<"*">>],
-        Opts
-    ).
+    maybe
+        WhitelistedFields = hb_ao:get(
+            <<"whitelisted-fields">>,
+            Base,
+            [<<"*">>],
+            Opts
+        ),
+        ValidList = case WhitelistedFields of
+            V when is_list(V) -> V;
+            _ -> {error, <<"Invalid `whitelisted-fields` type.">>}
+        end,
+        true ?= is_list(ValidList),
+        
+        lists:filter(
+            fun(X) -> is_binary(X) andalso byte_size(X) > 0 end,
+            ValidList
+        )
+end.
+
 %%% `~process@1.0' interface implementation.
 
 %% @doc No-op on process initialization.
@@ -323,18 +336,22 @@ secure_set(Base, Assignment, Opts) ->
         hb_ao:resolve(Base, Req#{ <<"path">> => <<"set">> }, Opts)
     end.
 enforce_whitelisted_fields(Base, Req, Opts) ->
-    Keys = hb_maps:keys(Req, Opts),
-    WhitelistedFields = whitelisted_auth_fields(Base, Opts),
-    case lists:member(<<"*">>, WhitelistedFields) of
-        true ->
-            true;
-        false ->
-            case lists:all(
-                fun(Key) -> lists:member(Key, WhitelistedFields) end,
-                Keys
-            ) of
-                true -> true;
-                false -> {error, <<"Attempted to set non-whitelisted fields.">>}
+    maybe
+        Keys = hb_maps:keys(Req, Opts),
+        WhitelistedFields = whitelisted_auth_fields(Base, Opts),
+        true ?= is_list(WhitelistedFields) orelse
+                    {error, <<"Invalid `whitelisted-fields` type.">>},
+        case lists:member(<<"*">>, WhitelistedFields) of
+            true ->
+                true;
+            false ->
+                case lists:all(
+                    fun(Key) -> lists:member(Key, WhitelistedFields) end,
+                    Keys
+                ) of
+                    true -> true;
+                    false -> {error, <<"Attempted to set non-whitelisted fields.">>}
+                end
             end
     end.
 

--- a/src/dev_token.erl
+++ b/src/dev_token.erl
@@ -43,23 +43,15 @@
     ]
 ).
 
-%% @doc Immutable token metadata fields
--define(IMMUTABLE_METADATA_FIELDS, [
-        <<"name">>,
-        <<"ticker">>,
-        <<"denomination">>,
-        <<"logo">>
-    ]
-).
-
-%% @doc Allowed Authority base parameters mutation
-whitelisted_auth_fields() -> [
-    <<"set-authority">>, % admin rotation
-    <<"set-authority-required">>,
-    <<"set-authority-match">>
-    ]
-    ++ ?IMMUTABLE_METADATA_FIELDS.
-
+%% @doc Return the configured `set` field whitelist. Defaults to open policy
+%% via wildcard unless `whitelisted-fields` is explicitly restricted.
+whitelisted_auth_fields(Base, Opts) ->
+    hb_ao:get(
+        <<"whitelisted-fields">>,
+        Base,
+        [<<"*">>],
+        Opts
+    ).
 %%% `~process@1.0' interface implementation.
 
 %% @doc No-op on process initialization.
@@ -313,7 +305,7 @@ ensure_mint_device(Base, Opts) ->
 %%% Secure `set' call orchestration.
 
 %% @doc Ensure that the caller is the `set' authority, and apply changes to the
-%% base state if so. The setter can only mutuate whitelisted fields.
+%% base state if so. The setter can only mutate whitelisted fields.
 secure_set(Base, Assignment, Opts) ->
     maybe
         {ok, Req} ?= hb_ao:resolve(Assignment, <<"body">>, Opts),
@@ -325,47 +317,25 @@ secure_set(Base, Assignment, Opts) ->
                 RawBody,
                 Opts
             ),
-        % check for immutable state variable update attempts
-        true ?= enforce_immutable_fields(Base, SetReq, Opts),
-        % check the auth is touching whitelisted fields only
-        true ?= enforce_whitelisted_fields(SetReq, Opts),
-        % Apply updates to base state
+        % Check the auth is touching whitelisted fields only.
+        true ?= enforce_whitelisted_fields(Base, SetReq, Opts),
+        % Apply updates to base state.
         hb_ao:resolve(Base, Req#{ <<"path">> => <<"set">> }, Opts)
     end.
-enforce_immutable_fields(Base, Req, Opts) ->
-    lists:foldl(
-        fun
-            (_Key, {error, _} = Err) ->
-                Err;
-            (Key, true) ->
-                immutable_not_already_set(Key, Base, Req, Opts)
-        end,
-        true,
-        ?IMMUTABLE_METADATA_FIELDS
-    ).
-
-immutable_not_already_set(Key, Base, Req, Opts) ->
-    case hb_maps:find(Key, Req, Opts) of
-        {ok, _NewValue} ->
-            case hb_maps:find(Key, Base, Opts) of
-                {ok, _Existing} -> {error, <<Key/binary, " is immutable once set.">>};
-                error -> true
-            end;
-        % immutable keys not present in Req
-        _ ->
-            true
-    end.
-
-enforce_whitelisted_fields(Req, Opts) ->
+enforce_whitelisted_fields(Base, Req, Opts) ->
     Keys = hb_maps:keys(Req, Opts),
-    case
-        lists:all(
-            fun(Key) -> lists:member(Key, whitelisted_auth_fields()) end,
-            Keys
-        )
-    of
-        true -> true;
-        false -> {error, <<"Attempted to set non-whitelisted fields.">>}
+    WhitelistedFields = whitelisted_auth_fields(Base, Opts),
+    case lists:member(<<"*">>, WhitelistedFields) of
+        true ->
+            true;
+        false ->
+            case lists:all(
+                fun(Key) -> lists:member(Key, WhitelistedFields) end,
+                Keys
+            ) of
+                true -> true;
+                false -> {error, <<"Attempted to set non-whitelisted fields.">>}
+            end
     end.
 
 %% @doc Enforce that the caller is the `set` authority. If `Base` configures
@@ -399,7 +369,7 @@ enforce_set_authority(Base, Req, Opts) ->
                 enforce_legacy_set_authority(Setter, Base, Opts)
         end,
         true ?= AuthRes
-	end.
+    end.
 
 enforce_legacy_set_authority(Setter, Base, Opts) ->
     case validate_address(Setter, []) of

--- a/src/dev_token_test_vectors.erl
+++ b/src/dev_token_test_vectors.erl
@@ -485,73 +485,6 @@ batch_mint_reserved_ao_recipient_rejected_test() ->
     ?assertEqual(<<"trie@1.0">>, maps:get(<<"device">>, Balances)),
     ?assertEqual(0, hb_ao:get(<<"total-supply">>, Base, Opts)).
 
-immutable_name_update_rejected_test() ->
-    Opts = opts(),
-    Setter = hb_opts:get(priv_wallet, hb:wallet(), Opts),
-    Base =
-        generate_process(
-            #{
-                extra => #{
-                    <<"set-authority">> => id(Setter)
-                }
-            },
-            Opts
-        ),
-    ?assertEqual(
-        {error, <<"name is immutable once set.">>},
-        dev_token:handle_action(
-            <<"set">>,
-            Base,
-            #{
-                <<"body">> => #{
-                    <<"from">> => id(Setter),
-                    <<"name">> => <<"New Token Name">>
-                }
-            },
-            Opts
-        )
-    ).
-
-logo_set_once_then_update_rejected_test() ->
-    Opts = opts(),
-    Setter = hb_opts:get(priv_wallet, hb:wallet(), Opts),
-    Base =
-        generate_process(
-            #{
-                extra => #{
-                    <<"set-authority">> => id(Setter)
-                }
-            },
-            Opts
-        ),
-    {ok, WithLogo} =
-        dev_token:handle_action(
-            <<"set">>,
-            Base,
-            #{
-                <<"body">> => #{
-                    <<"from">> => id(Setter),
-                    <<"logo">> => <<"logo-a">>
-                }
-            },
-            Opts
-        ),
-    ?assertEqual(<<"logo-a">>, hb_ao:get(<<"logo">>, WithLogo, Opts)),
-    ?assertEqual(
-        {error, <<"logo is immutable once set.">>},
-        dev_token:handle_action(
-            <<"set">>,
-            WithLogo,
-            #{
-                <<"body">> => #{
-                    <<"from">> => id(Setter),
-                    <<"logo">> => <<"logo-b">>
-                }
-            },
-            Opts
-        )
-    ).
-
 non_whitelisted_set_field_rejected_test() ->
     Opts = opts(),
     Setter = hb_opts:get(priv_wallet, hb:wallet(), Opts),
@@ -559,7 +492,16 @@ non_whitelisted_set_field_rejected_test() ->
         generate_process(
             #{
                 extra => #{
-                    <<"set-authority">> => id(Setter)
+                    <<"set-authority">> => id(Setter),
+                    <<"whitelisted-fields">> => [
+                        <<"set-authority">>,
+                        <<"set-authority-required">>,
+                        <<"set-authority-match">>,
+                        <<"name">>,
+                        <<"ticker">>,
+                        <<"denomination">>,
+                        <<"logo">>
+                    ]
                 }
             },
             Opts
@@ -577,6 +519,35 @@ non_whitelisted_set_field_rejected_test() ->
             },
             Opts
         )
+    ).
+
+default_whitelist_wildcard_allows_set_test() ->
+    Opts = opts(),
+    Setter = hb_opts:get(priv_wallet, hb:wallet(), Opts),
+    Base =
+        generate_process(
+            #{
+                extra => #{
+                    <<"set-authority">> => id(Setter)
+                }
+            },
+            Opts
+        ),
+    {ok, Updated} =
+        dev_token:handle_action(
+            <<"set">>,
+            Base,
+            #{
+                <<"body">> => #{
+                    <<"from">> => id(Setter),
+                    <<"balances">> => #{ <<"fake">> => 1 }
+                }
+            },
+            Opts
+        ),
+    ?assertEqual(
+        1,
+        hb_ao:get(<<"fake">>, hb_ao:get(<<"balances">>, Updated, #{}, Opts), 0, Opts)
     ).
 
 set_authority_required_uses_dev_security_test() ->


### PR DESCRIPTION
## About

This PR addresses a final version of the whitelisted token fields policy, after checking with the team for policy-feedback (https://github.com/permaweb/HyperBEAM/pull/804 and https://github.com/permaweb/HyperBEAM/pull/803)

TL;DR:
* removes the IMMUTABLE_METADATA_FIELDS policy (fields that can be set once, like token metadata)
* updates the `whitelisted_auth_fields` design to not allow only present whitelisted fields, but to default to `<<"whitelisted-fields">> => [<<"*>>]` where all fields are whitelisted unless set otherwise by the set authority 
* updated tests and added (`default_whitelist_wildcard_allows_set_test`)
* validate `<<"whitelisted-fields">>` value type (list) and list values (non-empty binaries)