### PR TITLE
impr: utilize Arweave offset in GraphQL cursors

### DIFF
--- a/src/dev_query_arweave.erl
+++ b/src/dev_query_arweave.erl
@@ -55,7 +55,7 @@ query(Obj, <<"transactions">>, Args, Opts) ->
         {field, <<"transactions">>},
         {args, Args}
     }),
-    Matches = match_args(Args, Opts),
+    Matches = filter_explicit_ids(match_args(Args, Opts), Args, Opts),
     Ordered =
         case annotate_ids(Matches, Opts) of
             unavailable -> [#{ <<"id">> => ID } || ID <- Matches];
@@ -363,29 +363,14 @@ match_args(Args, Opts) when is_map(Args) ->
 match_args([], [], _Opts) -> [];
 match_args([], Results, Opts) ->
     ?event({match_args_results, Results}),
-    PreparedResults = [prepare_match_ids(Result, Opts) || Result <- Results],
+    ResolvedResults = [ resolve_ids(Result, Opts) || Result <- Results ],
     Matches =
         lists:foldl(
-            fun(Result, Acc) ->
-                hb_util:list_with(match_result_ids(Result), Acc)
-            end,
-            match_result_ids(hd(PreparedResults)),
-            tl(PreparedResults)
+            fun(Result, Acc) -> hb_util:list_with(Result, Acc) end,
+            hd(ResolvedResults),
+            tl(ResolvedResults)
         ),
-    OutputMatches =
-        case explicit_match_ids(PreparedResults, Matches) of
-            [] -> Matches;
-            ExplicitMatches -> ExplicitMatches
-        end,
-    hb_util:unique(
-        lists:flatten(
-            [
-                all_ids(ID, Opts)
-            ||
-                ID <- OutputMatches
-            ]
-        )
-    );
+    hb_util:unique(lists:flatten([ all_ids(ID, Opts) || ID <- Matches ]));
 match_args([{Field, X} | Rest], Acc, Opts) ->
     MatchRes = match(Field, X, Opts),
     ?event({match, {field, Field}, {arg, X}, {match_res, MatchRes}}),
@@ -420,9 +405,9 @@ match(<<"height">>, Heights, Opts) ->
         )
     };
 match(<<"id">>, ID, _Opts) ->
-    {ok, {explicit_ids, [ID]}};
+    {ok, [ID]};
 match(<<"ids">>, IDs, _Opts) ->
-    {ok, {explicit_ids, IDs}};
+    {ok, IDs};
 match(<<"tags">>, Tags, Opts) ->
     hb_cache:match(dev_query_graphql:keys_to_template(Tags), Opts);
 match(<<"owners">>, Owners, Opts) ->
@@ -449,11 +434,14 @@ annotate_offsets([ID|IDs], StoreOpts, LastOffset, Ordinate, Opts) ->
     {Offset, Annotated} =
         case hb_store_arweave:read_offset(StoreOpts, ID) of
             {ok, #{ <<"start-offset">> := StartOffset, <<"length">> := Length }} ->
-                {StartOffset, #{
-                    <<"id">> => ID,
-                    <<"offset">> => StartOffset,
-                    <<"length">> => Length
-                }};
+                {
+                    StartOffset,
+                    #{
+                        <<"id">> => ID,
+                        <<"offset">> => StartOffset,
+                        <<"length">> => Length
+                    }
+                };
             _ ->
                 {undefined, #{ <<"id">> => ID }}
         end,
@@ -486,15 +474,13 @@ do_filter_offset_annotated(AnnotatedIDs, Heights, Opts) ->
         block_range_to_offset_range(Heights, Opts),
     Filtered =
         lists:filter(
-            fun
-                (#{ <<"offset">> := IDOffset, <<"length">> := Length }) ->
+            fun(#{ <<"offset">> := IDOffset, <<"length">> := Length }) ->
                     ((StartOffset =:= 0) orelse (IDOffset >= StartOffset)) andalso
                         (
                             (EndOffset =:= infinity) orelse
                                 (IDOffset + Length =< EndOffset)
                         );
-                (_) ->
-                    false
+                (_) -> false
             end,
             AnnotatedIDs
         ),
@@ -540,12 +526,14 @@ commitment_id_to_base_id(ID, Opts) ->
         not_found -> not_found
     end.
 
-%% @doc Find all IDs for a message, by any of its other IDs.
+%% @doc Find all IDs for a message, by any of its other IDs. It achieves this
+%% by resolving the given ID, recursing through its links, then returning all
+%% of the IDs found in that `BaseID/commitments' key.
 all_ids(ID, Opts) ->
-    Store = hb_opts:get(store, no_store, Opts),
-    case hb_store:list(Store, << ID/binary, "/commitments">>) of
-        {ok, []} -> [ID];
-        {ok, CommitmentIDs} -> CommitmentIDs;
+    Store = scoped_store(Opts),
+    ResolvedID = resolve_id(ID, Store),
+    case hb_store:list(Store, << ResolvedID/binary, "/commitments">>) of
+        {ok, CommitmentIDs} -> hb_util:unique([ID | CommitmentIDs]);
         _ -> [ID]
     end.
 
@@ -555,41 +543,36 @@ scope(Opts) ->
     Scope = hb_opts:get(query_arweave_scope, [local], Opts),
     hb_store:scope(Opts, Scope).
 
-prepare_match_ids({explicit_ids, RawIDs}, Opts) ->
-    {explicit_ids, RawIDs, resolve_ids(RawIDs, Opts)};
-prepare_match_ids(IDs, Opts) ->
-    resolve_ids(IDs, Opts).
+scoped_store(Opts) ->
+    hb_opts:get(store, no_store, scope(Opts)).
 
-match_result_ids({explicit_ids, _RawIDs, ResolvedIDs}) ->
-    ResolvedIDs;
-match_result_ids(IDs) ->
-    IDs.
+filter_explicit_ids(IDs, Args, Opts) ->
+    case explicit_ids(Args, Opts) of
+        [] -> IDs;
+        ExplicitIDs -> [ID || ID <- IDs, lists:member(ID, ExplicitIDs)]
+    end.
 
-explicit_match_ids(Results, Matches) ->
+%% @doc Return the explicit IDs from the arguments, if given. Searches for
+%% both `ids' and `id' keys.
+explicit_ids(Args, Opts) ->
     hb_util:unique(
-        lists:flatten(
-            [
-                [
-                    RawID
-                ||
-                    {RawID, ResolvedID} <- lists:zip(RawIDs, ResolvedIDs),
-                    lists:member(ResolvedID, Matches)
-                ]
-            ||
-                {explicit_ids, RawIDs, ResolvedIDs} <- Results
-            ]
-        )
+        case hb_maps:get(<<"ids">>, Args, [], Opts) of
+            IDs when is_list(IDs) -> IDs;
+            _ -> []
+        end ++
+        case hb_maps:find(<<"id">>, Args, Opts) of
+            {ok, ID} -> [ID];
+            error -> []
+        end
     ).
 
 %% @doc Resolve a list of IDs to their store paths, using the stores provided.
 resolve_ids(IDs, Opts) ->
-    Scoped = scope(Opts),
-    lists:map(
-        fun(ID) ->
-            case hb_cache:read(ID, Opts) of
-                {ok, Msg} -> hb_message:id(Msg, uncommitted, Scoped);
-                not_found -> ID
-            end
-        end,
-        IDs
-    ).
+    Store = scoped_store(Opts),
+    [ resolve_id(ID, Store) || ID <- IDs ].
+
+resolve_id(ID, Store) ->
+    case hb_store:resolve(Store, ID) of
+        Resolved when is_binary(Resolved) -> Resolved;
+        _ -> ID
+    end.

--- a/src/dev_query_arweave.erl
+++ b/src/dev_query_arweave.erl
@@ -13,6 +13,10 @@
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
 
+%%% Default returned page size and maximum allowed page size.
+-define(DEFAULT_PAGE_SIZE, 10).
+-define(DEFAULT_MAX_PAGE_SIZE, 100).
+
 %% @doc The arguments that are supported by the Arweave GraphQL API.
 -define(SUPPORTED_QUERY_ARGS,
     [
@@ -26,14 +30,20 @@
 ).
 
 %% @doc Handle an Arweave GraphQL query for either transactions or blocks.
-query(List, <<"edges">>, _Args, _Opts) ->
-    {ok, [{ok, Msg} || Msg <- List]};
-query(Msg, <<"node">>, _Args, _Opts) ->
-    {ok, Msg};
+query(#{ <<"edges">> := Edges }, <<"edges">>, _Args, _Opts) ->
+    {ok, [{ok, Edge} || Edge <- Edges]};
+query(#{ <<"node">> := Node }, <<"node">>, _Args, _Opts) ->
+    {ok, Node};
+query(#{ <<"pageInfo">> := PageInfo }, <<"pageInfo">>, _Args, _Opts) ->
+    {ok, PageInfo};
+query(#{ <<"hasNextPage">> := HasNextPage }, <<"hasNextPage">>, _Args, _Opts) ->
+    {ok, HasNextPage};
+query(#{ <<"count">> := Count }, <<"count">>, _Args, _Opts) ->
+    {ok, Count};
 query(Obj, <<"transaction">>, Args, Opts) ->
     case query(Obj, <<"transactions">>, Args, Opts) of
-        {ok, []} -> {ok, null};
-        {ok, [Msg|_]} -> {ok, Msg}
+        {ok, #{ <<"edges">> := [] }} -> {ok, null};
+        {ok, #{ <<"edges">> := [#{ <<"node">> := Msg } | _] }} -> {ok, Msg}
     end;
 query(Obj, <<"transactions">>, Args, Opts) ->
     ?event({transactions_query,
@@ -44,33 +54,21 @@ query(Obj, <<"transactions">>, Args, Opts) ->
     Matches = match_args(Args, Opts),
     Ordered =
         case annotate_offsets(Matches, Opts) of
-            unavailable -> Matches;
+            unavailable -> [#{ <<"id">> => ID } || ID <- Matches];
             Annotated ->
                 Order = maps:get(<<"sort">>, Args, <<"HEIGHT_DESC">>),
-                remove_annotations(
-                    sort_offset_annotated(
-                        filter_offset_annotated(
-                            Annotated,
-                            maps:get(<<"block">>, Args, undefined),
-                            Opts
-                        ),
-                        Order,
+                sort_offset_annotated(
+                    filter_offset_annotated(
+                        Annotated,
+                        maps:get(<<"block">>, Args, undefined),
                         Opts
-                    )
+                    ),
+                    Order,
+                    Opts
                 )
         end,
     ?event({transactions_matches, Matches}),
-    Messages =
-        lists:filtermap(
-            fun(Match) ->
-                case hb_cache:read(Match, Opts) of
-                    {ok, Msg} -> {true, Msg};
-                    not_found -> false
-                end
-            end,
-            Ordered
-        ),
-    {ok, Messages};
+    {ok, connection(Ordered, Args, Opts)};
 query(Obj, <<"block">>, Args, Opts) ->
     case query(Obj, <<"blocks">>, Args, Opts) of
         {ok, []} -> {ok, null};
@@ -195,20 +193,74 @@ find_field_key(Field, Msg, Opts) ->
             end
     end.
 
+connection(Ordered, Args, Opts) ->
+    ResultsCount = length(Ordered),
+    {DroppedCount, AfterCursor} = drop_to_cursor(Args, Ordered, Opts),
+    CountToReturn = page_size(Args, Opts),
+    ResultsPage = read_ids(AfterCursor, CountToReturn, Opts),
+    #{
+        <<"count">> => hb_util:bin(ResultsCount),
+        <<"edges">> => ResultsPage,
+        <<"pageInfo">> =>
+            #{
+                <<"hasNextPage">> =>
+                    (DroppedCount + length(ResultsPage)) < ResultsCount
+            }
+    }.
+
+%% @doc Build edges from a list of offset-annotated messages.
+read_ids([], _Count, _Opts) -> [];
+read_ids(_, 0, _Opts) -> [];
+read_ids([AnnotatedID = #{ <<"id">> := ID } | Rest], Count, Opts) ->
+    case hb_cache:read(ID, Opts) of
+        {ok, Msg} ->
+            [AnnotatedID#{ <<"node">> => Msg } | read_ids(Rest, Count - 1, Opts)];
+        not_found ->
+            read_ids(Rest, Count, Opts)
+    end.
+
+%% @doc Drop to the cursor position, returning the number of items dropped and
+%% the list of items after the cursor.
+drop_to_cursor(Args, Ordered, Opts) ->
+    drop_to_cursor(Args, Ordered, Opts, 0).
+drop_to_cursor({offset, Offset}, [#{ <<"offset">> := Offset } | _], _Opts, Index) ->
+    {Index, Offset};
+drop_to_cursor(After, [_ | Rest], Opts, Index) ->
+    drop_to_cursor(After, Rest, Opts, Index + 1).
+
+%% @doc Return the page size, clamped to the maximum allowed.
+page_size(Args, Opts) ->
+    DefaultPageSize = hb_opts:get(default_page_size, ?DEFAULT_PAGE_SIZE, Opts),
+    MaxPageSize = hb_opts:get(max_page_size, ?DEFAULT_MAX_PAGE_SIZE, Opts),
+    max(
+        0,
+        min(
+            hb_maps:get(<<"first">>, Args, DefaultPageSize, Opts),
+            MaxPageSize
+        )
+    ).
+
 %% @doc Sort messages by their block height, if Arweave index store is available.
 %% Takes a list of IDs and returns the same list sorted by block height. IDs that
 %% do not have an offset are always placed at the end of the list -- regardless
 %% of the sort order.
-sort_offset_annotated(IDs, SortOrder, _Opts) ->
+sort_offset_annotated(AnnotatedIDs, SortOrder, _Opts) ->
     {WithOffset, WithoutOffset} =
         lists:partition(
-            fun({Offset, _, _}) -> Offset =/= undefined end,
-            IDs
+            fun(AnnotatedID) -> maps:is_key(<<"offset">>, AnnotatedID) end,
+            AnnotatedIDs
         ),
-    Sorted =
+    Ascending =
+        lists:sort(
+            fun(#{ <<"offset">> := OffsetA }, #{ <<"offset">> := OffsetB }) ->
+                OffsetA < OffsetB
+            end,
+            WithOffset
+        ),
+    UserOrderSorted =
         case SortOrder of
-            <<"HEIGHT_ASC">> -> lists:keysort(1, WithOffset);
-            _ -> lists:reverse(lists:keysort(1, WithOffset))
+            <<"HEIGHT_ASC">> -> Ascending;
+            _ -> lists:reverse(Ascending)
         end,
     ?event(
         {order_by_block,
@@ -217,7 +269,7 @@ sort_offset_annotated(IDs, SortOrder, _Opts) ->
             {without_offset, length(WithoutOffset)}
         }
     ),
-    Sorted ++ WithoutOffset.
+    UserOrderSorted ++ WithoutOffset.
 
 %% @doc Convert a block height range (`#{<<"min">> => Min, <<"max">> => Max}')
 %% into weave byte offset boundaries `{StartOffset, EndOffset}'. Notably, the
@@ -331,8 +383,7 @@ match(<<"height">>, Heights, Opts) ->
         case hb_maps:find(<<"max">>, Heights, Opts) of
             {ok, GivenMax} -> GivenMax;
             error ->
-                {ok, Latest} = dev_arweave_block_cache:latest(Opts),
-                Latest
+                hb_util:ok(dev_arweave_block_cache:latest(Opts))
         end,
     #{ store := ScopedStores } = scope(Opts),
     {ok,
@@ -377,34 +428,41 @@ annotate_offsets(IDs, StoreOpts, _Opts) ->
         fun(ID) ->
             case hb_store_arweave:read_offset(StoreOpts, ID) of
                 {ok, #{ <<"start-offset">> := Offset, <<"length">> := Length }} ->
-                    {Offset, Length, ID};
-                _ -> {undefined, undefined, ID}
+                    #{
+                        <<"id">> => ID,
+                        <<"offset">> => Offset,
+                        <<"length">> => Length
+                    };
+                _ ->
+                    #{ <<"id">> => ID }
             end
         end,
         IDs
     ).
 
-%% @doc Remove all annotations of start offset and length from a list of IDs.
-remove_annotations(IDs) -> lists:map(fun({_, _, ID}) -> ID end, IDs).
-
 %% @doc Apply the `block' height range as a post-filter over candidate IDs.
 %% Each candidate's offset is checked against the block range boundaries,
 %% avoiding materialisation of the full store.
-filter_offset_annotated(IDs, HeightRange, _Opts)
+filter_offset_annotated(AnnotatedIDs, HeightRange, _Opts)
         when HeightRange =:= undefined orelse HeightRange =:= null ->
-    IDs;
-filter_offset_annotated(IDs, Heights, Opts) ->
+    AnnotatedIDs;
+filter_offset_annotated(AnnotatedIDs, Heights, Opts) ->
     {StartOffset, EndOffset} =
         block_range_to_offset_range(Heights, Opts),
     Filtered =
         lists:filter(
-            fun({IDOffset, Length, _}) ->
+            fun(UnknownOffset) when not is_map_key(<<"offset">>, UnknownOffset) ->
+                true;
+            (#{ <<"offset">> := IDOffset, <<"length">> := Length }) ->
                 ((StartOffset =:= 0) orelse (IDOffset >= StartOffset)) andalso
-                    ((EndOffset =:= infinity) orelse (IDOffset + Length =< EndOffset))
+                    (
+                        (EndOffset =:= infinity) orelse
+                            (IDOffset + Length =< EndOffset)
+                    )
             end,
-            IDs
+            AnnotatedIDs
         ),
-    ?event({filtered_out_of_range, length(IDs) - length(Filtered)}),
+    ?event({filtered_out_of_range, length(AnnotatedIDs) - length(Filtered)}),
     Filtered.
 
 %% @doc Return the base IDs for messages that have a matching commitment.

--- a/src/dev_query_arweave.erl
+++ b/src/dev_query_arweave.erl
@@ -30,10 +30,14 @@
 ).
 
 %% @doc Handle an Arweave GraphQL query for either transactions or blocks.
+query(List, <<"edges">>, _Args, _Opts) when is_list(List) ->
+    {ok, [{ok, Msg} || Msg <- List]};
 query(#{ <<"edges">> := Edges }, <<"edges">>, _Args, _Opts) ->
     {ok, [{ok, Edge} || Edge <- Edges]};
 query(#{ <<"node">> := Node }, <<"node">>, _Args, _Opts) ->
     {ok, Node};
+query(Msg, <<"node">>, _Args, _Opts) ->
+    {ok, Msg};
 query(#{ <<"pageInfo">> := PageInfo }, <<"pageInfo">>, _Args, _Opts) ->
     {ok, PageInfo};
 query(#{ <<"hasNextPage">> := HasNextPage }, <<"hasNextPage">>, _Args, _Opts) ->
@@ -195,9 +199,9 @@ find_field_key(Field, Msg, Opts) ->
 
 connection(Ordered, Args, Opts) ->
     ResultsCount = length(Ordered),
-    {DroppedCount, AfterCursor} = drop_to_cursor(Args, Ordered, Opts),
+    {DroppedCount, Remaining} = drop_to_cursor(Args, Ordered, Opts),
     CountToReturn = page_size(Args, Opts),
-    ResultsPage = read_ids(AfterCursor, CountToReturn, Opts),
+    ResultsPage = read_ids(Remaining, CountToReturn, Opts),
     #{
         <<"count">> => hb_util:bin(ResultsCount),
         <<"edges">> => ResultsPage,
@@ -222,11 +226,25 @@ read_ids([AnnotatedID = #{ <<"id">> := ID } | Rest], Count, Opts) ->
 %% @doc Drop to the cursor position, returning the number of items dropped and
 %% the list of items after the cursor.
 drop_to_cursor(Args, Ordered, Opts) ->
-    drop_to_cursor(Args, Ordered, Opts, 0).
-drop_to_cursor({offset, Offset}, [#{ <<"offset">> := Offset } | _], _Opts, Index) ->
-    {Index, Offset};
-drop_to_cursor(After, [_ | Rest], Opts, Index) ->
-    drop_to_cursor(After, Rest, Opts, Index + 1).
+    drop_to_cursor(
+        hb_maps:get(<<"after">>, Args, null, Opts),
+        Ordered,
+        Opts,
+        0
+    ).
+drop_to_cursor(Cursor, Ordered, _Opts, Index)
+        when Cursor =:= null orelse Cursor =:= undefined orelse Ordered =:= [] ->
+    {Index, Ordered};
+drop_to_cursor(After, [AnnotatedID | Rest], Opts, Index) ->
+    ID = maps:get(<<"id">>, AnnotatedID, undefined),
+    Offset = maps:get(<<"offset">>, AnnotatedID, undefined),
+    case
+        (After =:= ID) orelse
+            ((Offset =/= undefined) andalso (After =:= hb_util:bin(Offset)))
+    of
+        true -> {Index + 1, Rest};
+        false -> drop_to_cursor(After, Rest, Opts, Index + 1)
+    end.
 
 %% @doc Return the page size, clamped to the maximum allowed.
 page_size(Args, Opts) ->

--- a/src/dev_query_arweave.erl
+++ b/src/dev_query_arweave.erl
@@ -55,9 +55,14 @@ query(Obj, <<"transactions">>, Args, Opts) ->
         {field, <<"transactions">>},
         {args, Args}
     }),
-    Matches = filter_explicit_ids(match_args(Args, Opts), Args, Opts),
+    Matches = match_args(Args, Opts),
+    WithExplicit =
+        case explicit_ids(Args, Opts) of
+            [] -> Matches;
+            ExplicitIDs -> hb_util:list_with(Matches, ExplicitIDs)
+        end,
     Ordered =
-        case annotate_ids(Matches, Opts) of
+        case annotate_ids(WithExplicit, Opts) of
             unavailable -> [#{ <<"id">> => ID } || ID <- Matches];
             Annotated ->
                 Order = maps:get(<<"sort">>, Args, <<"HEIGHT_DESC">>),
@@ -197,6 +202,8 @@ find_field_key(Field, Msg, Opts) ->
             end
     end.
 
+%% @doc Generate the connection response for a ordered, annotated list of 
+%% results.
 connection(Ordered, Args, Opts) ->
     ResultsCount = length(Ordered),
     {DroppedCount, Remaining} = drop_to_cursor(Args, Ordered, Opts),
@@ -212,7 +219,8 @@ connection(Ordered, Args, Opts) ->
             }
     }.
 
-%% @doc Build edges from a list of offset-annotated messages.
+%% @doc Read IDs into their Arweave GraphQL-compliant object form, from a list
+%% of offset-annotated messages.
 read_ids([], _Count, _Opts) -> [];
 read_ids(_, 0, _Opts) -> [];
 read_ids([AnnotatedID = #{ <<"id">> := ID } | Rest], Count, Opts) ->
@@ -363,22 +371,30 @@ match_args(Args, Opts) when is_map(Args) ->
 match_args([], [], _Opts) -> [];
 match_args([], Results, Opts) ->
     ?event({match_args_results, Results}),
-    ResolvedResults = [ resolve_ids(Result, Opts) || Result <- Results ],
+    Store = scoped_store(Opts),
+    % For every ID in every result, we resolve it to its uncommitted ID form.
+    ResolvedResults =
+        [
+            [ hb_store:resolve(Store, ID) || ID <- Result ]
+        ||
+            Result <- Results
+        ],
+    % Next, we find the intersection of all the results. Having the uncommitted 
+    % ID gives us their 'neutral' form: correctly returning a result with `SignedID1`
+    % from one matcher and `SignedID2` from another matcher -- while they are
+    % unequal, but pertain to the same message.
     Matches =
         lists:foldl(
             fun(Result, Acc) -> hb_util:list_with(Result, Acc) end,
             hd(ResolvedResults),
             tl(ResolvedResults)
         ),
-    hb_util:unique(lists:flatten([ all_ids(ID, Opts) || ID <- Matches ]));
+    hb_util:unique(lists:flatten([ all_signed_ids(ID, Store, Opts) || ID <- Matches ]));
 match_args([{Field, X} | Rest], Acc, Opts) ->
-    MatchRes = match(Field, X, Opts),
-    ?event({match, {field, Field}, {arg, X}, {match_res, MatchRes}}),
-    case MatchRes of
-        {ok, Result} ->
-            match_args(Rest, [Result | Acc], Opts);
-        _Error ->
-            match_args(Rest, Acc, Opts)
+    ?event({match, {field, Field}, {arg, X}}),
+    case match(Field, X, Opts) of
+        {ok, Result} -> match_args(Rest, [Result | Acc], Opts);
+        _Error -> match_args(Rest, Acc, Opts)
     end.
 
 %% @doc Generate a match upon `tags' in the arguments, if given.
@@ -391,7 +407,7 @@ match(<<"height">>, Heights, Opts) ->
             error ->
                 hb_util:ok(dev_arweave_block_cache:latest(Opts))
         end,
-    #{ store := ScopedStores } = scope(Opts),
+    ScopedStores = scoped_store(Opts),
     {ok,
         lists:filtermap(
             fun(Height) ->
@@ -529,50 +545,45 @@ commitment_id_to_base_id(ID, Opts) ->
 %% @doc Find all IDs for a message, by any of its other IDs. It achieves this
 %% by resolving the given ID, recursing through its links, then returning all
 %% of the IDs found in that `BaseID/commitments' key.
-all_ids(ID, Opts) ->
-    Store = scoped_store(Opts),
-    ResolvedID = resolve_id(ID, Store),
+all_signed_ids(ID, Store, _Opts) ->
+    ResolvedID = hb_store:resolve(Store, ID),
     case hb_store:list(Store, << ResolvedID/binary, "/commitments">>) of
-        {ok, CommitmentIDs} -> hb_util:unique([ID | CommitmentIDs]);
+        {ok, CommitmentIDs} ->
+            lists:filter(
+                fun(CommitmentID) ->
+                    ResolvedCommitmentMsgID =
+                        hb_store:resolve(
+                            Store,
+                            <<
+                                ResolvedID/binary,
+                                "/commitments/",
+                                CommitmentID/binary,
+                                "/committer"
+                            >>
+                        ),
+                    hb_store:read(Store, ResolvedCommitmentMsgID) =/= not_found
+                end,
+                CommitmentIDs
+            );
         _ -> [ID]
     end.
 
 %% @doc Scope the stores used for block matching. The searched stores can be
 %% scoped by setting the `query_arweave_scope' option.
-scope(Opts) ->
-    Scope = hb_opts:get(query_arweave_scope, [local], Opts),
-    hb_store:scope(Opts, Scope).
-
 scoped_store(Opts) ->
-    hb_opts:get(store, no_store, scope(Opts)).
-
-filter_explicit_ids(IDs, Args, Opts) ->
-    case explicit_ids(Args, Opts) of
-        [] -> IDs;
-        ExplicitIDs -> [ID || ID <- IDs, lists:member(ID, ExplicitIDs)]
-    end.
+    Scope = hb_opts:get(query_arweave_scope, [local], Opts),
+    hb_opts:get(store, no_store, hb_store:scope(Opts, Scope)).
 
 %% @doc Return the explicit IDs from the arguments, if given. Searches for
 %% both `ids' and `id' keys.
 explicit_ids(Args, Opts) ->
     hb_util:unique(
-        case hb_maps:get(<<"ids">>, Args, [], Opts) of
+        case hb_maps:get(<<"ids">>, Args, null, Opts) of
             IDs when is_list(IDs) -> IDs;
             _ -> []
         end ++
-        case hb_maps:find(<<"id">>, Args, Opts) of
-            {ok, ID} -> [ID];
-            error -> []
+        case hb_maps:get(<<"id">>, Args, null, Opts) of
+            ID when is_binary(ID) -> [ID];
+            _ -> []
         end
     ).
-
-%% @doc Resolve a list of IDs to their store paths, using the stores provided.
-resolve_ids(IDs, Opts) ->
-    Store = scoped_store(Opts),
-    [ resolve_id(ID, Store) || ID <- IDs ].
-
-resolve_id(ID, Store) ->
-    case hb_store:resolve(Store, ID) of
-        Resolved when is_binary(Resolved) -> Resolved;
-        _ -> ID
-    end.

--- a/src/dev_query_arweave.erl
+++ b/src/dev_query_arweave.erl
@@ -57,7 +57,7 @@ query(Obj, <<"transactions">>, Args, Opts) ->
     }),
     Matches = match_args(Args, Opts),
     Ordered =
-        case annotate_offsets(Matches, Opts) of
+        case annotate_ids(Matches, Opts) of
             unavailable -> [#{ <<"id">> => ID } || ID <- Matches];
             Annotated ->
                 Order = maps:get(<<"sort">>, Args, <<"HEIGHT_DESC">>),
@@ -237,11 +237,8 @@ drop_to_cursor(Cursor, Ordered, _Opts, Index)
     {Index, Ordered};
 drop_to_cursor(After, [AnnotatedID | Rest], Opts, Index) ->
     ID = maps:get(<<"id">>, AnnotatedID, undefined),
-    Offset = maps:get(<<"offset">>, AnnotatedID, undefined),
-    case
-        (After =:= ID) orelse
-            ((Offset =/= undefined) andalso (After =:= hb_util:bin(Offset)))
-    of
+    Cursor = maps:get(<<"cursor">>, AnnotatedID, undefined),
+    case (After =:= ID) orelse (After =:= Cursor) of
         true -> {Index + 1, Rest};
         false -> drop_to_cursor(After, Rest, Opts, Index + 1)
     end.
@@ -436,27 +433,34 @@ match(UnsupportedFilter, _, _) ->
 %%% Block range post-filter
 
 %% @doc Offset-annotate a list of IDs, returning {StartOffset, ID} pairs.
-annotate_offsets(IDs, Opts) ->
+annotate_ids(IDs, Opts) ->
     case hb_store_arweave:store_from_opts(Opts) of
         no_store -> unavailable;
-        StoreOpts -> annotate_offsets(IDs, StoreOpts, Opts)
+        StoreOpts -> annotate_offsets(IDs, StoreOpts, undefined, 0, Opts)
     end.
-annotate_offsets(IDs, StoreOpts, _Opts) ->
-    lists:map(
-        fun(ID) ->
-            case hb_store_arweave:read_offset(StoreOpts, ID) of
-                {ok, #{ <<"start-offset">> := Offset, <<"length">> := Length }} ->
-                    #{
-                        <<"id">> => ID,
-                        <<"offset">> => Offset,
-                        <<"length">> => Length
-                    };
-                _ ->
-                    #{ <<"id">> => ID }
-            end
+annotate_offsets([], _StoreOpts, _LastOffset, _Ordinate, _Opts) -> [];
+annotate_offsets([ID|IDs], StoreOpts, LastOffset, Ordinate, Opts) ->
+    {Offset, Annotated} =
+        case hb_store_arweave:read_offset(StoreOpts, ID) of
+            {ok, #{ <<"start-offset">> := StartOffset, <<"length">> := Length }} ->
+                {StartOffset, #{
+                    <<"id">> => ID,
+                    <<"offset">> => StartOffset,
+                    <<"length">> => Length
+                }};
+            _ ->
+                {undefined, #{ <<"id">> => ID }}
         end,
-        IDs
-    ).
+    {NewOrdinate, Postfix} =
+        case Offset =:= LastOffset of
+            true -> {Ordinate + 1, <<"-", (hb_util:bin(Ordinate + 1))/binary>>};
+            false -> {0, <<>>}
+        end,
+    WithCursor =
+        Annotated#{
+            <<"cursor">> => << (hb_util:bin(Offset))/binary, Postfix/binary >>
+        },
+    [WithCursor | annotate_offsets(IDs, StoreOpts, Offset, NewOrdinate, Opts)].
 
 %% @doc Apply the `block' height range as a post-filter over candidate IDs.
 %% Each candidate's offset is checked against the block range boundaries,

--- a/src/dev_query_arweave.erl
+++ b/src/dev_query_arweave.erl
@@ -363,20 +363,26 @@ match_args(Args, Opts) when is_map(Args) ->
 match_args([], [], _Opts) -> [];
 match_args([], Results, Opts) ->
     ?event({match_args_results, Results}),
+    PreparedResults = [prepare_match_ids(Result, Opts) || Result <- Results],
     Matches =
         lists:foldl(
             fun(Result, Acc) ->
-                hb_util:list_with(resolve_ids(Result, Opts), Acc)
+                hb_util:list_with(match_result_ids(Result), Acc)
             end,
-            resolve_ids(hd(Results), Opts),
-            tl(Results)
+            match_result_ids(hd(PreparedResults)),
+            tl(PreparedResults)
         ),
+    OutputMatches =
+        case explicit_match_ids(PreparedResults, Matches) of
+            [] -> Matches;
+            ExplicitMatches -> ExplicitMatches
+        end,
     hb_util:unique(
         lists:flatten(
             [
                 all_ids(ID, Opts)
             ||
-                ID <- Matches
+                ID <- OutputMatches
             ]
         )
     );
@@ -414,9 +420,9 @@ match(<<"height">>, Heights, Opts) ->
         )
     };
 match(<<"id">>, ID, _Opts) ->
-    {ok, [ID]};
+    {ok, {explicit_ids, [ID]}};
 match(<<"ids">>, IDs, _Opts) ->
-    {ok, IDs};
+    {ok, {explicit_ids, IDs}};
 match(<<"tags">>, Tags, Opts) ->
     hb_cache:match(dev_query_graphql:keys_to_template(Tags), Opts);
 match(<<"owners">>, Owners, Opts) ->
@@ -469,18 +475,26 @@ filter_offset_annotated(AnnotatedIDs, HeightRange, _Opts)
         when HeightRange =:= undefined orelse HeightRange =:= null ->
     AnnotatedIDs;
 filter_offset_annotated(AnnotatedIDs, Heights, Opts) ->
+    case hb_opts:get(query_arweave_ignore_block_ranges, false, Opts) of
+        true ->
+            AnnotatedIDs;
+        false ->
+            do_filter_offset_annotated(AnnotatedIDs, Heights, Opts)
+    end.
+do_filter_offset_annotated(AnnotatedIDs, Heights, Opts) ->
     {StartOffset, EndOffset} =
         block_range_to_offset_range(Heights, Opts),
     Filtered =
         lists:filter(
-            fun(UnknownOffset) when not is_map_key(<<"offset">>, UnknownOffset) ->
-                true;
-            (#{ <<"offset">> := IDOffset, <<"length">> := Length }) ->
-                ((StartOffset =:= 0) orelse (IDOffset >= StartOffset)) andalso
-                    (
-                        (EndOffset =:= infinity) orelse
-                            (IDOffset + Length =< EndOffset)
-                    )
+            fun
+                (#{ <<"offset">> := IDOffset, <<"length">> := Length }) ->
+                    ((StartOffset =:= 0) orelse (IDOffset >= StartOffset)) andalso
+                        (
+                            (EndOffset =:= infinity) orelse
+                                (IDOffset + Length =< EndOffset)
+                        );
+                (_) ->
+                    false
             end,
             AnnotatedIDs
         ),
@@ -540,6 +554,32 @@ all_ids(ID, Opts) ->
 scope(Opts) ->
     Scope = hb_opts:get(query_arweave_scope, [local], Opts),
     hb_store:scope(Opts, Scope).
+
+prepare_match_ids({explicit_ids, RawIDs}, Opts) ->
+    {explicit_ids, RawIDs, resolve_ids(RawIDs, Opts)};
+prepare_match_ids(IDs, Opts) ->
+    resolve_ids(IDs, Opts).
+
+match_result_ids({explicit_ids, _RawIDs, ResolvedIDs}) ->
+    ResolvedIDs;
+match_result_ids(IDs) ->
+    IDs.
+
+explicit_match_ids(Results, Matches) ->
+    hb_util:unique(
+        lists:flatten(
+            [
+                [
+                    RawID
+                ||
+                    {RawID, ResolvedID} <- lists:zip(RawIDs, ResolvedIDs),
+                    lists:member(ResolvedID, Matches)
+                ]
+            ||
+                {explicit_ids, RawIDs, ResolvedIDs} <- Results
+            ]
+        )
+    ).
 
 %% @doc Resolve a list of IDs to their store paths, using the stores provided.
 resolve_ids(IDs, Opts) ->

--- a/src/dev_query_graphql.erl
+++ b/src/dev_query_graphql.erl
@@ -221,8 +221,8 @@ message_query(Msg = #{ <<"independent_hash">> := _ }, <<"id">>, _Args, Opts) ->
 message_query(Msg, <<"id">>, _Args, Opts) ->
     ?event({message_query_id, {object, Msg}}),
     {ok, hb_message:id(Msg, all, Opts)};
-message_query(_Msg, <<"cursor">>, _Args, _Opts) ->
-    {ok, <<"">>};
+message_query(Msg, <<"cursor">>, _Args, Opts) ->
+    {ok, hb_maps:get(<<"cursor">>, Msg, hb_util:bin(hb_maps:get(<<"offset">>, Msg, <<>>, Opts)), Opts)};
 message_query(_Obj, _Field, _, _) ->
     {ok, <<"Not found.">>}.
 

--- a/src/dev_query_test_vectors.erl
+++ b/src/dev_query_test_vectors.erl
@@ -1048,9 +1048,9 @@ transaction_query_with_anchor_test() ->
             store => [hb_test_utils:test_store()]
         },
     Node = hb_http_server:start_node(Opts),
-    {ok, ID} =
+    {ok, _UnsignedID} =
         hb_cache:write(
-            hb_message:convert(
+            Msg = hb_message:convert(
                 ar_bundles:sign_item(
                     #tx {
                         anchor = AnchorID = crypto:strong_rand_bytes(32),
@@ -1064,6 +1064,7 @@ transaction_query_with_anchor_test() ->
             ),
             Opts
         ),
+    SignedID = hb_message:id(Msg, signed, Opts),
     EncodedAnchor = hb_util:encode(AnchorID),
     Query =
         <<"""
@@ -1082,7 +1083,7 @@ transaction_query_with_anchor_test() ->
             Node,
             Query,
             #{
-                <<"id">> => ID
+                <<"id">> => SignedID
             },
             Opts
         ),

--- a/src/dev_query_test_vectors.erl
+++ b/src/dev_query_test_vectors.erl
@@ -668,6 +668,116 @@ transactions_query_filter_by_block_test() ->
     VerifyFun(1892157, 1892158, [EarlierID], [LaterID]),
     VerifyFun(1892159, 1892160, [LaterID], [EarlierID]).
 
+transactions_query_cursor_by_offset_test() ->
+    {ok, Node, Opts} = test_env_with_blocks(1892159, 1892158),
+    EarlierID = <<"xBpOR2KOjYEgv5HmddMlAgYa-yMvfEVl-0XzRIfm2uY">>,
+    LaterID = <<"HVr7EpRhlPkbwdnoXKHf25p7BPa0qJOs6C7XueLthA0">>,
+    StoreOpts = hb_store_arweave:store_from_opts(Opts),
+    {ok, #{ <<"start-offset">> := EarlierOffset }} =
+        hb_store_arweave:read_offset(StoreOpts, EarlierID),
+    {ok, #{ <<"start-offset">> := LaterOffset }} =
+        hb_store_arweave:read_offset(StoreOpts, LaterID),
+    Query =
+        <<"""
+            query($ids: [ID!], $sort: SortOrder, $first: Int, $after: String) {
+                transactions(
+                    ids: $ids,
+                    sort: $sort,
+                    first: $first,
+                    after: $after
+                ) {
+                    count
+                    pageInfo {
+                        hasNextPage
+                    }
+                    edges {
+                        cursor
+                        node {
+                            id
+                        }
+                    }
+                }
+            }
+        """>>,
+    VerifyFun =
+        fun(Order, FirstID, FirstOffset, SecondID, SecondOffset) ->
+            FirstRes =
+                dev_query_graphql:test_query(
+                    Node,
+                    Query,
+                    #{
+                        <<"ids">> => [EarlierID, LaterID],
+                        <<"sort">> => Order,
+                        <<"first">> => 1
+                    },
+                    Opts
+                ),
+            #{
+                <<"data">> := #{
+                    <<"transactions">> := #{
+                        <<"count">> := <<"2">>,
+                        <<"pageInfo">> := #{
+                            <<"hasNextPage">> := true
+                        },
+                        <<"edges">> := [
+                            #{
+                                <<"cursor">> := FirstCursor,
+                                <<"node">> := #{
+                                    <<"id">> := FirstID
+                                }
+                            }
+                        ]
+                    }
+                }
+            } = FirstRes,
+            ?assertEqual(hb_util:bin(FirstOffset), FirstCursor),
+            SecondRes =
+                dev_query_graphql:test_query(
+                    Node,
+                    Query,
+                    #{
+                        <<"ids">> => [EarlierID, LaterID],
+                        <<"sort">> => Order,
+                        <<"first">> => 1,
+                        <<"after">> => FirstID
+                    },
+                    Opts
+                ),
+            #{
+                <<"data">> := #{
+                    <<"transactions">> := #{
+                        <<"count">> := <<"2">>,
+                        <<"pageInfo">> := #{
+                            <<"hasNextPage">> := false
+                        },
+                        <<"edges">> := [
+                            #{
+                                <<"cursor">> := SecondCursor,
+                                <<"node">> := #{
+                                    <<"id">> := SecondID
+                                }
+                            }
+                        ]
+                    }
+                }
+            } = SecondRes,
+            ?assertEqual(hb_util:bin(SecondOffset), SecondCursor)
+        end,
+    VerifyFun(
+        <<"HEIGHT_ASC">>,
+        EarlierID,
+        EarlierOffset,
+        LaterID,
+        LaterOffset
+    ),
+    VerifyFun(
+        <<"HEIGHT_DESC">>,
+        LaterID,
+        LaterOffset,
+        EarlierID,
+        EarlierOffset
+    ).
+
 %% @doc Test single transaction query by ID
 transaction_query_by_id_test() ->
     Opts =

--- a/src/dev_query_test_vectors.erl
+++ b/src/dev_query_test_vectors.erl
@@ -668,6 +668,105 @@ transactions_query_filter_by_block_test() ->
     VerifyFun(1892157, 1892158, [EarlierID], [LaterID]),
     VerifyFun(1892159, 1892160, [LaterID], [EarlierID]).
 
+transactions_query_filter_by_block_excludes_unknown_offsets_test() ->
+    {ok, _Node, Opts} = test_env_with_blocks(1892159, 1892158),
+    {ok, ID} =
+        hb_cache:write(
+            #{
+                <<"type">> => <<"Message">>,
+                <<"data">> => <<"local-only">>
+            },
+            Opts
+        ),
+    ?assertEqual(
+        not_found,
+        hb_store_arweave:read_offset(hb_store_arweave:store_from_opts(Opts), ID)
+    ),
+    ?assertMatch(
+        {ok, #{
+            <<"count">> := <<"0">>,
+            <<"edges">> := []
+        }},
+        dev_query_arweave:query(
+            #{},
+            <<"transactions">>,
+            #{
+                <<"ids">> => [ID],
+                <<"block">> => #{
+                    <<"min">> => 1892158,
+                    <<"max">> => 1892158
+                }
+            },
+            Opts
+        )
+    ).
+
+transactions_query_filter_by_block_can_ignore_ranges_test() ->
+    {ok, _Node, BaseOpts} = test_env_with_blocks(1892159, 1892158),
+    Opts = BaseOpts#{ query_arweave_ignore_block_ranges => true },
+    {ok, ID} =
+        hb_cache:write(
+            #{
+                <<"type">> => <<"Message">>,
+                <<"data">> => <<"local-only">>
+            },
+            Opts
+        ),
+    ?assertMatch(
+        {ok, #{
+            <<"count">> := <<"1">>,
+            <<"edges">> := [
+                #{
+                    <<"id">> := ID,
+                    <<"node">> := _
+                }
+            ]
+        }},
+        dev_query_arweave:query(
+            #{},
+            <<"transactions">>,
+            #{
+                <<"ids">> => [ID],
+                <<"block">> => #{
+                    <<"min">> => 1892158,
+                    <<"max">> => 1892158
+                }
+            },
+            Opts
+        )
+    ).
+
+transactions_query_ids_preserve_arweave_tx_id_test() ->
+    {ok, _Node, Opts} = test_env_with_blocks(1892487, 1892487),
+    ID = <<"mT7pIQx9ORnemXoIzWmKwymiZJxtOSvzxm3P44M9C1A">>,
+    ?assertMatch(
+        {ok, #{ <<"start-offset">> := _ }},
+        hb_store_arweave:read_offset(hb_store_arweave:store_from_opts(Opts), ID)
+    ),
+    ?assertMatch(
+        {ok, #{
+            <<"count">> := <<"1">>,
+            <<"edges">> := [
+                #{
+                    <<"id">> := ID,
+                    <<"node">> := _
+                }
+            ]
+        }},
+        dev_query_arweave:query(
+            #{},
+            <<"transactions">>,
+            #{
+                <<"ids">> => [ID],
+                <<"block">> => #{
+                    <<"min">> => 1892487,
+                    <<"max">> => 1892487
+                }
+            },
+            Opts
+        )
+    ).
+
 transactions_query_cursor_by_offset_test() ->
     {ok, Node, Opts} = test_env_with_blocks(1892159, 1892158),
     EarlierID = <<"xBpOR2KOjYEgv5HmddMlAgYa-yMvfEVl-0XzRIfm2uY">>,


### PR DESCRIPTION
Building on #821, utilizes the Arweave offset of returned IDs (if known) as the query cursor. In circumstances where either the offset does not increment between IDs (base layer Arweave transactions without data elements) or is simply unknown to the node, the cursor increments monotonically instead.