### PR TITLE
fix: query device block related issues

### DIFF
--- a/src/dev_query_arweave.erl
+++ b/src/dev_query_arweave.erl
@@ -363,20 +363,26 @@ match_args(Args, Opts) when is_map(Args) ->
 match_args([], [], _Opts) -> [];
 match_args([], Results, Opts) ->
     ?event({match_args_results, Results}),
+    ResolvedResults = [resolve_match_ids(Result, Opts) || Result <- Results],
     Matches =
         lists:foldl(
             fun(Result, Acc) ->
-                hb_util:list_with(resolve_ids(Result, Opts), Acc)
+                hb_util:list_with(Result, Acc)
             end,
-            resolve_ids(hd(Results), Opts),
-            tl(Results)
+            hd(ResolvedResults),
+            tl(ResolvedResults)
         ),
+    OutputMatches =
+        case explicit_match_ids(Results, Matches) of
+            [] -> Matches;
+            ExplicitMatches -> ExplicitMatches
+        end,
     hb_util:unique(
         lists:flatten(
             [
                 all_ids(ID, Opts)
             ||
-                ID <- Matches
+                ID <- OutputMatches
             ]
         )
     );
@@ -413,10 +419,10 @@ match(<<"height">>, Heights, Opts) ->
             lists:seq(Min, Max)
         )
     };
-match(<<"id">>, ID, _Opts) ->
-    {ok, [ID]};
-match(<<"ids">>, IDs, _Opts) ->
-    {ok, IDs};
+match(<<"id">>, ID, Opts) ->
+    {ok, {explicit_ids, [ID], resolve_ids([ID], Opts)}};
+match(<<"ids">>, IDs, Opts) ->
+    {ok, {explicit_ids, IDs, resolve_ids(IDs, Opts)}};
 match(<<"tags">>, Tags, Opts) ->
     hb_cache:match(dev_query_graphql:keys_to_template(Tags), Opts);
 match(<<"owners">>, Owners, Opts) ->
@@ -473,14 +479,15 @@ filter_offset_annotated(AnnotatedIDs, Heights, Opts) ->
         block_range_to_offset_range(Heights, Opts),
     Filtered =
         lists:filter(
-            fun(UnknownOffset) when not is_map_key(<<"offset">>, UnknownOffset) ->
-                true;
-            (#{ <<"offset">> := IDOffset, <<"length">> := Length }) ->
-                ((StartOffset =:= 0) orelse (IDOffset >= StartOffset)) andalso
-                    (
-                        (EndOffset =:= infinity) orelse
-                            (IDOffset + Length =< EndOffset)
-                    )
+            fun
+                (#{ <<"offset">> := IDOffset, <<"length">> := Length }) ->
+                    ((StartOffset =:= 0) orelse (IDOffset >= StartOffset)) andalso
+                        (
+                            (EndOffset =:= infinity) orelse
+                                (IDOffset + Length =< EndOffset)
+                        );
+                (_) ->
+                    false
             end,
             AnnotatedIDs
         ),
@@ -540,6 +547,30 @@ all_ids(ID, Opts) ->
 scope(Opts) ->
     Scope = hb_opts:get(query_arweave_scope, [local], Opts),
     hb_store:scope(Opts, Scope).
+
+%% @doc Map surviving explicit ID matches back to the user-provided IDs after
+%% matching has been done on the resolved identity space.
+explicit_match_ids(Results, Matches) ->
+    hb_util:unique(
+        lists:flatten(
+            [
+                [
+                    RawID
+                ||
+                    {RawID, ResolvedID} <- lists:zip(RawIDs, ResolvedIDs),
+                    lists:member(ResolvedID, Matches)
+                ]
+            ||
+                {explicit_ids, RawIDs, ResolvedIDs} <- Results
+            ]
+        )
+    ).
+
+%% @doc Resolve a list of IDs to their store paths, using the stores provided.
+resolve_match_ids({explicit_ids, _RawIDs, ResolvedIDs}, _Opts) ->
+    ResolvedIDs;
+resolve_match_ids(IDs, Opts) ->
+    resolve_ids(IDs, Opts).
 
 %% @doc Resolve a list of IDs to their store paths, using the stores provided.
 resolve_ids(IDs, Opts) ->

--- a/src/dev_query_test_vectors.erl
+++ b/src/dev_query_test_vectors.erl
@@ -668,6 +668,79 @@ transactions_query_filter_by_block_test() ->
     VerifyFun(1892157, 1892158, [EarlierID], [LaterID]),
     VerifyFun(1892159, 1892160, [LaterID], [EarlierID]).
 
+transactions_query_filter_by_block_excludes_unknown_offsets_test() ->
+    {ok, Node, Opts} = test_env_with_blocks(1892159, 1892158),
+    {ok, ID} =
+        hb_cache:write(
+            #{
+                <<"type">> => <<"Message">>,
+                <<"data">> => <<"local-only">>
+            },
+            Opts
+        ),
+    ?assertEqual(
+        not_found,
+        hb_store_arweave:read_offset(hb_store_arweave:store_from_opts(Opts), ID)
+    ),
+    ?assertMatch(
+        #{
+            <<"data">> := #{
+                <<"transactions">> := #{
+                    <<"count">> := <<"0">>,
+                    <<"edges">> := []
+                }
+            }
+        },
+        dev_query_graphql:test_query(
+            Node,
+            <<"
+                query($ids:[ID!],$min:Int,$max:Int){
+                    transactions(ids:$ids,block:{min:$min,max:$max}){
+                        count
+                        edges{
+                            node{id}
+                        }
+                    }
+                }
+            ">>,
+            #{
+                <<"ids">> => [ID],
+                <<"min">> => 1892487,
+                <<"max">> => 1892487
+            },
+            Opts
+        )
+    ).
+
+transactions_query_ids_preserve_arweave_tx_id_test() ->
+    {ok, _Node, Opts} = test_env_with_blocks(1892487, 1892487),
+    ID = <<"mT7pIQx9ORnemXoIzWmKwymiZJxtOSvzxm3P44M9C1A">>,
+    ?assertMatch(
+        {ok, #{ <<"start-offset">> := _ }},
+        hb_store_arweave:read_offset(hb_store_arweave:store_from_opts(Opts), ID)
+    ),
+    ?assertMatch(
+        {ok,
+            #{
+                <<"count">> := <<"1">>,
+                <<"edges">> := [
+                    #{ <<"id">> := ID, <<"node">> := #{ <<"commitments">> := _ } }
+                ]
+            }},
+        dev_query_arweave:query(
+            #{},
+            <<"transactions">>,
+            #{
+                <<"ids">> => [ID],
+                <<"block">> => #{
+                    <<"min">> => 1892487,
+                    <<"max">> => 1892487
+                }
+            },
+            Opts
+        )
+    ).
+
 transactions_query_cursor_by_offset_test() ->
     {ok, Node, Opts} = test_env_with_blocks(1892159, 1892158),
     EarlierID = <<"xBpOR2KOjYEgv5HmddMlAgYa-yMvfEVl-0XzRIfm2uY">>,


### PR DESCRIPTION
been playing with the query device on expr/offset-cursor-sister branch (#822 822), noticed interesting behaviors and i decided to open this PR as PoC

## findings

 A  - `transactions(..., block: ...)` is not a strict block filter on this branch. a locally written message with no indexed Arweave offset still gets returned for a concrete block range
    
Repro:

```erl
    {ok, ID} = hb_cache:write(#{<<"type">> => <<"Message">>, <<"data">> => <<"local-only">>}, Opts).
    hb_store_arweave:read_offset(hb_store_arweave:store_from_opts(Opts), ID).

    dev_query_arweave:query(#{}, <<"transactions">>, #{<<"ids">> => [ID], <<"block">> => #{<<"min">> => 1892487, <<"max">> => 1892487}}, Opts).
    %% or 
    %% Node = hb_http_server:start_node(Opts).
    %%  dev_query_graphql:test_query(Node, <<"query($ids:[ID!],$min:Int,$max:Int){transactions(ids:$ids,block:{min:$min,max:$max}){count edges{node{id}}}}">>, #{<<"ids">> => [ID], <<"min">> => 1892487, <<"max">> => 1892487}, Opts).
```

example return:

```erl
23> dev_query_graphql:test_query(Node, <<"query($ids:[ID!],$min:Int,$max:Int){transactions(ids:$ids,block:{min:$min,max:$max}){count edges{node{id}}}}">>, #{<<"ids">> => [ID], <<"min">> => 1892487, <<"max">> => 1892487}, Opts).
=== HB DEBUG ===[0ms in g1Gvt..CWqTY (<0.5163.0>) @ hb_http_server:411 / hb_http:529]==>
sent, status: 200, duration: 29, body_size: 111, method: POST, ip: 127.0.0.1, path: ~query@1.0/graphql
#{<<"data">> =>
      #{<<"transactions">> =>
            #{<<"count">> => <<"1">>,
              <<"edges">> =>
                  [#{<<"node">> =>
                         #{<<"id">> =>
                               <<"BJl9x9wXsQ6jkqfoL7VxEk8JdxPv9WDcMcvidK6KmuQ">>}}]}}}
```
1- current behavior: returns that ID
2- expected: empty result
  

B - (codex helped here) xxplicit id/ids handling semms wrong for Arweave tx lookups, so instead of preserving the caller provided TXID, the query path resolves it through `hb_cache:read/2` / `resolve_ids/2`, which can rewrite the identity or force remote materialization work

Repro: (bundle root tx: https://viewblock.io/arweave/tx/mT7pIQx9ORnemXoIzWmKwymiZJxtOSvzxm3P44M9C1A)
    
    
```erl    
ID2 = <<"mT7pIQx9ORnemXoIzWmKwymiZJxtOSvzxm3P44M9C1A">>.
    
case hb_cache:read(ID2, Opts) of {ok, Msg} -> {ID2, hb_message:id(Msg, uncommitted, hb_store:scope(Opts, hb_opts:get(query_arweave_scope, [local], Opts)))} end.
    
dev_query_arweave:query(#{}, <<"transactions">>, #{<<"ids">> => [ID2], <<"block">> => #{<<"min">> => 1892487, <<"max">> => 1892487}},Opts).
```
    

1- current behavior: goes through the broken resolution/materialization path 
2- expected: treat ID2 as the explicit Arweave TXID being queried

## patches (PoC, potential approaches)

  
- make block filtering exclude candidates that do not have an indexed Arweave offset, so `transactions(..., block: ...)` only returns provable matches
  
- Preserve explicit id/ids as query-supplied Arweave TXIDs, while still allowing resolved IDs intersection when combined with other filters
  
- added regressions for both cases:
      - unknown-offset locally written messages must not match block
      - explicit Arweave TXIDs must survive `transactions(ids: ..., block: ...)` without going down the broken resolution path