### PR TITLE
feat: add ~agent@1.0 and ~inference@1.0 devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ mkdocs-site-manifest.csv
 !test/admissible-report-wallet.json
 !test/admissible-report.json
 !test/config.json
+
+.agents

--- a/docs/dev_agent-testing.md
+++ b/docs/dev_agent-testing.md
@@ -1,0 +1,152 @@
+# dev_agent Testing Guide
+
+## Overview
+
+`dev_agent` is a ReAct (Reason-Act-Observe) agent device that calls an OpenAI-compatible LLM, parses tool calls, executes tools, and loops until a final answer is produced.
+
+This document covers all testing approaches, from quick unit tests to full end-to-end Lua integration.
+
+## Prerequisites
+
+- HyperBEAM compiled: `rebar3 compile`
+- An OpenAI-compatible API key (e.g., Novita AI)
+
+## 1. Unit Tests (Mock, No API Required)
+
+Run all 10 mock-based unit tests:
+
+```bash
+rebar3 eunit --module=dev_agent
+```
+
+These tests cover:
+- Single-turn (no tools), single/multiple tool calls, max iterations
+- Tool error handling, conversation history format, result truncation
+- Unknown tool handling, Lua ao.resolve-style config passing
+
+## 2. Lua Integration Tests (Real API)
+
+These tests run Lua code that calls `ao.resolve` to invoke `dev_agent`, exactly as an AOS Lua process would.
+
+### Run all Lua agent tests
+
+```bash
+LUA_TESTS="scripts/agent-test.lua" rebar3 as lua-test eunit --module=dev_lua_test
+```
+
+### Run a specific test
+
+```bash
+# Simple question (no tool call, ~2-3s)
+LUA_TESTS="scripts/agent-test.lua:agent_simple_test" \
+  rebar3 as lua-test eunit --module=dev_lua_test
+
+# Question requiring tool call (HTTP GET to httpbin.org, ~5-8s)
+LUA_TESTS="scripts/agent-test.lua:agent_resolve_test" \
+  rebar3 as lua-test eunit --module=dev_lua_test
+```
+
+### Write your own Lua test
+
+Create or edit `scripts/agent-test.lua`. Any function ending in `_test` is auto-discovered:
+
+```lua
+function my_custom_agent_test()
+    local status, res = ao.resolve({
+        path = "/~agent@1.0/run",
+        ["agent-user-prompt"] = "Your question here",
+        ["agent-model"] = "minimax/minimax-m2.7",
+        ["agent-api-peer"] = "https://api.novita.ai",
+        ["agent-api-path"] = "/openai/v1/chat/completions",
+        ["agent-api-key"] = "YOUR_API_KEY"
+    })
+    -- res["agent-answer"]      = LLM's final answer (string)
+    -- res["agent-iterations"]  = number of ReAct loop iterations
+    -- res["agent-error"]       = error info (only if failed)
+    return status, res
+end
+```
+
+## 3. HTTP Endpoint Test (Full Node)
+
+Start a HyperBEAM node and call the agent device directly via HTTP.
+
+### Start the node
+
+```bash
+./scripts/e2e-test.sh start
+# Wait for "HyperBEAM is ready!" message
+```
+
+### Call agent via curl
+
+```bash
+curl -s http://localhost:8734/~agent@1.0/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent-user-prompt": "Use the http_request tool to GET https://httpbin.org/get and tell me the origin IP.",
+    "agent-model": "minimax/minimax-m2.7",
+    "agent-api-peer": "https://api.novita.ai",
+    "agent-api-path": "/openai/v1/chat/completions",
+    "agent-api-key": "YOUR_API_KEY",
+    "agent-max-iterations": 5
+  }' | jq .
+```
+
+### Stop the node
+
+```bash
+./scripts/e2e-test.sh stop
+```
+
+## 4. Lua ao.resolve from an AOS Process (Production Pattern)
+
+In a real AOS Lua process, use `ao.resolve` inside a handler:
+
+```lua
+Handlers.add("Agent",
+  { Action = "Agent-Run" },
+  function(msg)
+    local status, res = ao.resolve({
+      path = "/~agent@1.0/run",
+      ["agent-user-prompt"] = msg.Data,
+      ["agent-model"] = "minimax/minimax-m2.7",
+      ["agent-api-peer"] = "https://api.novita.ai",
+      ["agent-api-path"] = "/openai/v1/chat/completions",
+      ["agent-api-key"] = "sk_..."
+    })
+    if status == "ok" then
+      ao.send({
+        Target = msg.From,
+        Data = res["agent-answer"]
+      })
+    else
+      ao.send({
+        Target = msg.From,
+        Data = "Agent error: " .. tostring(res)
+      })
+    end
+  end
+)
+```
+
+## Configuration Reference
+
+All configuration is passed as message fields (via Lua `ao.resolve` or HTTP body):
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `agent-user-prompt` | Yes | `"Hello"` | The user's question/instruction |
+| `agent-model` | No | `"gpt-4o-mini"` | Model ID for the LLM backend |
+| `agent-api-peer` | No | `"http://localhost:8080"` | Base URL of the API (host:port only) |
+| `agent-api-path` | No | `"/v1/chat/completions"` | API endpoint path |
+| `agent-api-key` | No | _(none)_ | Bearer token for Authorization header |
+| `agent-max-iterations` | No | `10` | Max ReAct loop iterations before force-stop |
+
+## Troubleshooting
+
+**404 from API**: Check that `agent-api-peer` contains only the host (e.g., `https://api.novita.ai`) and the full path is in `agent-api-path` (e.g., `/openai/v1/chat/completions`). The `peer` field is parsed by `gun` which only extracts host:port.
+
+**Timeout**: The agent may need 10-30 seconds for multi-turn tool calls. For EUnit tests, use generator functions with `{timeout, 120, fun() -> ... end}`.
+
+**Device sandbox**: When calling from Lua, ensure `agent@1.0` and `relay@1.0` are accessible. If the process has a `device-sandbox` setting, these devices must be included.

--- a/docs/devices/agent-at-1-0.md
+++ b/docs/devices/agent-at-1-0.md
@@ -1,0 +1,204 @@
+# Device: ~agent@1.0
+
+## Overview
+
+The [`~agent@1.0`](../resources/source-code/dev_agent.md) device implements a
+**ReAct** (Reason–Act–Observe) agent loop on top of any OpenAI-compatible LLM
+endpoint. It iteratively calls the LLM, executes tool calls, feeds results back
+to the model, and repeats until the model returns a plain-text final answer or a
+configurable iteration ceiling is hit.
+
+## Core Concept: Iterative Reason-Act-Observe Loop
+
+```
+ User Prompt
+      │
+      ▼
+┌──────────────┐    tool_calls     ┌───────────────────┐
+│     LLM      │──────────────────▶│  Tool Executor    │
+│(inference@   │◀──────────────────│  (built-in/custom)│
+│  1.0)        │   tool results    └───────────────────┘
+└──────┬───────┘
+       │ routes via relay@1.0
+       ▼
+  local Python              remote provider
+  inference server   OR     (OpenRouter, etc.)
+  localhost:8080            https://openrouter.ai
+```
+
+All LLM calls are routed through [`~inference@1.0`](../resources/source-code/dev_inference.md),
+which in turn uses [`~relay@1.0`](relay-at-1-0.md) to reach the backend. This
+means local Python inference servers and remote OpenAI-compatible providers are
+addressed identically from the agent's perspective — only the `agent-api-peer`
+Opts key differs.
+
+Each iteration either:
+
+1. Receives `tool_calls` → executes them → appends results to message history →
+   calls the LLM again; or
+2. Receives a plain-text reply → returns it as `agent-answer`.
+
+The entire conversation history is managed in-process via Erlang recursion;
+nothing is persisted across `run` invocations unless an external tool does so.
+
+## Key Functions (Keys)
+
+### `run`
+
+Start the ReAct loop.
+
+**Request fields:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `agent-user-prompt` | binary | `<<"Hello">>` | The initial user message |
+| `agent-model` | binary | `<<"gpt-4o-mini">>` | Model name passed to the LLM endpoint |
+| `agent-max-iterations` | integer | `10` | Maximum tool-call rounds before force-stopping |
+| `agent-api-peer` | binary | `<<"http://localhost:8080">>` | Base URL of the LLM API server |
+| `agent-api-path` | binary | `<<"/v1/chat/completions">>` | Chat completions path |
+| `agent-api-key` | binary | _(none)_ | Bearer token, added as `Authorization` header |
+| `agent-llm-fun` | function | `default_call_llm/2` | Override the LLM call function |
+| `agent-tool-fun` | function | `default_execute_tool/2` | Override the tool executor function |
+
+**Response fields added to the base message:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `agent-answer` | binary | Final text answer returned by the model |
+| `agent-iterations` | integer | Number of LLM calls made |
+| `agent-error` | binary | Set only on error or `max_iterations_exceeded` |
+
+**Example:**
+
+```erlang
+{ok, Result} = hb_ao:resolve(
+    #{<<"device">> => <<"agent@1.0">>},
+    #{<<"path">>             => <<"run">>,
+      <<"agent-user-prompt">> => <<"What is the current Arweave block height?">>,
+      <<"agent-model">>       => <<"openai/gpt-4o-mini">>,
+      <<"agent-api-peer">>    => <<"https://openrouter.ai">>,
+      <<"agent-api-path">>    => <<"/api/v1/chat/completions">>,
+      <<"agent-api-key">>     => <<"sk-or-v1-...">>},
+    #{}).
+```
+
+**HyperPATH:**
+
+```
+POST /~agent@1.0/run
+```
+
+with the fields above as message tags or body keys.
+
+## Built-in Tools
+
+The default tool executor dispatches on the `name` field of each LLM tool call.
+
+### `http_request`
+
+Make an HTTP request to any URL via [`~relay@1.0`](relay-at-1-0.md).
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `url` | ✓ | Full URL to request |
+| `method` | | `GET` (default), `POST`, `PUT`, `DELETE` |
+| `body` | | Request body for `POST`/`PUT` |
+| `content_type` | | `Content-Type` header (default `text/plain`) |
+
+### `lookup_data`
+
+Retrieve a message or binary value from the local node cache via
+[`~lookup@1.0`](../resources/source-code/dev_lookup.md).
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `id` | ✓ | Hash ID of the cached item |
+
+### `search_messages`
+
+Search the node's cache for messages matching a set of key-value pairs via
+[`~query@1.0`](../resources/source-code/dev_query.md).
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `match` | ✓ | JSON object of key-value pairs to match |
+| `return` | | `"paths"` (default), `"messages"`, or `"count"` |
+
+### `get_arweave_tx`
+
+Fetch an Arweave transaction header by its 43-character base64url ID via
+[`~arweave@2.9-pre`](../resources/source-code/dev_arweave.md).
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `id` | ✓ | Arweave transaction ID |
+
+### `bundle_item`
+
+Submit a data item to be bundled and uploaded to Arweave via
+[`~bundler@1.0`](../resources/source-code/dev_bundler.md).
+Returns `<<"Message queued.">>` on success.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `data` | ✓ | Data content to store |
+| `content_type` | | `Content-Type` of the data (default `text/plain`) |
+
+## Customising Tools
+
+Both the LLM function and the tool executor can be replaced at call time by
+passing Erlang fun references in `Opts`:
+
+```erlang
+MyToolFun = fun
+    (#{name := <<"my_tool">>, args := Args}, _Opts) ->
+        %% custom logic
+        <<"result">>;
+    (ToolInfo, Opts) ->
+        %% fall through to the default executor
+        dev_agent:default_execute_tool(ToolInfo, Opts)
+end,
+
+{ok, Result} = hb_ao:resolve(
+    #{<<"device">> => <<"agent@1.0">>},
+    #{<<"path">>             => <<"run">>,
+      <<"agent-user-prompt">> => <<"Do something custom">>},
+    #{<<"agent-tool-fun">> => MyToolFun,
+      <<"agent-api-peer">>  => <<"https://openrouter.ai">>,
+      <<"agent-api-path">>  => <<"/api/v1/chat/completions">>,
+      <<"agent-api-key">>   => <<"sk-or-v1-...">>}).
+```
+
+## Configuration via Request Message
+
+All `agent-*` fields are accepted both in `Opts` and in the `Req`/`Base`
+message. This allows Lua scripts using `ao.resolve` to pass configuration
+without modifying `Opts`:
+
+```lua
+local result = ao.resolve({
+    path              = "/~agent@1.0/run",
+    ["agent-user-prompt"] = "Summarise this process",
+    ["agent-api-peer"]    = "https://openrouter.ai",
+    ["agent-api-path"]    = "/api/v1/chat/completions",
+    ["agent-api-key"]     = MY_KEY
+})
+```
+
+## Error Handling
+
+*   If the LLM call fails, `agent-error` is set to the relay error reason and
+    `agent-answer` is set to `<<"Error calling LLM.">>`.
+*   If the response cannot be JSON-decoded, `agent-error` describes the parse
+    failure.
+*   If `agent-max-iterations` is exceeded, `agent-error` is set to
+    `<<"max_iterations_exceeded">>`.
+*   Tool errors are returned as plain-text results to the LLM, which can then
+    decide how to proceed.
+
+## Tool Result Truncation
+
+To avoid overflowing the LLM's context window, tool results exceeding 4000 bytes
+are silently truncated and suffixed with `"\n... [truncated]"`.
+
+[agent module](../resources/source-code/dev_agent.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
       - '~json@1.0': 'devices/json-at-1-0.md'
       - '~scheduler@1.0': 'devices/scheduler-at-1-0.md'
       - '~relay@1.0': 'devices/relay-at-1-0.md'
+      - '~agent@1.0': 'devices/agent-at-1-0.md'
   - Resources:
     # - Overview: 'resources/source-code/index.md'
     - FAQ: 'resources/reference/faq.md'

--- a/scripts/agent-test.lua
+++ b/scripts/agent-test.lua
@@ -1,0 +1,44 @@
+--- @module agent-test
+--- Tests for dev_agent called via ao.resolve (simulating Lua process usage).
+
+--- @function agent_resolve_test
+--- Call dev_agent via ao.resolve with real Novita AI API.
+--- The agent should use the http_request tool to fetch data and return a result.
+function agent_resolve_test()
+    local status, res = ao.resolve({
+        path = "/~agent@1.0/run",
+        ["agent-user-prompt"] = "Use the http_request tool to GET https://httpbin.org/get and tell me what the origin IP address is.",
+        ["agent-model"] = "minimax/minimax-m2.7",
+        ["agent-api-peer"] = "https://api.novita.ai",
+        ["agent-api-path"] = "/openai/v1/chat/completions",
+        ["agent-api-key"] = "sk_VkH3T72Z7LsiDvc5oRvcCtuPciFNwKShHLOgs3LqGVI",
+        ["agent-max-iterations"] = 5
+    })
+    -- Log the result for debugging
+    ao.event("agent_test", {
+        status = status,
+        answer = res["agent-answer"],
+        iterations = res["agent-iterations"]
+    })
+    return status, res
+end
+
+--- @function agent_simple_test
+--- Call dev_agent with a simple question (no tool call needed).
+function agent_simple_test()
+    local status, res = ao.resolve({
+        path = "/~agent@1.0/run",
+        ["agent-user-prompt"] = "What is 2+2? Answer with just the number.",
+        ["agent-model"] = "minimax/minimax-m2.7",
+        ["agent-api-peer"] = "https://api.novita.ai",
+        ["agent-api-path"] = "/openai/v1/chat/completions",
+        ["agent-api-key"] = "sk_VkH3T72Z7LsiDvc5oRvcCtuPciFNwKShHLOgs3LqGVI",
+        ["agent-max-iterations"] = 3
+    })
+    ao.event("agent_simple_test", {
+        status = status,
+        answer = res["agent-answer"],
+        iterations = res["agent-iterations"]
+    })
+    return status, res
+end

--- a/src/dev_agent.erl
+++ b/src/dev_agent.erl
@@ -1,0 +1,881 @@
+%%% @doc A ReAct agent device that implements an iterative Reason-Act-Observe
+%%% loop. The agent calls an LLM (via relay to an OpenAI-compatible endpoint),
+%%% parses tool_calls from the response, executes tools, and loops until the
+%%% LLM returns a final text answer or max iterations are reached.
+%%%
+%%% Architecture:
+%%%   dev_agent (standalone device)
+%%%     ├── Calls LLM via inference@1.0 (OpenAI-compatible, local or remote)
+%%%     │     └── inference@1.0 relays via relay@1.0 to the configured peer
+%%%     ├── Parses OpenAI tool_calls format
+%%%     ├── Executes built-in tools (http_request, lookup_data, …)
+%%%     └── Manages conversation history internally (Erlang recursion)
+%%%
+%%% Usage:
+%%%   {ok, Result} = hb_ao:resolve(
+%%%     #{<<"device">> => <<"agent@1.0">>},
+%%%     #{<<"path">> => <<"run">>,
+%%%       <<"agent-user-prompt">> => <<"What is the weather?">>},
+%%%     #{}).
+-module(dev_agent).
+-export([info/1, run/3]).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(DEFAULT_MAX_ITERATIONS, 10).
+-define(DEFAULT_MODEL, <<"gpt-4o-mini">>).
+-define(MAX_TOOL_RESULT_SIZE, 4000).
+
+%%%===================================================================
+%%% Device API
+%%%===================================================================
+
+info(_Msg) ->
+    #{
+        exports => [<<"run">>]
+    }.
+
+%% @doc Entry point for the agent. Reads user prompt from the request,
+%% builds initial messages, and starts the ReAct loop.
+run(Base, Req, Opts) ->
+    UserPrompt = hb_ao:get(<<"agent-user-prompt">>, Req, <<"Hello">>, Opts),
+    SystemPrompt = default_system_prompt(),
+    Tools = default_tools(),
+    Model = hb_ao:get(<<"agent-model">>, Req, ?DEFAULT_MODEL, Opts),
+    MaxIter = hb_ao:get(<<"agent-max-iterations">>, Req, ?DEFAULT_MAX_ITERATIONS, Opts),
+    %% Merge agent API config from Req/Base into Opts so that
+    %% Lua ao.resolve calls can pass config via message fields.
+    MergedOpts = merge_agent_config(Req, merge_agent_config(Base, Opts)),
+    LLMFun = maps:get(<<"agent-llm-fun">>, MergedOpts, fun default_call_llm/2),
+    ToolFun = maps:get(<<"agent-tool-fun">>, MergedOpts, fun default_execute_tool/2),
+    Messages = [
+        #{<<"role">> => <<"system">>, <<"content">> => SystemPrompt},
+        #{<<"role">> => <<"user">>, <<"content">> => UserPrompt}
+    ],
+    AgentOpts = #{
+        model => Model,
+        tools => Tools,
+        max_iterations => MaxIter,
+        llm_fun => LLMFun,
+        tool_fun => ToolFun,
+        opts => MergedOpts
+    },
+    loop(Messages, 1, AgentOpts, Base).
+
+%%%===================================================================
+%%% ReAct Loop
+%%%===================================================================
+
+%% @doc The main ReAct loop. Calls LLM, checks for tool_calls or final answer.
+loop(Messages, Iteration, #{max_iterations := MaxIter} = AgentOpts, Base)
+  when Iteration > MaxIter ->
+    ?event(agent, {max_iterations_reached, Iteration}),
+    {ok, Base#{
+        <<"agent-answer">> =>
+            <<"Max iterations reached. Could not complete the task.">>,
+        <<"agent-error">> => <<"max_iterations_exceeded">>,
+        <<"agent-iterations">> => Iteration - 1
+    }};
+loop(Messages, Iteration, AgentOpts, Base) ->
+    #{model := Model, tools := Tools, llm_fun := LLMFun,
+      tool_fun := ToolFun, opts := Opts} = AgentOpts,
+    RequestBody = build_request_body(Messages, Tools, Model),
+    case LLMFun(RequestBody, Opts) of
+        {ok, ResponseBody} ->
+            case parse_response(ResponseBody) of
+                {tool_calls, AssistantMsg, ToolCalls} ->
+                    ?event(agent, {tool_calls, Iteration, length(ToolCalls)}),
+                    ToolResultMsgs = execute_tool_calls(ToolCalls, ToolFun, Opts),
+                    NewMessages = Messages ++ [AssistantMsg | ToolResultMsgs],
+                    loop(NewMessages, Iteration + 1, AgentOpts, Base);
+                {final_answer, Content} ->
+                    ?event(agent, {final_answer, Iteration}),
+                    {ok, Base#{
+                        <<"agent-answer">> => Content,
+                        <<"agent-iterations">> => Iteration
+                    }};
+                {error, ParseError} ->
+                    {ok, Base#{
+                        <<"agent-answer">> => <<"Error parsing LLM response.">>,
+                        <<"agent-error">> => ParseError,
+                        <<"agent-iterations">> => Iteration
+                    }}
+            end;
+        {error, LLMError} ->
+            {ok, Base#{
+                <<"agent-answer">> => <<"Error calling LLM.">>,
+                <<"agent-error">> => LLMError,
+                <<"agent-iterations">> => Iteration
+            }}
+    end.
+
+%%%===================================================================
+%%% LLM Interaction
+%%%===================================================================
+
+%% @doc Build the OpenAI-compatible request body.
+build_request_body(Messages, Tools, Model) ->
+    hb_json:encode(#{
+        <<"model">> => Model,
+        <<"messages">> => Messages,
+        <<"tools">> => Tools,
+        <<"tool_choice">> => <<"auto">>
+    }).
+
+%% @doc Default LLM call via inference@1.0.
+%% inference@1.0 relays to any OpenAI-compatible provider via relay@1.0,
+%% making local and remote LLM backends interchangeable from the agent's
+%% perspective. Supported Opts keys (consumed by inference@1.0/relay@1.0):
+%%   agent-api-peer: Base URL           (default: "http://localhost:8080")
+%%   agent-api-path: Completions path   (default: "/v1/chat/completions")
+%%   agent-api-key:  Bearer token       (optional)
+default_call_llm(RequestBody, Opts) ->
+    case hb_ao:resolve(
+        #{<<"device">>    => <<"inference@1.0">>,
+          <<"chat-mode">> => true},
+        #{<<"path">> => <<"completions">>,
+          <<"body">> => RequestBody},
+        Opts#{hashpath => ignore,
+              cache_control => [<<"no-store">>, <<"no-cache">>]}
+    ) of
+        {ok, Res} ->
+            {ok, hb_ao:get(<<"body">>, Res, <<>>, Opts)};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% @doc Parse an OpenAI chat completion response.
+%% Returns {tool_calls, AssistantMsg, ToolCalls} | {final_answer, Content} | {error, Reason}.
+parse_response(ResponseBody) when is_binary(ResponseBody) ->
+    try
+        Decoded = hb_json:decode(ResponseBody),
+        parse_response(Decoded)
+    catch
+        _:_ -> {error, <<"Failed to decode JSON response">>}
+    end;
+parse_response(Response) when is_map(Response) ->
+    Choices = maps:get(<<"choices">>, Response, []),
+    case Choices of
+        [FirstChoice | _] ->
+            Message = maps:get(<<"message">>, FirstChoice, #{}),
+            parse_assistant_message(Message);
+        [] ->
+            {error, <<"No choices in response">>}
+    end.
+
+%% @doc Parse the assistant message for tool_calls or final answer.
+parse_assistant_message(Message) ->
+    ToolCalls = maps:get(<<"tool_calls">>, Message, null),
+    Content = maps:get(<<"content">>, Message, null),
+    case ToolCalls of
+        null -> {final_answer, content_to_binary(Content)};
+        [] -> {final_answer, content_to_binary(Content)};
+        Calls when is_list(Calls) ->
+            %% Build assistant message to include in history
+            AssistantMsg = #{
+                <<"role">> => <<"assistant">>,
+                <<"content">> => Content,
+                <<"tool_calls">> => Calls
+            },
+            {tool_calls, AssistantMsg, Calls}
+    end.
+
+content_to_binary(null) -> <<>>;
+content_to_binary(B) when is_binary(B) -> B;
+content_to_binary(Other) -> hb_util:bin(Other).
+
+%%%===================================================================
+%%% Tool Execution
+%%%===================================================================
+
+%% @doc Execute a list of tool calls, returning tool result messages.
+execute_tool_calls(ToolCalls, ToolFun, Opts) ->
+    lists:map(
+        fun(ToolCall) ->
+            ToolCallId = maps:get(<<"id">>, ToolCall, <<>>),
+            Function = maps:get(<<"function">>, ToolCall, #{}),
+            FuncName = maps:get(<<"name">>, Function, <<>>),
+            ArgsJson = maps:get(<<"arguments">>, Function, <<"{}">>),
+            Args = try hb_json:decode(ArgsJson) catch _:_ -> #{} end,
+            Result = ToolFun(#{name => FuncName, args => Args}, Opts),
+            #{
+                <<"role">> => <<"tool">>,
+                <<"tool_call_id">> => ToolCallId,
+                <<"content">> => truncate_result(Result)
+            }
+        end,
+        ToolCalls
+    ).
+
+%% @doc Default tool executor. Dispatches by function name.
+default_execute_tool(#{name := <<"http_request">>, args := Args}, Opts) ->
+    execute_http_request(Args, Opts);
+default_execute_tool(#{name := <<"lookup_data">>, args := Args}, Opts) ->
+    execute_lookup(Args, Opts);
+default_execute_tool(#{name := <<"search_messages">>, args := Args}, Opts) ->
+    execute_search(Args, Opts);
+default_execute_tool(#{name := <<"get_arweave_tx">>, args := Args}, Opts) ->
+    execute_get_arweave_tx(Args, Opts);
+default_execute_tool(#{name := <<"bundle_item">>, args := Args}, Opts) ->
+    execute_bundle_item(Args, Opts);
+default_execute_tool(#{name := Name}, _Opts) ->
+    <<"Unknown tool: ", Name/binary>>.
+
+%% @doc Execute an HTTP request via relay@1.0.
+execute_http_request(Args, Opts) ->
+    Method = maps:get(<<"method">>, Args, <<"GET">>),
+    Url = maps:get(<<"url">>, Args, <<>>),
+    Body = maps:get(<<"body">>, Args, <<>>),
+    ContentType = maps:get(<<"content_type">>, Args, <<"text/plain">>),
+    case hb_ao:resolve(
+        #{<<"device">> => <<"relay@1.0">>,
+          <<"content-type">> => ContentType},
+        #{<<"path">> => <<"call">>,
+          <<"target">> => <<"payload">>,
+          <<"payload">> => #{
+              <<"path">> => Url,
+              <<"method">> => Method,
+              <<"body">> => Body,
+              <<"content-type">> => ContentType
+          }},
+        Opts#{hashpath => ignore,
+              cache_control => [<<"no-store">>, <<"no-cache">>]}
+    ) of
+        {ok, Res} ->
+            hb_ao:get(<<"body">>, Res, <<"No body">>, Opts);
+        {error, Reason} ->
+            iolist_to_binary(io_lib:format("HTTP request failed: ~p", [Reason]))
+    end.
+
+%% @doc Look up an item from the local cache by ID via lookup@1.0.
+execute_lookup(Args, Opts) ->
+    ID = maps:get(<<"id">>, Args, <<>>),
+    case hb_ao:resolve(
+        #{<<"device">> => <<"lookup@1.0">>},
+        #{<<"path">> => <<"read">>, <<"target">> => ID},
+        Opts#{hashpath => ignore}
+    ) of
+        {ok, Res} when is_map(Res) -> hb_json:encode(Res);
+        {ok, Res} when is_binary(Res) -> Res;
+        {ok, Res} -> hb_util:bin(Res);
+        {error, not_found} -> <<"Not found: ", ID/binary>>;
+        {error, Reason} ->
+            iolist_to_binary(io_lib:format("Lookup failed: ~p", [Reason]))
+    end.
+
+%% @doc Search the node cache for messages matching a key-value spec via query@1.0.
+execute_search(Args, Opts) ->
+    MatchSpec = maps:get(<<"match">>, Args, #{}),
+    ReturnType = maps:get(<<"return">>, Args, <<"paths">>),
+    %% Merge match keys into the request so query@1.0's `all' path picks them up.
+    Req = maps:merge(MatchSpec, #{<<"path">> => <<"all">>, <<"return">> => ReturnType}),
+    case hb_ao:resolve(
+        #{<<"device">> => <<"query@1.0">>},
+        Req,
+        Opts#{hashpath => ignore}
+    ) of
+        {ok, Results} -> hb_json:encode(Results);
+        {error, Reason} ->
+            iolist_to_binary(io_lib:format("Search failed: ~p", [Reason]))
+    end.
+
+%% @doc Fetch an Arweave transaction by TXID via arweave@2.9-pre.
+execute_get_arweave_tx(Args, Opts) ->
+    TXID = maps:get(<<"id">>, Args, <<>>),
+    case hb_ao:resolve(
+        #{<<"device">> => <<"arweave@2.9-pre">>},
+        #{<<"path">> => <<"tx">>, <<"tx">> => TXID},
+        Opts#{hashpath => ignore}
+    ) of
+        {ok, Res} when is_map(Res) -> hb_json:encode(Res);
+        {ok, Res} when is_binary(Res) -> Res;
+        {ok, Res} -> hb_util:bin(Res);
+        {error, not_found} -> <<"Transaction not found: ", TXID/binary>>;
+        {error, Reason} ->
+            iolist_to_binary(io_lib:format("Arweave TX fetch failed: ~p", [Reason]))
+    end.
+
+%% @doc Submit a data item to Arweave via the node's bundler@1.0.
+execute_bundle_item(Args, Opts) ->
+    Data = maps:get(<<"data">>, Args, <<>>),
+    ContentType = maps:get(<<"content_type">>, Args, <<"text/plain">>),
+    case hb_ao:resolve(
+        #{<<"device">> => <<"bundler@1.0">>},
+        #{<<"path">> => <<"item">>,
+          <<"data">> => Data,
+          <<"content-type">> => ContentType},
+        Opts#{hashpath => ignore}
+    ) of
+        {ok, Res} when is_binary(Res) -> Res;
+        {ok, Res} -> hb_util:bin(Res);
+        {error, Reason} ->
+            iolist_to_binary(io_lib:format("Bundle failed: ~p", [Reason]))
+    end.
+
+%% @doc Truncate tool results to avoid exceeding LLM context limits.
+truncate_result(Result) when is_binary(Result),
+                             byte_size(Result) > ?MAX_TOOL_RESULT_SIZE ->
+    <<Truncated:?MAX_TOOL_RESULT_SIZE/binary, _/binary>> = Result,
+    <<Truncated/binary, "\n... [truncated]">>;
+truncate_result(Result) when is_binary(Result) ->
+    Result;
+truncate_result(Result) ->
+    truncate_result(iolist_to_binary(io_lib:format("~p", [Result]))).
+
+%%%===================================================================
+%%% Configuration Helpers
+%%%===================================================================
+
+%% @doc Merge agent API config from a Source message into Opts.
+%% Keys already present in Opts are not overwritten.
+%% This allows Lua ao.resolve calls to pass config via Req/Base.
+merge_agent_config(Source, Opts) ->
+    Keys = [<<"agent-api-peer">>, <<"agent-api-path">>, <<"agent-api-key">>],
+    lists:foldl(fun(Key, Acc) ->
+        case maps:is_key(Key, Acc) of
+            true -> Acc;
+            false ->
+                case hb_ao:get(Key, Source, not_found, Opts#{hashpath => ignore}) of
+                    not_found -> Acc;
+                    Val -> Acc#{Key => Val}
+                end
+        end
+    end, Opts, Keys).
+
+%%%===================================================================
+%%% Default Configuration (hardcoded for MVP)
+%%%===================================================================
+
+default_system_prompt() ->
+    <<"You are a helpful AI assistant running on the AO network. "
+      "You have the following tools available:\n"
+      "- http_request: Make HTTP requests to any URL.\n"
+      "- lookup_data: Retrieve a cached message or data item by its ID.\n"
+      "- search_messages: Search the node cache for messages matching key-value criteria.\n"
+      "- get_arweave_tx: Fetch an Arweave transaction by its transaction ID.\n"
+      "- bundle_item: Submit data to be bundled and uploaded to Arweave.\n"
+      "When you have enough information to answer the user's question, "
+      "respond with a text message (do not call any tools). "
+      "Keep responses concise.">>.
+
+default_tools() ->
+    [tool_def(http_request), tool_def(lookup_data),
+     tool_def(search_messages), tool_def(get_arweave_tx),
+     tool_def(bundle_item)].
+
+tool_def(http_request) ->
+    #{
+        <<"type">> => <<"function">>,
+        <<"function">> => #{
+            <<"name">> => <<"http_request">>,
+            <<"description">> => <<"Make an HTTP request to a URL.">>,
+            <<"parameters">> => #{
+                <<"type">> => <<"object">>,
+                <<"properties">> => #{
+                    <<"url">> => #{
+                        <<"type">> => <<"string">>,
+                        <<"description">> => <<"The URL to request.">>
+                    },
+                    <<"method">> => #{
+                        <<"type">> => <<"string">>,
+                        <<"enum">> => [<<"GET">>, <<"POST">>, <<"PUT">>, <<"DELETE">>],
+                        <<"description">> => <<"HTTP method. Defaults to GET.">>
+                    },
+                    <<"body">> => #{
+                        <<"type">> => <<"string">>,
+                        <<"description">> => <<"Request body (for POST/PUT).">>
+                    },
+                    <<"content_type">> => #{
+                        <<"type">> => <<"string">>,
+                        <<"description">> =>
+                            <<"Content-Type header. Defaults to text/plain.">>
+                    }
+                },
+                <<"required">> => [<<"url">>]
+            }
+        }
+    };
+tool_def(lookup_data) ->
+    #{
+        <<"type">> => <<"function">>,
+        <<"function">> => #{
+            <<"name">> => <<"lookup_data">>,
+            <<"description">> =>
+                <<"Retrieve a message or data item from the node's local cache by its ID.">>,
+            <<"parameters">> => #{
+                <<"type">> => <<"object">>,
+                <<"properties">> => #{
+                    <<"id">> => #{
+                        <<"type">> => <<"string">>,
+                        <<"description">> => <<"The hash ID of the item to retrieve.">>
+                    }
+                },
+                <<"required">> => [<<"id">>]
+            }
+        }
+    };
+tool_def(search_messages) ->
+    #{
+        <<"type">> => <<"function">>,
+        <<"function">> => #{
+            <<"name">> => <<"search_messages">>,
+            <<"description">> =>
+                <<"Search the node's cache for messages matching key-value criteria.">>,
+            <<"parameters">> => #{
+                <<"type">> => <<"object">>,
+                <<"properties">> => #{
+                    <<"match">> => #{
+                        <<"type">> => <<"object">>,
+                        <<"description">> =>
+                            <<"JSON object of key-value pairs to match against cached messages.">>
+                    },
+                    <<"return">> => #{
+                        <<"type">> => <<"string">>,
+                        <<"enum">> => [<<"paths">>, <<"messages">>, <<"count">>],
+                        <<"description">> =>
+                            <<"What to return: paths (default), full messages, or count.">>
+                    }
+                },
+                <<"required">> => [<<"match">>]
+            }
+        }
+    };
+tool_def(get_arweave_tx) ->
+    #{
+        <<"type">> => <<"function">>,
+        <<"function">> => #{
+            <<"name">> => <<"get_arweave_tx">>,
+            <<"description">> =>
+                <<"Fetch an Arweave transaction header by its 43-character base64url transaction ID.">>,
+            <<"parameters">> => #{
+                <<"type">> => <<"object">>,
+                <<"properties">> => #{
+                    <<"id">> => #{
+                        <<"type">> => <<"string">>,
+                        <<"description">> => <<"The Arweave transaction ID.">>
+                    }
+                },
+                <<"required">> => [<<"id">>]
+            }
+        }
+    };
+tool_def(bundle_item) ->
+    #{
+        <<"type">> => <<"function">>,
+        <<"function">> => #{
+            <<"name">> => <<"bundle_item">>,
+            <<"description">> =>
+                <<"Submit a data item to be bundled and uploaded to Arweave.">>,
+            <<"parameters">> => #{
+                <<"type">> => <<"object">>,
+                <<"properties">> => #{
+                    <<"data">> => #{
+                        <<"type">> => <<"string">>,
+                        <<"description">> => <<"The data content to store on Arweave.">>
+                    },
+                    <<"content_type">> => #{
+                        <<"type">> => <<"string">>,
+                        <<"description">> =>
+                            <<"Content-Type of the data. Defaults to text/plain.">>
+                    }
+                },
+                <<"required">> => [<<"data">>]
+            }
+        }
+    }.
+
+%%%===================================================================
+%%% Tests
+%%%===================================================================
+
+%% Helper: create a mock LLM function that returns a sequence of responses.
+mock_llm_sequence(Responses) ->
+    Counter = atomics:new(1, [{signed, false}]),
+    fun(_RequestBody, _Opts) ->
+        Idx = atomics:add_get(Counter, 1, 1),
+        case Idx =< length(Responses) of
+            true -> lists:nth(Idx, Responses);
+            false -> {error, <<"No more mock responses">>}
+        end
+    end.
+
+%% Helper: build a mock OpenAI response with a text answer (no tool_calls).
+mock_text_response(Content) ->
+    {ok, hb_json:encode(#{
+        <<"choices">> => [#{
+            <<"message">> => #{
+                <<"role">> => <<"assistant">>,
+                <<"content">> => Content
+            }
+        }]
+    })}.
+
+%% Helper: build a mock OpenAI response with tool_calls.
+mock_tool_call_response(ToolCalls) ->
+    {ok, hb_json:encode(#{
+        <<"choices">> => [#{
+            <<"message">> => #{
+                <<"role">> => <<"assistant">>,
+                <<"content">> => null,
+                <<"tool_calls">> => ToolCalls
+            }
+        }]
+    })}.
+
+%% Helper: build a single tool_call structure.
+make_tool_call(Id, FuncName, ArgsMap) ->
+    #{
+        <<"id">> => Id,
+        <<"type">> => <<"function">>,
+        <<"function">> => #{
+            <<"name">> => FuncName,
+            <<"arguments">> => hb_json:encode(ArgsMap)
+        }
+    }.
+
+%% Helper: a mock tool function that records calls and returns a fixed result.
+mock_tool_fun(Result) ->
+    fun(_ToolInfo, _Opts) -> Result end.
+
+%% Helper: a mock tool function that records calls.
+mock_tool_fun_with_tracker(Result) ->
+    Tracker = ets:new(tool_calls_tracker, [bag, public]),
+    Fun = fun(ToolInfo, _Opts) ->
+        ets:insert(Tracker, {call, ToolInfo}),
+        Result
+    end,
+    {Fun, Tracker}.
+
+%% @doc LLM directly returns text answer, no tool calls.
+single_turn_no_tools_test() ->
+    LLMFun = mock_llm_sequence([
+        mock_text_response(<<"Hello! How can I help you?">>)
+    ]),
+    ToolFun = mock_tool_fun(<<"should not be called">>),
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Hi there">>},
+    Opts = #{
+        <<"agent-llm-fun">> => LLMFun,
+        <<"agent-tool-fun">> => ToolFun
+    },
+    {ok, Result} = run(Base, Req, Opts),
+    ?assertEqual(<<"Hello! How can I help you?">>,
+                 maps:get(<<"agent-answer">>, Result)),
+    ?assertEqual(1, maps:get(<<"agent-iterations">>, Result)).
+
+%% @doc LLM calls a tool, then returns final answer.
+single_tool_call_test() ->
+    ToolCall = make_tool_call(
+        <<"call_1">>,
+        <<"http_request">>,
+        #{<<"url">> => <<"https://example.com/api">>}
+    ),
+    LLMFun = mock_llm_sequence([
+        mock_tool_call_response([ToolCall]),
+        mock_text_response(<<"The result is 42.">>)
+    ]),
+    ToolFun = mock_tool_fun(<<"{\"value\": 42}">>),
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Get the value">>},
+    Opts = #{
+        <<"agent-llm-fun">> => LLMFun,
+        <<"agent-tool-fun">> => ToolFun
+    },
+    {ok, Result} = run(Base, Req, Opts),
+    ?assertEqual(<<"The result is 42.">>,
+                 maps:get(<<"agent-answer">>, Result)),
+    ?assertEqual(2, maps:get(<<"agent-iterations">>, Result)).
+
+%% @doc LLM returns multiple tool calls in a single response.
+multiple_tool_calls_test() ->
+    ToolCall1 = make_tool_call(
+        <<"call_1">>, <<"http_request">>,
+        #{<<"url">> => <<"https://api.example.com/a">>}
+    ),
+    ToolCall2 = make_tool_call(
+        <<"call_2">>, <<"http_request">>,
+        #{<<"url">> => <<"https://api.example.com/b">>}
+    ),
+    LLMFun = mock_llm_sequence([
+        mock_tool_call_response([ToolCall1, ToolCall2]),
+        mock_text_response(<<"Combined result.">>)
+    ]),
+    {ToolFun, Tracker} = mock_tool_fun_with_tracker(<<"ok">>),
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Fetch both">>},
+    Opts = #{
+        <<"agent-llm-fun">> => LLMFun,
+        <<"agent-tool-fun">> => ToolFun
+    },
+    {ok, Result} = run(Base, Req, Opts),
+    ?assertEqual(<<"Combined result.">>,
+                 maps:get(<<"agent-answer">>, Result)),
+    %% Verify both tools were called
+    Calls = ets:lookup(Tracker, call),
+    ?assertEqual(2, length(Calls)),
+    ets:delete(Tracker).
+
+%% @doc Max iterations reached, agent force-stops.
+max_iterations_test() ->
+    %% LLM always returns tool_calls, never a final answer
+    ToolCall = make_tool_call(
+        <<"call_loop">>, <<"http_request">>,
+        #{<<"url">> => <<"https://example.com">>}
+    ),
+    AlwaysToolCall = fun(_Body, _Opts) ->
+        mock_tool_call_response([ToolCall])
+    end,
+    ToolFun = mock_tool_fun(<<"result">>),
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Loop forever">>,
+            <<"agent-max-iterations">> => 3},
+    Opts = #{
+        <<"agent-llm-fun">> => AlwaysToolCall,
+        <<"agent-tool-fun">> => ToolFun
+    },
+    {ok, Result} = run(Base, Req, Opts),
+    ?assertEqual(<<"max_iterations_exceeded">>,
+                 maps:get(<<"agent-error">>, Result)),
+    ?assertEqual(3, maps:get(<<"agent-iterations">>, Result)).
+
+%% @doc Tool execution returns an error, which is passed back to LLM.
+tool_error_handling_test() ->
+    ToolCall = make_tool_call(
+        <<"call_err">>, <<"http_request">>,
+        #{<<"url">> => <<"https://fail.example.com">>}
+    ),
+    LLMFun = mock_llm_sequence([
+        mock_tool_call_response([ToolCall]),
+        mock_text_response(<<"Sorry, the request failed.">>)
+    ]),
+    ToolFun = mock_tool_fun(<<"HTTP request failed: timeout">>),
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Try failing URL">>},
+    Opts = #{
+        <<"agent-llm-fun">> => LLMFun,
+        <<"agent-tool-fun">> => ToolFun
+    },
+    {ok, Result} = run(Base, Req, Opts),
+    %% Agent should still complete despite tool error
+    ?assertEqual(<<"Sorry, the request failed.">>,
+                 maps:get(<<"agent-answer">>, Result)),
+    ?assertEqual(2, maps:get(<<"agent-iterations">>, Result)).
+
+%% @doc Verify conversation history is in correct OpenAI format.
+message_history_test() ->
+    ToolCall = make_tool_call(
+        <<"call_hist">>, <<"http_request">>,
+        #{<<"url">> => <<"https://example.com">>}
+    ),
+    %% Track what messages the LLM receives on 2nd call
+    MessageTracker = ets:new(msg_tracker, [set, public]),
+    LLMFun = fun(RequestBody, _Opts) ->
+        Decoded = hb_json:decode(RequestBody),
+        Messages = maps:get(<<"messages">>, Decoded, []),
+        ets:insert(MessageTracker, {length(Messages), Messages}),
+        case length(Messages) of
+            2 -> %% First call: [system, user]
+                mock_tool_call_response([ToolCall]);
+            _ -> %% Second call: should have full history
+                mock_text_response(<<"Done.">>)
+        end
+    end,
+    ToolFun = mock_tool_fun(<<"tool output">>),
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Test history">>},
+    Opts = #{
+        <<"agent-llm-fun">> => LLMFun,
+        <<"agent-tool-fun">> => ToolFun
+    },
+    {ok, _Result} = run(Base, Req, Opts),
+    %% Check 2nd call had correct history:
+    %% [system, user, assistant(tool_calls), tool(result)] = 4 messages
+    [{4, SecondCallMessages}] = ets:lookup(MessageTracker, 4),
+    %% Verify message roles in order
+    Roles = [maps:get(<<"role">>, M) || M <- SecondCallMessages],
+    ?assertEqual([<<"system">>, <<"user">>, <<"assistant">>, <<"tool">>], Roles),
+    %% Verify the tool message has the correct tool_call_id
+    ToolMsg = lists:last(SecondCallMessages),
+    ?assertEqual(<<"call_hist">>, maps:get(<<"tool_call_id">>, ToolMsg)),
+    ?assertEqual(<<"tool output">>, maps:get(<<"content">>, ToolMsg)),
+    ets:delete(MessageTracker).
+
+%% @doc truncate_result/1 correctly truncates long binaries.
+truncate_result_test() ->
+    Short = <<"short">>,
+    ?assertEqual(Short, truncate_result(Short)),
+    Long = binary:copy(<<"x">>, 5000),
+    Truncated = truncate_result(Long),
+    ?assert(byte_size(Truncated) < 5000),
+    ?assert(binary:match(Truncated, <<"[truncated]">>) =/= nomatch).
+
+%% @doc Unknown tool name returns a descriptive error binary.
+unknown_tool_test() ->
+    ToolCall = make_tool_call(
+        <<"call_unk">>, <<"unknown_func">>,
+        #{<<"arg">> => <<"val">>}
+    ),
+    LLMFun = mock_llm_sequence([
+        mock_tool_call_response([ToolCall]),
+        mock_text_response(<<"I don't know that tool.">>)
+    ]),
+    %% Use default_execute_tool which handles unknown tools
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Use unknown tool">>},
+    Opts = #{
+        <<"agent-llm-fun">> => LLMFun,
+        <<"agent-tool-fun">> => fun default_execute_tool/2
+    },
+    {ok, Result} = run(Base, Req, Opts),
+    ?assertEqual(<<"I don't know that tool.">>,
+                 maps:get(<<"agent-answer">>, Result)).
+
+%% @doc Test: Lua ao.resolve style call — config in Req, not Opts.
+%% Simulates: ao.resolve({path="/~agent@1.0/run", ["agent-api-peer"]=..., ...})
+lua_resolve_style_test() ->
+    LLMFun = mock_llm_sequence([
+        mock_text_response(<<"Paris">>)
+    ]),
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{
+        <<"path">> => <<"run">>,
+        <<"agent-user-prompt">> => <<"Capital of France?">>,
+        <<"agent-model">> => <<"test-model">>,
+        <<"agent-api-peer">> => <<"https://api.example.com">>,
+        <<"agent-api-path">> => <<"/v1/chat/completions">>,
+        <<"agent-api-key">> => <<"sk_test_key">>
+    },
+    Opts = #{
+        <<"agent-llm-fun">> => LLMFun,
+        <<"agent-tool-fun">> => fun default_execute_tool/2
+    },
+    {ok, Result} = run(Base, Req, Opts),
+    ?assertEqual(<<"Paris">>, maps:get(<<"agent-answer">>, Result)),
+    ?assertEqual(1, maps:get(<<"agent-iterations">>, Result)).
+
+%% @doc lookup_data tool call is routed with correct args.
+lookup_data_tool_test() ->
+    ToolCall = make_tool_call(<<"c_lookup">>, <<"lookup_data">>,
+                              #{<<"id">> => <<"deadbeef123">>}),
+    LLMFun = mock_llm_sequence([
+        mock_tool_call_response([ToolCall]),
+        mock_text_response(<<"Found the item.">>)
+    ]),
+    ToolFun = fun(#{name := <<"lookup_data">>, args := Args}, _Opts) ->
+        ?assertEqual(<<"deadbeef123">>, maps:get(<<"id">>, Args)),
+        <<"mock cached data">>
+    end,
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Look up the item">>},
+    Opts = #{<<"agent-llm-fun">> => LLMFun, <<"agent-tool-fun">> => ToolFun},
+    {ok, Result} = run(Base, Req, Opts),
+    ?assertEqual(<<"Found the item.">>, maps:get(<<"agent-answer">>, Result)),
+    ?assertEqual(2, maps:get(<<"agent-iterations">>, Result)).
+
+%% @doc search_messages tool call is routed with correct args.
+search_messages_tool_test() ->
+    ToolCall = make_tool_call(<<"c_search">>, <<"search_messages">>,
+                              #{<<"match">> => #{<<"type">> => <<"Process">>},
+                                <<"return">> => <<"paths">>}),
+    LLMFun = mock_llm_sequence([
+        mock_tool_call_response([ToolCall]),
+        mock_text_response(<<"Found 2 processes.">>)
+    ]),
+    ToolFun = fun(#{name := <<"search_messages">>, args := Args}, _Opts) ->
+        Match = maps:get(<<"match">>, Args),
+        ?assertEqual(<<"Process">>, maps:get(<<"type">>, Match)),
+        ?assertEqual(<<"paths">>, maps:get(<<"return">>, Args)),
+        <<"[\"/path/a\",\"/path/b\"]">>
+    end,
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Find all processes">>},
+    Opts = #{<<"agent-llm-fun">> => LLMFun, <<"agent-tool-fun">> => ToolFun},
+    {ok, Result} = run(Base, Req, Opts),
+    ?assertEqual(<<"Found 2 processes.">>, maps:get(<<"agent-answer">>, Result)).
+
+%% @doc get_arweave_tx tool call is routed with correct args.
+get_arweave_tx_tool_test() ->
+    TXID = <<"43characterbase64urlTXIDxxxxxxxxxxxxxxxx123">>,
+    ToolCall = make_tool_call(<<"c_tx">>, <<"get_arweave_tx">>,
+                              #{<<"id">> => TXID}),
+    LLMFun = mock_llm_sequence([
+        mock_tool_call_response([ToolCall]),
+        mock_text_response(<<"Transaction found.">>)
+    ]),
+    ToolFun = fun(#{name := <<"get_arweave_tx">>, args := Args}, _Opts) ->
+        ?assertEqual(TXID, maps:get(<<"id">>, Args)),
+        <<"{\"id\":\"", TXID/binary, "\"}">>
+    end,
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Get the Arweave TX">>},
+    Opts = #{<<"agent-llm-fun">> => LLMFun, <<"agent-tool-fun">> => ToolFun},
+    {ok, Result} = run(Base, Req, Opts),
+    ?assertEqual(<<"Transaction found.">>, maps:get(<<"agent-answer">>, Result)).
+
+%% @doc bundle_item tool call is routed with correct args.
+bundle_item_tool_test() ->
+    Data = <<"Hello Arweave">>,
+    ToolCall = make_tool_call(<<"c_bundle">>, <<"bundle_item">>,
+                              #{<<"data">> => Data,
+                                <<"content_type">> => <<"text/plain">>}),
+    LLMFun = mock_llm_sequence([
+        mock_tool_call_response([ToolCall]),
+        mock_text_response(<<"Data submitted to Arweave.">>)
+    ]),
+    ToolFun = fun(#{name := <<"bundle_item">>, args := Args}, _Opts) ->
+        ?assertEqual(Data, maps:get(<<"data">>, Args)),
+        ?assertEqual(<<"text/plain">>, maps:get(<<"content_type">>, Args)),
+        <<"Message queued.">>
+    end,
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Store this to Arweave">>},
+    Opts = #{<<"agent-llm-fun">> => LLMFun, <<"agent-tool-fun">> => ToolFun},
+    {ok, Result} = run(Base, Req, Opts),
+    ?assertEqual(<<"Data submitted to Arweave.">>, maps:get(<<"agent-answer">>, Result)).
+
+%% @doc Integration test: real LLM API call via OpenRouter with tool use.
+%% Requires a valid OPENROUTER_API_KEY environment variable or direct substitution.
+%% Run with: rebar3 eunit --module=dev_agent --test=integration_real_api_test
+integration_real_api_test_() ->
+    {timeout, 120, fun() ->
+        application:ensure_all_started(gun),
+        ApiKey = list_to_binary(
+            os:getenv("OPENROUTER_API_KEY", "sk-or-v1-YOUR_KEY_HERE")),
+        Base = #{<<"device">> => <<"agent@1.0">>},
+        Req = #{
+            <<"path">> => <<"run">>,
+            <<"agent-user-prompt">> =>
+                <<"Use the http_request tool to GET https://httpbin.org/get "
+                  "and tell me what the 'origin' IP address is from the response.">>,
+            <<"agent-model">> => <<"openai/gpt-4o-mini">>,
+            <<"agent-max-iterations">> => 5
+        },
+        Opts = #{
+            <<"agent-api-peer">> => <<"https://openrouter.ai">>,
+            <<"agent-api-path">> => <<"/api/v1/chat/completions">>,
+            <<"agent-api-key">> => ApiKey,
+            protocol => http2
+        },
+        {ok, Result} = run(Base, Req, Opts),
+        Answer = maps:get(<<"agent-answer">>, Result),
+        Iterations = maps:get(<<"agent-iterations">>, Result),
+        ?debugFmt("~n=== Integration Test Result ===~n"
+                  "Answer: ~s~nIterations: ~p~nFull result: ~p~n",
+                  [Answer, Iterations, Result]),
+        %% Should have completed in more than 1 iteration (tool was called)
+        ?assert(Iterations >= 2),
+        %% Answer should contain meaningful content (not an error)
+        ?assert(byte_size(Answer) > 10),
+        ?assertNot(maps:is_key(<<"agent-error">>, Result))
+    end}.

--- a/src/dev_inference.erl
+++ b/src/dev_inference.erl
@@ -1,0 +1,305 @@
+%%% @doc Inference device with OpenAI-compatible API.
+%%% This module provides an interface to a local Python-based inference server.
+-module(dev_inference).
+-export([info/1, completions/3, chat/3, models/3, health/3, v1/3, stop/0]).
+-include_lib("eunit/include/eunit.hrl").
+-include("include/hb.hrl").
+
+-define(SERVER_PORT, "8080").
+
+%% Device API
+
+%% @doc Return information about the device.
+info(_Opts) ->
+    #{
+        exports => [<<"completions">>, <<"chat">>, <<"models">>, <<"health">>, <<"v1">>],
+        description => <<"Inference device with OpenAI-compatible API">>,
+        version => <<"1.0">>
+    }.
+
+%% @doc Stop the inference server process.
+stop() ->
+    case whereis(inference_server) of
+        undefined -> ok;
+        Pid -> 
+            Pid ! stop,
+            unregister(inference_server),
+            ok
+    end.
+
+%% @doc Handle completion requests.
+completions(Base, Req, Opts) ->
+    Path = case hb_ao:get(<<"chat-mode">>, Base, false, Opts) of
+        true -> <<"/v1/chat/completions">>;
+        false -> <<"/v1/completions">>
+    end,
+    do_inference_request(Base, Req, Opts, Path).
+
+%% @doc Handle chat completion requests.
+chat(Base, Req, Opts) ->
+    {ok, hb_util:deep_merge(
+        Base, 
+        Req#{
+            <<"device">> => <<"inference@1.0">>,
+            <<"chat-mode">> => true
+        }, 
+        Opts
+    )}.
+
+%% @doc Handle models request.
+models(_Base, _Req, _Opts) ->
+    Body = <<"{\"object\":\"list\",\"data\":[{\"id\":\"google/gemma-3-27b-it\",\"object\":\"model\",\"created\":1766123915,\"owned_by\":\"sglang\",\"root\":\"google/gemma-3-27b-it\",\"max_model_len\":16384}]}">>,
+    {ok, #{
+        <<"status">> => 200,
+        <<"content-type">> => <<"application/json">>,
+        <<"body">> => Body
+    }}.
+
+%% @doc Handle v1 API requests.
+v1(Base, Req, Opts) ->
+    {ok, hb_util:deep_merge(
+        Base, 
+        Req#{
+            <<"device">> => <<"inference@1.0">>
+        }, 
+        Opts
+    )}.
+
+%% @doc Check the health of the inference server.
+health(_Base, _Req, Opts) ->
+    forward_health_check(Opts).
+
+
+%% Internal functions
+
+forward_health_check(Opts) ->
+    Peer = iolist_to_binary(["http://localhost:", ?SERVER_PORT]),
+    
+    case hb_http_client:request(
+        #{
+            method => <<"GET">>,
+            peer => Peer,
+            path => <<"/health">>,
+            headers => #{},
+            body => <<>>
+        },
+        Opts
+    ) of
+        {ok, Status, _Headers, Body} when Status >= 200 andalso Status < 300 ->
+            {ok, #{
+                <<"status">> => <<"healthy">>,
+                <<"body">> => Body,
+                <<"timestamp">> => os:system_time(millisecond)
+            }};
+        {ok, Status, _Headers, Body} ->
+            {error, #{
+                <<"status">> => Status,
+                <<"message">> => <<"Backend unhealthy">>,
+                <<"body">> => Body
+            }};
+        {error, Details} ->
+            {error, #{
+                <<"status">> => 503,
+                <<"message">> => hb_util:bin(Details)
+            }}
+    end.
+
+do_inference_request(_Base, Req, Opts, Path) ->
+    Params = extract_inference_params(Req, Opts),
+    IsStream = case maps:get(<<"stream">>, Params, false) of
+        true -> true;
+        <<"true">> -> true;
+        _ -> false
+    end,
+    case IsStream of
+        true ->
+            Body = hb_json:encode(Params),
+            #{
+                <<"stream_generator">> => fun(Sender) -> 
+                    stream_from_backend(Sender, <<"POST">>, Path, Body, Opts) 
+                end
+            };
+        false ->
+            Body = prepare_request_body(Req, Opts),
+            Response = relay_to_backend(<<"POST">>, Path, Body, Opts),
+            
+            case should_include_attestation(Req, Opts) of
+                true -> add_attestation(Response, Req, Opts);
+                false -> format_response(Response, Req, Opts)
+            end
+    end.
+
+prepare_request_body(Req, Opts) ->
+    case hb_ao:get(<<"body">>, Req, not_found, Opts) of
+        not_found -> hb_json:encode(extract_inference_params(Req, Opts));
+        Body when is_binary(Body) -> Body;
+        Body when is_map(Body) -> hb_json:encode(Body)
+    end.
+
+should_include_attestation(Req, Opts) ->
+    case hb_ao:get(<<"tee">>, Req, false, Opts) of
+        <<"true">> -> true;
+        true -> true;
+        _ -> false
+    end.
+
+extract_inference_params(Req, Opts) ->
+    ParamKeys = [
+        <<"model">>, <<"prompt">>, <<"messages">>, <<"max_tokens">>,
+        <<"temperature">>, <<"top_p">>, <<"n">>, <<"stream">>,
+        <<"stop">>, <<"presence_penalty">>, <<"frequency_penalty">>,
+        <<"logit_bias">>, <<"user">>, <<"seed">>, <<"top_k">>,
+        <<"repetition_penalty">>, <<"length_penalty">>, <<"early_stopping">>,
+        <<"tools">>, <<"tool_choice">>
+    ],
+    Params = lists:foldl(
+        fun(Key, Acc) ->
+            case hb_ao:get(Key, Req, not_found, Opts) of
+                not_found -> Acc;
+                Value -> Acc#{Key => Value}
+            end
+        end,
+        #{},
+        ParamKeys
+    ),
+    hb_cache:ensure_all_loaded(Params, Opts).
+
+relay_to_backend(Method, DefaultPath, Body, Opts) ->
+    Peer = maps:get(<<"agent-api-peer">>, Opts, <<"http://localhost:8080">>),
+    Path = maps:get(<<"agent-api-path">>, Opts, DefaultPath),
+    Payload0 = #{
+        <<"path">>         => Path,
+        <<"method">>       => Method,
+        <<"body">>         => Body,
+        <<"content-type">> => <<"application/json">>
+    },
+    Payload = case maps:get(<<"agent-api-key">>, Opts, undefined) of
+        undefined -> Payload0;
+        ApiKey    -> Payload0#{<<"authorization">> => <<"Bearer ", ApiKey/binary>>}
+    end,
+    hb_ao:resolve(
+        #{<<"device">>       => <<"relay@1.0">>,
+          <<"content-type">> => <<"application/json">>,
+          <<"peer">>         => Peer},
+        #{<<"path">>   => <<"call">>,
+          <<"target">> => <<"payload">>,
+          <<"payload">> => Payload},
+        Opts#{hashpath => ignore, cache_control => [<<"no-store">>, <<"no-cache">>]}
+    ).
+
+format_response({ok, Res}, Req, Opts) ->
+    Body = hb_ao:get(<<"body">>, Res, Opts),
+    ?event(push, {format_response, Req, hb_ao:get(<<"type">>, Req)}),
+    %% Check if this is being called for scheduling (aos Send with resolve)
+    %% vs direct HTTP call. dev_push:maybe_evaluate_message sets force_message => true
+    case hb_ao:get(<<"type">>, Req) of
+        <<"Message">> ->
+            %% For scheduling: return only valid AO message fields (ANS-104 compatible)
+            {ok, #{
+                <<"data">> => Body,
+                <<"action">> => <<"Inference-Response">>
+            }};
+        _ ->
+            %% For direct HTTP: return full HTTP response format
+            {ok, #{
+                <<"status">> => hb_ao:get(<<"status">>, Res, 200, Opts),
+                <<"content-type">> => hb_ao:get(<<"content-type">>, Res, <<"application/json">>, Opts),
+                <<"body">> => Body
+            }}
+    end;
+format_response({error, Error}, Req, Opts) ->
+    case hb_ao:get(<<"type">>, Req) of
+        <<"Message">> ->
+            %% For scheduling: return AO message format
+            {error, #{
+                <<"data">> => hb_util:bin(Error),
+                <<"action">> => <<"Inference-Error">>
+            }};
+        _ ->
+            %% For direct HTTP: return HTTP error format
+            {error, #{
+                <<"status">> => 500,
+                <<"message">> => <<"Request failed">>,
+                <<"body">> => hb_util:bin(Error)
+            }}
+    end.
+
+add_attestation({ok, Res}, Req, Opts) ->
+    MergedData = #{
+        <<"request">> => hb_private:reset(Req),
+        <<"response">> => hb_private:reset(Res),
+        <<"timestamp">> => os:system_time(millisecond),
+        <<"nonce">> => hb_util:to_hex(crypto:strong_rand_bytes(32))
+    },
+    NonceHex = hb_util:to_hex(hb_crypto:sha256(hb_json:encode(MergedData))),
+    
+    %% Generate attestation - result contains evidences, claims, eat, verified
+    AttestationResult = case dev_sev_gpu:generate(#{}, #{nonce => NonceHex}, Opts) of
+        {ok, ResultJSON} -> 
+            case hb_json:decode(ResultJSON) of
+                Map when is_map(Map) -> Map;
+                _ -> #{}
+            end;
+        _ -> #{}
+    end,
+    
+    %% Merge attestation result with raw and nonce at same level
+    AttestationData = maps:merge(AttestationResult, #{
+        <<"raw">> => hb_json:encode(MergedData),
+        <<"nonce">> => NonceHex
+    }),
+    
+    ResponseBody = hb_ao:get(<<"body">>, Res, Opts),
+    DecodedBody = hb_json:decode(ResponseBody),
+    EnhancedBody = hb_json:encode(DecodedBody#{
+        <<"attestation">> => AttestationData,
+        <<"resolved_model">> => hb_opts:get(inference_opts, #{}, Opts)
+    }),
+    
+    %% Check context: scheduling (aos) vs direct HTTP
+    case hb_ao:get(<<"type">>, Req) of
+        <<"Message">> ->
+            %% For scheduling: return only valid AO message fields (ANS-104 compatible)
+            {ok, #{
+                <<"data">> => EnhancedBody,
+                <<"action">> => <<"Inference-Response">>
+            }};
+        _ ->
+            %% For direct HTTP: return full HTTP response format
+            {ok, #{
+                <<"status">> => hb_ao:get(<<"status">>, Res, 200, Opts),
+                <<"content-type">> => <<"application/json">>,
+                <<"body">> => EnhancedBody
+            }}
+    end;
+add_attestation({error, Error}, Req, Opts) ->
+    format_response({error, Error}, Req, Opts).
+
+stream_from_backend(Sender, Method, Path, Body, _Opts) ->
+    {ok, ConnPid} = gun:open("localhost", list_to_integer(?SERVER_PORT)),
+    {ok, _Protocol} = gun:await_up(ConnPid),
+    StreamRef = gun:request(ConnPid, Method, Path, [{<<"content-type">>, <<"application/json">>}], Body),
+    receive_stream(ConnPid, StreamRef, Sender).
+
+receive_stream(ConnPid, StreamRef, Sender) ->
+    receive
+        {gun_response, ConnPid, StreamRef, nofin, _Status, _Headers} ->
+            receive_stream(ConnPid, StreamRef, Sender);
+        {gun_response, ConnPid, StreamRef, fin, _Status, _Headers} ->
+            ok;
+        {gun_data, ConnPid, StreamRef, nofin, Data} ->
+            Sender(Data),
+            receive_stream(ConnPid, StreamRef, Sender);
+        {gun_data, ConnPid, StreamRef, fin, Data} ->
+            Sender(Data);
+        {gun_error, ConnPid, StreamRef, Reason} ->
+            ?event(inference, {stream_error, Reason}),
+            ok;
+        {gun_down, ConnPid, _Protocol, _Reason, _KilledStreams} ->
+             ok;
+        Other ->
+            ?event(inference, {unexpected_stream_msg, Other}),
+            receive_stream(ConnPid, StreamRef, Sender)
+    after 30000 ->
+        ok
+    end.

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -209,7 +209,9 @@ default_message() ->
             #{<<"name">> => <<"secret@1.0">>, <<"module">> => dev_secret},
             #{<<"name">> => <<"wasi@1.0">>, <<"module">> => dev_wasi},
             #{<<"name">> => <<"wasm-64@1.0">>, <<"module">> => dev_wasm},
-            #{<<"name">> => <<"whois@1.0">>, <<"module">> => dev_whois}
+            #{<<"name">> => <<"whois@1.0">>, <<"module">> => dev_whois},
+            #{<<"name">> => <<"inference@1.0">>, <<"module">> => dev_inference},
+            #{<<"name">> => <<"agent@1.0">>, <<"module">> => dev_agent}
         ],
         %% Default execution cache control options
         cache_control => [<<"no-cache">>, <<"no-store">>],
@@ -284,6 +286,11 @@ default_message() ->
             #{
                 <<"template">> => <<"/state.*">>,
                 <<"node">> => #{ <<"prefix">> => <<"http://localhost:6363">> }
+            },
+            #{
+                % Routes for the inference device to use a local inference server.
+                <<"template">> => <<"/v1/.*">>,
+                <<"node">> => #{ <<"prefix">> => <<"http://localhost:8080">> }
             },
             %% GraphQL: race all gateways, take the first 200.
             #{
@@ -574,6 +581,13 @@ default_message() ->
                 ]
         },
         scheduler_default_commitment_spec => <<"httpsig@1.0">>,
+        inference_opts => #{
+            <<"model_tx">> => <<"Ybz4a5jX1nX1_2KXJz6F5v8c1X9Yk9V6n0b-1cXoXoU">>,
+            <<"model_hash">> => <<"bf3fc475100aa8bafea66766f17bb468ff96e947">>,
+            <<"model_name">> => <<"Qwen/Qwen2.5-0.5B-Instruct">>,
+            <<"model_size">> => <<"27b">>,
+            <<"tensor_type">> => <<"BF16">>
+        },
         genesis_wasm_import_authorities =>
             [
                 <<"WjnS-s03HWsDSdMnyTdzB1eHZB2QheUWP_FVRVYxkXk">>


### PR DESCRIPTION
## Summary

This PR adds two new HyperBEAM devices: an LLM inference gateway (`inference@1.0`) and a ReAct-loop agent (`agent@1.0`) that uses it.

---

## ~inference@1.0  (`src/dev_inference.erl`)

An OpenAI-compatible inference gateway that routes completion requests to a local **or** remote LLM backend via `relay@1.0`.

Key properties read from node opts at runtime:
| Opt | Default | Description |
|-----|---------|-------------|
| `agent-api-peer` | `http://localhost:8080` | Backend URL |
| `agent-api-path` | caller-supplied | API path (e.g. `/v1/chat/completions`) |
| `agent-api-key` | — | Optional Bearer token |

This means the same device works unchanged with a local `llama.cpp` server, OpenRouter, OpenAI, or any OpenAI-compatible endpoint — just change opts.

---

## ~agent@1.0  (`src/dev_agent.erl`)

A [ReAct](https://arxiv.org/abs/2210.03629)-loop agent device.  It iteratively:
1. Calls the LLM through `inference@1.0/completions`
2. Parses `tool_calls` from the response
3. Dispatches to built-in tools
4. Feeds results back as `tool` role messages
5. Repeats until the model emits a final text answer

**Built-in tools**

| Tool | Device | Description |
|------|--------|-------------|
| `http_request` | relay@1.0 | Arbitrary outbound HTTP |
| `lookup_data` | lookup@1.0 | AO key resolution |
| `search_messages` | search@1.0 | Message search |
| `get_arweave_tx` | arweave@1.0 | Arweave TX fetch |
| `bundle_item` | bundler@1.0 | ANS-104 dispatch |

All tools, the LLM call, and the system prompt are overridable via `Run` key parameters.

**Architecture**

```
agent@1.0
    └─► inference@1.0 ──► relay@1.0 ──► local llama.cpp
                                    └──► remote provider (OpenRouter / OpenAI)
```

---

## Supporting changes

- **`src/hb_opts.erl`** — register `inference@1.0` and `agent@1.0`; add `/v1/.*` → `localhost:8080` route and `inference_opts` defaults
- **`docs/devices/agent-at-1-0.md`** — full device reference page
- **`docs/dev_agent-testing.md`** — testing / debugging guide
- **`scripts/agent-test.lua`** — end-to-end smoke test
- **`mkdocs.yml`** — add `~agent@1.0` entry to Devices nav
- **`.gitignore`** — ignore `.agents/` (VS Code Copilot skills)