### PR TITLE
fix: token -> pot `subject` body to outter hoisting 

### DIFF
--- a/src/dev_token.erl
+++ b/src/dev_token.erl
@@ -262,38 +262,23 @@ transfer_notices(From, Recipient, Quantity, Req, Opts) ->
 %%% Mint device orchestration.
 
 %% @doc Call the mint device's main entrypoint, allowing it to handle explicit
-%% mint requests, normalize its state (prior to `transfer's, etc), or ignore
-%% the request altogether.
+%% mint requests, normalize its state (prior to `transfer`s, etc), or ignore
+%% the request altogether. If a public token `mint` request includes
+%% `body.subject`, hoist it to the top-level request shape expected by the mint
+%% device before dispatch.
 mint(Base, Assignment, Opts) ->
-    as_mint_device(<<"mint">>, Base, Assignment, Opts).
-
-%% @doc Public persisted `mint` requests may target either the global scope
-%% (no `subject`) or the caller's own account. Internal normalization paths call
-%% `mint/3` directly and do not pass through this gate.
-secure_mint(Base, Assignment, Opts) ->
     case hb_ao:resolve(Assignment, <<"body">>, Opts) of
-        {error, _} = Err ->
-            Err;
+        {error, _} ->
+            as_mint_device(<<"mint">>, Base, Assignment, Opts);
         {ok, Req} ->
             case hb_maps:find(<<"subject">>, Req, Opts) of
                 error ->
-                    mint(Base, Assignment, Opts);
+                    as_mint_device(<<"mint">>, Base, Assignment, Opts);
                 {ok, Subject} ->
                     maybe
-                        {ok, From} ?=
-                            hb_maps:find(
-                                <<"from">>,
-                                Req,
-                                <<"No `from' address provided.">>,
-                                Opts
-                            ),
-                        true ?= validate_address(From, []),
                         true ?= validate_address(Subject, []),
-                        true ?= (From =:= Subject) orelse
-                            {error, <<"Invalid mint caller.">>},
                         MintReq1 = hb_ao:set(Assignment, <<"subject">>, Subject, Opts),
-                        MintReq2 = hb_ao:set(MintReq1, <<"from">>, From, Opts),
-                        mint(Base, MintReq2, Opts)
+                        as_mint_device(<<"mint">>, Base, MintReq1, Opts)
                     end
             end
     end.
@@ -315,7 +300,7 @@ is_supported_mint_action(Action) ->
 %% send_error/4 codepath.
 action_as_mint_device(Action, Base, Req, Opts) ->
     case is_supported_mint_action(Action) of
-        true when Action =:= <<"mint">> -> secure_mint(Base, Req, Opts);
+        true when Action =:= <<"mint">> -> mint(Base, Req, Opts);
         true -> as_mint_device(Action, Base, Req, Opts);
         false ->
             ?event(error, {unsupported_token_action, Action}, Opts),

--- a/src/dev_token.erl
+++ b/src/dev_token.erl
@@ -267,6 +267,33 @@ transfer_notices(From, Recipient, Quantity, Req, Opts) ->
 mint(Base, Assignment, Opts) ->
     as_mint_device(<<"mint">>, Base, Assignment, Opts).
 
+%% @doc Public persisted `mint` requests may target either the global scope
+%% (no `subject`) or the caller's own account. Internal normalization paths call
+%% `mint/3` directly and do not pass through this gate.
+secure_mint(Base, Assignment, Opts) ->
+    maybe
+        {ok, Req} ?= hb_ao:resolve(Assignment, <<"body">>, Opts),
+        case hb_maps:find(<<"subject">>, Req, Opts) of
+            error ->
+                mint(Base, Assignment, Opts);
+            {ok, Subject} ->
+                maybe
+                    {ok, From} ?=
+                        hb_maps:find(
+                            <<"from">>,
+                            Req,
+                            <<"No `from' address provided.">>,
+                            Opts
+                        ),
+                    true ?= validate_address(From, []),
+                    true ?= validate_address(Subject, []),
+                    true ?= (From =:= Subject) orelse
+                        {error, <<"Invalid mint caller.">>},
+                    mint(Base, Assignment, Opts)
+                end
+        end
+    end.
+
 %% @doc Execute the mint device's main key, but return the state in its 
 %% unmodified form if the execution returns an error.
 normalize_mint(Base, Assignment, Opts) ->
@@ -284,11 +311,12 @@ is_supported_mint_action(Action) ->
 %% send_error/4 codepath.
 action_as_mint_device(Action, Base, Req, Opts) ->
     case is_supported_mint_action(Action) of
+        true when Action =:= <<"mint">> -> secure_mint(Base, Req, Opts);
         true -> as_mint_device(Action, Base, Req, Opts);
         false ->
             ?event(error, {unsupported_token_action, Action}, Opts),
             send_error(Base, Req, <<"unsupported action: ", Action/binary>>, Opts)
-    end.
+        end.
 
 %% @doc Run a given `path' on the mint device.
 as_mint_device(Path, Base, Req, Opts) ->

--- a/src/dev_token.erl
+++ b/src/dev_token.erl
@@ -271,27 +271,31 @@ mint(Base, Assignment, Opts) ->
 %% (no `subject`) or the caller's own account. Internal normalization paths call
 %% `mint/3` directly and do not pass through this gate.
 secure_mint(Base, Assignment, Opts) ->
-    maybe
-        {ok, Req} ?= hb_ao:resolve(Assignment, <<"body">>, Opts),
-        case hb_maps:find(<<"subject">>, Req, Opts) of
-            error ->
-                mint(Base, Assignment, Opts);
-            {ok, Subject} ->
-                maybe
-                    {ok, From} ?=
-                        hb_maps:find(
-                            <<"from">>,
-                            Req,
-                            <<"No `from' address provided.">>,
-                            Opts
-                        ),
-                    true ?= validate_address(From, []),
-                    true ?= validate_address(Subject, []),
-                    true ?= (From =:= Subject) orelse
-                        {error, <<"Invalid mint caller.">>},
-                    mint(Base, Assignment, Opts)
-                end
-        end
+    case hb_ao:resolve(Assignment, <<"body">>, Opts) of
+        {error, _} = Err ->
+            Err;
+        {ok, Req} ->
+            case hb_maps:find(<<"subject">>, Req, Opts) of
+                error ->
+                    mint(Base, Assignment, Opts);
+                {ok, Subject} ->
+                    maybe
+                        {ok, From} ?=
+                            hb_maps:find(
+                                <<"from">>,
+                                Req,
+                                <<"No `from' address provided.">>,
+                                Opts
+                            ),
+                        true ?= validate_address(From, []),
+                        true ?= validate_address(Subject, []),
+                        true ?= (From =:= Subject) orelse
+                            {error, <<"Invalid mint caller.">>},
+                        MintReq1 = hb_ao:set(Assignment, <<"subject">>, Subject, Opts),
+                        MintReq2 = hb_ao:set(MintReq1, <<"from">>, From, Opts),
+                        mint(Base, MintReq2, Opts)
+                    end
+            end
     end.
 
 %% @doc Execute the mint device's main key, but return the state in its 

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -953,6 +953,44 @@ public_mint_rejects_foreign_subject_test() ->
     ?assertEqual(1000, dev_token_lib:balance(Process, AliceAddr, Opts)),
     ?assertEqual(1000, hb_ao:get(<<"now/total-supply">>, Process, Opts)).
 
+%% @doc Test that public persisted mint may still claim yield for the caller.
+public_mint_allows_self_subject_test() ->
+    Opts = test_opts(),
+    AliceWallet = ar_wallet:new(),
+    AliceAddr = id(AliceWallet),
+    ResourceOxygen = <<"oxygen">>,
+    PotFields = #{
+        mint_cap => 10000,
+        mint_prop_numerator => 1,
+        mint_prop_denominator => 2,
+        t => 0,
+        last_drip => 0
+    },
+    TokenFields = #{
+        initial_balances => #{AliceAddr => 1000},
+        total_supply => 1000
+    },
+    Process = generate_process(PotFields, TokenFields, Opts),
+    push_set_weight(Process, ResourceOxygen, 100, Opts),
+    push_deposit(
+        Process,
+        ResourceOxygen,
+        AliceWallet,
+        10,
+        Opts
+    ),
+    _ = push_request(
+        Process,
+        #{
+            <<"action">> => <<"mint">>,
+            <<"subject">> => AliceAddr
+        },
+        AliceWallet,
+        Opts
+    ),
+    ?assertEqual(8000, dev_token_lib:balance(Process, AliceAddr, Opts)),
+    ?assertEqual(8000, hb_ao:get(<<"now/total-supply">>, Process, Opts)).
+
 %% @doc Test direct claim_yield functionality from a single resource
 claim_yield_single_resource_test() ->
     Opts = test_opts(),

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -914,8 +914,9 @@ normalized_balance_normalizes_lazy_mint_test() ->
     ?assertEqual(7500, dev_token_lib:normalized_balance(Process, AliceAddr, Opts)),
     ?assertEqual(7500, balance(Process, AliceAddr, Opts)).
 
-%% @doc Test that public persisted mint cannot claim yield for another account.
-public_mint_rejects_foreign_subject_test() ->
+%% @doc Test that public persisted mint forwards `body.subject` for foreign
+%% callers too, allowing the request to persist the subject claim.
+public_mint_allows_foreign_subject_test() ->
     Opts = test_opts(),
     AliceWallet = ar_wallet:new(),
     BobWallet = ar_wallet:new(),
@@ -950,10 +951,11 @@ public_mint_rejects_foreign_subject_test() ->
         BobWallet,
         Opts
     ),
-    ?assertEqual(1000, dev_token_lib:balance(Process, AliceAddr, Opts)),
-    ?assertEqual(1000, hb_ao:get(<<"now/total-supply">>, Process, Opts)).
+    ?assertEqual(8000, dev_token_lib:balance(Process, AliceAddr, Opts)),
+    ?assertEqual(8000, hb_ao:get(<<"now/total-supply">>, Process, Opts)).
 
-%% @doc Test that public persisted mint may still claim yield for the caller.
+%% @doc Test that public persisted mint forwards `body.subject` for the caller,
+%% allowing the request to persist the subject claim.
 public_mint_allows_self_subject_test() ->
     Opts = test_opts(),
     AliceWallet = ar_wallet:new(),

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -914,6 +914,45 @@ normalized_balance_normalizes_lazy_mint_test() ->
     ?assertEqual(7500, dev_token_lib:normalized_balance(Process, AliceAddr, Opts)),
     ?assertEqual(7500, balance(Process, AliceAddr, Opts)).
 
+%% @doc Test that public persisted mint cannot claim yield for another account.
+public_mint_rejects_foreign_subject_test() ->
+    Opts = test_opts(),
+    AliceWallet = ar_wallet:new(),
+    BobWallet = ar_wallet:new(),
+    AliceAddr = id(AliceWallet),
+    ResourceOxygen = <<"oxygen">>,
+    PotFields = #{
+        mint_cap => 10000,
+        mint_prop_numerator => 1,
+        mint_prop_denominator => 2,
+        t => 0,
+        last_drip => 0
+    },
+    TokenFields = #{
+        initial_balances => #{AliceAddr => 1000},
+        total_supply => 1000
+    },
+    Process = generate_process(PotFields, TokenFields, Opts),
+    push_set_weight(Process, ResourceOxygen, 100, Opts),
+    push_deposit(
+        Process,
+        ResourceOxygen,
+        AliceWallet,
+        10,
+        Opts
+    ),
+    _ = push_request(
+        Process,
+        #{
+            <<"action">> => <<"mint">>,
+            <<"subject">> => AliceAddr
+        },
+        BobWallet,
+        Opts
+    ),
+    ?assertEqual(1000, dev_token_lib:balance(Process, AliceAddr, Opts)),
+    ?assertEqual(1000, hb_ao:get(<<"now/total-supply">>, Process, Opts)).
+
 %% @doc Test direct claim_yield functionality from a single resource
 claim_yield_single_resource_test() ->
     Opts = test_opts(),

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -914,6 +914,86 @@ normalized_balance_normalizes_lazy_mint_test() ->
     ?assertEqual(7500, dev_token_lib:normalized_balance(Process, AliceAddr, Opts)),
     ?assertEqual(7500, balance(Process, AliceAddr, Opts)).
 
+%% @doc Test that public global mint still advances pot accrual state even when
+%% no `subject' is provided.
+public_global_mint_still_drips_without_subject_test() ->
+    Opts = test_opts(),
+    AliceWallet = ar_wallet:new(),
+    BobWallet = ar_wallet:new(),
+    AliceAddr = id(AliceWallet),
+    ResourceOxygen = <<"oxygen">>,
+    PotFields = #{
+        mint_cap => 10000,
+        mint_prop_numerator => 1,
+        mint_prop_denominator => 2,
+        t => 0,
+        last_drip => 0
+    },
+    TokenFields = #{
+        initial_balances => #{AliceAddr => 500},
+        total_supply => 500
+    },
+    Process = generate_process(PotFields, TokenFields, Opts),
+    push_set_weight(Process, ResourceOxygen, 100, Opts),
+    push_deposit(
+        Process,
+        ResourceOxygen,
+        AliceWallet,
+        10,
+        Opts
+    ),
+    _ = push_request(
+        Process,
+        #{
+            <<"action">> => <<"mint">>
+        },
+        BobWallet,
+        Opts
+    ),
+    ?assertEqual(500, dev_token_lib:balance(Process, AliceAddr, Opts)),
+    ?assertEqual(7500, hb_ao:get(<<"now/minted">>, Process, Opts)),
+    ?assertEqual(7, hb_ao:get(<<"now/accumulator">>, Process, Opts)),
+    ?assertEqual(7500, dev_token_lib:normalized_balance(Process, AliceAddr, Opts)).
+
+%% @doc Test that invalid subject addresses are rejected before mint-device
+%% dispatch and do not mutate persisted state.
+public_mint_rejects_invalid_subject_address_test() ->
+    Opts = test_opts(),
+    AliceWallet = ar_wallet:new(),
+    AliceAddr = id(AliceWallet),
+    ResourceOxygen = <<"oxygen">>,
+    PotFields = #{
+        mint_cap => 10000,
+        mint_prop_numerator => 1,
+        mint_prop_denominator => 2,
+        t => 0,
+        last_drip => 0
+    },
+    TokenFields = #{
+        initial_balances => #{AliceAddr => 1000},
+        total_supply => 1000
+    },
+    Process = generate_process(PotFields, TokenFields, Opts),
+    push_set_weight(Process, ResourceOxygen, 100, Opts),
+    push_deposit(
+        Process,
+        ResourceOxygen,
+        AliceWallet,
+        10,
+        Opts
+    ),
+    _ = push_request(
+        Process,
+        #{
+            <<"action">> => <<"mint">>,
+            <<"subject">> => <<"keys">>
+        },
+        AliceWallet,
+        Opts
+    ),
+    ?assertEqual(1000, dev_token_lib:balance(Process, AliceAddr, Opts)),
+    ?assertEqual(1000, hb_ao:get(<<"now/total-supply">>, Process, Opts)).
+
 %% @doc Test that public persisted mint forwards `body.subject` for foreign
 %% callers too, allowing the request to persist the subject claim.
 public_mint_allows_foreign_subject_test() ->


### PR DESCRIPTION
this PR fixes a bug where the token device reads the mint `Subject` from request's Body, and fwd'd the request as is to the `~pot@1.0` device.

the issue is, the pot device reads the `Subject` from the request top level instead of body, therefore `dev_pot:mint/3` will always default to `<<"global">>` dripping instead of subject'd mint.

The fix hoists `body.subject` to the top level request in dev_token before dispatching to dev_pot

also added tests in dev_token_pot_test_vectors