### PR TITLE
fix: hb_store scope when access is defined

### DIFF
--- a/src/hb_store.erl
+++ b/src/hb_store.erl
@@ -76,9 +76,9 @@ behavior_info(callbacks) ->
 
 %% @doc Store access policies to function names.
 -define(STORE_ACCESS_POLICIES, #{
-    <<"read">> => [read, resolve, list, type, path, add_path, join],
-    <<"write">> => [write, make_link, make_group, reset, path, add_path, join],
-    <<"admin">> => [start, stop, reset]
+    <<"read">> => [read, resolve, list, type, path, add_path, join, scope],
+    <<"write">> => [write, make_link, make_group, reset, path, add_path, join, scope],
+    <<"admin">> => [start, stop, reset, scope]
 }).
 
 %%% Store named terms registry functions.
@@ -1049,3 +1049,12 @@ make_link_access_test() ->
     ?event(testing, {read_linked_value, ReadResult}),
     ?assertEqual({ok, TestValue}, ReadResult),
     ?assertEqual(ok, LinkResult).
+
+%% Prevent stores with access property to return local scope if they are defined as remote.
+get_store_scope_access_test() ->
+    ReadStore = #{<<"store-module">> => hb_store_remote_node, <<"access">> => [<<"read">>]},
+    ?assertEqual(remote, get_store_scope(ReadStore)),
+    WriteStore = #{<<"store-module">> => hb_store_remote_node, <<"access">> => [<<"write">>]},
+    ?assertEqual(remote, get_store_scope(WriteStore)),
+    AdminStore = #{<<"store-module">> => hb_store_remote_node, <<"access">> => [<<"admin">>]},
+    ?assertEqual(remote, get_store_scope(AdminStore)).


### PR DESCRIPTION
This PR fixes a bug when a store is defined with `<<"access">>` property, and we want to check the `scope`, it will always return `local`. This happens because the `scope` function isn't inside the store access policies, returning `not_found`, which then uses the default scope `local`.