### PR TITLE
fix: Correct bundler path query parameter

### DIFF
--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -127,7 +127,7 @@ post_binary_ans104(SerializedTX, LogExtra, Opts) ->
     Res = hb_http:post(
         hb_opts:get(bundler_ans104, not_found, Opts),
         #{
-            <<"path">> => <<"/~bundler@1.0/tx&codec-device=ans104@1.0">>,
+            <<"path">> => <<"/~bundler@1.0/tx?codec-device=ans104@1.0">>,
             <<"content-type">> => <<"application/octet-stream">>,
             <<"body">> => SerializedTX
         },


### PR DESCRIPTION
`~arweave@2.9` previously incorrectly made the `codec-device` local to the request message of a proxied bundler dispatch. This patch corrects it to be in the global scope, such that it is detected by the `hb_http` flow on the receiving end
