### PR TITLE
impr: dev_security prod mode & dev_pot authorities federation  

### DIFF
--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -24,9 +24,7 @@
 %%% in the original process can earn their yield in the form of `child` mints.
 %%% Each mint can operate asynchronously and in real-time.
 %%% 
-%%% TODO: ADDRESSED IN enforce_resource_config_authority & apply_resource_config
-%%% - Add `secure-set` (set guarded by address) for resource-weights and 
-%%%   supported resources.
+%%% TODO: Add `secure-set` (set guarded by address) for resource-scoped config.
 -module(dev_pot).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -495,13 +493,18 @@ notify(State, Assignment, Opts) ->
             {error, <<"Unsupported notification action">>},
         OriginalFrom = hb_maps:get(<<"from">>, ForwardedMsg, <<"unknown">>, Opts),
         dev_token:handle_action(
-            Action, 
-            State, 
+            Action,
+            State,
             #{
                 <<"type">> => <<"notification">>,
                 <<"original-from">> => OriginalFrom,
-                <<"body">> => ForwardedMsg#{ <<"from">> => NotifyFrom, <<"resource-authority">> => NotifyFrom }
-            }, 
+                <<"body">> =>
+                    ForwardedMsg#{
+                        <<"from">> => NotifyFrom,
+                        <<"resource-authority">> => NotifyFrom,
+                        <<"weight-authority">> => NotifyFrom
+                    }
+            },
             Opts)
     end.
 
@@ -941,9 +944,9 @@ ensure_undelegation_cover(FromAddr, ToAddr, ResourceID, Amount, S, Opts) ->
     end.
 
 %% @doc Resource configuration entrypoint. Validates the target resource and
-%% caller, enforces resource-config authority via
-%% `enforce_resource_config_authority/5`, then applies supported
-%% resource-scoped config mutations.
+%% caller, then applies supported resource-scoped config mutations. Weight
+%% updates can be delegated to a per-resource `weight-authority`, while
+%% authority rotation remains parent-or-mint-authority only.
 register(State, Assignment, Opts) ->
     ?event(debug_pot, {register, Assignment}, Opts),
     maybe
@@ -964,18 +967,50 @@ register(State, Assignment, Opts) ->
                 Opts
             ),
         true ?= dev_token:validate_address(From, ?RESERVED_KEYS),
-        true ?= enforce_resource_config_authority(From, State, Req, Opts),
-        apply_resource_config(ResID, State, Req, Opts)
+        true ?=
+            case {
+                hb_maps:find(<<"resource-authority">>, Req, Opts),
+                hb_maps:find(<<"weight-authority">>, Req, Opts),
+                hb_maps:find(<<"weight">>, Req, Opts)
+            } of
+                {{ok, _}, _, _} ->
+                    enforce_resource_config_authority(From, State, Req, Opts);
+                {_, {ok, _}, _} ->
+                    enforce_resource_config_authority(From, State, Req, Opts);
+                {_, _, {ok, _}} ->
+                    enforce_resource_weight_authority(ResID, From, State, Req, Opts);
+                _ ->
+                    true
+            end,
+        State2 =
+            case hb_maps:find(<<"weight">>, Req, Opts) of
+                {ok, Weight} -> register_resource(ResID, Weight, State, Opts);
+                _ -> State
+            end,
+        true ?= is_map(State2) orelse State2,
+        State3 =
+            case hb_maps:find(<<"weight-authority">>, Req, Opts) of
+                {ok, WeightAuth} ->
+                    register_resource_weight_authority(
+                        ResID,
+                        WeightAuth,
+                        State2,
+                        Opts
+                    );
+                _ -> State2
+            end,
+        true ?= is_map(State3) orelse State3,
+        case hb_maps:find(<<"resource-authority">>, Req, Opts) of
+            {ok, ResAuth} ->
+                register_resource_authority(ResID, ResAuth, State3, Opts);
+            _ -> State3
+        end
     end.
 %% @doc Enforce authorization for resource configuration updates.
 %% Authorization is evaluated against:
 %% - `State/parent`, if set and equal to `from`
 %% - `mint-authority` security policy on the pot state, if configured
-%% - `authority` security policy on the target resource, if configured
-%%
-%% N.B: `dev_security` is open-by-default when no valid/required/match policy
-%% is present, so absent authority config does not restrict this action. check
-%% `AuthRes` logic chain for better gating-understanding.
+%% Resource-level write or weight authorities do not grant config authority.
 enforce_resource_config_authority(From, State, Req, Opts) ->
     ?event(debug_pot, {enforce_resource_config_authority, Req}, Opts),
     maybe
@@ -990,25 +1025,66 @@ enforce_resource_config_authority(From, State, Req, Opts) ->
         end,
         true ?= AuthRes
     end.
-%% @doc Apply supported resource-scoped configuration updates. If an earlier
-%% mutation fails, later mutations in the same request are not applied.
-apply_resource_config(ResID, State, Req, Opts) ->
+%% @doc Enforce authorization for weight-only updates. Parent may always
+%% reconfigure its children, explicit per-resource weight-authority can update
+%% the weight, and mint-authority remains the global override.
+enforce_resource_weight_authority(ResourceID, From, State, Req, Opts) ->
+    ?event(debug_pot, {enforce_resource_weight_authority, Req}, Opts),
     maybe
-        State2 =
-            case hb_maps:find(<<"weight">>, Req, Opts) of
-                {ok, Weight} -> register_resource(ResID, Weight, State, Opts);
-                _ -> State
+        AuthRes =
+            case (hb_maps:get(<<"parent">>, State, no_parent, Opts) =:= From) of
+                true -> true;
+                false ->
+                    case verify_weight_authority(ResourceID, State, Req, Opts) of
+                        true -> true;
+                        {error, _} ->
+                            case dev_security:validate(
+                                <<"mint-authority">>,
+                                State,
+                                Req,
+                                From,
+                                Opts#{ dev_security_mode => prod }
+                            ) of
+                                true -> true;
+                                {error, _} ->
+                                    {error, <<"Caller is not authorized to update resource weight.">>}
+                            end
+                    end
             end,
-        true ?= is_map(State2) orelse State2,
-        case hb_maps:find(<<"resource-authority">>, Req, Opts) of
-            {ok, ResAuth} ->
-                register_resource_authority(ResID, ResAuth, State2, Opts);
-            _ -> State2
-        end
-    else
-        Reason -> 
-            ?event(debug_pot, {error, Reason}, Opts),
-            Reason
+        true ?= AuthRes
+    end.
+%% @doc Verify a request against the weight-authority for a specific resource.
+verify_weight_authority(ResourceID, Base, Req, Opts) ->
+    maybe
+        {ok, From} ?=
+            hb_maps:find(
+                <<"from">>,
+                Req,
+                <<"No `from' address provided.">>,
+                Opts
+            ),
+        {ok, Resources} ?=
+            hb_maps:find(
+                <<"resources">>,
+                Base,
+                <<"No resources found in mint state.">>,
+                Opts
+            ),
+        {ok, Resource} ?=
+            hb_maps:find(
+                ResourceID,
+                Resources,
+                <<"Requested resource not initialized in mint state.">>,
+                Opts
+            ),
+        true ?=
+            dev_security:validate(
+                <<"weight-authority">>,
+                Resource,
+                Req,
+                From,
+                Opts#{ dev_security_mode => prod }
+            )
     end.
 %% @doc Update the authority record for a specific resource in the pot.
 register_resource_authority(ResourceID, Authority, S, Opts) ->
@@ -1018,6 +1094,18 @@ register_resource_authority(ResourceID, Authority, S, Opts) ->
         hb_ao:set(
             S,
             <<"/resources/", ResourceID/binary, "/authority">>,
+            Authority,
+            Opts
+        )
+end.
+%% @doc Update the weight-authority record for a specific resource in the pot.
+register_resource_weight_authority(ResourceID, Authority, S, Opts) ->
+    maybe
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
+        true ?= dev_token:validate_address(Authority, ?RESERVED_KEYS),
+        hb_ao:set(
+            S,
+            <<"/resources/", ResourceID/binary, "/weight-authority">>,
             Authority,
             Opts
         )

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -966,18 +966,19 @@ register(State, Assignment, Opts) ->
                 <<"No `from' address provided.">>, 
                 Opts
             ),
-        true ?= dev_token:validate_address(From, ?RESERVED_KEYS),
+        true ?= validate_signer_config(From, Opts),
+        HasAdminMutation =
+            hb_maps:find(<<"resource-authority">>, Req, Opts) =/= error orelse
+            hb_maps:find(<<"resource-authority-required">>, Req, Opts) =/= error orelse
+            hb_maps:find(<<"resource-authority-match">>, Req, Opts) =/= error orelse
+            hb_maps:find(<<"weight-authority">>, Req, Opts) =/= error orelse
+            hb_maps:find(<<"weight-authority-required">>, Req, Opts) =/= error orelse
+            hb_maps:find(<<"weight-authority-match">>, Req, Opts) =/= error,
         true ?=
-            case {
-                hb_maps:find(<<"resource-authority">>, Req, Opts),
-                hb_maps:find(<<"weight-authority">>, Req, Opts),
-                hb_maps:find(<<"weight">>, Req, Opts)
-            } of
-                {{ok, _}, _, _} ->
+            case {HasAdminMutation, hb_maps:find(<<"weight">>, Req, Opts)} of
+                {true, _} ->
                     enforce_resource_config_authority(From, State, Req, Opts);
-                {_, {ok, _}, _} ->
-                    enforce_resource_config_authority(From, State, Req, Opts);
-                {_, _, {ok, _}} ->
+                {false, {ok, _}} ->
                     enforce_resource_weight_authority(ResID, From, State, Req, Opts);
                 _ ->
                     true
@@ -1000,10 +1001,53 @@ register(State, Assignment, Opts) ->
                 _ -> State2
             end,
         true ?= is_map(State3) orelse State3,
-        case hb_maps:find(<<"resource-authority">>, Req, Opts) of
-            {ok, ResAuth} ->
-                register_resource_authority(ResID, ResAuth, State3, Opts);
-            _ -> State3
+        State4 =
+            case hb_maps:find(<<"weight-authority-required">>, Req, Opts) of
+                {ok, WeightRequired} ->
+                    register_resource_weight_authority_required(
+                        ResID,
+                        WeightRequired,
+                        State3,
+                        Opts
+                    );
+                _ -> State3
+            end,
+        true ?= is_map(State4) orelse State4,
+        State5 =
+            case hb_maps:find(<<"weight-authority-match">>, Req, Opts) of
+                {ok, WeightMatch} ->
+                    register_resource_weight_authority_match(
+                        ResID,
+                        WeightMatch,
+                        State4,
+                        Opts
+                    );
+                _ -> State4
+            end,
+        true ?= is_map(State5) orelse State5,
+        State6 =
+            case hb_maps:find(<<"resource-authority">>, Req, Opts) of
+                {ok, ResAuth} ->
+                    register_resource_authority(ResID, ResAuth, State5, Opts);
+                _ -> State5
+            end,
+        true ?= is_map(State6) orelse State6,
+        State7 =
+            case hb_maps:find(<<"resource-authority-required">>, Req, Opts) of
+                {ok, ResRequired} ->
+                    register_resource_authority_required(
+                        ResID,
+                        ResRequired,
+                        State6,
+                        Opts
+                    );
+                _ -> State6
+            end,
+        true ?= is_map(State7) orelse State7,
+        case hb_maps:find(<<"resource-authority-match">>, Req, Opts) of
+            {ok, ResMatch} ->
+                register_resource_authority_match(ResID, ResMatch, State7, Opts);
+            _ -> State7
         end
     end.
 %% @doc Enforce authorization for resource configuration updates.
@@ -1090,7 +1134,7 @@ verify_weight_authority(ResourceID, Base, Req, Opts) ->
 register_resource_authority(ResourceID, Authority, S, Opts) ->
     maybe
         true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
-        true ?= dev_token:validate_address(Authority, ?RESERVED_KEYS),
+        true ?= validate_signer_config(Authority, Opts),
         hb_ao:set(
             S,
             <<"/resources/", ResourceID/binary, "/authority">>,
@@ -1098,11 +1142,33 @@ register_resource_authority(ResourceID, Authority, S, Opts) ->
             Opts
         )
 end.
+register_resource_authority_required(ResourceID, Required, S, Opts) ->
+    maybe
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
+        true ?= validate_signer_config(Required, Opts),
+        hb_ao:set(
+            S,
+            <<"/resources/", ResourceID/binary, "/authority-required">>,
+            Required,
+            Opts
+        )
+end.
+register_resource_authority_match(ResourceID, Match, S, Opts) ->
+    maybe
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
+        true ?= validate_match_config(Match),
+        hb_ao:set(
+            S,
+            <<"/resources/", ResourceID/binary, "/authority-match">>,
+            Match,
+            Opts
+        )
+end.
 %% @doc Update the weight-authority record for a specific resource in the pot.
 register_resource_weight_authority(ResourceID, Authority, S, Opts) ->
     maybe
         true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
-        true ?= dev_token:validate_address(Authority, ?RESERVED_KEYS),
+        true ?= validate_signer_config(Authority, Opts),
         hb_ao:set(
             S,
             <<"/resources/", ResourceID/binary, "/weight-authority">>,
@@ -1110,6 +1176,65 @@ register_resource_weight_authority(ResourceID, Authority, S, Opts) ->
             Opts
         )
 end.
+register_resource_weight_authority_required(ResourceID, Required, S, Opts) ->
+    maybe
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
+        true ?= validate_signer_config(Required, Opts),
+        hb_ao:set(
+            S,
+            <<"/resources/", ResourceID/binary, "/weight-authority-required">>,
+            Required,
+            Opts
+        )
+end.
+register_resource_weight_authority_match(ResourceID, Match, S, Opts) ->
+    maybe
+        true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
+        true ?= validate_match_config(Match),
+        hb_ao:set(
+            S,
+            <<"/resources/", ResourceID/binary, "/weight-authority-match">>,
+            Match,
+            Opts
+        )
+end.
+validate_signer_config(Value, Opts) when is_binary(Value) ->
+    try validate_signer_config(hb_util:binary_to_strings(Value), Opts)
+    catch
+        _:_ -> {error, <<"Signer config must be a valid binary or list.">>}
+    end;
+validate_signer_config(Value, Opts) when is_list(Value) ->
+    case Value of
+        [] ->
+            {error, <<"Signer config list must not be empty.">>};
+        _ ->
+            case lists:all(fun is_binary/1, Value) of
+                false ->
+                    {error, <<"Signer config list must contain binary addresses.">>};
+                true ->
+                    lists:foldl(
+                        fun(Signer, true) ->
+                            dev_token:validate_address(Signer, ?RESERVED_KEYS);
+                           (_Signer, {error, _} = Err) ->
+                            Err
+                        end,
+                        true,
+                        Value
+                    )
+            end
+    end;
+validate_signer_config(_, _) ->
+    {error, <<"Signer config must be a binary or a list.">>}.
+validate_match_config(Match) when is_integer(Match), Match >= 0 -> true;
+validate_match_config(Match) when is_binary(Match) ->
+    try binary_to_integer(Match) of
+        Int when is_integer(Int), Int >= 0 -> true;
+        _ -> {error, <<"Match threshold must be a non-negative integer.">>}
+    catch
+        _:_ -> {error, <<"Match threshold must be a non-negative integer.">>}
+    end;
+validate_match_config(_) ->
+    {error, <<"Match threshold must be a non-negative integer.">>}.
 
 %% @doc Set the weight of a specific resource in the pot, updating the pot state
 %% as necessary.

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -964,7 +964,7 @@ register(State, Assignment, Opts) ->
                 Opts
             ),
         true ?= dev_token:validate_address(From, ?RESERVED_KEYS),
-        true ?= enforce_resource_config_authority(From, ResID, State, Req, Opts),
+        true ?= enforce_resource_config_authority(From, State, Req, Opts),
         apply_resource_config(ResID, State, Req, Opts)
     end.
 %% @doc Enforce authorization for resource configuration updates.
@@ -976,7 +976,7 @@ register(State, Assignment, Opts) ->
 %% N.B: `dev_security` is open-by-default when no valid/required/match policy
 %% is present, so absent authority config does not restrict this action. check
 %% `AuthRes` logic chain for better gating-understanding.
-enforce_resource_config_authority(From, ResID, State, Req, Opts) ->
+enforce_resource_config_authority(From, State, Req, Opts) ->
     ?event(debug_pot, {enforce_resource_config_authority, Req}, Opts),
     maybe
         AuthRes = case (hb_maps:get(<<"parent">>, State, no_parent, Opts) =:= From) of

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -977,8 +977,8 @@ enforce_resource_config_authority(From, ResID, State, Req, Opts) ->
             false -> 
                 case dev_security:validate(<<"mint-authority">>, State, Req, From, Opts) of
                     true -> true;
-                    {error, _} -> 
-                        verify_resource_authority(ResID, State, Req, Opts)
+                    {error, _} -> false
+                        % verify_resource_authority(ResID, State, Req, Opts)
                     end  
         end,
         true ?= AuthRes

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -23,6 +23,17 @@
 %%% their own mints using the same `pot` functionality as the parent, depositors
 %%% in the original process can earn their yield in the form of `child` mints.
 %%% Each mint can operate asynchronously and in real-time.
+%%%
+%%% Authority model:
+%%% - `deposit` / `withdraw` are authorized per resource by that resource's
+%%%   `authority` security policy.
+%%% - `weight` updates may be delegated per resource via `weight-authority`.
+%%% - resource config changes (`authority*`, `weight-authority*`) remain
+%%%   guarded by the pot-wide `mint-authority` policy, or by the configured
+%%%   `parent` when the pot is acting as a child mint.
+%%% - child mints trust their direct `parent` process for inherited resource
+%%%   config and writes; forwarded parent `register` notifications set both
+%%%   `resource-authority` and `weight-authority` to that parent process.
 %%% 
 %%% TODO: Add `secure-set` (set guarded by address) for resource-scoped config.
 -module(dev_pot).
@@ -419,7 +430,9 @@ parse_deposit_modification(Base, Assignment, Opts) ->
         {ok, {Address, ResourceID, Amount}}
     end.
 
-%% @doc Verify a request against the authority for a specific resource.
+%% @doc Verify a request against the resource-local `authority` policy for a
+%% specific resource. In prod mode, requests fail closed if the resource has no
+%% explicit authority policy configured.
 verify_resource_authority(ResourceID, Base, Req, Opts) ->
     maybe
         {ok, From} ?=
@@ -455,7 +468,9 @@ verify_resource_authority(ResourceID, Base, Req, Opts) ->
 
 %% @doc Interpret forwarded `register' notifications from the configured
 %% `parent' mint process. Notifications from any other sender, or notifications
-%% forwarding a non-`register' action, are rejected.
+%% forwarding a non-`register' action, are rejected. Child mints trust their
+%% direct parent for inherited resource config, so forwarded notifications set
+%% both `resource-authority' and `weight-authority' to the parent process ID.
 notify(State, Assignment, Opts) ->
     maybe
         {ok, Req} ?=
@@ -944,9 +959,17 @@ ensure_undelegation_cover(FromAddr, ToAddr, ResourceID, Amount, S, Opts) ->
     end.
 
 %% @doc Resource configuration entrypoint. Validates the target resource and
-%% caller, then applies supported resource-scoped config mutations. Weight
-%% updates can be delegated to a per-resource `weight-authority`, while
-%% authority rotation remains parent-or-mint-authority only.
+%% caller, then applies supported resource-scoped config mutations.
+%% 
+%% Authorization model:
+%% - `weight`-only updates may be performed by:
+%%   - the configured `parent`
+%%   - the pot-wide `mint-authority`
+%%   - the resource-local `weight-authority`
+%% - updates touching `resource-authority*` or `weight-authority*` are treated
+%%   as admin mutations and may only be performed by:
+%%   - the configured `parent`
+%%   - the pot-wide `mint-authority`
 register(State, Assignment, Opts) ->
     ?event(debug_pot, {register, Assignment}, Opts),
     maybe
@@ -1070,8 +1093,8 @@ enforce_resource_config_authority(From, State, Req, Opts) ->
         true ?= AuthRes
     end.
 %% @doc Enforce authorization for weight-only updates. Parent may always
-%% reconfigure its children, explicit per-resource weight-authority can update
-%% the weight, and mint-authority remains the global override.
+%% reconfigure its children, explicit per-resource `weight-authority` can
+%% update the weight, and `mint-authority` remains the global override.
 enforce_resource_weight_authority(ResourceID, From, State, Req, Opts) ->
     ?event(debug_pot, {enforce_resource_weight_authority, Req}, Opts),
     maybe
@@ -1097,7 +1120,9 @@ enforce_resource_weight_authority(ResourceID, From, State, Req, Opts) ->
             end,
         true ?= AuthRes
     end.
-%% @doc Verify a request against the weight-authority for a specific resource.
+%% @doc Verify a request against the resource-local `weight-authority` policy
+%% for a specific resource. In prod mode, requests fail closed if the resource
+%% has no explicit weight-authority policy configured.
 verify_weight_authority(ResourceID, Base, Req, Opts) ->
     maybe
         {ok, From} ?=

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -445,7 +445,14 @@ verify_resource_authority(ResourceID, Base, Req, Opts) ->
                 <<"Requested resource not initialized in mint state.">>,
                 Opts
             ),
-        true ?= dev_security:validate(<<"authority">>, Resource, Req, From, Opts)
+        true ?=
+            dev_security:validate(
+                <<"authority">>,
+                Resource,
+                Req,
+                From,
+                Opts#{ dev_security_mode => prod }
+            )
     end.
 
 %% @doc Interpret forwarded `register' notifications from the configured
@@ -493,7 +500,7 @@ notify(State, Assignment, Opts) ->
             #{
                 <<"type">> => <<"notification">>,
                 <<"original-from">> => OriginalFrom,
-                <<"body">> => ForwardedMsg#{ <<"from">> => NotifyFrom }
+                <<"body">> => ForwardedMsg#{ <<"from">> => NotifyFrom, <<"resource-authority">> => NotifyFrom }
             }, 
             Opts)
     end.
@@ -975,11 +982,11 @@ enforce_resource_config_authority(From, ResID, State, Req, Opts) ->
         AuthRes = case (hb_maps:get(<<"parent">>, State, no_parent, Opts) =:= From) of
             true -> true;
             false -> 
-                case dev_security:validate(<<"mint-authority">>, State, Req, From, Opts) of
+                case dev_security:validate(<<"mint-authority">>, State, Req, From, Opts#{dev_security_mode => prod}) of
                     true -> true;
-                    {error, _} -> false
-                        % verify_resource_authority(ResID, State, Req, Opts)
-                    end  
+                    {error, _} ->
+                        {error, <<"Caller is not authorized to configure resources.">>}
+                end  
         end,
         true ?= AuthRes
     end.

--- a/src/dev_pot_test_vectors.erl
+++ b/src/dev_pot_test_vectors.erl
@@ -257,6 +257,115 @@ multiresource_modified_weight_test() ->
     ?assertEqual(12, dev_pot:balance(Bob, S5, Opts)),
     ok.
 
+weight_authority_match_requires_multiple_signers_test() ->
+    Admin = <<"admin">>,
+    WeightA = <<"weight-a">>,
+    WeightB = <<"weight-b">>,
+    Resource = <<"oxygen">>,
+    Opts = #{},
+    S0 = (pot_state_empty([Resource]))#{ <<"mint-authority">> => Admin },
+    S1 =
+        dev_pot:register(
+            S0,
+            #{
+                <<"body">> => #{
+                    <<"resource">> => Resource,
+                    <<"weight">> => 100,
+                    <<"from">> => Admin,
+                    <<"weight-authority">> => [WeightA, WeightB],
+                    <<"weight-authority-match">> => 2
+                }
+            },
+            Opts
+        ),
+    ?assert(is_map(S1)),
+    ?assertEqual(100, hb_ao:get(<<"/resources/oxygen/weight">>, S1, 0, Opts)),
+    ?assertMatch(
+        {error, _},
+        dev_pot:register(
+            S1,
+            #{
+                <<"body">> => #{
+                    <<"resource">> => Resource,
+                    <<"weight">> => 200,
+                    <<"from">> => WeightA
+                }
+            },
+            Opts
+        )
+    ),
+    ?assertEqual(100, hb_ao:get(<<"/resources/oxygen/weight">>, S1, 0, Opts)),
+    S2 =
+        dev_pot:register(
+            S1,
+            #{
+                <<"body">> => #{
+                    <<"resource">> => Resource,
+                    <<"weight">> => 200,
+                    <<"from">> => [WeightA, WeightB]
+                }
+            },
+            Opts
+        ),
+    ?assert(is_map(S2)),
+    ?assertEqual(200, hb_ao:get(<<"/resources/oxygen/weight">>, S2, 0, Opts)).
+
+resource_authority_required_signer_is_enforced_test() ->
+    Admin = <<"admin">>,
+    Alice = <<"alice">>,
+    ResourceA = <<"resource-a">>,
+    ResourceB = <<"resource-b">>,
+    Resource = <<"oxygen">>,
+    Opts = #{},
+    S0 = (pot_state_empty([Resource]))#{ <<"mint-authority">> => Admin },
+    S1 =
+        dev_pot:register(
+            S0,
+            #{
+                <<"body">> => #{
+                    <<"resource">> => Resource,
+                    <<"weight">> => 100,
+                    <<"from">> => Admin,
+                    <<"resource-authority">> => [ResourceA, ResourceB],
+                    <<"resource-authority-required">> => [ResourceA],
+                    <<"resource-authority-match">> => 1
+                }
+            },
+            Opts
+        ),
+    ?assert(is_map(S1)),
+    ?assertMatch(
+        {error, _},
+        dev_pot:deposit(
+            S1,
+            #{
+                <<"body">> => #{
+                    <<"address">> => Alice,
+                    <<"resource">> => Resource,
+                    <<"quantity">> => 10,
+                    <<"from">> => ResourceB
+                }
+            },
+            Opts
+        )
+    ),
+    ?assertEqual(0, dev_pot:get_deposit(Alice, Resource, S1, Opts)),
+    S2 =
+        dev_pot:deposit(
+            S1,
+            #{
+                <<"body">> => #{
+                    <<"address">> => Alice,
+                    <<"resource">> => Resource,
+                    <<"quantity">> => 10,
+                    <<"from">> => [ResourceA, ResourceB]
+                }
+            },
+            Opts
+        ),
+    ?assert(is_map(S2)),
+    ?assertEqual(10, dev_pot:get_deposit(Alice, Resource, S2, Opts)).
+
 simple_delegation_test() ->
     Alice = <<"alice">>,
     Bob = <<"bob">>,

--- a/src/dev_security.erl
+++ b/src/dev_security.erl
@@ -81,6 +81,14 @@ validate(Key, Base, SubjectMsg, Opts) ->
     validate(Key, Base, SubjectMsg, hb_message:signers(SubjectMsg, Opts), Opts).
 validate(Key, Base, SubjectMsg, RawFrom, Opts) ->
     maybe
+        true ?=
+            case is_prod_mode(Opts) of
+                true ->
+                    has_explicit_policy(Key, Base, Opts)
+                        orelse {error, <<"Security policy not configured.">>};
+                false ->
+                    true
+            end,
         %% Dedup identities so duplicate committers cannot satisfy min-N thresholds.
         From = lists:uniq(as_list(RawFrom, Opts)),
         ValidOrError = as_signer_config_list(hb_ao:get(Key, Base, [], Opts), Opts),
@@ -115,6 +123,18 @@ validate(Key, Base, SubjectMsg, RawFrom, Opts) ->
         ),
         satisfies_constraints(Key, From, RequiredList, Valid, Match, Opts)
 end.
+
+is_prod_mode(Opts) ->
+    case maps:get(dev_security_mode, Opts, maps:get(<<"dev-security-mode">>, Opts, dev)) of
+        prod -> true;
+        <<"prod">> -> true;
+        _ -> false
+    end.
+
+has_explicit_policy(Key, Base, Opts) ->
+    hb_ao:get(Key, Base, not_found, Opts) =/= not_found orelse
+    hb_ao:get(<<Key/binary, "-required">>, Base, not_found, Opts) =/= not_found orelse
+    hb_ao:get(<<Key/binary, "-match">>, Base, not_found, Opts) =/= not_found.
 
 %% @doc Validate that the request satisfies the given constraints.
 %% Returns true if:

--- a/src/dev_security.erl
+++ b/src/dev_security.erl
@@ -256,3 +256,29 @@ comma_separated_authority_config_supported_test() ->
             #{}
         )
     ).
+
+prod_mode_requires_explicit_policy_test() ->
+    ?assertEqual(
+        {error, <<"Security policy not configured.">>},
+        validate(
+            <<"authority">>,
+            #{},
+            #{},
+            [<<"alice">>],
+            #{ dev_security_mode => prod }
+        )
+    ).
+
+prod_mode_allows_explicit_single_signer_policy_test() ->
+    ?assertEqual(
+        true,
+        validate(
+            <<"authority">>,
+            #{
+                <<"authority">> => <<"alice">>
+            },
+            #{},
+            [<<"alice">>],
+            #{ dev_security_mode => prod }
+        )
+    ).

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -99,11 +99,12 @@ id(Bin) when is_binary(Bin) ->
     << Bin/binary, Suffix/binary >>;
 id(Other) -> hb_util:human_id(Other).
 
-set_weight_req(Resource, Weight) ->
+set_weight_req(Resource, Weight, Authority) ->
     #{
         <<"action">> => <<"register">>,
         <<"resource">> => Resource,
-        <<"weight">> => Weight
+        <<"weight">> => Weight,
+        <<"resource-authority">> => Authority
     }.
 
 deposit_req(Resource, Addr, Qty) ->
@@ -199,6 +200,7 @@ generate_base_process_state(ExtraKeys, Opts) ->
 
 %% @doc Generate pot state for integration testing
 generate_pot_state(Params, Opts) ->
+    Authority = id(hb_opts:get(priv_wallet, no_wallet, Opts)),
     MintCap = hb_maps:get(mint_cap, Params, 10000, Opts),
     MintPropN = hb_maps:get(mint_prop_numerator, Params, 1, Opts),
     MintPropD = hb_maps:get(mint_prop_denominator, Params, 2, Opts),
@@ -225,6 +227,7 @@ generate_pot_state(Params, Opts) ->
     Merged = maps:merge(MaybeParent, MaybeIndexKeys),
     Merged#{
         <<"mint-device">> => hb_maps:get(mint_device, Params, <<"pot@1.0">>, Opts),
+        <<"mint-authority">> => hb_maps:get(mint_authority, Params, Authority, Opts),
         <<"mint-cap">> => MintCap,
         <<"mint-prop-numerator">> => MintPropN,
         <<"mint-prop-denominator">> => MintPropD,
@@ -308,7 +311,11 @@ push_request(Process, Body, Wallet, Opts) ->
 push_set_weight(Process, Resource, Weight, Opts) ->
     push_request(
         Process,
-        set_weight_req(Resource, Weight),
+        set_weight_req(
+            Resource,
+            Weight,
+            id(hb_opts:get(priv_wallet, no_wallet, Opts))
+        ),
         Opts
     ),
     dev_token_lib:now(Process, Opts).

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -99,12 +99,19 @@ id(Bin) when is_binary(Bin) ->
     << Bin/binary, Suffix/binary >>;
 id(Other) -> hb_util:human_id(Other).
 
-set_weight_req(Resource, Weight, Authority) ->
+set_weight_req(Resource, Weight) ->
+    #{
+        <<"action">> => <<"register">>,
+        <<"resource">> => Resource,
+        <<"weight">> => Weight
+    }.
+set_weight_req(Resource, Weight, ResourceAuthority, WeightAuthority) ->
     #{
         <<"action">> => <<"register">>,
         <<"resource">> => Resource,
         <<"weight">> => Weight,
-        <<"resource-authority">> => Authority
+        <<"resource-authority">> => ResourceAuthority,
+        <<"weight-authority">> => WeightAuthority
     }.
 
 deposit_req(Resource, Addr, Qty) ->
@@ -314,6 +321,7 @@ push_set_weight(Process, Resource, Weight, Opts) ->
         set_weight_req(
             Resource,
             Weight,
+            id(hb_opts:get(priv_wallet, no_wallet, Opts)),
             id(hb_opts:get(priv_wallet, no_wallet, Opts))
         ),
         Opts
@@ -433,6 +441,44 @@ simple_pot_process_test() ->
     ?assertEqual(1, balance(Process, id(Bob),Opts)),
     ?assertEqual(8999, balance(Process, id(Alice), Opts)),
     ?assertEqual(9000, hb_ao:get(<<"now/total-supply">>, Process, Opts)).
+
+weight_authority_can_update_weight_without_resource_config_authority_test() ->
+    Opts = test_opts(),
+    Resource = <<"oxygen">>,
+    WeightWallet = ar_wallet:new(),
+    ResourceWallet = ar_wallet:new(),
+    Process =
+        generate_process(
+            #{
+                mint_cap => 10000,
+                mint_prop_numerator => 1,
+                mint_prop_denominator => 2
+            },
+            Opts
+        ),
+    push_request(
+        Process,
+        set_weight_req(Resource, 100, id(ResourceWallet), id(WeightWallet)),
+        Opts
+    ),
+    ?assertEqual(100, weight(Process, Resource, Opts)),
+    ?assertMatch(
+        {error, _},
+        push_request(
+            Process,
+            set_weight_req(Resource, 200),
+            ResourceWallet,
+            Opts
+        )
+    ),
+    ?assertEqual(100, weight(Process, Resource, Opts)),
+    push_request(
+        Process,
+        set_weight_req(Resource, 200),
+        WeightWallet,
+        Opts
+    ),
+    ?assertEqual(200, weight(Process, Resource, Opts)).
 
 pot_delegation_test() ->
     Opts = test_opts(),


### PR DESCRIPTION
## Federated Authorities
 this PR focus on hardening `~pot@1.0` resource auth and splits resource write authority from weight-update authority -> authority federation

### new model

* deposit/withdraw are authorized by per resource `resource-authority`
 * weight updates can be authorized by per resource `weight-authority`
 * resource config changes (`resource-authority*`, `weight-authority*`) remain pot-admin only:
      - `parent`
      - or `mint-authority`

 also `resource-authority` and `weight-authority` now support the normal `dev_security` signer policy shape:

 - single signer
 - signer list
 - *-required
 - *-match
 
 which results in the followingdev_security usage hardening:
  - resource writers can no longer update weights
  - weight updaters can no longer rotate authorities
  - only mint-authority / parent can rotate resource config (both resources and weights)
  
 ## Prod Security Mode
added a new field to the Opts `dev_security_mode => prod` which enables fail-closed dev_security enforcement on the pot public authority paths (verify_resource_authority, verify_weight_authority, and register)
  
### effect:

  - missing authority policy no longer defaults open on these paths
  - empty signer lists are rejected at config time
  - explicit signer policies are required for prod resource writes, weight updates and admin config

### child pot behavior:

  - fwd parent register notifications now set both:
      - `resource-authority = Parent`
      - `weight-authority = Parent`
  - so child mints explicitly trust their direct parent process for inherited resource config and writes, instead of relying on permissive defaults
