### PR TITLE
fix: Timeout on 500 when detail message is too large

### DIFF
--- a/src/hb_format.erl
+++ b/src/hb_format.erl
@@ -16,11 +16,13 @@
 -export([binary/2, error/2, trace/1, trace_short/0, trace_short/1]).
 -export([indent/2, indent/3, indent/4, indent_lines/2, maybe_multiline/3]).
 -export([remove_leading_noise/1, remove_trailing_noise/1, remove_noise/1]).
+-export([truncate/2]).
 %%% Public Utility Functions.
 -export([escape_format/1, short_id/1, trace_to_list/1]).
 -export([get_trace/1, print_trace/4, trace_macro_helper/5, print_trace_short/4]).
 -export([process_from_trace/1]).
 -include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
 
 %%% Characters that are considered noise and should be removed from strings
 %%% with the `remove_noise_[leading|trailing]' functions.
@@ -355,6 +357,23 @@ do_to_lines(In =[RawElem | Rest]) ->
         true -> lists:flatten(lists:join("\n", In));
         false -> Elem ++ ", " ++ do_to_lines(Rest)
     end.
+
+truncate(Str, MaxSize) when is_list(Str) ->
+    StrLen = length(Str),
+    StrEnd = case StrLen > MaxSize of
+        true -> "...";
+        false -> ""
+    end,
+    string:substr(Str, 1, min (StrLen, MaxSize)) ++ StrEnd;
+
+truncate(Bin, MaxSize) when is_binary(Bin) ->
+    BinLen = byte_size(Bin),
+    BinEnd = case BinLen > MaxSize of 
+        true -> <<"...">>;
+        false -> <<>>
+    end,
+    TruncatedBin = binary:part(Bin, 0, min(BinLen, MaxSize)),
+    <<TruncatedBin/binary, BinEnd/binary>>.
 
 %% @doc Remove any leading or trailing noise from a string.
 remove_noise(Str) ->
@@ -1079,3 +1098,29 @@ max_keys(Opts) ->
         infinity -> infinity;
         Term -> hb_util:int(Term)
     end.
+
+%%% Tests
+
+truncate_list_no_truncation_test() ->
+    ?assertEqual("hello", truncate("hello", 10)).
+
+truncate_list_exact_size_test() ->
+    ?assertEqual("hello", truncate("hello", 5)).
+
+truncate_list_with_truncation_test() ->
+    ?assertEqual("he...", truncate("hello", 2)).
+
+truncate_binary_no_truncation_test() ->
+    ?assertEqual(<<"hello">>, truncate(<<"hello">>, 10)).
+
+truncate_binary_exact_size_test() ->
+    ?assertEqual(<<"hello">>, truncate(<<"hello">>, 5)).
+
+truncate_binary_with_truncation_test() ->
+    ?assertEqual(<<"he...">>, truncate(<<"hello">>, 2)).
+
+truncate_empty_list_test() ->
+    ?assertEqual("", truncate("", 5)).
+
+truncate_empty_binary_test() ->
+    ?assertEqual(<<>>, truncate(<<>>, 5)).

--- a/src/hb_format.erl
+++ b/src/hb_format.erl
@@ -358,14 +358,6 @@ do_to_lines(In =[RawElem | Rest]) ->
         false -> Elem ++ ", " ++ do_to_lines(Rest)
     end.
 
-truncate(Str, MaxSize) when is_list(Str) ->
-    StrLen = length(Str),
-    StrEnd = case StrLen > MaxSize of
-        true -> "...";
-        false -> ""
-    end,
-    string:substr(Str, 1, min (StrLen, MaxSize)) ++ StrEnd;
-
 truncate(Bin, MaxSize) when is_binary(Bin) ->
     BinLen = byte_size(Bin),
     BinEnd = case BinLen > MaxSize of 
@@ -1101,26 +1093,14 @@ max_keys(Opts) ->
 
 %%% Tests
 
-truncate_list_no_truncation_test() ->
-    ?assertEqual("hello", truncate("hello", 10)).
-
-truncate_list_exact_size_test() ->
-    ?assertEqual("hello", truncate("hello", 5)).
-
-truncate_list_with_truncation_test() ->
-    ?assertEqual("he...", truncate("hello", 2)).
-
-truncate_binary_no_truncation_test() ->
+truncate_no_truncation_test() ->
     ?assertEqual(<<"hello">>, truncate(<<"hello">>, 10)).
 
-truncate_binary_exact_size_test() ->
+truncate_exact_size_test() ->
     ?assertEqual(<<"hello">>, truncate(<<"hello">>, 5)).
 
-truncate_binary_with_truncation_test() ->
+truncate_with_truncation_test() ->
     ?assertEqual(<<"he...">>, truncate(<<"hello">>, 2)).
 
-truncate_empty_list_test() ->
-    ?assertEqual("", truncate("", 5)).
-
-truncate_empty_binary_test() ->
+truncate_empty_test() ->
     ?assertEqual(<<>>, truncate(<<>>, 5)).

--- a/src/hb_format.erl
+++ b/src/hb_format.erl
@@ -358,6 +358,7 @@ do_to_lines(In =[RawElem | Rest]) ->
         false -> Elem ++ ", " ++ do_to_lines(Rest)
     end.
 
+%% @doc Truncate binary (if larger than) to a max size.
 truncate(Bin, MaxSize) when is_binary(Bin) ->
     BinLen = byte_size(Bin),
     BinEnd = case BinLen > MaxSize of 

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -16,6 +16,8 @@
 -export([start_node/0, start_node/1]).
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
+%% Define the max size we can return in 500 error details field.
+-define(DEFAULT_ERROR_DETAILS_MAX_SIZE, 32*1024).
 
 %% @doc Starts the HTTP server. Optionally accepts an `Opts' message, which
 %% is used as the source for server configuration settings, as well as the
@@ -458,11 +460,13 @@ handle_error(Req, Singleton, Type, Details, Stacktrace, NodeMsg) ->
         },
         NodeMsg
     ),
+    ErrorDetailsMaxSize = maps:get(error_details_max_size, NodeMsg, ?DEFAULT_ERROR_DETAILS_MAX_SIZE),
+    DetailsBin = hb_util:bin(hb_format:remove_noise(DetailsStr)),
     % Remove leading and trailing noise from the stacktrace and details.
     FormattedErrorMsg =
         ErrorMsg#{
             <<"stacktrace">> => hb_util:bin(hb_format:remove_noise(StacktraceStr)),
-            <<"details">> => hb_util:bin(hb_format:remove_noise(DetailsStr))
+            <<"details">> => binary:part(DetailsBin, 0, min(ErrorDetailsMaxSize, byte_size(DetailsBin)))
         },
     hb_http:reply(Req, Singleton, FormattedErrorMsg, NodeMsg).
 

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -461,12 +461,11 @@ handle_error(Req, Singleton, Type, Details, Stacktrace, NodeMsg) ->
         NodeMsg
     ),
     ErrorDetailsMaxSize = maps:get(error_details_max_size, NodeMsg, ?DEFAULT_ERROR_DETAILS_MAX_SIZE),
-    DetailsBin = hb_util:bin(hb_format:remove_noise(DetailsStr)),
     % Remove leading and trailing noise from the stacktrace and details.
     FormattedErrorMsg =
         ErrorMsg#{
             <<"stacktrace">> => hb_util:bin(hb_format:remove_noise(StacktraceStr)),
-            <<"details">> => binary:part(DetailsBin, 0, min(ErrorDetailsMaxSize, byte_size(DetailsBin)))
+            <<"details">> => hb_util:bin(hb_format:truncate(hb_format:remove_noise(DetailsStr), ErrorDetailsMaxSize))
         },
     hb_http:reply(Req, Singleton, FormattedErrorMsg, NodeMsg).
 

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -460,7 +460,7 @@ handle_error(Req, Singleton, Type, Details, Stacktrace, NodeMsg) ->
         },
         NodeMsg
     ),
-    ErrorDetailsMaxSize = maps:get(error_details_max_size, NodeMsg, ?DEFAULT_ERROR_DETAILS_MAX_SIZE),
+    ErrorDetailsMaxSize = hb_opts:get(error_details_max_size, ?DEFAULT_ERROR_DETAILS_MAX_SIZE, NodeMsg),
     % Remove leading and trailing noise from the stacktrace and details.
     FormattedErrorMsg =
         ErrorMsg#{

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -465,7 +465,7 @@ handle_error(Req, Singleton, Type, Details, Stacktrace, NodeMsg) ->
     FormattedErrorMsg =
         ErrorMsg#{
             <<"stacktrace">> => hb_util:bin(hb_format:remove_noise(StacktraceStr)),
-            <<"details">> => hb_util:bin(hb_format:truncate(hb_format:remove_noise(DetailsStr), ErrorDetailsMaxSize))
+            <<"details">> => hb_format:truncate(hb_util:bin(hb_format:remove_noise(DetailsStr)), ErrorDetailsMaxSize)
         },
     hb_http:reply(Req, Singleton, FormattedErrorMsg, NodeMsg).
 


### PR DESCRIPTION
In some cases, for example, ANS104 invalid signature, the details contained a large binary (1MB). Trying to send it over the socket would consume too many resources. 

The default value now is 32KB, which can be changed using `error_details_max_size`.