### PR TITLE
feat: support ao.unset sentinel for patch field removal

### DIFF
--- a/src/dev_json_iface.erl
+++ b/src/dev_json_iface.erl
@@ -253,7 +253,13 @@ json_to_message(Resp, Opts) when is_map(Resp) ->
                             )
                     ]
                 ),
-            <<"patches">> => lists:map(fun(Patch) -> tags_to_map(Patch, Opts) end, Patches),
+            <<"patches">> => 
+                lists:map(
+                    fun(Patch) -> 
+                        convert_unset_values(tags_to_map(Patch, Opts)) 
+                    end, 
+                    Patches
+                ),
             <<"data">> => Data
         },
     {ok, Output};
@@ -405,17 +411,19 @@ preprocess_results(Msg, Opts) ->
             Msg,
             Opts
         ),
-    hb_maps:merge(
-        hb_maps:from_list(
-            lists:map(
-                fun({Key, Value}) ->
-                    {hb_ao:normalize_key(Key), Value}
-                end,
-                hb_maps:to_list(FilteredMsg, Opts)
-            )
-        ),
-        Tags,
-        Opts
+    convert_unset_values(
+        hb_maps:merge(
+            hb_maps:from_list(
+                lists:map(
+                    fun({Key, Value}) ->
+                        {hb_ao:normalize_key(Key), Value}
+                    end,
+                    hb_maps:to_list(FilteredMsg, Opts)
+                )
+            ),
+            Tags,
+            Opts
+        )
     ).
 
 %% @doc Convert a message with tags into a map of their key-value pairs.
@@ -429,6 +437,21 @@ tags_to_map(Msg, Opts) ->
             Tag <- RawTags
         ],
     hb_maps:from_list(TagList).
+
+%% @doc Recursively convert <<"__ao-unset__">> binary values to the `unset'
+%% atom, so that dev_message:set/3 will remove those keys during patch
+%% application. This bridges the gap between Lua's nil (which removes keys
+%% from tables entirely) and HyperBEAM's unset atom (which signals removal).
+convert_unset_values(Map) when is_map(Map) ->
+    maps:map(
+        fun(_Key, <<"__ao-unset__">>) -> unset;
+           (_Key, Value) when is_map(Value) -> convert_unset_values(Value);
+           (_Key, Value) -> Value
+        end,
+        Map
+    );
+convert_unset_values(Other) ->
+    Other.
 
 %% @doc Post-process messages in the outbox to add the correct `from-process'
 %% and `from-image' tags.


### PR DESCRIPTION
## Summary

- Adds `convert_unset_values/1` to `dev_json_iface` that recursively converts `<<"__ao-unset__">>` sentinel strings to the `unset` atom during JSON result deserialization
- Applied in both `preprocess_results` (outbox messages) and `json_to_message` (patches path)
- `dev_message:set/3` already handles the `unset` atom by removing those keys -- no changes needed there

## Problem

When AOS processes use `patch@1.0` to cache state for frontend HTTP access, removing a field from a nested map is impossible. Lua `nil` deletes the key from the table before serialization, so the patch system never learns the field should be removed. The deep merge in `dev_message:set` preserves old keys that are absent from the new patch.

## Solution

A sentinel value `"__ao-unset__"` that survives Lua table serialization and JSON encoding. At the HB boundary (`dev_json_iface`), it is converted to the `unset` atom that `dev_message:set` already handles.

Requires a companion change in the AOS repo: `ao.unset = "__ao-unset__"` in `ao.lua`.

## Usage

```lua
ao.unset = "__ao-unset__"  -- defined once in ao.lua

-- Remove cherry from nested map, update apple, keep banana
Send({device="patch@1.0", prices={apple="200", cherry=ao.unset}})

-- Clear a top-level key (set to empty map)
Send({device="patch@1.0", mode={}})
```