### PR TITLE
fix: prevent cyclic undelegation/liquidation state corruption

### DIFF
--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -777,11 +777,17 @@ undelegate(FromAddr, ToAddr, ResourceID, Amount, S, Opts) when is_integer(Amount
         case Validation of
             {error, _} = Err -> Err;
             ok ->
-                RecipientDeposit = get_deposit(ToAddr, ResourceID, S, Opts),
-                case liquidate(ToAddr, ResourceID, Amount - RecipientDeposit, S, Opts) of
+                case ensure_undelegation_cover(
+                    FromAddr,
+                    ToAddr,
+                    ResourceID,
+                    Amount,
+                    S,
+                    Opts
+                ) of
                     {error, _} = Err -> Err;
-                    {ok, Liquidated} ->
-                        GlobalDrippedS = drip_global(Liquidated, Opts),
+                    {ok, Prepared} ->
+                        GlobalDrippedS = drip_global(Prepared, Opts),
                         DrippedS = drip_resource(ResourceID, GlobalDrippedS, Opts),
                         S0 = drip_user(FromAddr, DrippedS, Opts),
                         S1 = drip_user(ToAddr, S0, Opts),
@@ -880,6 +886,52 @@ undelegate(_, _, _, Amount, _, _) when is_integer(Amount), Amount =:= 0 ->
     {error, <<"Undelegate amount must be a non-zero positive Integer.">>};
 undelegate(_, _, _, Amount, _, _) when not is_integer(Amount)->
     {error, <<"Undelegate Amount must be of integer type">>}.
+
+%% @doc Repeatedly liquidate the recipient until the requested undelegation is
+%% directly coverable, or fail if the outer delegation edge has already been
+%% consumed by recursive unwind.
+ensure_undelegation_cover(FromAddr, ToAddr, ResourceID, Amount, S, Opts) ->
+    ExistingDelegation =
+        case FromAddr =:= ToAddr of
+            true -> 0;
+            false ->
+                hb_ao:get(
+                    <<
+                        "/resources/",
+                        ResourceID/binary,
+                        "/deposits/",
+                        FromAddr/binary,
+                        "/delegations/",
+                        ToAddr/binary
+                    >>,
+                    S,
+                    0,
+                    Opts
+                )
+        end,
+    RecipientDeposit = get_deposit(ToAddr, ResourceID, S, Opts),
+    case FromAddr =:= ToAddr of
+        true ->
+            {ok, S};
+        false when ExistingDelegation < Amount ->
+            {error, <<"Undelegation amount exceeds existing delegation.">>};
+        false when RecipientDeposit >= Amount ->
+            {ok, S};
+        false ->
+            case liquidate(ToAddr, ResourceID, Amount - RecipientDeposit, S, Opts) of
+                {error, _} = Err ->
+                    Err;
+                {ok, Liquidated} ->
+                    ensure_undelegation_cover(
+                        FromAddr,
+                        ToAddr,
+                        ResourceID,
+                        Amount,
+                        Liquidated,
+                        Opts
+                    )
+            end
+    end.
 
 %% @doc Resource configuration entrypoint. Validates the target resource and
 %% caller, enforces resource-config authority via

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -24,9 +24,7 @@
 %%% in the original process can earn their yield in the form of `child` mints.
 %%% Each mint can operate asynchronously and in real-time.
 %%% 
-%%% TODO: ADDRESSED IN enforce_resource_config_authority & apply_resource_config
-%%% - Add `secure-set` (set guarded by address) for resource-weights and 
-%%%   supported resources.
+%%% TODO: Add `secure-set` (set guarded by address) for resource-scoped config.
 -module(dev_pot).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -495,13 +493,18 @@ notify(State, Assignment, Opts) ->
             {error, <<"Unsupported notification action">>},
         OriginalFrom = hb_maps:get(<<"from">>, ForwardedMsg, <<"unknown">>, Opts),
         dev_token:handle_action(
-            Action, 
-            State, 
+            Action,
+            State,
             #{
                 <<"type">> => <<"notification">>,
                 <<"original-from">> => OriginalFrom,
-                <<"body">> => ForwardedMsg#{ <<"from">> => NotifyFrom, <<"resource-authority">> => NotifyFrom }
-            }, 
+                <<"body">> =>
+                    ForwardedMsg#{
+                        <<"from">> => NotifyFrom,
+                        <<"resource-authority">> => NotifyFrom,
+                        <<"weight-authority">> => NotifyFrom
+                    }
+            },
             Opts)
     end.
 
@@ -941,9 +944,9 @@ ensure_undelegation_cover(FromAddr, ToAddr, ResourceID, Amount, S, Opts) ->
     end.
 
 %% @doc Resource configuration entrypoint. Validates the target resource and
-%% caller, enforces resource-config authority via
-%% `enforce_resource_config_authority/5`, then applies supported
-%% resource-scoped config mutations.
+%% caller, then applies supported resource-scoped config mutations. Weight
+%% updates can be delegated to a per-resource `weight-authority`, while
+%% authority rotation remains parent-or-mint-authority only.
 register(State, Assignment, Opts) ->
     ?event(debug_pot, {register, Assignment}, Opts),
     maybe
@@ -964,18 +967,50 @@ register(State, Assignment, Opts) ->
                 Opts
             ),
         true ?= dev_token:validate_address(From, ?RESERVED_KEYS),
-        true ?= enforce_resource_config_authority(From, State, Req, Opts),
-        apply_resource_config(ResID, State, Req, Opts)
+        true ?=
+            case {
+                hb_maps:find(<<"resource-authority">>, Req, Opts),
+                hb_maps:find(<<"weight-authority">>, Req, Opts),
+                hb_maps:find(<<"weight">>, Req, Opts)
+            } of
+                {{ok, _}, _, _} ->
+                    enforce_resource_config_authority(From, State, Req, Opts);
+                {_, {ok, _}, _} ->
+                    enforce_resource_config_authority(From, State, Req, Opts);
+                {_, _, {ok, _}} ->
+                    enforce_resource_weight_authority(ResID, From, State, Req, Opts);
+                _ ->
+                    true
+            end,
+        State2 =
+            case hb_maps:find(<<"weight">>, Req, Opts) of
+                {ok, Weight} -> register_resource(ResID, Weight, State, Opts);
+                _ -> State
+            end,
+        true ?= is_map(State2) orelse State2,
+        State3 =
+            case hb_maps:find(<<"weight-authority">>, Req, Opts) of
+                {ok, WeightAuth} ->
+                    register_resource_weight_authority(
+                        ResID,
+                        WeightAuth,
+                        State2,
+                        Opts
+                    );
+                _ -> State2
+            end,
+        true ?= is_map(State3) orelse State3,
+        case hb_maps:find(<<"resource-authority">>, Req, Opts) of
+            {ok, ResAuth} ->
+                register_resource_authority(ResID, ResAuth, State3, Opts);
+            _ -> State3
+        end
     end.
 %% @doc Enforce authorization for resource configuration updates.
 %% Authorization is evaluated against:
 %% - `State/parent`, if set and equal to `from`
 %% - `mint-authority` security policy on the pot state, if configured
-%% - `authority` security policy on the target resource, if configured
-%%
-%% N.B: `dev_security` is open-by-default when no valid/required/match policy
-%% is present, so absent authority config does not restrict this action. check
-%% `AuthRes` logic chain for better gating-understanding.
+%% Resource-level write or weight authorities do not grant config authority.
 enforce_resource_config_authority(From, State, Req, Opts) ->
     ?event(debug_pot, {enforce_resource_config_authority, Req}, Opts),
     maybe
@@ -990,25 +1025,66 @@ enforce_resource_config_authority(From, State, Req, Opts) ->
         end,
         true ?= AuthRes
     end.
-%% @doc Apply supported resource-scoped configuration updates. If an earlier
-%% mutation fails, later mutations in the same request are not applied.
-apply_resource_config(ResID, State, Req, Opts) ->
+%% @doc Enforce authorization for weight-only updates. Parent may always
+%% reconfigure its children, explicit per-resource weight-authority can update
+%% the weight, and mint-authority remains the global override.
+enforce_resource_weight_authority(ResourceID, From, State, Req, Opts) ->
+    ?event(debug_pot, {enforce_resource_weight_authority, Req}, Opts),
     maybe
-        State2 =
-            case hb_maps:find(<<"weight">>, Req, Opts) of
-                {ok, Weight} -> register_resource(ResID, Weight, State, Opts);
-                _ -> State
+        AuthRes =
+            case (hb_maps:get(<<"parent">>, State, no_parent, Opts) =:= From) of
+                true -> true;
+                false ->
+                    case verify_weight_authority(ResourceID, State, Req, Opts) of
+                        true -> true;
+                        {error, _} ->
+                            case dev_security:validate(
+                                <<"mint-authority">>,
+                                State,
+                                Req,
+                                From,
+                                Opts#{ dev_security_mode => prod }
+                            ) of
+                                true -> true;
+                                {error, _} ->
+                                    {error, <<"Caller is not authorized to update resource weight.">>}
+                            end
+                    end
             end,
-        true ?= is_map(State2) orelse State2,
-        case hb_maps:find(<<"resource-authority">>, Req, Opts) of
-            {ok, ResAuth} ->
-                register_resource_authority(ResID, ResAuth, State2, Opts);
-            _ -> State2
-        end
-    else
-        Reason -> 
-            ?event(debug_pot, {error, Reason}, Opts),
-            Reason
+        true ?= AuthRes
+    end.
+%% @doc Verify a request against the weight-authority for a specific resource.
+verify_weight_authority(ResourceID, Base, Req, Opts) ->
+    maybe
+        {ok, From} ?=
+            hb_maps:find(
+                <<"from">>,
+                Req,
+                <<"No `from' address provided.">>,
+                Opts
+            ),
+        {ok, Resources} ?=
+            hb_maps:find(
+                <<"resources">>,
+                Base,
+                <<"No resources found in mint state.">>,
+                Opts
+            ),
+        {ok, Resource} ?=
+            hb_maps:find(
+                ResourceID,
+                Resources,
+                <<"Requested resource not initialized in mint state.">>,
+                Opts
+            ),
+        true ?=
+            dev_security:validate(
+                <<"weight-authority">>,
+                Resource,
+                Req,
+                From,
+                Opts#{ dev_security_mode => prod }
+            )
     end.
 %% @doc Update the authority record for a specific resource in the pot.
 register_resource_authority(ResourceID, Authority, S, Opts) ->
@@ -1018,6 +1094,18 @@ register_resource_authority(ResourceID, Authority, S, Opts) ->
         hb_ao:set(
             S,
             <<"/resources/", ResourceID/binary, "/authority">>,
+            Authority,
+            Opts
+        )
+end.
+%% @doc Update the weight-authority record for a specific resource in the pot.
+register_resource_weight_authority(ResourceID, Authority, S, Opts) ->
+    maybe
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
+        true ?= dev_token:validate_address(Authority, ?RESERVED_KEYS),
+        hb_ao:set(
+            S,
+            <<"/resources/", ResourceID/binary, "/weight-authority">>,
             Authority,
             Opts
         )

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -966,18 +966,19 @@ register(State, Assignment, Opts) ->
                 <<"No `from' address provided.">>, 
                 Opts
             ),
-        true ?= dev_token:validate_address(From, ?RESERVED_KEYS),
+        true ?= validate_signer_config(From, Opts),
+        HasAdminMutation =
+            hb_maps:find(<<"resource-authority">>, Req, Opts) =/= error orelse
+            hb_maps:find(<<"resource-authority-required">>, Req, Opts) =/= error orelse
+            hb_maps:find(<<"resource-authority-match">>, Req, Opts) =/= error orelse
+            hb_maps:find(<<"weight-authority">>, Req, Opts) =/= error orelse
+            hb_maps:find(<<"weight-authority-required">>, Req, Opts) =/= error orelse
+            hb_maps:find(<<"weight-authority-match">>, Req, Opts) =/= error,
         true ?=
-            case {
-                hb_maps:find(<<"resource-authority">>, Req, Opts),
-                hb_maps:find(<<"weight-authority">>, Req, Opts),
-                hb_maps:find(<<"weight">>, Req, Opts)
-            } of
-                {{ok, _}, _, _} ->
+            case {HasAdminMutation, hb_maps:find(<<"weight">>, Req, Opts)} of
+                {true, _} ->
                     enforce_resource_config_authority(From, State, Req, Opts);
-                {_, {ok, _}, _} ->
-                    enforce_resource_config_authority(From, State, Req, Opts);
-                {_, _, {ok, _}} ->
+                {false, {ok, _}} ->
                     enforce_resource_weight_authority(ResID, From, State, Req, Opts);
                 _ ->
                     true
@@ -1000,10 +1001,53 @@ register(State, Assignment, Opts) ->
                 _ -> State2
             end,
         true ?= is_map(State3) orelse State3,
-        case hb_maps:find(<<"resource-authority">>, Req, Opts) of
-            {ok, ResAuth} ->
-                register_resource_authority(ResID, ResAuth, State3, Opts);
-            _ -> State3
+        State4 =
+            case hb_maps:find(<<"weight-authority-required">>, Req, Opts) of
+                {ok, WeightRequired} ->
+                    register_resource_weight_authority_required(
+                        ResID,
+                        WeightRequired,
+                        State3,
+                        Opts
+                    );
+                _ -> State3
+            end,
+        true ?= is_map(State4) orelse State4,
+        State5 =
+            case hb_maps:find(<<"weight-authority-match">>, Req, Opts) of
+                {ok, WeightMatch} ->
+                    register_resource_weight_authority_match(
+                        ResID,
+                        WeightMatch,
+                        State4,
+                        Opts
+                    );
+                _ -> State4
+            end,
+        true ?= is_map(State5) orelse State5,
+        State6 =
+            case hb_maps:find(<<"resource-authority">>, Req, Opts) of
+                {ok, ResAuth} ->
+                    register_resource_authority(ResID, ResAuth, State5, Opts);
+                _ -> State5
+            end,
+        true ?= is_map(State6) orelse State6,
+        State7 =
+            case hb_maps:find(<<"resource-authority-required">>, Req, Opts) of
+                {ok, ResRequired} ->
+                    register_resource_authority_required(
+                        ResID,
+                        ResRequired,
+                        State6,
+                        Opts
+                    );
+                _ -> State6
+            end,
+        true ?= is_map(State7) orelse State7,
+        case hb_maps:find(<<"resource-authority-match">>, Req, Opts) of
+            {ok, ResMatch} ->
+                register_resource_authority_match(ResID, ResMatch, State7, Opts);
+            _ -> State7
         end
     end.
 %% @doc Enforce authorization for resource configuration updates.
@@ -1090,7 +1134,7 @@ verify_weight_authority(ResourceID, Base, Req, Opts) ->
 register_resource_authority(ResourceID, Authority, S, Opts) ->
     maybe
         true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
-        true ?= dev_token:validate_address(Authority, ?RESERVED_KEYS),
+        true ?= validate_signer_config(Authority, Opts),
         hb_ao:set(
             S,
             <<"/resources/", ResourceID/binary, "/authority">>,
@@ -1098,11 +1142,33 @@ register_resource_authority(ResourceID, Authority, S, Opts) ->
             Opts
         )
 end.
+register_resource_authority_required(ResourceID, Required, S, Opts) ->
+    maybe
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
+        true ?= validate_signer_config(Required, Opts),
+        hb_ao:set(
+            S,
+            <<"/resources/", ResourceID/binary, "/authority-required">>,
+            Required,
+            Opts
+        )
+end.
+register_resource_authority_match(ResourceID, Match, S, Opts) ->
+    maybe
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
+        true ?= validate_match_config(Match),
+        hb_ao:set(
+            S,
+            <<"/resources/", ResourceID/binary, "/authority-match">>,
+            Match,
+            Opts
+        )
+end.
 %% @doc Update the weight-authority record for a specific resource in the pot.
 register_resource_weight_authority(ResourceID, Authority, S, Opts) ->
     maybe
         true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
-        true ?= dev_token:validate_address(Authority, ?RESERVED_KEYS),
+        true ?= validate_signer_config(Authority, Opts),
         hb_ao:set(
             S,
             <<"/resources/", ResourceID/binary, "/weight-authority">>,
@@ -1110,6 +1176,65 @@ register_resource_weight_authority(ResourceID, Authority, S, Opts) ->
             Opts
         )
 end.
+register_resource_weight_authority_required(ResourceID, Required, S, Opts) ->
+    maybe
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
+        true ?= validate_signer_config(Required, Opts),
+        hb_ao:set(
+            S,
+            <<"/resources/", ResourceID/binary, "/weight-authority-required">>,
+            Required,
+            Opts
+        )
+end.
+register_resource_weight_authority_match(ResourceID, Match, S, Opts) ->
+    maybe
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
+        true ?= validate_match_config(Match),
+        hb_ao:set(
+            S,
+            <<"/resources/", ResourceID/binary, "/weight-authority-match">>,
+            Match,
+            Opts
+        )
+end.
+validate_signer_config(Value, Opts) when is_binary(Value) ->
+    try validate_signer_config(hb_util:binary_to_strings(Value), Opts)
+    catch
+        _:_ -> {error, <<"Signer config must be a valid binary or list.">>}
+    end;
+validate_signer_config(Value, Opts) when is_list(Value) ->
+    case Value of
+        [] ->
+            {error, <<"Signer config list must not be empty.">>};
+        _ ->
+            case lists:all(fun is_binary/1, Value) of
+                false ->
+                    {error, <<"Signer config list must contain binary addresses.">>};
+                true ->
+                    lists:foldl(
+                        fun(Signer, true) ->
+                            dev_token:validate_address(Signer, ?RESERVED_KEYS);
+                           (_Signer, {error, _} = Err) ->
+                            Err
+                        end,
+                        true,
+                        Value
+                    )
+            end
+    end;
+validate_signer_config(_, _) ->
+    {error, <<"Signer config must be a binary or a list.">>}.
+validate_match_config(Match) when is_integer(Match), Match >= 0 -> true;
+validate_match_config(Match) when is_binary(Match) ->
+    try binary_to_integer(Match) of
+        Int when is_integer(Int), Int >= 0 -> true;
+        _ -> {error, <<"Match threshold must be a non-negative integer.">>}
+    catch
+        _:_ -> {error, <<"Match threshold must be a non-negative integer.">>}
+    end;
+validate_match_config(_) ->
+    {error, <<"Match threshold must be a non-negative integer.">>}.
 
 %% @doc Set the weight of a specific resource in the pot, updating the pot state
 %% as necessary.

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -1336,7 +1336,7 @@ send_delegation_notice(FromAddr, ToAddr, ResourceID, Amount, S, Opts) ->
                 true -> <<"withdraw">>
                 end,
             <<"address">> => FromAddr,
-            <<"quantity">> => Amount,
+            <<"quantity">> => abs(Amount),
             <<"resource">> => ResourceID
         },
         S,

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -964,7 +964,7 @@ register(State, Assignment, Opts) ->
                 Opts
             ),
         true ?= dev_token:validate_address(From, ?RESERVED_KEYS),
-        true ?= enforce_resource_config_authority(From, ResID, State, Req, Opts),
+        true ?= enforce_resource_config_authority(From, State, Req, Opts),
         apply_resource_config(ResID, State, Req, Opts)
     end.
 %% @doc Enforce authorization for resource configuration updates.
@@ -976,7 +976,7 @@ register(State, Assignment, Opts) ->
 %% N.B: `dev_security` is open-by-default when no valid/required/match policy
 %% is present, so absent authority config does not restrict this action. check
 %% `AuthRes` logic chain for better gating-understanding.
-enforce_resource_config_authority(From, ResID, State, Req, Opts) ->
+enforce_resource_config_authority(From, State, Req, Opts) ->
     ?event(debug_pot, {enforce_resource_config_authority, Req}, Opts),
     maybe
         AuthRes = case (hb_maps:get(<<"parent">>, State, no_parent, Opts) =:= From) of

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -977,8 +977,8 @@ enforce_resource_config_authority(From, ResID, State, Req, Opts) ->
             false -> 
                 case dev_security:validate(<<"mint-authority">>, State, Req, From, Opts) of
                     true -> true;
-                    {error, _} -> 
-                        verify_resource_authority(ResID, State, Req, Opts)
+                    {error, _} -> false
+                        % verify_resource_authority(ResID, State, Req, Opts)
                     end  
         end,
         true ?= AuthRes

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -23,6 +23,17 @@
 %%% their own mints using the same `pot` functionality as the parent, depositors
 %%% in the original process can earn their yield in the form of `child` mints.
 %%% Each mint can operate asynchronously and in real-time.
+%%%
+%%% Authority model:
+%%% - `deposit` / `withdraw` are authorized per resource by that resource's
+%%%   `authority` security policy.
+%%% - `weight` updates may be delegated per resource via `weight-authority`.
+%%% - resource config changes (`authority*`, `weight-authority*`) remain
+%%%   guarded by the pot-wide `mint-authority` policy, or by the configured
+%%%   `parent` when the pot is acting as a child mint.
+%%% - child mints trust their direct `parent` process for inherited resource
+%%%   config and writes; forwarded parent `register` notifications set both
+%%%   `resource-authority` and `weight-authority` to that parent process.
 %%% 
 %%% TODO: Add `secure-set` (set guarded by address) for resource-scoped config.
 -module(dev_pot).
@@ -419,7 +430,9 @@ parse_deposit_modification(Base, Assignment, Opts) ->
         {ok, {Address, ResourceID, Amount}}
     end.
 
-%% @doc Verify a request against the authority for a specific resource.
+%% @doc Verify a request against the resource-local `authority` policy for a
+%% specific resource. In prod mode, requests fail closed if the resource has no
+%% explicit authority policy configured.
 verify_resource_authority(ResourceID, Base, Req, Opts) ->
     maybe
         {ok, From} ?=
@@ -455,7 +468,9 @@ verify_resource_authority(ResourceID, Base, Req, Opts) ->
 
 %% @doc Interpret forwarded `register' notifications from the configured
 %% `parent' mint process. Notifications from any other sender, or notifications
-%% forwarding a non-`register' action, are rejected.
+%% forwarding a non-`register' action, are rejected. Child mints trust their
+%% direct parent for inherited resource config, so forwarded notifications set
+%% both `resource-authority' and `weight-authority' to the parent process ID.
 notify(State, Assignment, Opts) ->
     maybe
         {ok, Req} ?=
@@ -944,9 +959,17 @@ ensure_undelegation_cover(FromAddr, ToAddr, ResourceID, Amount, S, Opts) ->
     end.
 
 %% @doc Resource configuration entrypoint. Validates the target resource and
-%% caller, then applies supported resource-scoped config mutations. Weight
-%% updates can be delegated to a per-resource `weight-authority`, while
-%% authority rotation remains parent-or-mint-authority only.
+%% caller, then applies supported resource-scoped config mutations.
+%% 
+%% Authorization model:
+%% - `weight`-only updates may be performed by:
+%%   - the configured `parent`
+%%   - the pot-wide `mint-authority`
+%%   - the resource-local `weight-authority`
+%% - updates touching `resource-authority*` or `weight-authority*` are treated
+%%   as admin mutations and may only be performed by:
+%%   - the configured `parent`
+%%   - the pot-wide `mint-authority`
 register(State, Assignment, Opts) ->
     ?event(debug_pot, {register, Assignment}, Opts),
     maybe
@@ -1070,8 +1093,8 @@ enforce_resource_config_authority(From, State, Req, Opts) ->
         true ?= AuthRes
     end.
 %% @doc Enforce authorization for weight-only updates. Parent may always
-%% reconfigure its children, explicit per-resource weight-authority can update
-%% the weight, and mint-authority remains the global override.
+%% reconfigure its children, explicit per-resource `weight-authority` can
+%% update the weight, and `mint-authority` remains the global override.
 enforce_resource_weight_authority(ResourceID, From, State, Req, Opts) ->
     ?event(debug_pot, {enforce_resource_weight_authority, Req}, Opts),
     maybe
@@ -1097,7 +1120,9 @@ enforce_resource_weight_authority(ResourceID, From, State, Req, Opts) ->
             end,
         true ?= AuthRes
     end.
-%% @doc Verify a request against the weight-authority for a specific resource.
+%% @doc Verify a request against the resource-local `weight-authority` policy
+%% for a specific resource. In prod mode, requests fail closed if the resource
+%% has no explicit weight-authority policy configured.
 verify_weight_authority(ResourceID, Base, Req, Opts) ->
     maybe
         {ok, From} ?=

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -445,7 +445,14 @@ verify_resource_authority(ResourceID, Base, Req, Opts) ->
                 <<"Requested resource not initialized in mint state.">>,
                 Opts
             ),
-        true ?= dev_security:validate(<<"authority">>, Resource, Req, From, Opts)
+        true ?=
+            dev_security:validate(
+                <<"authority">>,
+                Resource,
+                Req,
+                From,
+                Opts#{ dev_security_mode => prod }
+            )
     end.
 
 %% @doc Interpret forwarded `register' notifications from the configured
@@ -493,7 +500,7 @@ notify(State, Assignment, Opts) ->
             #{
                 <<"type">> => <<"notification">>,
                 <<"original-from">> => OriginalFrom,
-                <<"body">> => ForwardedMsg#{ <<"from">> => NotifyFrom }
+                <<"body">> => ForwardedMsg#{ <<"from">> => NotifyFrom, <<"resource-authority">> => NotifyFrom }
             }, 
             Opts)
     end.
@@ -975,11 +982,11 @@ enforce_resource_config_authority(From, ResID, State, Req, Opts) ->
         AuthRes = case (hb_maps:get(<<"parent">>, State, no_parent, Opts) =:= From) of
             true -> true;
             false -> 
-                case dev_security:validate(<<"mint-authority">>, State, Req, From, Opts) of
+                case dev_security:validate(<<"mint-authority">>, State, Req, From, Opts#{dev_security_mode => prod}) of
                     true -> true;
-                    {error, _} -> false
-                        % verify_resource_authority(ResID, State, Req, Opts)
-                    end  
+                    {error, _} ->
+                        {error, <<"Caller is not authorized to configure resources.">>}
+                end  
         end,
         true ?= AuthRes
     end.

--- a/src/dev_pot_test_vectors.erl
+++ b/src/dev_pot_test_vectors.erl
@@ -1367,7 +1367,8 @@ undelegate_notice_has_positive_quantity_test() ->
     Bob = <<"bob">>,
     ResourceOxygen = <<"oxygen">>,
     Opts = #{},
-    % Undelegation notice should have negative or zero quantity
+    % Undelegation notice should encode direction via `action', with a
+    % positive quantity so downstream `withdraw` handlers can accept it.
     S0 = pot_state_multi(ResourceOxygen, [{Alice, 10}, {Bob, 0}]),
     S0WithOutbox = S0#{ <<"results">> => #{ <<"outbox">> => [] } },
     S1 = delegate(Alice, Bob, ResourceOxygen, 5, S0WithOutbox, Opts),
@@ -1376,8 +1377,11 @@ undelegate_notice_has_positive_quantity_test() ->
     ?assertEqual(2, length(Outbox)),
     % Outbox is newest first, so undelegate notice is first
     [UndelegateNotice, _] = Outbox,
-    Quantity = hb_maps:get(<<"quantity">>, UndelegateNotice, Opts),
-    ?assert(Quantity >= 0).
+    ?assertEqual(Bob, hb_maps:get(<<"target">>, UndelegateNotice, not_found, Opts)),
+    ?assertEqual(<<"withdraw">>, hb_maps:get(<<"action">>, UndelegateNotice, not_found, Opts)),
+    ?assertEqual(Alice, hb_maps:get(<<"address">>, UndelegateNotice, not_found, Opts)),
+    ?assertEqual(5, hb_maps:get(<<"quantity">>, UndelegateNotice, not_found, Opts)),
+    ?assertEqual(ResourceOxygen, hb_maps:get(<<"resource">>, UndelegateNotice, not_found, Opts)).
 
 multiple_delegations_outbox_order_test() ->
     Alice = <<"alice">>,

--- a/src/dev_pot_test_vectors.erl
+++ b/src/dev_pot_test_vectors.erl
@@ -1362,7 +1362,7 @@ delegation_notice_message_format_test() ->
     ?assertEqual(5, hb_maps:get(<<"quantity">>, Notice, not_found, Opts)),
     ?assertEqual(ResourceOxygen, hb_maps:get(<<"resource">>, Notice, not_found, Opts)).
 
-undelegate_notice_has_negative_quantity_test() ->
+undelegate_notice_has_positive_quantity_test() ->
     Alice = <<"alice">>,
     Bob = <<"bob">>,
     ResourceOxygen = <<"oxygen">>,
@@ -1377,7 +1377,7 @@ undelegate_notice_has_negative_quantity_test() ->
     % Outbox is newest first, so undelegate notice is first
     [UndelegateNotice, _] = Outbox,
     Quantity = hb_maps:get(<<"quantity">>, UndelegateNotice, Opts),
-    ?assert(Quantity =< 0).
+    ?assert(Quantity >= 0).
 
 multiple_delegations_outbox_order_test() ->
     Alice = <<"alice">>,

--- a/src/dev_pot_test_vectors.erl
+++ b/src/dev_pot_test_vectors.erl
@@ -257,6 +257,115 @@ multiresource_modified_weight_test() ->
     ?assertEqual(12, dev_pot:balance(Bob, S5, Opts)),
     ok.
 
+weight_authority_match_requires_multiple_signers_test() ->
+    Admin = <<"admin">>,
+    WeightA = <<"weight-a">>,
+    WeightB = <<"weight-b">>,
+    Resource = <<"oxygen">>,
+    Opts = #{},
+    S0 = (pot_state_empty([Resource]))#{ <<"mint-authority">> => Admin },
+    S1 =
+        dev_pot:register(
+            S0,
+            #{
+                <<"body">> => #{
+                    <<"resource">> => Resource,
+                    <<"weight">> => 100,
+                    <<"from">> => Admin,
+                    <<"weight-authority">> => [WeightA, WeightB],
+                    <<"weight-authority-match">> => 2
+                }
+            },
+            Opts
+        ),
+    ?assert(is_map(S1)),
+    ?assertEqual(100, hb_ao:get(<<"/resources/oxygen/weight">>, S1, 0, Opts)),
+    ?assertMatch(
+        {error, _},
+        dev_pot:register(
+            S1,
+            #{
+                <<"body">> => #{
+                    <<"resource">> => Resource,
+                    <<"weight">> => 200,
+                    <<"from">> => WeightA
+                }
+            },
+            Opts
+        )
+    ),
+    ?assertEqual(100, hb_ao:get(<<"/resources/oxygen/weight">>, S1, 0, Opts)),
+    S2 =
+        dev_pot:register(
+            S1,
+            #{
+                <<"body">> => #{
+                    <<"resource">> => Resource,
+                    <<"weight">> => 200,
+                    <<"from">> => [WeightA, WeightB]
+                }
+            },
+            Opts
+        ),
+    ?assert(is_map(S2)),
+    ?assertEqual(200, hb_ao:get(<<"/resources/oxygen/weight">>, S2, 0, Opts)).
+
+resource_authority_required_signer_is_enforced_test() ->
+    Admin = <<"admin">>,
+    Alice = <<"alice">>,
+    ResourceA = <<"resource-a">>,
+    ResourceB = <<"resource-b">>,
+    Resource = <<"oxygen">>,
+    Opts = #{},
+    S0 = (pot_state_empty([Resource]))#{ <<"mint-authority">> => Admin },
+    S1 =
+        dev_pot:register(
+            S0,
+            #{
+                <<"body">> => #{
+                    <<"resource">> => Resource,
+                    <<"weight">> => 100,
+                    <<"from">> => Admin,
+                    <<"resource-authority">> => [ResourceA, ResourceB],
+                    <<"resource-authority-required">> => [ResourceA],
+                    <<"resource-authority-match">> => 1
+                }
+            },
+            Opts
+        ),
+    ?assert(is_map(S1)),
+    ?assertMatch(
+        {error, _},
+        dev_pot:deposit(
+            S1,
+            #{
+                <<"body">> => #{
+                    <<"address">> => Alice,
+                    <<"resource">> => Resource,
+                    <<"quantity">> => 10,
+                    <<"from">> => ResourceB
+                }
+            },
+            Opts
+        )
+    ),
+    ?assertEqual(0, dev_pot:get_deposit(Alice, Resource, S1, Opts)),
+    S2 =
+        dev_pot:deposit(
+            S1,
+            #{
+                <<"body">> => #{
+                    <<"address">> => Alice,
+                    <<"resource">> => Resource,
+                    <<"quantity">> => 10,
+                    <<"from">> => [ResourceA, ResourceB]
+                }
+            },
+            Opts
+        ),
+    ?assert(is_map(S2)),
+    ?assertEqual(10, dev_pot:get_deposit(Alice, Resource, S2, Opts)).
+
 simple_delegation_test() ->
     Alice = <<"alice">>,
     Bob = <<"bob">>,

--- a/src/dev_security.erl
+++ b/src/dev_security.erl
@@ -81,6 +81,14 @@ validate(Key, Base, SubjectMsg, Opts) ->
     validate(Key, Base, SubjectMsg, hb_message:signers(SubjectMsg, Opts), Opts).
 validate(Key, Base, SubjectMsg, RawFrom, Opts) ->
     maybe
+        true ?=
+            case is_prod_mode(Opts) of
+                true ->
+                    has_explicit_policy(Key, Base, Opts)
+                        orelse {error, <<"Security policy not configured.">>};
+                false ->
+                    true
+            end,
         %% Dedup identities so duplicate committers cannot satisfy min-N thresholds.
         From = lists:uniq(as_list(RawFrom, Opts)),
         ValidOrError = as_signer_config_list(hb_ao:get(Key, Base, [], Opts), Opts),
@@ -115,6 +123,18 @@ validate(Key, Base, SubjectMsg, RawFrom, Opts) ->
         ),
         satisfies_constraints(Key, From, RequiredList, Valid, Match, Opts)
 end.
+
+is_prod_mode(Opts) ->
+    case maps:get(dev_security_mode, Opts, maps:get(<<"dev-security-mode">>, Opts, dev)) of
+        prod -> true;
+        <<"prod">> -> true;
+        _ -> false
+    end.
+
+has_explicit_policy(Key, Base, Opts) ->
+    hb_ao:get(Key, Base, not_found, Opts) =/= not_found orelse
+    hb_ao:get(<<Key/binary, "-required">>, Base, not_found, Opts) =/= not_found orelse
+    hb_ao:get(<<Key/binary, "-match">>, Base, not_found, Opts) =/= not_found.
 
 %% @doc Validate that the request satisfies the given constraints.
 %% Returns true if:

--- a/src/dev_security.erl
+++ b/src/dev_security.erl
@@ -256,3 +256,29 @@ comma_separated_authority_config_supported_test() ->
             #{}
         )
     ).
+
+prod_mode_requires_explicit_policy_test() ->
+    ?assertEqual(
+        {error, <<"Security policy not configured.">>},
+        validate(
+            <<"authority">>,
+            #{},
+            #{},
+            [<<"alice">>],
+            #{ dev_security_mode => prod }
+        )
+    ).
+
+prod_mode_allows_explicit_single_signer_policy_test() ->
+    ?assertEqual(
+        true,
+        validate(
+            <<"authority">>,
+            #{
+                <<"authority">> => <<"alice">>
+            },
+            #{},
+            [<<"alice">>],
+            #{ dev_security_mode => prod }
+        )
+    ).

--- a/src/dev_token.erl
+++ b/src/dev_token.erl
@@ -262,38 +262,23 @@ transfer_notices(From, Recipient, Quantity, Req, Opts) ->
 %%% Mint device orchestration.
 
 %% @doc Call the mint device's main entrypoint, allowing it to handle explicit
-%% mint requests, normalize its state (prior to `transfer's, etc), or ignore
-%% the request altogether.
+%% mint requests, normalize its state (prior to `transfer`s, etc), or ignore
+%% the request altogether. If a public token `mint` request includes
+%% `body.subject`, hoist it to the top-level request shape expected by the mint
+%% device before dispatch.
 mint(Base, Assignment, Opts) ->
-    as_mint_device(<<"mint">>, Base, Assignment, Opts).
-
-%% @doc Public persisted `mint` requests may target either the global scope
-%% (no `subject`) or the caller's own account. Internal normalization paths call
-%% `mint/3` directly and do not pass through this gate.
-secure_mint(Base, Assignment, Opts) ->
     case hb_ao:resolve(Assignment, <<"body">>, Opts) of
-        {error, _} = Err ->
-            Err;
+        {error, _} ->
+            as_mint_device(<<"mint">>, Base, Assignment, Opts);
         {ok, Req} ->
             case hb_maps:find(<<"subject">>, Req, Opts) of
                 error ->
-                    mint(Base, Assignment, Opts);
+                    as_mint_device(<<"mint">>, Base, Assignment, Opts);
                 {ok, Subject} ->
                     maybe
-                        {ok, From} ?=
-                            hb_maps:find(
-                                <<"from">>,
-                                Req,
-                                <<"No `from' address provided.">>,
-                                Opts
-                            ),
-                        true ?= validate_address(From, []),
                         true ?= validate_address(Subject, []),
-                        true ?= (From =:= Subject) orelse
-                            {error, <<"Invalid mint caller.">>},
                         MintReq1 = hb_ao:set(Assignment, <<"subject">>, Subject, Opts),
-                        MintReq2 = hb_ao:set(MintReq1, <<"from">>, From, Opts),
-                        mint(Base, MintReq2, Opts)
+                        as_mint_device(<<"mint">>, Base, MintReq1, Opts)
                     end
             end
     end.
@@ -315,7 +300,7 @@ is_supported_mint_action(Action) ->
 %% send_error/4 codepath.
 action_as_mint_device(Action, Base, Req, Opts) ->
     case is_supported_mint_action(Action) of
-        true when Action =:= <<"mint">> -> secure_mint(Base, Req, Opts);
+        true when Action =:= <<"mint">> -> mint(Base, Req, Opts);
         true -> as_mint_device(Action, Base, Req, Opts);
         false ->
             ?event(error, {unsupported_token_action, Action}, Opts),

--- a/src/dev_token.erl
+++ b/src/dev_token.erl
@@ -267,6 +267,33 @@ transfer_notices(From, Recipient, Quantity, Req, Opts) ->
 mint(Base, Assignment, Opts) ->
     as_mint_device(<<"mint">>, Base, Assignment, Opts).
 
+%% @doc Public persisted `mint` requests may target either the global scope
+%% (no `subject`) or the caller's own account. Internal normalization paths call
+%% `mint/3` directly and do not pass through this gate.
+secure_mint(Base, Assignment, Opts) ->
+    maybe
+        {ok, Req} ?= hb_ao:resolve(Assignment, <<"body">>, Opts),
+        case hb_maps:find(<<"subject">>, Req, Opts) of
+            error ->
+                mint(Base, Assignment, Opts);
+            {ok, Subject} ->
+                maybe
+                    {ok, From} ?=
+                        hb_maps:find(
+                            <<"from">>,
+                            Req,
+                            <<"No `from' address provided.">>,
+                            Opts
+                        ),
+                    true ?= validate_address(From, []),
+                    true ?= validate_address(Subject, []),
+                    true ?= (From =:= Subject) orelse
+                        {error, <<"Invalid mint caller.">>},
+                    mint(Base, Assignment, Opts)
+                end
+        end
+    end.
+
 %% @doc Execute the mint device's main key, but return the state in its 
 %% unmodified form if the execution returns an error.
 normalize_mint(Base, Assignment, Opts) ->
@@ -284,11 +311,12 @@ is_supported_mint_action(Action) ->
 %% send_error/4 codepath.
 action_as_mint_device(Action, Base, Req, Opts) ->
     case is_supported_mint_action(Action) of
+        true when Action =:= <<"mint">> -> secure_mint(Base, Req, Opts);
         true -> as_mint_device(Action, Base, Req, Opts);
         false ->
             ?event(error, {unsupported_token_action, Action}, Opts),
             send_error(Base, Req, <<"unsupported action: ", Action/binary>>, Opts)
-    end.
+        end.
 
 %% @doc Run a given `path' on the mint device.
 as_mint_device(Path, Base, Req, Opts) ->

--- a/src/dev_token.erl
+++ b/src/dev_token.erl
@@ -271,27 +271,31 @@ mint(Base, Assignment, Opts) ->
 %% (no `subject`) or the caller's own account. Internal normalization paths call
 %% `mint/3` directly and do not pass through this gate.
 secure_mint(Base, Assignment, Opts) ->
-    maybe
-        {ok, Req} ?= hb_ao:resolve(Assignment, <<"body">>, Opts),
-        case hb_maps:find(<<"subject">>, Req, Opts) of
-            error ->
-                mint(Base, Assignment, Opts);
-            {ok, Subject} ->
-                maybe
-                    {ok, From} ?=
-                        hb_maps:find(
-                            <<"from">>,
-                            Req,
-                            <<"No `from' address provided.">>,
-                            Opts
-                        ),
-                    true ?= validate_address(From, []),
-                    true ?= validate_address(Subject, []),
-                    true ?= (From =:= Subject) orelse
-                        {error, <<"Invalid mint caller.">>},
-                    mint(Base, Assignment, Opts)
-                end
-        end
+    case hb_ao:resolve(Assignment, <<"body">>, Opts) of
+        {error, _} = Err ->
+            Err;
+        {ok, Req} ->
+            case hb_maps:find(<<"subject">>, Req, Opts) of
+                error ->
+                    mint(Base, Assignment, Opts);
+                {ok, Subject} ->
+                    maybe
+                        {ok, From} ?=
+                            hb_maps:find(
+                                <<"from">>,
+                                Req,
+                                <<"No `from' address provided.">>,
+                                Opts
+                            ),
+                        true ?= validate_address(From, []),
+                        true ?= validate_address(Subject, []),
+                        true ?= (From =:= Subject) orelse
+                            {error, <<"Invalid mint caller.">>},
+                        MintReq1 = hb_ao:set(Assignment, <<"subject">>, Subject, Opts),
+                        MintReq2 = hb_ao:set(MintReq1, <<"from">>, From, Opts),
+                        mint(Base, MintReq2, Opts)
+                    end
+            end
     end.
 
 %% @doc Execute the mint device's main key, but return the state in its 

--- a/src/dev_token_lib.erl
+++ b/src/dev_token_lib.erl
@@ -12,6 +12,7 @@
 -export([register/3, subscribe/3, unsubscribe/3]).
 %%% Query wrappers.
 -export([now/2, balance/3, balance_total/3, balances/2, balances/3]).
+-export([execution_balance/3]).
 -export([supply/2, supply/3]).
 -export([subscribers/3, subscribers/4]).
 -export([subledger_supply/3, user_supply/3]).
@@ -205,6 +206,34 @@ balance(ProcMsg, User, Opts) when not ?IS_ID(User) ->
     balance(ProcMsg, hb_util:human_id(ar_wallet:to_address(User)), Opts);
 balance(ProcMsg, ID, Opts) ->
     hb_ao:get(<<"now/balances/", ID/binary>>, ProcMsg, 0, Opts).
+
+%% @doc Retrieve a single balance through the execution device's `balance`
+%% path, allowing lazy mint devices to normalize account state first.
+execution_balance(ProcMsg, User, Opts) when not ?IS_ID(User) ->
+    execution_balance(ProcMsg, hb_util:human_id(ar_wallet:to_address(User)), Opts);
+execution_balance(ProcMsg, ID, Opts) ->
+    CurrentSlot = hb_ao:get(<<"slot/current">>, ProcMsg, Opts),
+    Res =
+        hb_ao:resolve_many(
+            [
+                ProcMsg,
+                #{ <<"path">> => <<"now">> },
+                #{
+                    <<"path">> => <<"as">>,
+                    <<"as">> => <<"execution">>
+                },
+                #{
+                    <<"path">> => <<"balance">>,
+                    <<"balance">> => ID,
+                    <<"slot">> => hb_cache:ensure_loaded(CurrentSlot, Opts)
+                }
+            ],
+            Opts
+        ),
+    case Res of
+        {ok, Balance} -> Balance;
+        {error, not_found} -> 0
+    end.
 
 %% @doc Get the total balance for an ID across all ledgers in a set.
 balance_total(Procs, ID, Opts) ->

--- a/src/dev_token_lib.erl
+++ b/src/dev_token_lib.erl
@@ -12,7 +12,7 @@
 -export([register/3, subscribe/3, unsubscribe/3]).
 %%% Query wrappers.
 -export([now/2, balance/3, balance_total/3, balances/2, balances/3]).
--export([execution_balance/3]).
+-export([normalized_balance/3]).
 -export([supply/2, supply/3]).
 -export([subscribers/3, subscribers/4]).
 -export([subledger_supply/3, user_supply/3]).
@@ -209,9 +209,9 @@ balance(ProcMsg, ID, Opts) ->
 
 %% @doc Retrieve a single balance through the execution device's `balance`
 %% path, allowing lazy mint devices to normalize account state first.
-execution_balance(ProcMsg, User, Opts) when not ?IS_ID(User) ->
-    execution_balance(ProcMsg, hb_util:human_id(ar_wallet:to_address(User)), Opts);
-execution_balance(ProcMsg, ID, Opts) ->
+normalized_balance(ProcMsg, User, Opts) when not ?IS_ID(User) ->
+    normalized_balance(ProcMsg, hb_util:human_id(ar_wallet:to_address(User)), Opts);
+normalized_balance(ProcMsg, ID, Opts) ->
     CurrentSlot = hb_ao:get(<<"slot/current">>, ProcMsg, Opts),
     Res =
         hb_ao:resolve_many(

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -872,6 +872,44 @@ transfer_with_unclaimed_yield_test() ->
     % Initial: 500, Minted: 5000, New total: 5500
     ?assertEqual(7500, hb_ao:get(<<"now/total-supply">>, Process, Opts)).
 
+execution_balance_normalizes_lazy_mint_test() ->
+    Opts = test_opts(),
+    Alice = ar_wallet:new(),
+    AliceAddr = id(Alice),
+    ResourceOxygen = <<"oxygen">>,
+    PotFields = #{
+        mint_cap => 10000,
+        mint_prop_numerator => 1,
+        mint_prop_denominator => 2,
+        t => 0,
+        last_drip => 0
+    },
+    TokenFields = #{
+        initial_balances => #{AliceAddr => 500},
+        total_supply => 500
+    },
+    Process = generate_process(PotFields, TokenFields, Opts),
+    push_set_weight(Process, ResourceOxygen, 100, Opts),
+    push_deposit(
+        Process,
+        ResourceOxygen,
+        Alice,
+        10,
+        Opts
+    ),
+    push_request(
+        Process,
+        #{
+            <<"action">> => <<"mint">>
+        },
+        Alice,
+        Opts
+    ),
+    % non-normalized /now 'stale' balance
+    ?assertEqual(500, dev_token_lib:balance(Process, AliceAddr, Opts)),
+    % normalized balance (now balance + claimable balance)
+    ?assertEqual(5500, dev_token_lib:execution_balance(Process, AliceAddr, Opts)).
+
 %% @doc Test direct claim_yield functionality from a single resource
 claim_yield_single_resource_test() ->
     Opts = test_opts(),

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -953,6 +953,44 @@ public_mint_rejects_foreign_subject_test() ->
     ?assertEqual(1000, dev_token_lib:balance(Process, AliceAddr, Opts)),
     ?assertEqual(1000, hb_ao:get(<<"now/total-supply">>, Process, Opts)).
 
+%% @doc Test that public persisted mint may still claim yield for the caller.
+public_mint_allows_self_subject_test() ->
+    Opts = test_opts(),
+    AliceWallet = ar_wallet:new(),
+    AliceAddr = id(AliceWallet),
+    ResourceOxygen = <<"oxygen">>,
+    PotFields = #{
+        mint_cap => 10000,
+        mint_prop_numerator => 1,
+        mint_prop_denominator => 2,
+        t => 0,
+        last_drip => 0
+    },
+    TokenFields = #{
+        initial_balances => #{AliceAddr => 1000},
+        total_supply => 1000
+    },
+    Process = generate_process(PotFields, TokenFields, Opts),
+    push_set_weight(Process, ResourceOxygen, 100, Opts),
+    push_deposit(
+        Process,
+        ResourceOxygen,
+        AliceWallet,
+        10,
+        Opts
+    ),
+    _ = push_request(
+        Process,
+        #{
+            <<"action">> => <<"mint">>,
+            <<"subject">> => AliceAddr
+        },
+        AliceWallet,
+        Opts
+    ),
+    ?assertEqual(8000, dev_token_lib:balance(Process, AliceAddr, Opts)),
+    ?assertEqual(8000, hb_ao:get(<<"now/total-supply">>, Process, Opts)).
+
 %% @doc Test direct claim_yield functionality from a single resource
 claim_yield_single_resource_test() ->
     Opts = test_opts(),

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -914,8 +914,9 @@ normalized_balance_normalizes_lazy_mint_test() ->
     ?assertEqual(7500, dev_token_lib:normalized_balance(Process, AliceAddr, Opts)),
     ?assertEqual(7500, balance(Process, AliceAddr, Opts)).
 
-%% @doc Test that public persisted mint cannot claim yield for another account.
-public_mint_rejects_foreign_subject_test() ->
+%% @doc Test that public persisted mint forwards `body.subject` for foreign
+%% callers too, allowing the request to persist the subject claim.
+public_mint_allows_foreign_subject_test() ->
     Opts = test_opts(),
     AliceWallet = ar_wallet:new(),
     BobWallet = ar_wallet:new(),
@@ -950,10 +951,11 @@ public_mint_rejects_foreign_subject_test() ->
         BobWallet,
         Opts
     ),
-    ?assertEqual(1000, dev_token_lib:balance(Process, AliceAddr, Opts)),
-    ?assertEqual(1000, hb_ao:get(<<"now/total-supply">>, Process, Opts)).
+    ?assertEqual(8000, dev_token_lib:balance(Process, AliceAddr, Opts)),
+    ?assertEqual(8000, hb_ao:get(<<"now/total-supply">>, Process, Opts)).
 
-%% @doc Test that public persisted mint may still claim yield for the caller.
+%% @doc Test that public persisted mint forwards `body.subject` for the caller,
+%% allowing the request to persist the subject claim.
 public_mint_allows_self_subject_test() ->
     Opts = test_opts(),
     AliceWallet = ar_wallet:new(),

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -99,11 +99,12 @@ id(Bin) when is_binary(Bin) ->
     << Bin/binary, Suffix/binary >>;
 id(Other) -> hb_util:human_id(Other).
 
-set_weight_req(Resource, Weight) ->
+set_weight_req(Resource, Weight, Authority) ->
     #{
         <<"action">> => <<"register">>,
         <<"resource">> => Resource,
-        <<"weight">> => Weight
+        <<"weight">> => Weight,
+        <<"resource-authority">> => Authority
     }.
 
 deposit_req(Resource, Addr, Qty) ->
@@ -199,6 +200,7 @@ generate_base_process_state(ExtraKeys, Opts) ->
 
 %% @doc Generate pot state for integration testing
 generate_pot_state(Params, Opts) ->
+    Authority = id(hb_opts:get(priv_wallet, no_wallet, Opts)),
     MintCap = hb_maps:get(mint_cap, Params, 10000, Opts),
     MintPropN = hb_maps:get(mint_prop_numerator, Params, 1, Opts),
     MintPropD = hb_maps:get(mint_prop_denominator, Params, 2, Opts),
@@ -225,6 +227,7 @@ generate_pot_state(Params, Opts) ->
     Merged = maps:merge(MaybeParent, MaybeIndexKeys),
     Merged#{
         <<"mint-device">> => hb_maps:get(mint_device, Params, <<"pot@1.0">>, Opts),
+        <<"mint-authority">> => hb_maps:get(mint_authority, Params, Authority, Opts),
         <<"mint-cap">> => MintCap,
         <<"mint-prop-numerator">> => MintPropN,
         <<"mint-prop-denominator">> => MintPropD,
@@ -308,7 +311,11 @@ push_request(Process, Body, Wallet, Opts) ->
 push_set_weight(Process, Resource, Weight, Opts) ->
     push_request(
         Process,
-        set_weight_req(Resource, Weight),
+        set_weight_req(
+            Resource,
+            Weight,
+            id(hb_opts:get(priv_wallet, no_wallet, Opts))
+        ),
         Opts
     ),
     dev_token_lib:now(Process, Opts).

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -445,7 +445,7 @@ pot_delegation_test() ->
         )
     ).
 
-cyclic_undelegate_liquidation_corrupts_state_test() ->
+cyclic_undelegate_liquidation_fails_cleanly_test() ->
     Opts = test_opts(),
     Alice = ar_wallet:new(),
     Bob = ar_wallet:new(),
@@ -475,13 +475,16 @@ cyclic_undelegate_liquidation_corrupts_state_test() ->
     ?assertEqual(20, delegation(Process, Resource, AliceAddr, BobAddr, Opts)),
     ?assertEqual(10, delegation(Process, Resource, BobAddr, CharlieAddr, Opts)),
     ?assertEqual(10, delegation(Process, Resource, CharlieAddr, AliceAddr, Opts)),
-    {ok, _} = push_undelegate(Process, Alice, BobAddr, Resource, 20, Opts),
-    ?assertEqual(20, deposit(Process, Resource, AliceAddr, <<"quantity">>, Opts)),
-    ?assertEqual(-10, deposit(Process, Resource, BobAddr, <<"quantity">>, Opts)),
+    ?assertMatch(
+        {error, _},
+        push_undelegate(Process, Alice, BobAddr, Resource, 20, Opts)
+    ),
+    ?assertEqual(0, deposit(Process, Resource, AliceAddr, <<"quantity">>, Opts)),
+    ?assertEqual(10, deposit(Process, Resource, BobAddr, <<"quantity">>, Opts)),
     ?assertEqual(0, deposit(Process, Resource, CharlieAddr, <<"quantity">>, Opts)),
-    ?assertEqual(-10, delegation(Process, Resource, AliceAddr, BobAddr, Opts)),
-    ?assertEqual(0, delegation(Process, Resource, BobAddr, CharlieAddr, Opts)),
-    ?assertEqual(0, delegation(Process, Resource, CharlieAddr, AliceAddr, Opts)).
+    ?assertEqual(20, delegation(Process, Resource, AliceAddr, BobAddr, Opts)),
+    ?assertEqual(10, delegation(Process, Resource, BobAddr, CharlieAddr, Opts)),
+    ?assertEqual(10, delegation(Process, Resource, CharlieAddr, AliceAddr, Opts)).
 
 balance_without_explicit_mint_same_slot_test() ->
     Opts = test_opts(),

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -661,24 +661,22 @@ claim_yield_single_resource_test() ->
     },
     Process = generate_process(PotFields, TokenFields, Opts),
     push_set_weight(Process, ResourceOxygen, 100, Opts),
-    NewBase = 
-        push_deposit(
-            Process,
-            ResourceOxygen,
-            AliceWallet,
-            10,
-            Opts
-        ),
-    ?event(pot_claim, {new_pot, NewBase}, Opts),
+    push_deposit(
+        Process,
+        ResourceOxygen,
+        AliceWallet,
+        10,
+        Opts
+    ),
     push_request(
-        NewBase,
+        Process,
         #{
             <<"action">> => <<"mint">>
         },
         AliceWallet,
         Opts
     ),
-    BaseAfterClaim = dev_token_lib:now(NewBase, Opts),
+    BaseAfterClaim = dev_token_lib:now(Process, Opts),
     ?event({after_claim, BaseAfterClaim}),
     ?assertEqual(8000, balance(BaseAfterClaim, AliceAddr,Opts)).
 

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -620,6 +620,44 @@ cyclic_undelegation_liquidation_still_succeeds_when_edge_is_not_reentered_test()
     ?assertEqual(0, delegation(Process, Resource, BobAddr, CharlieAddr, Opts)),
     ?assertEqual(0, delegation(Process, Resource, CharlieAddr, AliceAddr, Opts)).
 
+cyclic_undelegation_from_charlie_to_alice_succeeds_test() ->
+    Opts = test_opts(),
+    Alice = ar_wallet:new(),
+    Bob = ar_wallet:new(),
+    Charlie = ar_wallet:new(),
+    AliceAddr = id(Alice),
+    BobAddr = id(Bob),
+    CharlieAddr = id(Charlie),
+    Resource = <<"oxygen">>,
+    Process =
+        generate_process(
+            #{
+                mint_cap => 10_000,
+                mint_prop_numerator => 1,
+                mint_prop_denominator => 2
+            },
+            Opts
+        ),
+    push_set_weight(Process, Resource, 100, Opts),
+    push_deposit(Process, Resource, Alice, 10, Opts),
+    push_delegate(Process, Resource, Alice, BobAddr, 10, Opts),
+    push_delegate(Process, Resource, Bob, CharlieAddr, 10, Opts),
+    push_delegate(Process, Resource, Charlie, AliceAddr, 10, Opts),
+    push_delegate(Process, Resource, Alice, BobAddr, 10, Opts),
+    ?assertEqual(0, deposit(Process, Resource, AliceAddr, <<"quantity">>, Opts)),
+    ?assertEqual(10, deposit(Process, Resource, BobAddr, <<"quantity">>, Opts)),
+    ?assertEqual(0, deposit(Process, Resource, CharlieAddr, <<"quantity">>, Opts)),
+    ?assertEqual(20, delegation(Process, Resource, AliceAddr, BobAddr, Opts)),
+    ?assertEqual(10, delegation(Process, Resource, BobAddr, CharlieAddr, Opts)),
+    ?assertEqual(10, delegation(Process, Resource, CharlieAddr, AliceAddr, Opts)),
+    {ok, _} = push_undelegate(Process, Charlie, AliceAddr, Resource, 10, Opts),
+    ?assertEqual(0, deposit(Process, Resource, AliceAddr, <<"quantity">>, Opts)),
+    ?assertEqual(0, deposit(Process, Resource, BobAddr, <<"quantity">>, Opts)),
+    ?assertEqual(10, deposit(Process, Resource, CharlieAddr, <<"quantity">>, Opts)),
+    ?assertEqual(10, delegation(Process, Resource, AliceAddr, BobAddr, Opts)),
+    ?assertEqual(10, delegation(Process, Resource, BobAddr, CharlieAddr, Opts)),
+    ?assertEqual(0, delegation(Process, Resource, CharlieAddr, AliceAddr, Opts)).
+
 plain_chain_undelegation_liquidates_successfully_test() ->
     Opts = test_opts(),
     Alice = ar_wallet:new(),

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -99,12 +99,19 @@ id(Bin) when is_binary(Bin) ->
     << Bin/binary, Suffix/binary >>;
 id(Other) -> hb_util:human_id(Other).
 
-set_weight_req(Resource, Weight, Authority) ->
+set_weight_req(Resource, Weight) ->
+    #{
+        <<"action">> => <<"register">>,
+        <<"resource">> => Resource,
+        <<"weight">> => Weight
+    }.
+set_weight_req(Resource, Weight, ResourceAuthority, WeightAuthority) ->
     #{
         <<"action">> => <<"register">>,
         <<"resource">> => Resource,
         <<"weight">> => Weight,
-        <<"resource-authority">> => Authority
+        <<"resource-authority">> => ResourceAuthority,
+        <<"weight-authority">> => WeightAuthority
     }.
 
 deposit_req(Resource, Addr, Qty) ->
@@ -314,6 +321,7 @@ push_set_weight(Process, Resource, Weight, Opts) ->
         set_weight_req(
             Resource,
             Weight,
+            id(hb_opts:get(priv_wallet, no_wallet, Opts)),
             id(hb_opts:get(priv_wallet, no_wallet, Opts))
         ),
         Opts
@@ -433,6 +441,44 @@ simple_pot_process_test() ->
     ?assertEqual(1, balance(Process, id(Bob),Opts)),
     ?assertEqual(8999, balance(Process, id(Alice), Opts)),
     ?assertEqual(9000, hb_ao:get(<<"now/total-supply">>, Process, Opts)).
+
+weight_authority_can_update_weight_without_resource_config_authority_test() ->
+    Opts = test_opts(),
+    Resource = <<"oxygen">>,
+    WeightWallet = ar_wallet:new(),
+    ResourceWallet = ar_wallet:new(),
+    Process =
+        generate_process(
+            #{
+                mint_cap => 10000,
+                mint_prop_numerator => 1,
+                mint_prop_denominator => 2
+            },
+            Opts
+        ),
+    push_request(
+        Process,
+        set_weight_req(Resource, 100, id(ResourceWallet), id(WeightWallet)),
+        Opts
+    ),
+    ?assertEqual(100, weight(Process, Resource, Opts)),
+    ?assertMatch(
+        {error, _},
+        push_request(
+            Process,
+            set_weight_req(Resource, 200),
+            ResourceWallet,
+            Opts
+        )
+    ),
+    ?assertEqual(100, weight(Process, Resource, Opts)),
+    push_request(
+        Process,
+        set_weight_req(Resource, 200),
+        WeightWallet,
+        Opts
+    ),
+    ?assertEqual(200, weight(Process, Resource, Opts)).
 
 pot_delegation_test() ->
     Opts = test_opts(),

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -872,7 +872,7 @@ transfer_with_unclaimed_yield_test() ->
     % Initial: 500, Minted: 5000, New total: 5500
     ?assertEqual(7500, hb_ao:get(<<"now/total-supply">>, Process, Opts)).
 
-execution_balance_normalizes_lazy_mint_test() ->
+normalized_balance_normalizes_lazy_mint_test() ->
     Opts = test_opts(),
     Alice = ar_wallet:new(),
     AliceAddr = id(Alice),
@@ -908,7 +908,7 @@ execution_balance_normalizes_lazy_mint_test() ->
     % non-normalized /now 'stale' balance
     ?assertEqual(500, dev_token_lib:balance(Process, AliceAddr, Opts)),
     % normalized balance (now balance + claimable balance)
-    ?assertEqual(5500, dev_token_lib:execution_balance(Process, AliceAddr, Opts)).
+    ?assertEqual(5500, dev_token_lib:normalized_balance(Process, AliceAddr, Opts)).
 
 %% @doc Test direct claim_yield functionality from a single resource
 claim_yield_single_resource_test() ->

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -875,6 +875,7 @@ transfer_with_unclaimed_yield_test() ->
 normalized_balance_normalizes_lazy_mint_test() ->
     Opts = test_opts(),
     Alice = ar_wallet:new(),
+    Bob = ar_wallet:new(),
     AliceAddr = id(Alice),
     ResourceOxygen = <<"oxygen">>,
     PotFields = #{
@@ -902,13 +903,16 @@ normalized_balance_normalizes_lazy_mint_test() ->
         #{
             <<"action">> => <<"mint">>
         },
-        Alice,
+        Bob,
         Opts
     ),
-    % non-normalized /now 'stale' balance
+    % Raw `now/balances` remains stale because explicit `mint` advances global
+    % pot state, but does not claim Alice's user-specific lazy yield.
     ?assertEqual(500, dev_token_lib:balance(Process, AliceAddr, Opts)),
-    % normalized balance (now balance + claimable balance)
-    ?assertEqual(5500, dev_token_lib:normalized_balance(Process, AliceAddr, Opts)).
+    % After the global mint, Alice has 7000 lazy claimable yield on top of her
+    % explicit 500 token balance.
+    ?assertEqual(7500, dev_token_lib:normalized_balance(Process, AliceAddr, Opts)),
+    ?assertEqual(7500, balance(Process, AliceAddr, Opts)).
 
 %% @doc Test direct claim_yield functionality from a single resource
 claim_yield_single_resource_test() ->

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -486,6 +486,44 @@ cyclic_undelegate_liquidation_fails_cleanly_test() ->
     ?assertEqual(10, delegation(Process, Resource, BobAddr, CharlieAddr, Opts)),
     ?assertEqual(10, delegation(Process, Resource, CharlieAddr, AliceAddr, Opts)).
 
+cyclic_undelegation_can_be_unwound_in_safe_steps_test() ->
+    Opts = test_opts(),
+    Alice = ar_wallet:new(),
+    Bob = ar_wallet:new(),
+    Charlie = ar_wallet:new(),
+    AliceAddr = id(Alice),
+    BobAddr = id(Bob),
+    CharlieAddr = id(Charlie),
+    Resource = <<"oxygen">>,
+    Process =
+        generate_process(
+            #{
+                mint_cap => 10_000,
+                mint_prop_numerator => 1,
+                mint_prop_denominator => 2
+            },
+            Opts
+        ),
+    push_set_weight(Process, Resource, 100, Opts),
+    push_deposit(Process, Resource, Alice, 10, Opts),
+    push_delegate(Process, Resource, Alice, BobAddr, 10, Opts),
+    push_delegate(Process, Resource, Bob, CharlieAddr, 10, Opts),
+    push_delegate(Process, Resource, Charlie, AliceAddr, 10, Opts),
+    push_delegate(Process, Resource, Alice, BobAddr, 10, Opts),
+    ?assertMatch(
+        {error, _},
+        push_undelegate(Process, Alice, BobAddr, Resource, 20, Opts)
+    ),
+    {ok, _} = push_undelegate(Process, Alice, BobAddr, Resource, 10, Opts),
+    {ok, _} = push_undelegate(Process, Charlie, AliceAddr, Resource, 10, Opts),
+    {ok, _} = push_undelegate(Process, Alice, BobAddr, Resource, 10, Opts),
+    ?assertEqual(10, deposit(Process, Resource, AliceAddr, <<"quantity">>, Opts)),
+    ?assertEqual(0, deposit(Process, Resource, BobAddr, <<"quantity">>, Opts)),
+    ?assertEqual(0, deposit(Process, Resource, CharlieAddr, <<"quantity">>, Opts)),
+    ?assertEqual(0, delegation(Process, Resource, AliceAddr, BobAddr, Opts)),
+    ?assertEqual(0, delegation(Process, Resource, BobAddr, CharlieAddr, Opts)),
+    ?assertEqual(0, delegation(Process, Resource, CharlieAddr, AliceAddr, Opts)).
+
 balance_without_explicit_mint_same_slot_test() ->
     Opts = test_opts(),
     Alice = ar_wallet:new(),

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -542,6 +542,55 @@ withdraw_through_cyclic_liquidation_fails_cleanly_test() ->
     ?assertEqual(10, delegation(Process, Resource, BobAddr, CharlieAddr, Opts)),
     ?assertEqual(10, delegation(Process, Resource, CharlieAddr, AliceAddr, Opts)).
 
+withdraw_through_cyclic_liquidation_can_recover_principal_test() ->
+    Opts = test_opts(),
+    Alice = ar_wallet:new(),
+    Bob = ar_wallet:new(),
+    Charlie = ar_wallet:new(),
+    AliceAddr = id(Alice),
+    BobAddr = id(Bob),
+    CharlieAddr = id(Charlie),
+    Resource = <<"oxygen">>,
+    Process =
+        generate_process(
+            #{
+                mint_cap => 10_000,
+                mint_prop_numerator => 1,
+                mint_prop_denominator => 2
+            },
+            Opts
+        ),
+    push_set_weight(Process, Resource, 100, Opts),
+    push_deposit(Process, Resource, Alice, 10, Opts),
+    push_delegate(Process, Resource, Alice, BobAddr, 10, Opts),
+    push_delegate(Process, Resource, Bob, CharlieAddr, 10, Opts),
+    push_delegate(Process, Resource, Charlie, AliceAddr, 10, Opts),
+    push_delegate(Process, Resource, Alice, BobAddr, 10, Opts),
+    push_delegate(Process, Resource, Bob, CharlieAddr, 10, Opts),
+    ?assertEqual(0, deposit(Process, Resource, AliceAddr, <<"quantity">>, Opts)),
+    ?assertEqual(0, deposit(Process, Resource, BobAddr, <<"quantity">>, Opts)),
+    ?assertEqual(10, deposit(Process, Resource, CharlieAddr, <<"quantity">>, Opts)),
+    ?assertEqual(20, delegation(Process, Resource, AliceAddr, BobAddr, Opts)),
+    ?assertEqual(20, delegation(Process, Resource, BobAddr, CharlieAddr, Opts)),
+    ?assertEqual(10, delegation(Process, Resource, CharlieAddr, AliceAddr, Opts)),
+    ?assertMatch(
+        {error, _},
+        push_withdraw(Process, Resource, AliceAddr, 20, Opts)
+    ),
+    ?assertEqual(0, deposit(Process, Resource, AliceAddr, <<"quantity">>, Opts)),
+    ?assertEqual(0, deposit(Process, Resource, BobAddr, <<"quantity">>, Opts)),
+    ?assertEqual(10, deposit(Process, Resource, CharlieAddr, <<"quantity">>, Opts)),
+    ?assertEqual(20, delegation(Process, Resource, AliceAddr, BobAddr, Opts)),
+    ?assertEqual(20, delegation(Process, Resource, BobAddr, CharlieAddr, Opts)),
+    ?assertEqual(10, delegation(Process, Resource, CharlieAddr, AliceAddr, Opts)),
+    {ok, _} = push_withdraw(Process, Resource, AliceAddr, 10, Opts),
+    ?assertEqual(0, deposit(Process, Resource, AliceAddr, <<"quantity">>, Opts)),
+    ?assertEqual(0, deposit(Process, Resource, BobAddr, <<"quantity">>, Opts)),
+    ?assertEqual(0, deposit(Process, Resource, CharlieAddr, <<"quantity">>, Opts)),
+    ?assertEqual(10, delegation(Process, Resource, AliceAddr, BobAddr, Opts)),
+    ?assertEqual(10, delegation(Process, Resource, BobAddr, CharlieAddr, Opts)),
+    ?assertEqual(10, delegation(Process, Resource, CharlieAddr, AliceAddr, Opts)).
+
 cyclic_undelegation_can_be_unwound_in_safe_steps_test() ->
     Opts = test_opts(),
     Alice = ar_wallet:new(),

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -524,6 +524,46 @@ cyclic_undelegation_can_be_unwound_in_safe_steps_test() ->
     ?assertEqual(0, delegation(Process, Resource, BobAddr, CharlieAddr, Opts)),
     ?assertEqual(0, delegation(Process, Resource, CharlieAddr, AliceAddr, Opts)).
 
+cyclic_undelegation_liquidation_still_succeeds_when_edge_is_not_reentered_test() ->
+    Opts = test_opts(),
+    Alice = ar_wallet:new(),
+    Bob = ar_wallet:new(),
+    Charlie = ar_wallet:new(),
+    AliceAddr = id(Alice),
+    BobAddr = id(Bob),
+    CharlieAddr = id(Charlie),
+    Resource = <<"oxygen">>,
+    Process =
+        generate_process(
+            #{
+                mint_cap => 10_000,
+                mint_prop_numerator => 1,
+                mint_prop_denominator => 2
+            },
+            Opts
+        ),
+    push_set_weight(Process, Resource, 100, Opts),
+    push_deposit(Process, Resource, Alice, 10, Opts),
+    push_delegate(Process, Resource, Alice, BobAddr, 10, Opts),
+    push_delegate(Process, Resource, Bob, CharlieAddr, 10, Opts),
+    push_delegate(Process, Resource, Charlie, AliceAddr, 10, Opts),
+    push_delegate(Process, Resource, Alice, BobAddr, 10, Opts),
+    {ok, _} = push_undelegate(Process, Alice, BobAddr, Resource, 10, Opts),
+    {ok, _} = push_undelegate(Process, Charlie, AliceAddr, Resource, 10, Opts),
+    ?assertEqual(0, deposit(Process, Resource, AliceAddr, <<"quantity">>, Opts)),
+    ?assertEqual(0, deposit(Process, Resource, BobAddr, <<"quantity">>, Opts)),
+    ?assertEqual(10, deposit(Process, Resource, CharlieAddr, <<"quantity">>, Opts)),
+    ?assertEqual(10, delegation(Process, Resource, AliceAddr, BobAddr, Opts)),
+    ?assertEqual(10, delegation(Process, Resource, BobAddr, CharlieAddr, Opts)),
+    ?assertEqual(0, delegation(Process, Resource, CharlieAddr, AliceAddr, Opts)),
+    {ok, _} = push_undelegate(Process, Alice, BobAddr, Resource, 10, Opts),
+    ?assertEqual(10, deposit(Process, Resource, AliceAddr, <<"quantity">>, Opts)),
+    ?assertEqual(0, deposit(Process, Resource, BobAddr, <<"quantity">>, Opts)),
+    ?assertEqual(0, deposit(Process, Resource, CharlieAddr, <<"quantity">>, Opts)),
+    ?assertEqual(0, delegation(Process, Resource, AliceAddr, BobAddr, Opts)),
+    ?assertEqual(0, delegation(Process, Resource, BobAddr, CharlieAddr, Opts)),
+    ?assertEqual(0, delegation(Process, Resource, CharlieAddr, AliceAddr, Opts)).
+
 balance_without_explicit_mint_same_slot_test() ->
     Opts = test_opts(),
     Alice = ar_wallet:new(),

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -914,6 +914,45 @@ normalized_balance_normalizes_lazy_mint_test() ->
     ?assertEqual(7500, dev_token_lib:normalized_balance(Process, AliceAddr, Opts)),
     ?assertEqual(7500, balance(Process, AliceAddr, Opts)).
 
+%% @doc Test that public persisted mint cannot claim yield for another account.
+public_mint_rejects_foreign_subject_test() ->
+    Opts = test_opts(),
+    AliceWallet = ar_wallet:new(),
+    BobWallet = ar_wallet:new(),
+    AliceAddr = id(AliceWallet),
+    ResourceOxygen = <<"oxygen">>,
+    PotFields = #{
+        mint_cap => 10000,
+        mint_prop_numerator => 1,
+        mint_prop_denominator => 2,
+        t => 0,
+        last_drip => 0
+    },
+    TokenFields = #{
+        initial_balances => #{AliceAddr => 1000},
+        total_supply => 1000
+    },
+    Process = generate_process(PotFields, TokenFields, Opts),
+    push_set_weight(Process, ResourceOxygen, 100, Opts),
+    push_deposit(
+        Process,
+        ResourceOxygen,
+        AliceWallet,
+        10,
+        Opts
+    ),
+    _ = push_request(
+        Process,
+        #{
+            <<"action">> => <<"mint">>,
+            <<"subject">> => AliceAddr
+        },
+        BobWallet,
+        Opts
+    ),
+    ?assertEqual(1000, dev_token_lib:balance(Process, AliceAddr, Opts)),
+    ?assertEqual(1000, hb_ao:get(<<"now/total-supply">>, Process, Opts)).
+
 %% @doc Test direct claim_yield functionality from a single resource
 claim_yield_single_resource_test() ->
     Opts = test_opts(),

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -914,6 +914,86 @@ normalized_balance_normalizes_lazy_mint_test() ->
     ?assertEqual(7500, dev_token_lib:normalized_balance(Process, AliceAddr, Opts)),
     ?assertEqual(7500, balance(Process, AliceAddr, Opts)).
 
+%% @doc Test that public global mint still advances pot accrual state even when
+%% no `subject' is provided.
+public_global_mint_still_drips_without_subject_test() ->
+    Opts = test_opts(),
+    AliceWallet = ar_wallet:new(),
+    BobWallet = ar_wallet:new(),
+    AliceAddr = id(AliceWallet),
+    ResourceOxygen = <<"oxygen">>,
+    PotFields = #{
+        mint_cap => 10000,
+        mint_prop_numerator => 1,
+        mint_prop_denominator => 2,
+        t => 0,
+        last_drip => 0
+    },
+    TokenFields = #{
+        initial_balances => #{AliceAddr => 500},
+        total_supply => 500
+    },
+    Process = generate_process(PotFields, TokenFields, Opts),
+    push_set_weight(Process, ResourceOxygen, 100, Opts),
+    push_deposit(
+        Process,
+        ResourceOxygen,
+        AliceWallet,
+        10,
+        Opts
+    ),
+    _ = push_request(
+        Process,
+        #{
+            <<"action">> => <<"mint">>
+        },
+        BobWallet,
+        Opts
+    ),
+    ?assertEqual(500, dev_token_lib:balance(Process, AliceAddr, Opts)),
+    ?assertEqual(7500, hb_ao:get(<<"now/minted">>, Process, Opts)),
+    ?assertEqual(7, hb_ao:get(<<"now/accumulator">>, Process, Opts)),
+    ?assertEqual(7500, dev_token_lib:normalized_balance(Process, AliceAddr, Opts)).
+
+%% @doc Test that invalid subject addresses are rejected before mint-device
+%% dispatch and do not mutate persisted state.
+public_mint_rejects_invalid_subject_address_test() ->
+    Opts = test_opts(),
+    AliceWallet = ar_wallet:new(),
+    AliceAddr = id(AliceWallet),
+    ResourceOxygen = <<"oxygen">>,
+    PotFields = #{
+        mint_cap => 10000,
+        mint_prop_numerator => 1,
+        mint_prop_denominator => 2,
+        t => 0,
+        last_drip => 0
+    },
+    TokenFields = #{
+        initial_balances => #{AliceAddr => 1000},
+        total_supply => 1000
+    },
+    Process = generate_process(PotFields, TokenFields, Opts),
+    push_set_weight(Process, ResourceOxygen, 100, Opts),
+    push_deposit(
+        Process,
+        ResourceOxygen,
+        AliceWallet,
+        10,
+        Opts
+    ),
+    _ = push_request(
+        Process,
+        #{
+            <<"action">> => <<"mint">>,
+            <<"subject">> => <<"keys">>
+        },
+        AliceWallet,
+        Opts
+    ),
+    ?assertEqual(1000, dev_token_lib:balance(Process, AliceAddr, Opts)),
+    ?assertEqual(1000, hb_ao:get(<<"now/total-supply">>, Process, Opts)).
+
 %% @doc Test that public persisted mint forwards `body.subject` for foreign
 %% callers too, allowing the request to persist the subject claim.
 public_mint_allows_foreign_subject_test() ->

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -564,6 +564,40 @@ cyclic_undelegation_liquidation_still_succeeds_when_edge_is_not_reentered_test()
     ?assertEqual(0, delegation(Process, Resource, BobAddr, CharlieAddr, Opts)),
     ?assertEqual(0, delegation(Process, Resource, CharlieAddr, AliceAddr, Opts)).
 
+plain_chain_undelegation_liquidates_successfully_test() ->
+    Opts = test_opts(),
+    Alice = ar_wallet:new(),
+    Bob = ar_wallet:new(),
+    Charlie = ar_wallet:new(),
+    AliceAddr = id(Alice),
+    BobAddr = id(Bob),
+    CharlieAddr = id(Charlie),
+    Resource = <<"oxygen">>,
+    Process =
+        generate_process(
+            #{
+                mint_cap => 10_000,
+                mint_prop_numerator => 1,
+                mint_prop_denominator => 2
+            },
+            Opts
+        ),
+    push_set_weight(Process, Resource, 100, Opts),
+    push_deposit(Process, Resource, Alice, 10, Opts),
+    push_delegate(Process, Resource, Alice, BobAddr, 10, Opts),
+    push_delegate(Process, Resource, Bob, CharlieAddr, 10, Opts),
+    ?assertEqual(0, deposit(Process, Resource, AliceAddr, <<"quantity">>, Opts)),
+    ?assertEqual(0, deposit(Process, Resource, BobAddr, <<"quantity">>, Opts)),
+    ?assertEqual(10, deposit(Process, Resource, CharlieAddr, <<"quantity">>, Opts)),
+    ?assertEqual(10, delegation(Process, Resource, AliceAddr, BobAddr, Opts)),
+    ?assertEqual(10, delegation(Process, Resource, BobAddr, CharlieAddr, Opts)),
+    {ok, _} = push_undelegate(Process, Alice, BobAddr, Resource, 10, Opts),
+    ?assertEqual(10, deposit(Process, Resource, AliceAddr, <<"quantity">>, Opts)),
+    ?assertEqual(0, deposit(Process, Resource, BobAddr, <<"quantity">>, Opts)),
+    ?assertEqual(0, deposit(Process, Resource, CharlieAddr, <<"quantity">>, Opts)),
+    ?assertEqual(0, delegation(Process, Resource, AliceAddr, BobAddr, Opts)),
+    ?assertEqual(0, delegation(Process, Resource, BobAddr, CharlieAddr, Opts)).
+
 balance_without_explicit_mint_same_slot_test() ->
     Opts = test_opts(),
     Alice = ar_wallet:new(),

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -130,6 +130,14 @@ undelegate_req(Resource, Addr, Qty) ->
         <<"quantity">> => Qty
     }.
 
+withdraw_req(Resource, Addr, Qty) ->
+    #{
+        <<"action">> => <<"withdraw">>,
+        <<"resource">> => Resource,
+        <<"address">> => Addr,
+        <<"quantity">> => Qty
+    }.
+
 transfer_req(Addr, Qty) ->
     transfer_req(Addr, Qty, #{}).
 transfer_req(Addr, Qty, Params) ->
@@ -338,6 +346,13 @@ push_undelegate(Process, Wallet, FromAddr, Resource, Qty, Opts) ->
         Opts
     ).
 
+push_withdraw(Process, Resource, Addr, Qty, Opts) ->
+    push_request(
+        Process,
+        withdraw_req(Resource, Addr, Qty),
+        Opts
+    ).
+
 %%% Test Cases.
 %%% ----------------------------------------------------------------------------
 
@@ -478,6 +493,47 @@ cyclic_undelegate_liquidation_fails_cleanly_test() ->
     ?assertMatch(
         {error, _},
         push_undelegate(Process, Alice, BobAddr, Resource, 20, Opts)
+    ),
+    ?assertEqual(0, deposit(Process, Resource, AliceAddr, <<"quantity">>, Opts)),
+    ?assertEqual(10, deposit(Process, Resource, BobAddr, <<"quantity">>, Opts)),
+    ?assertEqual(0, deposit(Process, Resource, CharlieAddr, <<"quantity">>, Opts)),
+    ?assertEqual(20, delegation(Process, Resource, AliceAddr, BobAddr, Opts)),
+    ?assertEqual(10, delegation(Process, Resource, BobAddr, CharlieAddr, Opts)),
+    ?assertEqual(10, delegation(Process, Resource, CharlieAddr, AliceAddr, Opts)).
+
+withdraw_through_cyclic_liquidation_fails_cleanly_test() ->
+    Opts = test_opts(),
+    Alice = ar_wallet:new(),
+    Bob = ar_wallet:new(),
+    Charlie = ar_wallet:new(),
+    AliceAddr = id(Alice),
+    BobAddr = id(Bob),
+    CharlieAddr = id(Charlie),
+    Resource = <<"oxygen">>,
+    Process =
+        generate_process(
+            #{
+                mint_cap => 10_000,
+                mint_prop_numerator => 1,
+                mint_prop_denominator => 2
+            },
+            Opts
+        ),
+    push_set_weight(Process, Resource, 100, Opts),
+    push_deposit(Process, Resource, Alice, 10, Opts),
+    push_delegate(Process, Resource, Alice, BobAddr, 10, Opts),
+    push_delegate(Process, Resource, Bob, CharlieAddr, 10, Opts),
+    push_delegate(Process, Resource, Charlie, AliceAddr, 10, Opts),
+    push_delegate(Process, Resource, Alice, BobAddr, 10, Opts),
+    ?assertEqual(0, deposit(Process, Resource, AliceAddr, <<"quantity">>, Opts)),
+    ?assertEqual(10, deposit(Process, Resource, BobAddr, <<"quantity">>, Opts)),
+    ?assertEqual(0, deposit(Process, Resource, CharlieAddr, <<"quantity">>, Opts)),
+    ?assertEqual(20, delegation(Process, Resource, AliceAddr, BobAddr, Opts)),
+    ?assertEqual(10, delegation(Process, Resource, BobAddr, CharlieAddr, Opts)),
+    ?assertEqual(10, delegation(Process, Resource, CharlieAddr, AliceAddr, Opts)),
+    ?assertMatch(
+        {error, _},
+        push_withdraw(Process, Resource, AliceAddr, 20, Opts)
     ),
     ?assertEqual(0, deposit(Process, Resource, AliceAddr, <<"quantity">>, Opts)),
     ?assertEqual(10, deposit(Process, Resource, BobAddr, <<"quantity">>, Opts)),


### PR DESCRIPTION
## About

This fixes a `~pot@1.0` corruption bug in cyclic undelegation/liquidation, while preserving the current delegation model

## Problem

  - `undelegate(From, To, Amount)` validated the outer edge before liquidation, then liquidated `To` if needed
  - in cyclic graphs, recursive liquidation could re-enter and partially consume that same outer `From -> To` edge before the original frame resumed
  - the outer frame then still subtracted the full original `Amount`, producing negative deposits / negative delegation edges

### pseudo example:
```
  - Start:
      - deposits: A=0, B=10, C=0
      - edges: A->B=20, B->C=10, C->A=10
  - Call: undelegate(A, B, 20)
  - Liquidation path:
      - unwind B->C 10
      - then C->A 10
      - then re-enter A->B 10
  - At that point recursion has already reduced A->B from 20 to 10
  - Old behavior then still finalized the original outer undelegate(A, B, 20) and wrote:
      - B = -10
      - A->B = -10
```

  ## Fix

  - keep the current delegation model, including cycles and greedy largest-first liquidation
  - before finalizing the outer undelegation, recheck that the request is still coverable after recursive liquidation
  - if recursive unwind has already reduced the outer edge below the requested amount, fail cleanly instead of corrupting state

 ### pseudo example:
```
  - Same start:
      - deposits: A=0, B=10, C=0
      - edges: A->B=20, B->C=10, C->A=10
  - Call: undelegate(A, B, 20)
  - Recursive liquidation again reduces the outer edge to A->B=10
  - New behavior re-checks the outer edge before final subtraction
  - Since the original request was still for 20, but only 10 remains on A->B, the call now returns error and leaves state unchanged
```
 
## Behavioral effect

  - valid non-cyclic and non-reentering liquidations still succeed
  - the bad cyclic oversized path now returns error and leaves state unchanged
  - some oversized one-shot undelegations / withdrawals on cyclic graphs are no longer possible atomically, and must be unwound across multiple actions instead (in case of undelegations)

  ### pseudo examples
```
  - Same cyclic graph:
      - undelegate(A, B, 20) now fails cleanly
      - withdraw(A, 20) now also fails cleanly
  - But Alice can still recover her real principal herself:
      - undelegate(A, B, 10)
      - undelegate(A, B, 10)
  - Or withdraw her real principal through liquidation:
      - withdraw(A, 10)
```
  
## clarifications

  - the  patch does not block cycles, or change greedy liquidation ordering
  - it does not make nominal cyclic edge balances equal to atomically redeemable principal
  - it only prevents the implementation from corrupting state when recursive liquidation re-enters the same outer edge
  - the patch a safety/correctness fix, not a redesign of undelegation semantics


 ## Tests added

  - `cyclic_undelegate_liquidation_fails_cleanly_test`: oversized cyclic `undelegate(A, B, 20)` now fails cleanly and preserves state
  - `withdraw_through_cyclic_liquidation_fails_cleanly_test`: oversized cyclic `withdraw(A, 20)` now fails cleanly and preserves state
  - `withdraw_through_cyclic_liquidation_can_recover_principal_test`: Alice can still `withdraw(A, 10)` through deeper liquidation on the same cyclic shape
  - `cyclic_undelegation_can_be_unwound_in_safe_steps_test`: the same cyclic graph can still be fully unwound across smaller safe undelegations
  - `cyclic_undelegation_liquidation_still_succeeds_when_edge_is_not_reentered_test`: liquidating undelegation still succeeds when the unwind path does not re-enter the same outer edge
  - `cyclic_undelegation_from_charlie_to_alice_succeeds_test` direct `undelegate(C, A, 10)` still succeeds on the same cyclic graph
  - `plain_chain_undelegation_liquidates_successfully_test`: plain non-cyclic `A -> B -> C` liquidation still succeeds