### PR TITLE
wip: named offsets experiment

### DIFF
--- a/src/dev_offset_name.erl
+++ b/src/dev_offset_name.erl
@@ -1,7 +1,7 @@
 %%% @doc Allows Arweave offsets to be used via deterministic hostname-safe
 %%% aliases, then delegates the actual load to `arweave@2.9`.
 -module(dev_offset_name).
--export([info/1, encode/1, decode/1]).
+-export([info/1, alias/3, encode/1, decode/1]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -72,6 +72,16 @@ info(_Opts) ->
         excludes => [<<"keys">>, <<"set">>]
     }.
 
+%% @doc Return the deterministic alias for an offset. Supports both
+%% `/~offset-name@1.0/alias?offset=<offset>` and `/~offset-name@1.0/alias/<offset>`.
+alias(_Base, Req, Opts) ->
+    case hb_ao:get(<<"offset">>, Req, not_found, Opts) of
+        not_found ->
+            {ok, {as, alias_route_device(), #{}}};
+        Offset ->
+            encode_result(Offset)
+    end.
+
 %% @doc Resolve an offset alias by decoding it back to a numeric offset, then
 %% delegating to the standard Arweave offset resolver.
 get(Key, _, _Req, Opts) ->
@@ -111,6 +121,27 @@ decode(_Alias) ->
 
 target_device(Opts) ->
     hb_opts:get(offset_name_target, ?DEFAULT_TARGET_DEVICE, Opts).
+
+alias_route_device() ->
+    #{
+        info =>
+            fun() ->
+                #{
+                    default => fun alias_lookup/4,
+                    excludes => [<<"keys">>, <<"set">>]
+                }
+            end
+    }.
+
+alias_lookup(Key, _, _Req, _Opts) ->
+    encode_result(Key).
+
+encode_result(Offset) ->
+    try
+        {ok, encode(Offset)}
+    catch
+        _:_ -> {error, not_found}
+    end.
 
 encode_base32(0) ->
     <<"0">>;
@@ -238,6 +269,28 @@ get_delegates_to_offset_target_test() ->
     ?assertEqual(
         integer_to_binary(Offset),
         maps:get(<<"resolved-offset">>, Resolved)
+    ).
+
+alias_query_param_test() ->
+    Offset = <<"152974576623958">>,
+    ?assertEqual(
+        {ok, encode(Offset)},
+        hb_ao:resolve(
+            #{ <<"device">> => <<"offset-name@1.0">> },
+            #{ <<"path">> => <<"alias">>, <<"offset">> => Offset },
+            #{}
+        )
+    ).
+
+alias_path_route_test() ->
+    Offset = <<"152974576623958">>,
+    ?assertEqual(
+        {ok, encode(Offset)},
+        hb_ao:resolve(
+            #{ <<"device">> => <<"offset-name@1.0">> },
+            <<"alias/152974576623958">>,
+            #{}
+        )
     ).
 
 reverse_alias_resolve_test() ->

--- a/src/dev_offset_name.erl
+++ b/src/dev_offset_name.erl
@@ -202,6 +202,19 @@ get_delegates_to_offset_target_test() ->
         maps:get(<<"resolved-offset">>, Resolved)
     ).
 
+reverse_alias_resolve_test() ->
+    Alias = <<"grand-brook-az9wqrtem2">>,
+    {ok, Resolved} =
+        hb_ao:resolve(
+            #{ <<"device">> => <<"offset-name@1.0">> },
+            Alias,
+            #{ offset_name_target => test_target_device() }
+        ),
+    ?assertEqual(
+        <<"386268681550466">>,
+        maps:get(<<"resolved-offset">>, Resolved)
+    ).
+
 name_resolver_lookup_test() ->
     Offset = 152974576623958,
     Alias = encode(Offset),

--- a/src/dev_offset_name.erl
+++ b/src/dev_offset_name.erl
@@ -1,0 +1,222 @@
+%%% @doc Allows Arweave offsets to be used via deterministic hostname-safe
+%%% aliases, then delegates the actual load to `arweave@2.9`.
+-module(dev_offset_name).
+-export([info/1, encode/1, decode/1]).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(BASE32_ALPHABET, <<"0123456789abcdefghjkmnpqrstvwxyz">>).
+-define(DEFAULT_TARGET_DEVICE, #{ <<"device">> => <<"arweave@2.9">> }).
+-define(ADJECTIVES,
+    [
+        <<"amber">>, <<"brisk">>, <<"calm">>, <<"clever">>,
+        <<"copper">>, <<"coral">>, <<"ember">>, <<"feral">>,
+        <<"floral">>, <<"gentle">>, <<"golden">>, <<"grand">>,
+        <<"hidden">>, <<"lucid">>, <<"mellow">>, <<"misty">>,
+        <<"noble">>, <<"polished">>, <<"quiet">>, <<"rapid">>,
+        <<"silent">>, <<"silver">>, <<"solar">>, <<"steady">>,
+        <<"swift">>, <<"tidal">>, <<"velvet">>, <<"vivid">>,
+        <<"wild">>, <<"winter">>, <<"yellow">>, <<"zesty">>
+    ]
+).
+-define(NOUNS,
+    [
+        <<"anchor">>, <<"beacon">>, <<"brook">>, <<"canyon">>,
+        <<"cedar">>, <<"cloud">>, <<"comet">>, <<"creek">>,
+        <<"delta">>, <<"dune">>, <<"falcon">>, <<"field">>,
+        <<"forest">>, <<"harbor">>, <<"island">>, <<"lagoon">>,
+        <<"meadow">>, <<"mesa">>, <<"mist">>, <<"orchid">>,
+        <<"pebble">>, <<"prairie">>, <<"quarry">>, <<"river">>,
+        <<"rocket">>, <<"shadow">>, <<"summit">>, <<"thunder">>,
+        <<"valley">>, <<"willow">>, <<"wind">>, <<"zephyr">>
+    ]
+).
+
+info(_Opts) ->
+    #{
+        default => fun get/4,
+        excludes => [<<"keys">>, <<"set">>]
+    }.
+
+%% @doc Resolve an offset alias by decoding it back to a numeric offset, then
+%% delegating to the standard Arweave offset resolver.
+get(Key, _, _Req, Opts) ->
+    case decode(Key) of
+        {ok, Offset} ->
+            hb_ao:resolve(target_device(Opts), integer_to_binary(Offset), Opts);
+        error ->
+            {error, not_found}
+    end.
+
+%% @doc Convert an offset into a hostname-safe alias.
+encode(Offset) when is_integer(Offset), Offset >= 0 ->
+    {Adjective, Noun} = checksum_words(Offset),
+    Tail = encode_base32(Offset),
+    <<
+        Adjective/binary,
+        "-",
+        Noun/binary,
+        "-",
+        Tail/binary
+    >>;
+encode(Offset) when is_binary(Offset) ->
+    try encode(hb_util:int(Offset))
+    catch _:_ -> error({cannot_encode_offset_alias, Offset})
+    end;
+encode(Offset) ->
+    error({cannot_encode_offset_alias, Offset}).
+
+%% @doc Decode an offset alias back to its canonical integer offset.
+decode(Alias) when is_binary(Alias) ->
+    case binary:split(Alias, <<"-">>, [global]) of
+        [_Adjective, _Noun, Tail] -> decode_canonical_alias(Alias, Tail);
+        _ -> error
+    end;
+decode(_Alias) ->
+    error.
+
+target_device(Opts) ->
+    hb_opts:get(offset_name_target, ?DEFAULT_TARGET_DEVICE, Opts).
+
+encode_base32(0) ->
+    <<"0">>;
+encode_base32(Offset) when is_integer(Offset), Offset > 0 ->
+    encode_base32(Offset, <<>>).
+
+encode_base32(0, Acc) ->
+    Acc;
+encode_base32(Offset, Acc) ->
+    Digit = binary:at(?BASE32_ALPHABET, Offset rem 32),
+    encode_base32(Offset div 32, <<Digit, Acc/binary>>).
+
+decode_base32(<<>>) ->
+    error;
+decode_base32(AliasTail) when is_binary(AliasTail) ->
+    decode_base32(AliasTail, 0).
+
+decode_base32(<<>>, Offset) ->
+    {ok, Offset};
+decode_base32(<<Char, Rest/binary>>, Offset) ->
+    case decode_digit(Char) of
+        error ->
+            error;
+        Value ->
+            decode_base32(Rest, Offset * 32 + Value)
+    end.
+
+decode_canonical_alias(Alias, Tail) ->
+    case decode_base32(Tail) of
+        {ok, Offset} ->
+            case Alias =:= encode(Offset) of
+                true -> {ok, Offset};
+                _ -> error
+            end;
+        error ->
+            error
+    end.
+
+decode_digit(Char) ->
+    Normalized = normalize_char(Char),
+    case binary:match(?BASE32_ALPHABET, <<Normalized>>) of
+        {Index, 1} -> Index;
+        nomatch -> error
+    end.
+
+normalize_char(Char) when Char >= $A, Char =< $Z ->
+    Char + 32;
+normalize_char(Char) ->
+    Char.
+
+checksum_words(Offset) ->
+    <<AdjByte, NounByte, _/binary>> =
+        crypto:hash(sha256, integer_to_binary(Offset)),
+    {
+        lists:nth((AdjByte rem length(?ADJECTIVES)) + 1, ?ADJECTIVES),
+        lists:nth((NounByte rem length(?NOUNS)) + 1, ?NOUNS)
+    }.
+
+test_target_device() ->
+    #{
+        <<"device">> =>
+            #{
+                info =>
+                    fun() ->
+                        #{
+                            default =>
+                                fun(Key, _, _Req, _Opts) ->
+                                    {ok, #{ <<"resolved-offset">> => Key }}
+                                end
+                        }
+                    end
+            }
+    }.
+
+roundtrip_test() ->
+    Offset = 152974576623958,
+    ?assertEqual(
+        {ok, Offset},
+        decode(encode(Offset))
+    ).
+
+format_shape_test() ->
+    [Adjective, Noun, Tail] =
+        binary:split(encode(152974576623958), <<"-">>, [global]),
+    ?assert(lists:member(Adjective, ?ADJECTIVES)),
+    ?assert(lists:member(Noun, ?NOUNS)),
+    ?assertMatch({ok, _}, decode(<<Adjective/binary, "-", Noun/binary, "-", Tail/binary>>)).
+
+uppercase_alias_rejected_test() ->
+    Alias = encode(152974576623958),
+    ?assertEqual(
+        error,
+        decode(list_to_binary(string:uppercase(binary_to_list(Alias))))
+    ).
+
+invalid_alias_test() ->
+    [_, Noun, Tail] =
+        binary:split(encode(152974576623958), <<"-">>, [global]),
+    ?assertEqual(error, decode(<<"wrong-", Noun/binary, "-", Tail/binary>>)),
+    ?assertEqual(error, decode(<<"amber-", Noun/binary, "-open">>)),
+    ?assertEqual(error, decode(<<"only-two">>)).
+
+leading_zero_tail_rejected_test() ->
+    [Adjective, Noun, Tail] =
+        binary:split(encode(152974576623958), <<"-">>, [global]),
+    ?assertEqual(
+        error,
+        decode(<<Adjective/binary, "-", Noun/binary, "-0", Tail/binary>>)
+    ).
+
+get_delegates_to_offset_target_test() ->
+    Offset = 152974576623958,
+    Alias = encode(Offset),
+    {ok, Resolved} =
+        get(
+            Alias,
+            #{},
+            #{},
+            #{ offset_name_target => test_target_device() }
+        ),
+    ?assertEqual(
+        integer_to_binary(Offset),
+        maps:get(<<"resolved-offset">>, Resolved)
+    ).
+
+name_resolver_lookup_test() ->
+    Offset = 152974576623958,
+    Alias = encode(Offset),
+    {ok, Resolved} =
+        hb_ao:resolve_many(
+            [
+                #{ <<"device">> => <<"name@1.0">> },
+                #{ <<"path">> => Alias }
+            ],
+            #{
+                offset_name_target => test_target_device(),
+                name_resolvers => [#{ <<"device">> => <<"offset-name@1.0">> }]
+            }
+        ),
+    ?assertEqual(
+        integer_to_binary(Offset),
+        maps:get(<<"resolved-offset">>, Resolved)
+    ).

--- a/src/dev_offset_name.erl
+++ b/src/dev_offset_name.erl
@@ -16,7 +16,24 @@
         <<"noble">>, <<"polished">>, <<"quiet">>, <<"rapid">>,
         <<"silent">>, <<"silver">>, <<"solar">>, <<"steady">>,
         <<"swift">>, <<"tidal">>, <<"velvet">>, <<"vivid">>,
-        <<"wild">>, <<"winter">>, <<"yellow">>, <<"zesty">>
+        <<"wild">>, <<"winter">>, <<"yellow">>, <<"zesty">>,
+        <<"ancient">>, <<"autumn">>, <<"azure">>, <<"bright">>,
+        <<"bronze">>, <<"crimson">>, <<"crystal">>, <<"curious">>,
+        <<"daring">>, <<"dusky">>, <<"eager">>, <<"frozen">>,
+        <<"glimmer">>, <<"hollow">>, <<"iron">>, <<"ivory">>,
+        <<"kindred">>, <<"lunar">>, <<"marble">>, <<"midnight">>,
+        <<"obsidian">>, <<"ocean">>, <<"opal">>, <<"patient">>,
+        <<"royal">>, <<"sacred">>, <<"scarlet">>, <<"shaded">>,
+        <<"ashen">>, <<"bitter">>, <<"hazy">>, <<"verdant">>,
+        <<"agile">>, <<"alpine">>, <<"apricot">>, <<"bold">>,
+        <<"breezy">>, <<"cobalt">>, <<"cosmic">>, <<"desert">>,
+        <<"electric">>, <<"emerald">>, <<"faithful">>, <<"fiery">>,
+        <<"glassy">>, <<"grassy">>, <<"humble">>, <<"icy">>,
+        <<"jolly">>, <<"lucky">>, <<"magnetic">>, <<"neat">>,
+        <<"nimble">>, <<"orange">>, <<"pepper">>, <<"rosy">>,
+        <<"rustic">>, <<"sandy">>, <<"smoky">>, <<"snowy">>,
+        <<"spotted">>, <<"sunny">>, <<"tranquil">>, <<"urban">>,
+        <<"warm">>, <<"wise">>, <<"woody">>, <<"young">>
     ]
 ).
 -define(NOUNS,
@@ -28,7 +45,24 @@
         <<"meadow">>, <<"mesa">>, <<"mist">>, <<"orchid">>,
         <<"pebble">>, <<"prairie">>, <<"quarry">>, <<"river">>,
         <<"rocket">>, <<"shadow">>, <<"summit">>, <<"thunder">>,
-        <<"valley">>, <<"willow">>, <<"wind">>, <<"zephyr">>
+        <<"valley">>, <<"willow">>, <<"wind">>, <<"zephyr">>,
+        <<"asteroid">>, <<"bay">>, <<"blossom">>, <<"branch">>,
+        <<"citadel">>, <<"cliff">>, <<"cove">>, <<"ember">>,
+        <<"feather">>, <<"fjord">>, <<"flare">>, <<"garden">>,
+        <<"glacier">>, <<"grove">>, <<"horizon">>, <<"jungle">>,
+        <<"kingfisher">>, <<"lantern">>, <<"lotus">>, <<"meteor">>,
+        <<"monsoon">>, <<"moon">>, <<"morning">>, <<"pine">>,
+        <<"reef">>, <<"signal">>, <<"stone">>, <<"sunrise">>,
+        <<"aurora">>, <<"bridge">>, <<"cascade">>, <<"voyage">>,
+        <<"airship">>, <<"arbor">>, <<"campfire">>, <<"caravan">>,
+        <<"chamber">>, <<"compass">>, <<"crown">>, <<"dawn">>,
+        <<"estuary">>, <<"firefly">>, <<"fountain">>, <<"galaxy">>,
+        <<"gate">>, <<"hearth">>, <<"hill">>, <<"lighthouse">>,
+        <<"orchard">>, <<"owl">>, <<"palace">>, <<"path">>,
+        <<"pearl">>, <<"planet">>, <<"pond">>, <<"prism">>,
+        <<"ridge">>, <<"sail">>, <<"spring">>, <<"star">>,
+        <<"stream">>, <<"temple">>, <<"torch">>, <<"tower">>,
+        <<"trail">>, <<"wheat">>, <<"wave">>, <<"wing">>
     ]
 ).
 
@@ -158,6 +192,10 @@ roundtrip_test() ->
         decode(encode(Offset))
     ).
 
+word_pool_size_test() ->
+    ?assertEqual(100, length(?ADJECTIVES)),
+    ?assertEqual(100, length(?NOUNS)).
+
 format_shape_test() ->
     [Adjective, Noun, Tail] =
         binary:split(encode(152974576623958), <<"-">>, [global]),
@@ -203,11 +241,24 @@ get_delegates_to_offset_target_test() ->
     ).
 
 reverse_alias_resolve_test() ->
-    Alias = <<"grand-brook-az9wqrtem2">>,
+    Offset = 386268681550466,
+    Alias = encode(Offset),
     {ok, Resolved} =
         hb_ao:resolve(
             #{ <<"device">> => <<"offset-name@1.0">> },
             Alias,
+            #{ offset_name_target => test_target_device() }
+        ),
+    ?assertEqual(
+        integer_to_binary(Offset),
+        maps:get(<<"resolved-offset">>, Resolved)
+    ).
+
+reverse_known_alias_fixture_test() ->
+    {ok, Resolved} =
+        hb_ao:resolve(
+            #{ <<"device">> => <<"offset-name@1.0">> },
+            <<"frozen-campfire-az9wqrtem2">>,
             #{ offset_name_target => test_target_device() }
         ),
     ?assertEqual(

--- a/src/dev_offset_name.erl
+++ b/src/dev_offset_name.erl
@@ -1,7 +1,7 @@
 %%% @doc Allows Arweave offsets to be used via deterministic hostname-safe
 %%% aliases, then delegates the actual load to `arweave@2.9`.
 -module(dev_offset_name).
--export([info/1, alias/3, encode/1, decode/1]).
+-export([info/1, alias/3, offset/3, encode/1, decode/1]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -72,15 +72,13 @@ info(_Opts) ->
         excludes => [<<"keys">>, <<"set">>]
     }.
 
-%% @doc Return the deterministic alias for an offset. Supports both
-%% `/~offset-name@1.0/alias?offset=<offset>` and `/~offset-name@1.0/alias/<offset>`.
-alias(_Base, Req, Opts) ->
-    case hb_ao:get(<<"offset">>, Req, not_found, Opts) of
-        not_found ->
-            {ok, {as, alias_route_device(), #{}}};
-        Offset ->
-            encode_result(Offset)
-    end.
+%% @doc Route `/~offset-name@1.0/alias/<offset>` to the forward alias lookup.
+alias(_Base, _Req, _Opts) ->
+    {ok, {as, alias_route_device(), #{}}}.
+
+%% @doc Route `/~offset-name@1.0/offset/<alias>` to the reverse alias lookup.
+offset(_Base, _Req, _Opts) ->
+    {ok, {as, offset_route_device(), #{}}}.
 
 %% @doc Resolve an offset alias by decoding it back to a numeric offset, then
 %% delegating to the standard Arweave offset resolver.
@@ -136,11 +134,31 @@ alias_route_device() ->
 alias_lookup(Key, _, _Req, _Opts) ->
     encode_result(Key).
 
+offset_route_device() ->
+    #{
+        info =>
+            fun() ->
+                #{
+                    default => fun offset_lookup/4,
+                    excludes => [<<"keys">>, <<"set">>]
+                }
+            end
+    }.
+
+offset_lookup(Key, _, _Req, _Opts) ->
+    decode_result(Key).
+
 encode_result(Offset) ->
     try
         {ok, encode(Offset)}
     catch
         _:_ -> {error, not_found}
+    end.
+
+decode_result(Alias) ->
+    case decode(Alias) of
+        {ok, Offset} -> {ok, integer_to_binary(Offset)};
+        error -> {error, not_found}
     end.
 
 encode_base32(0) ->
@@ -271,17 +289,6 @@ get_delegates_to_offset_target_test() ->
         maps:get(<<"resolved-offset">>, Resolved)
     ).
 
-alias_query_param_test() ->
-    Offset = <<"152974576623958">>,
-    ?assertEqual(
-        {ok, encode(Offset)},
-        hb_ao:resolve(
-            #{ <<"device">> => <<"offset-name@1.0">> },
-            #{ <<"path">> => <<"alias">>, <<"offset">> => Offset },
-            #{}
-        )
-    ).
-
 alias_path_route_test() ->
     Offset = <<"152974576623958">>,
     ?assertEqual(
@@ -289,6 +296,17 @@ alias_path_route_test() ->
         hb_ao:resolve(
             #{ <<"device">> => <<"offset-name@1.0">> },
             <<"alias/152974576623958">>,
+            #{}
+        )
+    ).
+
+offset_path_route_test() ->
+    Alias = encode(152974576623958),
+    ?assertEqual(
+        {ok, <<"152974576623958">>},
+        hb_ao:resolve(
+            #{ <<"device">> => <<"offset-name@1.0">> },
+            <<"offset/", Alias/binary>>,
             #{}
         )
     ).

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -44,6 +44,7 @@
 -define(DEFAULT_NAME_RESOLVERS,
     [
         #{ <<"device">> => <<"arweave@2.9">> },
+        #{ <<"device">> => <<"offset-name@1.0">> },
         #{ <<"device">> => <<"b32-name@1.0">> },
         <<
             "G_gb7SAgogHMtmqycwaHaC6uC-CZ3akACdFv5PUaEE8",
@@ -207,6 +208,7 @@ default_message() ->
             #{<<"name">> => <<"monitor@1.0">>, <<"module">> => dev_monitor},
             #{<<"name">> => <<"multipass@1.0">>, <<"module">> => dev_multipass},
             #{<<"name">> => <<"name@1.0">>, <<"module">> => dev_name},
+            #{<<"name">> => <<"offset-name@1.0">>, <<"module">> => dev_offset_name},
             #{<<"name">> => <<"node-process@1.0">>, <<"module">> => dev_node_process},
             #{<<"name">> => <<"p4@1.0">>, <<"module">> => dev_p4},
             #{<<"name">> => <<"patch@1.0">>, <<"module">> => dev_patch},


### PR DESCRIPTION
## About

deterministic, HRA names (aliases) for ~arweave@2.9 offsets. the names are derived from the offset itself and take the form:

  `<adjective>-<noun>-<base32-offset>`

For example:
`386268681550466` -> `frozen-campfire-az9wqrtem2`
 
the trailing base32 segment is canonical and sufficient to recover the exact offset. The two words are a checksum-like human layer derived from the offset.

 The resolver works by:

  - decoding the alias back to its canonical offset
  - validating that the words match the decoded offset
  - delegating the actual load to `~arweave@2.9`

  This means that:

  - each offset has exactly one canonical alias under the ***current word lists***
  - aliases remain reversible without a registry
  - `~arweave@2.9` remains the canonical offset resolver


 the current dictionary fixed-word pools contain 100 adjectives and 100 nouns, giving 10k HRA word pairs. N.B: updating the dictionary means new alias for an offset (breaks the pre-change dictionary resolved aliases, so if we change the dict in prod, we need to version it with something like `v1-word1-word2-base32offset`
 
 ### Alias construction
 
  - compute `sha256(integer_to_binary(Offset))`
  - use the first byte of the hash, modulo the adjective list length, to choose the adjective
  - use the second byte of the hash, modulo the noun list length, to choose the noun
  - encode the offset itself as a lowercase base32 tail
  - join the three parts with `-`
  
  ### Alias reverse-resolving
  
  - split the alias into `<adjective>-<noun>-<tail>`
  - decode the lowercase base32 tail back into the numeric offset
  - recompute the canonical alias from that offset
  - accept only if the recomputed alias exactly matches the input
  - resolve the resulting offset through `~arweave@2.9`
  
  ## HTTP API
  
  - offset -> alias resolver: `http://localhost:8734/~offset-name@1.0/alias/152974576623958`
  - alias -> offset reverse resolver: `http://localhost:8734/~offset-name@1.0/offset/ocean-tower-4b44nms8ap`

<img width="2880" height="1774" alt="image" src="https://github.com/user-attachments/assets/9c2c1392-7264-4600-9f5e-badabe82143d" />
  
  
  ```bash
  ======================== EUnit ========================
module 'dev_offset_name'
  dev_offset_name: roundtrip_test...ok
  dev_offset_name: word_pool_size_test...ok
  dev_offset_name: format_shape_test...ok
  dev_offset_name: uppercase_alias_rejected_test...ok
  dev_offset_name: invalid_alias_test...ok
  dev_offset_name: leading_zero_tail_rejected_test...ok
  dev_offset_name: get_delegates_to_offset_target_test...[0.018 s] ok
  dev_offset_name: reverse_alias_resolve_test...ok
  dev_offset_name: reverse_known_alias_fixture_test...ok
  dev_offset_name: name_resolver_lookup_test...[0.002 s] ok
  [done in 0.050 s]
=======================================================
  All 10 tests passed.
  ```