### PR TITLE
feat: add ~agent@1.0, ~inference@1.0 and ~sev_gpu@1.0 devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ rebar3.crashdump
 
 native/hb_beamr/*.o
 native/hb_beamr/*.d
-
+!native/dev_sev_gpu/NVGPULocalv4Policy.json
 priv/*
 .DS_STORE
 cache-*
@@ -46,3 +46,11 @@ mkdocs-site-manifest.csv
 !test/admissible-report-wallet.json
 !test/admissible-report.json
 !test/config.json
+
+__pycache__
+native/dev_sev_gpu/*.log
+
+.agents
+.claude
+.specify
+CLAUDE.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "editor.detectIndentation": false,
   "editor.insertSpaces": true,
   "editor.tabSize": 4,
-  "editor.rulers": [80]
+  "editor.rulers": [80],
+  "cmake.sourceDirectory": "/home/jax/apuslabs/HyperBEAM/native/dev_sev_gpu_nif"
 }

--- a/Makefile
+++ b/Makefile
@@ -131,3 +131,98 @@ update-hyperbuddy-ui:
 	echo "Downloading source code from Arweave..." && \
 	curl -sL "$(ARWEAVE_GATEWAY)/$$TX_ID" -o "$(HYPERBUDDY_UI_TARGET)" && \
 	echo "Successfully updated $(HYPERBUDDY_UI_TARGET)"
+
+DETERMINISTIC_INFERENCE_BRANCH = main
+DETERMINISTIC_INFERENCE_DIR = _build/deterministic-inference
+DETERMINISTIC_INFERENCE_REPO = https://github.com/apuslabs/deterministic-inference.git
+
+setup-python:
+	@if ! command -v python3 > /dev/null; then \
+		echo "Error: Python3 is not installed. Please install Python3 before continuing."; \
+		echo "For Ubuntu/Debian, you can install it with:"; \
+		echo "  sudo apt-get update && sudo apt-get install -y python3 python3-pip python3-venv"; \
+		exit 1; \
+	fi
+	@if ! command -v uv > /dev/null; then \
+		echo "Installing uv package manager..."; \
+		curl -LsSf https://astral.sh/uv/install.sh | sh; \
+	fi
+
+# Set up deterministic-inference environment
+setup-inference: setup-python $(DETERMINISTIC_INFERENCE_DIR)
+	@echo "Setting up deterministic-inference..."
+	@cd $(DETERMINISTIC_INFERENCE_DIR) && \
+		uv sync && \
+		echo "Installed deterministic-inference package with uv."
+
+$(DETERMINISTIC_INFERENCE_DIR):
+	@echo "Cloning deterministic-inference repository..." && \
+		git clone -b $(DETERMINISTIC_INFERENCE_BRANCH) $(DETERMINISTIC_INFERENCE_REPO) $(DETERMINISTIC_INFERENCE_DIR) --single-branch && \
+		echo "Extracted deterministic-inference to $(DETERMINISTIC_INFERENCE_DIR)"
+
+CC_DIR = native/dev_sev_gpu
+# NVAT SDK Configuration  
+NVAT_SDK_BRANCH = main
+NVAT_SDK_REPO = https://github.com/NVIDIA/attestation-sdk.git
+NVAT_SDK_DIR = _build/attestation-sdk
+NVAT_BUILD_DIR = $(NVAT_SDK_DIR)/nv-attestation-sdk-cpp/build
+DEV_SEV_GPU_NIF_DIR = _build/dev_sev_gpu_nif
+
+# Check NVAT dependencies
+check-nvat-deps:
+	@missing=""; \
+	if ! command -v cmake > /dev/null; then missing="$$missing cmake"; fi; \
+	if ! command -v clang > /dev/null; then missing="$$missing clang"; fi; \
+	if ! command -v cargo > /dev/null; then missing="$$missing cargo(rust)"; fi; \
+	if ! pkg-config --exists libcurl 2>/dev/null; then missing="$$missing libcurl4-openssl-dev"; fi; \
+	if ! pkg-config --exists openssl 2>/dev/null; then missing="$$missing libssl-dev"; fi; \
+	if ! pkg-config --exists libxml-2.0 2>/dev/null; then missing="$$missing libxml2-dev"; fi; \
+	if ! pkg-config --exists xmlsec1 2>/dev/null; then missing="$$missing libxmlsec1-dev"; fi; \
+	if ! pkg-config --exists spdlog 2>/dev/null; then missing="$$missing libspdlog-dev"; fi; \
+	if [ -n "$$missing" ]; then \
+		echo "Error: Missing dependencies for nvat SDK:$$missing"; \
+		echo ""; \
+		echo "For Ubuntu/Debian, you can install them with:"; \
+		echo "  sudo apt-get update && sudo apt-get install -y cmake clang pkg-config \\"; \
+		echo "    libcurl4-openssl-dev libssl-dev libxml2-dev \\"; \
+		echo "    libxmlsec1-dev libxmlsec1-openssl libspdlog-dev"; \
+		echo ""; \
+		echo "For Rust, install with:"; \
+		echo "  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"; \
+		exit 1; \
+	fi
+	@echo "All nvat dependencies are installed."
+
+# Clone attestation-sdk repository
+$(NVAT_SDK_DIR):
+	@echo "Cloning NVIDIA attestation-sdk repository..." && \
+	git clone -b $(NVAT_SDK_BRANCH) $(NVAT_SDK_REPO) $(NVAT_SDK_DIR) --single-branch && \
+	echo "Cloned attestation-sdk to $(NVAT_SDK_DIR)"
+
+# Build nvat library
+$(NVAT_BUILD_DIR)/libnvat.so: check-nvat-deps $(NVAT_SDK_DIR)
+	@echo "Building nvat SDK..." && \
+	cmake -S $(NVAT_SDK_DIR)/nv-attestation-sdk-cpp \
+		-B $(NVAT_BUILD_DIR) \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DBUILD_SHARED_LIBS=ON && \
+	cmake --build $(NVAT_BUILD_DIR) -j$$(nproc) && \
+	echo "Built nvat SDK successfully"
+
+# Build dev_sev_gpu NIF
+$(DEV_SEV_GPU_NIF_DIR)/dev_sev_gpu_nif.so: $(NVAT_BUILD_DIR)/libnvat.so
+	@echo "Building dev_sev_gpu NIF..." && \
+	cmake -S native/dev_sev_gpu_nif \
+		-B $(DEV_SEV_GPU_NIF_DIR) \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DNVAT_SDK_DIR=$(CURDIR)/$(NVAT_SDK_DIR)/nv-attestation-sdk-cpp \
+		-DNVAT_BUILD_DIR=$(CURDIR)/$(NVAT_BUILD_DIR) \
+		-DNVAT_DEBUG_LOG=OFF && \
+	cmake --build $(DEV_SEV_GPU_NIF_DIR) && \
+	mkdir -p priv && \
+	cp $(DEV_SEV_GPU_NIF_DIR)/dev_sev_gpu_nif.so priv/ && \
+	echo "Built dev_sev_gpu NIF successfully"
+
+# Set up dev_sev_gpu environment (now uses nvat C++ SDK)
+setup-cc: $(DEV_SEV_GPU_NIF_DIR)/dev_sev_gpu_nif.so
+	@echo "Installed dev_sev_gpu NIF successfully."

--- a/docs/dev_agent-testing.md
+++ b/docs/dev_agent-testing.md
@@ -1,0 +1,152 @@
+# dev_agent Testing Guide
+
+## Overview
+
+`dev_agent` is a ReAct (Reason-Act-Observe) agent device that calls an OpenAI-compatible LLM, parses tool calls, executes tools, and loops until a final answer is produced.
+
+This document covers all testing approaches, from quick unit tests to full end-to-end Lua integration.
+
+## Prerequisites
+
+- HyperBEAM compiled: `rebar3 compile`
+- An OpenAI-compatible API key (e.g., Novita AI)
+
+## 1. Unit Tests (Mock, No API Required)
+
+Run all 10 mock-based unit tests:
+
+```bash
+rebar3 eunit --module=dev_agent
+```
+
+These tests cover:
+- Single-turn (no tools), single/multiple tool calls, max iterations
+- Tool error handling, conversation history format, result truncation
+- Unknown tool handling, Lua ao.resolve-style config passing
+
+## 2. Lua Integration Tests (Real API)
+
+These tests run Lua code that calls `ao.resolve` to invoke `dev_agent`, exactly as an AOS Lua process would.
+
+### Run all Lua agent tests
+
+```bash
+LUA_TESTS="scripts/agent-test.lua" rebar3 as lua-test eunit --module=dev_lua_test
+```
+
+### Run a specific test
+
+```bash
+# Simple question (no tool call, ~2-3s)
+LUA_TESTS="scripts/agent-test.lua:agent_simple_test" \
+  rebar3 as lua-test eunit --module=dev_lua_test
+
+# Question requiring tool call (HTTP GET to httpbin.org, ~5-8s)
+LUA_TESTS="scripts/agent-test.lua:agent_resolve_test" \
+  rebar3 as lua-test eunit --module=dev_lua_test
+```
+
+### Write your own Lua test
+
+Create or edit `scripts/agent-test.lua`. Any function ending in `_test` is auto-discovered:
+
+```lua
+function my_custom_agent_test()
+    local status, res = ao.resolve({
+        path = "/~agent@1.0/run",
+        ["agent-user-prompt"] = "Your question here",
+        ["agent-model"] = "minimax/minimax-m2.7",
+        ["agent-api-peer"] = "https://api.novita.ai",
+        ["agent-api-path"] = "/openai/v1/chat/completions",
+        ["agent-api-key"] = "YOUR_API_KEY"
+    })
+    -- res["agent-answer"]      = LLM's final answer (string)
+    -- res["agent-iterations"]  = number of ReAct loop iterations
+    -- res["agent-error"]       = error info (only if failed)
+    return status, res
+end
+```
+
+## 3. HTTP Endpoint Test (Full Node)
+
+Start a HyperBEAM node and call the agent device directly via HTTP.
+
+### Start the node
+
+```bash
+./scripts/e2e-test.sh start
+# Wait for "HyperBEAM is ready!" message
+```
+
+### Call agent via curl
+
+```bash
+curl -s http://localhost:8734/~agent@1.0/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent-user-prompt": "Use the http_request tool to GET https://httpbin.org/get and tell me the origin IP.",
+    "agent-model": "minimax/minimax-m2.7",
+    "agent-api-peer": "https://api.novita.ai",
+    "agent-api-path": "/openai/v1/chat/completions",
+    "agent-api-key": "YOUR_API_KEY",
+    "agent-max-iterations": 5
+  }' | jq .
+```
+
+### Stop the node
+
+```bash
+./scripts/e2e-test.sh stop
+```
+
+## 4. Lua ao.resolve from an AOS Process (Production Pattern)
+
+In a real AOS Lua process, use `ao.resolve` inside a handler:
+
+```lua
+Handlers.add("Agent",
+  { Action = "Agent-Run" },
+  function(msg)
+    local status, res = ao.resolve({
+      path = "/~agent@1.0/run",
+      ["agent-user-prompt"] = msg.Data,
+      ["agent-model"] = "minimax/minimax-m2.7",
+      ["agent-api-peer"] = "https://api.novita.ai",
+      ["agent-api-path"] = "/openai/v1/chat/completions",
+      ["agent-api-key"] = "sk_..."
+    })
+    if status == "ok" then
+      ao.send({
+        Target = msg.From,
+        Data = res["agent-answer"]
+      })
+    else
+      ao.send({
+        Target = msg.From,
+        Data = "Agent error: " .. tostring(res)
+      })
+    end
+  end
+)
+```
+
+## Configuration Reference
+
+All configuration is passed as message fields (via Lua `ao.resolve` or HTTP body):
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `agent-user-prompt` | Yes | `"Hello"` | The user's question/instruction |
+| `agent-model` | No | `"gpt-4o-mini"` | Model ID for the LLM backend |
+| `agent-api-peer` | No | `"http://localhost:8080"` | Base URL of the API (host:port only) |
+| `agent-api-path` | No | `"/v1/chat/completions"` | API endpoint path |
+| `agent-api-key` | No | _(none)_ | Bearer token for Authorization header |
+| `agent-max-iterations` | No | `10` | Max ReAct loop iterations before force-stop |
+
+## Troubleshooting
+
+**404 from API**: Check that `agent-api-peer` contains only the host (e.g., `https://api.novita.ai`) and the full path is in `agent-api-path` (e.g., `/openai/v1/chat/completions`). The `peer` field is parsed by `gun` which only extracts host:port.
+
+**Timeout**: The agent may need 10-30 seconds for multi-turn tool calls. For EUnit tests, use generator functions with `{timeout, 120, fun() -> ... end}`.
+
+**Device sandbox**: When calling from Lua, ensure `agent@1.0` and `relay@1.0` are accessible. If the process has a `device-sandbox` setting, these devices must be included.

--- a/docs/devices/agent-at-1-0.md
+++ b/docs/devices/agent-at-1-0.md
@@ -1,0 +1,204 @@
+# Device: ~agent@1.0
+
+## Overview
+
+The [`~agent@1.0`](../resources/source-code/dev_agent.md) device implements a
+**ReAct** (Reason–Act–Observe) agent loop on top of any OpenAI-compatible LLM
+endpoint. It iteratively calls the LLM, executes tool calls, feeds results back
+to the model, and repeats until the model returns a plain-text final answer or a
+configurable iteration ceiling is hit.
+
+## Core Concept: Iterative Reason-Act-Observe Loop
+
+```
+ User Prompt
+      │
+      ▼
+┌──────────────┐    tool_calls     ┌───────────────────┐
+│     LLM      │──────────────────▶│  Tool Executor    │
+│(inference@   │◀──────────────────│  (built-in/custom)│
+│  1.0)        │   tool results    └───────────────────┘
+└──────┬───────┘
+       │ routes via relay@1.0
+       ▼
+  local Python              remote provider
+  inference server   OR     (OpenRouter, etc.)
+  localhost:8080            https://openrouter.ai
+```
+
+All LLM calls are routed through [`~inference@1.0`](../resources/source-code/dev_inference.md),
+which in turn uses [`~relay@1.0`](relay-at-1-0.md) to reach the backend. This
+means local Python inference servers and remote OpenAI-compatible providers are
+addressed identically from the agent's perspective — only the `agent-api-peer`
+Opts key differs.
+
+Each iteration either:
+
+1. Receives `tool_calls` → executes them → appends results to message history →
+   calls the LLM again; or
+2. Receives a plain-text reply → returns it as `agent-answer`.
+
+The entire conversation history is managed in-process via Erlang recursion;
+nothing is persisted across `run` invocations unless an external tool does so.
+
+## Key Functions (Keys)
+
+### `run`
+
+Start the ReAct loop.
+
+**Request fields:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `agent-user-prompt` | binary | `<<"Hello">>` | The initial user message |
+| `agent-model` | binary | `<<"gpt-4o-mini">>` | Model name passed to the LLM endpoint |
+| `agent-max-iterations` | integer | `10` | Maximum tool-call rounds before force-stopping |
+| `agent-api-peer` | binary | `<<"http://localhost:8080">>` | Base URL of the LLM API server |
+| `agent-api-path` | binary | `<<"/v1/chat/completions">>` | Chat completions path |
+| `agent-api-key` | binary | _(none)_ | Bearer token, added as `Authorization` header |
+| `agent-llm-fun` | function | `default_call_llm/2` | Override the LLM call function |
+| `agent-tool-fun` | function | `default_execute_tool/2` | Override the tool executor function |
+
+**Response fields added to the base message:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `agent-answer` | binary | Final text answer returned by the model |
+| `agent-iterations` | integer | Number of LLM calls made |
+| `agent-error` | binary | Set only on error or `max_iterations_exceeded` |
+
+**Example:**
+
+```erlang
+{ok, Result} = hb_ao:resolve(
+    #{<<"device">> => <<"agent@1.0">>},
+    #{<<"path">>             => <<"run">>,
+      <<"agent-user-prompt">> => <<"What is the current Arweave block height?">>,
+      <<"agent-model">>       => <<"openai/gpt-4o-mini">>,
+      <<"agent-api-peer">>    => <<"https://openrouter.ai">>,
+      <<"agent-api-path">>    => <<"/api/v1/chat/completions">>,
+      <<"agent-api-key">>     => <<"sk-or-v1-...">>},
+    #{}).
+```
+
+**HyperPATH:**
+
+```
+POST /~agent@1.0/run
+```
+
+with the fields above as message tags or body keys.
+
+## Built-in Tools
+
+The default tool executor dispatches on the `name` field of each LLM tool call.
+
+### `http_request`
+
+Make an HTTP request to any URL via [`~relay@1.0`](relay-at-1-0.md).
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `url` | ✓ | Full URL to request |
+| `method` | | `GET` (default), `POST`, `PUT`, `DELETE` |
+| `body` | | Request body for `POST`/`PUT` |
+| `content_type` | | `Content-Type` header (default `text/plain`) |
+
+### `lookup_data`
+
+Retrieve a message or binary value from the local node cache via
+[`~lookup@1.0`](../resources/source-code/dev_lookup.md).
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `id` | ✓ | Hash ID of the cached item |
+
+### `search_messages`
+
+Search the node's cache for messages matching a set of key-value pairs via
+[`~query@1.0`](../resources/source-code/dev_query.md).
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `match` | ✓ | JSON object of key-value pairs to match |
+| `return` | | `"paths"` (default), `"messages"`, or `"count"` |
+
+### `get_arweave_tx`
+
+Fetch an Arweave transaction header by its 43-character base64url ID via
+[`~arweave@2.9-pre`](../resources/source-code/dev_arweave.md).
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `id` | ✓ | Arweave transaction ID |
+
+### `bundle_item`
+
+Submit a data item to be bundled and uploaded to Arweave via
+[`~bundler@1.0`](../resources/source-code/dev_bundler.md).
+Returns `<<"Message queued.">>` on success.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `data` | ✓ | Data content to store |
+| `content_type` | | `Content-Type` of the data (default `text/plain`) |
+
+## Customising Tools
+
+Both the LLM function and the tool executor can be replaced at call time by
+passing Erlang fun references in `Opts`:
+
+```erlang
+MyToolFun = fun
+    (#{name := <<"my_tool">>, args := Args}, _Opts) ->
+        %% custom logic
+        <<"result">>;
+    (ToolInfo, Opts) ->
+        %% fall through to the default executor
+        dev_agent:default_execute_tool(ToolInfo, Opts)
+end,
+
+{ok, Result} = hb_ao:resolve(
+    #{<<"device">> => <<"agent@1.0">>},
+    #{<<"path">>             => <<"run">>,
+      <<"agent-user-prompt">> => <<"Do something custom">>},
+    #{<<"agent-tool-fun">> => MyToolFun,
+      <<"agent-api-peer">>  => <<"https://openrouter.ai">>,
+      <<"agent-api-path">>  => <<"/api/v1/chat/completions">>,
+      <<"agent-api-key">>   => <<"sk-or-v1-...">>}).
+```
+
+## Configuration via Request Message
+
+All `agent-*` fields are accepted both in `Opts` and in the `Req`/`Base`
+message. This allows Lua scripts using `ao.resolve` to pass configuration
+without modifying `Opts`:
+
+```lua
+local result = ao.resolve({
+    path              = "/~agent@1.0/run",
+    ["agent-user-prompt"] = "Summarise this process",
+    ["agent-api-peer"]    = "https://openrouter.ai",
+    ["agent-api-path"]    = "/api/v1/chat/completions",
+    ["agent-api-key"]     = MY_KEY
+})
+```
+
+## Error Handling
+
+*   If the LLM call fails, `agent-error` is set to the relay error reason and
+    `agent-answer` is set to `<<"Error calling LLM.">>`.
+*   If the response cannot be JSON-decoded, `agent-error` describes the parse
+    failure.
+*   If `agent-max-iterations` is exceeded, `agent-error` is set to
+    `<<"max_iterations_exceeded">>`.
+*   Tool errors are returned as plain-text results to the LLM, which can then
+    decide how to proceed.
+
+## Tool Result Truncation
+
+To avoid overflowing the LLM's context window, tool results exceeding 4000 bytes
+are silently truncated and suffixed with `"\n... [truncated]"`.
+
+[agent module](../resources/source-code/dev_agent.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
       - '~json@1.0': 'devices/json-at-1-0.md'
       - '~scheduler@1.0': 'devices/scheduler-at-1-0.md'
       - '~relay@1.0': 'devices/relay-at-1-0.md'
+      - '~agent@1.0': 'devices/agent-at-1-0.md'
   - Resources:
     # - Overview: 'resources/source-code/index.md'
     - FAQ: 'resources/reference/faq.md'

--- a/native/dev_sev_gpu_nif/CMakeLists.txt
+++ b/native/dev_sev_gpu_nif/CMakeLists.txt
@@ -1,0 +1,69 @@
+cmake_minimum_required(VERSION 3.11)
+project(dev_sev_gpu_nif VERSION 0.1.0 LANGUAGES CXX)
+
+# Debug logging option (default: OFF for quiet operation)
+option(NVAT_DEBUG_LOG "Enable verbose debug logging from nvat SDK" OFF)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Find Erlang NIF headers
+find_path(ERL_NIF_INCLUDE_DIR erl_nif.h
+    HINTS /usr/local/lib/erlang/usr/include
+          /usr/lib/erlang/usr/include
+          $ENV{ERL_TOP}/erts-*/include
+)
+
+if(NOT ERL_NIF_INCLUDE_DIR)
+    message(FATAL_ERROR "Could not find erl_nif.h. Make sure Erlang development headers are installed.")
+endif()
+
+# NVAT SDK paths (passed from Makefile)
+set(NVAT_SDK_DIR "" CACHE PATH "Path to nvat SDK source")
+set(NVAT_BUILD_DIR "" CACHE PATH "Path to nvat SDK build")
+
+if(NOT NVAT_SDK_DIR OR NOT NVAT_BUILD_DIR)
+    message(FATAL_ERROR "NVAT_SDK_DIR and NVAT_BUILD_DIR must be specified")
+endif()
+
+# Find nlohmann/json from nvat build (it's fetched by nvat's CMake)
+find_path(NLOHMANN_JSON_INCLUDE_DIR nlohmann/json.hpp
+    HINTS ${NVAT_BUILD_DIR}/_deps/json-src/include
+          ${NVAT_BUILD_DIR}/_deps/json-src/single_include
+)
+
+if(NOT NLOHMANN_JSON_INCLUDE_DIR)
+    message(FATAL_ERROR "Could not find nlohmann/json.hpp. Make sure nvat SDK was built first.")
+endif()
+
+add_library(dev_sev_gpu_nif SHARED
+    dev_sev_gpu_nif.cpp
+)
+
+target_include_directories(dev_sev_gpu_nif PRIVATE
+    ${ERL_NIF_INCLUDE_DIR}
+    ${NVAT_BUILD_DIR}/include
+    ${NLOHMANN_JSON_INCLUDE_DIR}
+)
+
+target_link_directories(dev_sev_gpu_nif PRIVATE
+    ${NVAT_BUILD_DIR}
+)
+
+target_link_libraries(dev_sev_gpu_nif PRIVATE
+    nvat
+)
+
+# Add debug log definition if enabled
+if(NVAT_DEBUG_LOG)
+    target_compile_definitions(dev_sev_gpu_nif PRIVATE NVAT_DEBUG_LOG)
+endif()
+
+# Set output properties to match Erlang NIF expectations
+set_target_properties(dev_sev_gpu_nif PROPERTIES
+    PREFIX ""
+    SUFFIX ".so"
+    # Set RPATH to find libnvat.so at runtime
+    INSTALL_RPATH "$ORIGIN/../lib"
+    BUILD_WITH_INSTALL_RPATH TRUE
+)

--- a/native/dev_sev_gpu_nif/dev_sev_gpu_nif.cpp
+++ b/native/dev_sev_gpu_nif/dev_sev_gpu_nif.cpp
@@ -1,0 +1,487 @@
+/*
+ * NVIDIA GPU TEE Attestation NIF for Erlang
+ * 
+ * This C++ NIF wraps the nvat (NVIDIA Attestation) SDK to provide
+ * GPU attestation evidence collection and verification for Erlang.
+ * 
+ * Flow mapping to official nvattest CLI:
+ * - generate/1 = collect-evidence + attest (with nonce)
+ * - verify/1   = attest (with evidence file + nonce from evidence)
+ */
+
+#include <cstring>
+#include <cstdlib>
+#include <string>
+#include <memory>
+#include <mutex>
+#include <fstream>
+#include <unistd.h>
+
+#include "erl_nif.h"
+#include "nvat.h"
+#include "nlohmann/json.hpp"
+
+using json = nlohmann::json;
+
+/* ============================================================================
+ * RAII Deleters for NVAT types (matching nvattest_types.h pattern)
+ * ============================================================================ */
+
+template<class T> struct NvatDeleter;
+
+template<> struct NvatDeleter<nvat_attestation_ctx_t> {
+    void operator()(nvat_attestation_ctx_t* ptr) const {
+        if (ptr) nvat_attestation_ctx_free(ptr);
+    }
+};
+
+template<> struct NvatDeleter<nvat_sdk_opts_t> {
+    void operator()(nvat_sdk_opts_t* ptr) const {
+        if (ptr) nvat_sdk_opts_free(ptr);
+    }
+};
+
+template<> struct NvatDeleter<nvat_gpu_evidence_source_t> {
+    void operator()(nvat_gpu_evidence_source_t* ptr) const {
+        if (ptr) nvat_gpu_evidence_source_free(ptr);
+    }
+};
+
+template<> struct NvatDeleter<nvat_nonce_t> {
+    void operator()(nvat_nonce_t* ptr) const {
+        if (ptr) nvat_nonce_free(ptr);
+    }
+};
+
+template<> struct NvatDeleter<nvat_str_t> {
+    void operator()(nvat_str_t* ptr) const {
+        if (ptr) nvat_str_free(ptr);
+    }
+};
+
+template<> struct NvatDeleter<nvat_claims_collection_t> {
+    void operator()(nvat_claims_collection_t* ptr) const {
+        if (ptr) nvat_claims_collection_free(ptr);
+    }
+};
+
+template<class T>
+using nvat_ptr = std::unique_ptr<T, NvatDeleter<T>>;
+
+/* GPU evidence array wrapper with RAII - non-copyable */
+class GpuEvidenceArray {
+public:
+    nvat_gpu_evidence_t* evidences = nullptr;
+    size_t num_evidences = 0;
+    
+    GpuEvidenceArray() = default;
+    ~GpuEvidenceArray() {
+        if (evidences) {
+            nvat_gpu_evidence_array_free(&evidences, num_evidences);
+        }
+    }
+    
+    // Non-copyable
+    GpuEvidenceArray(const GpuEvidenceArray&) = delete;
+    GpuEvidenceArray& operator=(const GpuEvidenceArray&) = delete;
+};
+
+/* ============================================================================
+ * SDK Lifecycle Management
+ * ============================================================================ */
+
+static std::mutex sdk_mutex;
+static bool sdk_initialized = false;
+
+static nvat_rc_t ensure_sdk_initialized() {
+    std::lock_guard<std::mutex> lock(sdk_mutex);
+    
+    if (!sdk_initialized) {
+        nvat_sdk_opts_t raw_opts = nullptr;
+        nvat_rc_t err = nvat_sdk_opts_create(&raw_opts);
+        if (err != NVAT_RC_OK) return err;
+        
+        nvat_ptr<nvat_sdk_opts_t> opts(&raw_opts);
+        
+        /* Create logger */
+        nvat_logger_t logger = nullptr;
+#ifdef NVAT_DEBUG_LOG
+        err = nvat_logger_spdlog_create(&logger, "dev_sev_gpu_nif", NVAT_LOG_LEVEL_DEBUG);
+#else
+        err = nvat_logger_spdlog_create(&logger, "dev_sev_gpu_nif", NVAT_LOG_LEVEL_ERROR);
+#endif
+        if (err == NVAT_RC_OK && logger) {
+            nvat_sdk_opts_set_logger(*opts.get(), logger);
+            nvat_logger_free(&logger);
+        }
+        
+        err = nvat_sdk_init(*opts.get());
+        if (err != NVAT_RC_OK) return err;
+        
+        sdk_initialized = true;
+    }
+    
+    return NVAT_RC_OK;
+}
+
+/* ============================================================================
+ * NIF Helper Functions
+ * ============================================================================ */
+
+static ERL_NIF_TERM make_atom(ErlNifEnv* env, const char* atom) {
+    ERL_NIF_TERM ret;
+    if (enif_make_existing_atom(env, atom, &ret, ERL_NIF_LATIN1)) {
+        return ret;
+    }
+    return enif_make_atom(env, atom);
+}
+
+static ERL_NIF_TERM make_binary(ErlNifEnv* env, const std::string& str) {
+    ERL_NIF_TERM bin;
+    unsigned char* buf = enif_make_new_binary(env, str.size(), &bin);
+    if (buf) {
+        memcpy(buf, str.data(), str.size());
+    }
+    return bin;
+}
+
+static ERL_NIF_TERM make_ok(ErlNifEnv* env, ERL_NIF_TERM result) {
+    return enif_make_tuple2(env, make_atom(env, "ok"), result);
+}
+
+static ERL_NIF_TERM make_error(ErlNifEnv* env, const std::string& reason) {
+    return enif_make_tuple2(env, make_atom(env, "error"), make_binary(env, reason));
+}
+
+/* ============================================================================
+ * collect_evidence_nif/1
+ * 
+ * Equivalent to: nvattest collect-evidence --device gpu --nonce <nonce>
+ *              + nvattest attest --device gpu --verifier local --nonce <nonce>
+ * 
+ * Input: Nonce (binary hex string)
+ * Output: {ok, JSON} | {error, Reason}
+ *         JSON contains: nonce, evidences, claims, eat, verified
+ * ============================================================================ */
+static ERL_NIF_TERM collect_evidence_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
+    nvat_rc_t err = ensure_sdk_initialized();
+    if (err != NVAT_RC_OK) {
+        return make_error(env, nvat_rc_to_string(err));
+    }
+    
+    /* Parse nonce argument */
+    ErlNifBinary nonce_bin;
+    if (!enif_inspect_binary(env, argv[0], &nonce_bin)) {
+        return make_error(env, "nonce must be a binary");
+    }
+    std::string nonce_str(reinterpret_cast<char*>(nonce_bin.data), nonce_bin.size);
+    
+    /* ========== Phase 1: collect-evidence ========== */
+    
+    /* Create nonce */
+    nvat_nonce_t raw_nonce = nullptr;
+    err = nvat_nonce_from_hex(&raw_nonce, nonce_str.c_str());
+    if (err != NVAT_RC_OK) {
+        return make_error(env, nvat_rc_to_string(err));
+    }
+    nvat_ptr<nvat_nonce_t> nonce(&raw_nonce);
+    
+    /* Create NVML evidence source */
+    nvat_gpu_evidence_source_t raw_source = nullptr;
+    err = nvat_gpu_evidence_source_nvml_create(&raw_source);
+    if (err != NVAT_RC_OK) {
+        return make_error(env, nvat_rc_to_string(err));
+    }
+    nvat_ptr<nvat_gpu_evidence_source_t> source(&raw_source);
+    
+    /* Collect evidence */
+    GpuEvidenceArray evidence;
+    err = nvat_gpu_evidence_collect(*source.get(), *nonce.get(), 
+                                    &evidence.evidences, &evidence.num_evidences);
+    if (err != NVAT_RC_OK) {
+        return make_error(env, nvat_rc_to_string(err));
+    }
+    
+    /* Serialize evidence to JSON */
+    nvat_str_t raw_serialized = nullptr;
+    err = nvat_gpu_evidence_serialize_json(evidence.evidences, evidence.num_evidences, &raw_serialized);
+    if (err != NVAT_RC_OK) {
+        return make_error(env, nvat_rc_to_string(err));
+    }
+    nvat_ptr<nvat_str_t> serialized(&raw_serialized);
+    
+    char* evidence_data = nullptr;
+    err = nvat_str_get_data(*serialized.get(), &evidence_data);
+    if (err != NVAT_RC_OK) {
+        return make_error(env, nvat_rc_to_string(err));
+    }
+    
+    /* ========== Phase 2: attest (local verification) ========== */
+    
+    /* Create attestation context */
+    nvat_attestation_ctx_t raw_ctx = nullptr;
+    err = nvat_attestation_ctx_create(&raw_ctx);
+    if (err != NVAT_RC_OK) {
+        return make_error(env, nvat_rc_to_string(err));
+    }
+    nvat_ptr<nvat_attestation_ctx_t> ctx(&raw_ctx);
+    
+    /* Set device type to GPU */
+    err = nvat_attestation_ctx_set_device_type(*ctx.get(), NVAT_DEVICE_GPU);
+    if (err != NVAT_RC_OK) {
+        return make_error(env, nvat_rc_to_string(err));
+    }
+    
+    /* Create and set evidence policy (ownership transfers to context) */
+    nvat_evidence_policy_t raw_policy = nullptr;
+    err = nvat_evidence_policy_create_default(&raw_policy);
+    if (err != NVAT_RC_OK) {
+        return make_error(env, nvat_rc_to_string(err));
+    }
+    err = nvat_attestation_ctx_set_evidence_policy(*ctx.get(), &raw_policy);
+    if (err != NVAT_RC_OK) {
+        nvat_evidence_policy_free(&raw_policy);
+        return make_error(env, nvat_rc_to_string(err));
+    }
+    // Note: raw_policy ownership is transferred to ctx, do not free
+    
+    /* Set local verifier */
+    err = nvat_attestation_ctx_set_verifier_type(*ctx.get(), NVAT_VERIFY_LOCAL);
+    if (err != NVAT_RC_OK) {
+        return make_error(env, nvat_rc_to_string(err));
+    }
+    
+    /* Perform attestation */
+    nvat_str_t raw_eat = nullptr;
+    nvat_claims_collection_t raw_claims = nullptr;
+    err = nvat_attest_device(*ctx.get(), *nonce.get(), &raw_eat, &raw_claims);
+    
+    bool verified = (err == NVAT_RC_OK);
+    nvat_ptr<nvat_str_t> eat(&raw_eat);
+    nvat_ptr<nvat_claims_collection_t> claims(&raw_claims);
+    
+    /* Serialize claims */
+    std::string claims_json = "{}";
+    if (raw_claims) {
+        nvat_str_t raw_claims_str = nullptr;
+        if (nvat_claims_collection_serialize_json(raw_claims, &raw_claims_str) == NVAT_RC_OK) {
+            char* claims_data = nullptr;
+            if (nvat_str_get_data(raw_claims_str, &claims_data) == NVAT_RC_OK && claims_data) {
+                claims_json = claims_data;
+            }
+            nvat_str_free(&raw_claims_str);
+        }
+    }
+    
+    /* Get EAT data */
+    std::string eat_json = "{}";
+    if (raw_eat) {
+        char* eat_data = nullptr;
+        if (nvat_str_get_data(raw_eat, &eat_data) == NVAT_RC_OK && eat_data) {
+            eat_json = eat_data;
+        }
+    }
+    
+    /* Build result JSON */
+    json result;
+    result["verified"] = verified;
+    
+    try {
+        result["evidences"] = json::parse(evidence_data);
+    } catch (...) {
+        result["evidences"] = json::object();
+    }
+    
+    try {
+        result["claims"] = json::parse(claims_json);
+    } catch (...) {
+        result["claims"] = json::object();
+    }
+    
+    try {
+        result["eat"] = json::parse(eat_json);
+    } catch (...) {
+        result["eat"] = json::object();
+    }
+    
+    return make_ok(env, make_binary(env, result.dump()));
+}
+
+/* ============================================================================
+ * verify_evidence_nif/1
+ * 
+ * Equivalent to: nvattest attest --device gpu --verifier local 
+ *                --gpu-evidence <evidence_file> --nonce <nonce_from_evidence>
+ * 
+ * The evidence JSON already contains the nonce used during collection.
+ * Input: Evidence JSON (binary)
+ * Output: {ok, JSON} | {error, Reason}
+ *         JSON contains: verified, claims, eat
+ * ============================================================================ */
+static ERL_NIF_TERM verify_evidence_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
+    nvat_rc_t err = ensure_sdk_initialized();
+    if (err != NVAT_RC_OK) {
+        return make_error(env, nvat_rc_to_string(err));
+    }
+    
+    /* Parse evidence JSON argument */
+    ErlNifBinary evidence_bin;
+    if (!enif_inspect_binary(env, argv[0], &evidence_bin)) {
+        return make_error(env, "evidence must be a binary");
+    }
+    std::string evidence_str(reinterpret_cast<char*>(evidence_bin.data), evidence_bin.size);
+    
+    /* Extract nonce from evidence JSON */
+    std::string nonce_str;
+    try {
+        json evidence_json = json::parse(evidence_str);
+        if (evidence_json.contains("nonce") && evidence_json["nonce"].is_string()) {
+            nonce_str = evidence_json["nonce"].get<std::string>();
+        }
+    } catch (...) {
+        return make_error(env, "failed to parse evidence JSON");
+    }
+    
+    if (nonce_str.empty()) {
+        return make_error(env, "nonce not found in evidence JSON");
+    }
+    
+    /* Write evidence to temporary file (nvat requires file path for --gpu-evidence) */
+    char temp_path[] = "/tmp/nvat_evidence_XXXXXX.json";
+    int fd = mkstemps(temp_path, 5);
+    if (fd < 0) {
+        return make_error(env, "failed to create temp file");
+    }
+    ssize_t written = write(fd, evidence_bin.data, evidence_bin.size);
+    close(fd);
+    if (written != static_cast<ssize_t>(evidence_bin.size)) {
+        unlink(temp_path);
+        return make_error(env, "failed to write temp file");
+    }
+    
+    /* ========== attest with evidence file ========== */
+    
+    /* Create attestation context */
+    nvat_attestation_ctx_t raw_ctx = nullptr;
+    err = nvat_attestation_ctx_create(&raw_ctx);
+    if (err != NVAT_RC_OK) {
+        unlink(temp_path);
+        return make_error(env, nvat_rc_to_string(err));
+    }
+    nvat_ptr<nvat_attestation_ctx_t> ctx(&raw_ctx);
+    
+    /* Set device type to GPU */
+    err = nvat_attestation_ctx_set_device_type(*ctx.get(), NVAT_DEVICE_GPU);
+    if (err != NVAT_RC_OK) {
+        unlink(temp_path);
+        return make_error(env, nvat_rc_to_string(err));
+    }
+    
+    /* Set evidence source from JSON file (equivalent to --gpu-evidence option) */
+    err = nvat_attestation_ctx_set_gpu_evidence_source_json_file(*ctx.get(), temp_path);
+    unlink(temp_path);  /* Remove temp file immediately after reading */
+    if (err != NVAT_RC_OK) {
+        return make_error(env, nvat_rc_to_string(err));
+    }
+    
+    /* Create and set evidence policy (ownership transfers to context) */
+    nvat_evidence_policy_t raw_policy = nullptr;
+    err = nvat_evidence_policy_create_default(&raw_policy);
+    if (err != NVAT_RC_OK) {
+        return make_error(env, nvat_rc_to_string(err));
+    }
+    err = nvat_attestation_ctx_set_evidence_policy(*ctx.get(), &raw_policy);
+    if (err != NVAT_RC_OK) {
+        nvat_evidence_policy_free(&raw_policy);
+        return make_error(env, nvat_rc_to_string(err));
+    }
+    // Note: raw_policy ownership is transferred to ctx
+    
+    /* Set local verifier */
+    err = nvat_attestation_ctx_set_verifier_type(*ctx.get(), NVAT_VERIFY_LOCAL);
+    if (err != NVAT_RC_OK) {
+        return make_error(env, nvat_rc_to_string(err));
+    }
+    
+    /* Parse nonce from evidence */
+    nvat_nonce_t raw_nonce = nullptr;
+    err = nvat_nonce_from_hex(&raw_nonce, nonce_str.c_str());
+    if (err != NVAT_RC_OK) {
+        return make_error(env, "failed to parse nonce from evidence");
+    }
+    nvat_ptr<nvat_nonce_t> nonce(&raw_nonce);
+    
+    /* Perform attestation verification */
+    nvat_str_t raw_eat = nullptr;
+    nvat_claims_collection_t raw_claims = nullptr;
+    err = nvat_attest_device(*ctx.get(), *nonce.get(), &raw_eat, &raw_claims);
+    
+    bool verified = (err == NVAT_RC_OK);
+    nvat_ptr<nvat_str_t> eat(&raw_eat);
+    nvat_ptr<nvat_claims_collection_t> claims(&raw_claims);
+    
+    /* Serialize claims */
+    std::string claims_json = "{}";
+    if (raw_claims) {
+        nvat_str_t raw_claims_str = nullptr;
+        if (nvat_claims_collection_serialize_json(raw_claims, &raw_claims_str) == NVAT_RC_OK) {
+            char* claims_data = nullptr;
+            if (nvat_str_get_data(raw_claims_str, &claims_data) == NVAT_RC_OK && claims_data) {
+                claims_json = claims_data;
+            }
+            nvat_str_free(&raw_claims_str);
+        }
+    }
+    
+    /* Get EAT data */
+    std::string eat_json = "{}";
+    if (raw_eat) {
+        char* eat_data = nullptr;
+        if (nvat_str_get_data(raw_eat, &eat_data) == NVAT_RC_OK && eat_data) {
+            eat_json = eat_data;
+        }
+    }
+    
+    /* Build result JSON */
+    json result;
+    result["verified"] = verified;
+    
+    try {
+        result["claims"] = json::parse(claims_json);
+    } catch (...) {
+        result["claims"] = json::object();
+    }
+    
+    try {
+        result["eat"] = json::parse(eat_json);
+    } catch (...) {
+        result["eat"] = json::object();
+    }
+    
+    return make_ok(env, make_binary(env, result.dump()));
+}
+
+/* ============================================================================
+ * NIF Registration
+ * ============================================================================ */
+
+static ErlNifFunc nif_funcs[] = {
+    {"collect_evidence_nif", 1, collect_evidence_nif, ERL_NIF_DIRTY_JOB_IO_BOUND},
+    {"verify_evidence_nif", 1, verify_evidence_nif, ERL_NIF_DIRTY_JOB_IO_BOUND}
+};
+
+static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info) {
+    return 0;
+}
+
+static void unload(ErlNifEnv* env, void* priv_data) {
+    std::lock_guard<std::mutex> lock(sdk_mutex);
+    if (sdk_initialized) {
+        nvat_sdk_shutdown();
+        sdk_initialized = false;
+    }
+}
+
+extern "C" {
+    ERL_NIF_INIT(dev_sev_gpu, nif_funcs, load, NULL, NULL, unload)
+}

--- a/rebar.config
+++ b/rebar.config
@@ -45,6 +45,34 @@
             {sys_config, "config/app.config"}
         ]}
     ]},
+    {inference, [
+        {erl_opts, [{d, 'ENABLE_INFERENCE', true}]},
+        {pre_hooks, [
+            {compile, "make -C \"${REBAR_ROOT_DIR}\" setup-inference"},
+            {compile, "make -C \"${REBAR_ROOT_DIR}\" setup-cc"}
+        ]},
+        {relx, [
+            {overlay, [
+                {copy,
+                    "_build/deterministic-inference",
+                    "deterministic-inference"
+                },
+                {copy,
+                    "priv/dev_sev_gpu_nif.so",
+                    "bin/priv/dev_sev_gpu_nif.so"
+                },
+                {copy,
+                    "_build/attestation-sdk/nv-attestation-sdk-cpp/build/libnvat.so.0",
+                    "bin/lib/libnvat.so.0"
+                }
+            ]}
+        ]}
+    ]},
+    {dev_sev_gpu, [
+        {pre_hooks, [
+            {compile, "make -C \"${REBAR_ROOT_DIR}\" setup-cc"}
+        ]}
+    ]},
     {rocksdb, [
         {deps, [{rocksdb, "1.8.0"}]},
         {erl_opts, [

--- a/scripts/agent-test.lua
+++ b/scripts/agent-test.lua
@@ -1,0 +1,44 @@
+--- @module agent-test
+--- Tests for dev_agent called via ao.resolve (simulating Lua process usage).
+
+--- @function agent_resolve_test
+--- Call dev_agent via ao.resolve with real Novita AI API.
+--- The agent should use the http_request tool to fetch data and return a result.
+function agent_resolve_test()
+    local status, res = ao.resolve({
+        path = "/~agent@1.0/run",
+        ["agent-user-prompt"] = "Use the http_request tool to GET https://httpbin.org/get and tell me what the origin IP address is.",
+        ["agent-model"] = "minimax/minimax-m2.7",
+        ["agent-api-peer"] = "https://api.novita.ai",
+        ["agent-api-path"] = "/openai/v1/chat/completions",
+        ["agent-api-key"] = "sk_VkH3T72Z7LsiDvc5oRvcCtuPciFNwKShHLOgs3LqGVI",
+        ["agent-max-iterations"] = 5
+    })
+    -- Log the result for debugging
+    ao.event("agent_test", {
+        status = status,
+        answer = res["agent-answer"],
+        iterations = res["agent-iterations"]
+    })
+    return status, res
+end
+
+--- @function agent_simple_test
+--- Call dev_agent with a simple question (no tool call needed).
+function agent_simple_test()
+    local status, res = ao.resolve({
+        path = "/~agent@1.0/run",
+        ["agent-user-prompt"] = "What is 2+2? Answer with just the number.",
+        ["agent-model"] = "minimax/minimax-m2.7",
+        ["agent-api-peer"] = "https://api.novita.ai",
+        ["agent-api-path"] = "/openai/v1/chat/completions",
+        ["agent-api-key"] = "sk_VkH3T72Z7LsiDvc5oRvcCtuPciFNwKShHLOgs3LqGVI",
+        ["agent-max-iterations"] = 3
+    })
+    ao.event("agent_simple_test", {
+        status = status,
+        answer = res["agent-answer"],
+        iterations = res["agent-iterations"]
+    })
+    return status, res
+end

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+# E2E Test Script for HyperBEAM
+# This script starts HyperBEAM in background mode and tests connectivity
+# Works in non-interactive environments like Claude Code
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+LOG_FILE="/tmp/hyperbeam-e2e.log"
+PID_FILE="/tmp/hyperbeam-e2e.pid"
+PORT="${HB_PORT:-8734}"
+PROFILE="${HB_PROFILE:-default}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log() {
+    echo -e "${GREEN}[E2E]${NC} $1"
+}
+
+warn() {
+    echo -e "${YELLOW}[E2E]${NC} $1"
+}
+
+error() {
+    echo -e "${RED}[E2E]${NC} $1"
+}
+
+cleanup() {
+    log "Cleaning up..."
+    if [ -f "$PID_FILE" ]; then
+        PID=$(cat "$PID_FILE")
+        if kill -0 "$PID" 2>/dev/null; then
+            kill "$PID" 2>/dev/null || true
+            sleep 2
+            kill -9 "$PID" 2>/dev/null || true
+        fi
+        rm -f "$PID_FILE"
+    fi
+    # Also kill any stray beam processes from this script
+    pkill -f "beam.smp.*start_mainnet" 2>/dev/null || true
+}
+
+start_hyperbeam() {
+    log "Starting HyperBEAM (profile: $PROFILE, port: $PORT)..."
+
+    cd "$PROJECT_DIR"
+
+    # Compile first
+    log "Compiling..."
+    if [ "$PROFILE" = "default" ]; then
+        rebar3 compile > /dev/null 2>&1
+    else
+        rebar3 as "$PROFILE" compile > /dev/null 2>&1
+    fi
+
+    # Build ebin paths
+    EBINS=""
+    if [ "$PROFILE" != "default" ]; then
+        for dir in $(find "_build/${PROFILE}/lib" -name ebin -type d 2>/dev/null); do
+            EBINS="$EBINS -pa $dir"
+        done
+    fi
+    for dir in $(find _build/default/lib -name ebin -type d 2>/dev/null); do
+        EBINS="$EBINS -pa $dir"
+    done
+
+    # Start HyperBEAM in background
+    erl $EBINS \
+        -noinput \
+        -s hb start_mainnet \
+        > "$LOG_FILE" 2>&1 &
+
+    echo $! > "$PID_FILE"
+    log "Started with PID $(cat $PID_FILE)"
+}
+
+wait_for_ready() {
+    log "Waiting for HyperBEAM to be ready..."
+    local max_attempts=30
+    local attempt=1
+
+    # Give erlang time to start up
+    sleep 5
+
+    while [ $attempt -le $max_attempts ]; do
+        # Check if the process is still running
+        if [ -f "$PID_FILE" ]; then
+            PID=$(cat "$PID_FILE")
+            if ! kill -0 "$PID" 2>/dev/null; then
+                error "HyperBEAM process died"
+                error "Log output:"
+                cat "$LOG_FILE" | tail -100
+                return 1
+            fi
+        fi
+
+        # Try to connect - use -f to fail silently on HTTP errors, check for any response
+        local http_code
+        http_code=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:${PORT}/~meta@1.0/info" 2>/dev/null || echo "000")
+
+        if [ "$http_code" = "200" ]; then
+            log "HyperBEAM is ready! (HTTP $http_code)"
+            return 0
+        fi
+
+        sleep 1
+        attempt=$((attempt + 1))
+    done
+
+    error "HyperBEAM failed to start within ${max_attempts} seconds"
+    error "Log output:"
+    cat "$LOG_FILE" | tail -100
+    return 1
+}
+
+test_endpoint() {
+    log "Testing /~meta@1.0/info endpoint..."
+    local response
+    response=$(curl -s -w "\n%{http_code}" "http://localhost:${PORT}/~meta@1.0/info")
+    local http_code=$(echo "$response" | tail -n1)
+
+    if [ "$http_code" = "200" ]; then
+        log "Endpoint test passed (HTTP 200)"
+        return 0
+    else
+        error "Endpoint test failed (HTTP $http_code)"
+        return 1
+    fi
+}
+
+test_aos() {
+    if ! command -v aos &> /dev/null; then
+        warn "aos CLI not found, skipping aos test"
+        return 0
+    fi
+
+    log "Testing aos connection (this may take a moment)..."
+    # Run aos with a timeout - it will try to connect and may fail if process doesn't exist
+    # but we're just checking if the connection is attempted
+    timeout 30 aos --url "http://localhost:${PORT}" 2>&1 | head -20 || true
+    log "aos connection test completed"
+}
+
+show_logs() {
+    log "HyperBEAM logs:"
+    echo "----------------------------------------"
+    tail -50 "$LOG_FILE" 2>/dev/null || echo "No logs available"
+    echo "----------------------------------------"
+}
+
+usage() {
+    echo "Usage: $0 [command]"
+    echo ""
+    echo "Commands:"
+    echo "  start     Start HyperBEAM in background"
+    echo "  stop      Stop HyperBEAM"
+    echo "  test      Run connectivity tests"
+    echo "  logs      Show HyperBEAM logs"
+    echo "  full      Start, test, and keep running (default)"
+    echo "  cleanup   Stop and cleanup"
+    echo ""
+    echo "Environment variables:"
+    echo "  HB_PORT     Port to use (default: 8734)"
+    echo "  HB_PROFILE  Build profile (default: default, options: inference, rocksdb)"
+}
+
+case "${1:-full}" in
+    start)
+        cleanup
+        start_hyperbeam
+        wait_for_ready
+        ;;
+    stop|cleanup)
+        cleanup
+        log "Stopped"
+        ;;
+    test)
+        test_endpoint
+        test_aos
+        ;;
+    logs)
+        show_logs
+        ;;
+    full)
+        trap cleanup EXIT
+        cleanup
+        start_hyperbeam
+        if wait_for_ready; then
+            test_endpoint
+            log "HyperBEAM is running at http://localhost:${PORT}"
+            log "To connect with aos: aos --url http://localhost:${PORT}"
+            log "Press Ctrl+C to stop"
+            # Keep running and show logs
+            tail -f "$LOG_FILE"
+        else
+            exit 1
+        fi
+        ;;
+    -h|--help|help)
+        usage
+        ;;
+    *)
+        error "Unknown command: $1"
+        usage
+        exit 1
+        ;;
+esac

--- a/src/dev_agent.erl
+++ b/src/dev_agent.erl
@@ -1,0 +1,881 @@
+%%% @doc A ReAct agent device that implements an iterative Reason-Act-Observe
+%%% loop. The agent calls an LLM (via relay to an OpenAI-compatible endpoint),
+%%% parses tool_calls from the response, executes tools, and loops until the
+%%% LLM returns a final text answer or max iterations are reached.
+%%%
+%%% Architecture:
+%%%   dev_agent (standalone device)
+%%%     ├── Calls LLM via inference@1.0 (OpenAI-compatible, local or remote)
+%%%     │     └── inference@1.0 relays via relay@1.0 to the configured peer
+%%%     ├── Parses OpenAI tool_calls format
+%%%     ├── Executes built-in tools (http_request, lookup_data, …)
+%%%     └── Manages conversation history internally (Erlang recursion)
+%%%
+%%% Usage:
+%%%   {ok, Result} = hb_ao:resolve(
+%%%     #{<<"device">> => <<"agent@1.0">>},
+%%%     #{<<"path">> => <<"run">>,
+%%%       <<"agent-user-prompt">> => <<"What is the weather?">>},
+%%%     #{}).
+-module(dev_agent).
+-export([info/1, run/3]).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(DEFAULT_MAX_ITERATIONS, 10).
+-define(DEFAULT_MODEL, <<"gpt-4o-mini">>).
+-define(MAX_TOOL_RESULT_SIZE, 4000).
+
+%%%===================================================================
+%%% Device API
+%%%===================================================================
+
+info(_Msg) ->
+    #{
+        exports => [<<"run">>]
+    }.
+
+%% @doc Entry point for the agent. Reads user prompt from the request,
+%% builds initial messages, and starts the ReAct loop.
+run(Base, Req, Opts) ->
+    UserPrompt = hb_ao:get(<<"agent-user-prompt">>, Req, <<"Hello">>, Opts),
+    SystemPrompt = default_system_prompt(),
+    Tools = default_tools(),
+    Model = hb_ao:get(<<"agent-model">>, Req, ?DEFAULT_MODEL, Opts),
+    MaxIter = hb_ao:get(<<"agent-max-iterations">>, Req, ?DEFAULT_MAX_ITERATIONS, Opts),
+    %% Merge agent API config from Req/Base into Opts so that
+    %% Lua ao.resolve calls can pass config via message fields.
+    MergedOpts = merge_agent_config(Req, merge_agent_config(Base, Opts)),
+    LLMFun = maps:get(<<"agent-llm-fun">>, MergedOpts, fun default_call_llm/2),
+    ToolFun = maps:get(<<"agent-tool-fun">>, MergedOpts, fun default_execute_tool/2),
+    Messages = [
+        #{<<"role">> => <<"system">>, <<"content">> => SystemPrompt},
+        #{<<"role">> => <<"user">>, <<"content">> => UserPrompt}
+    ],
+    AgentOpts = #{
+        model => Model,
+        tools => Tools,
+        max_iterations => MaxIter,
+        llm_fun => LLMFun,
+        tool_fun => ToolFun,
+        opts => MergedOpts
+    },
+    loop(Messages, 1, AgentOpts, Base).
+
+%%%===================================================================
+%%% ReAct Loop
+%%%===================================================================
+
+%% @doc The main ReAct loop. Calls LLM, checks for tool_calls or final answer.
+loop(Messages, Iteration, #{max_iterations := MaxIter} = AgentOpts, Base)
+  when Iteration > MaxIter ->
+    ?event(agent, {max_iterations_reached, Iteration}),
+    {ok, Base#{
+        <<"agent-answer">> =>
+            <<"Max iterations reached. Could not complete the task.">>,
+        <<"agent-error">> => <<"max_iterations_exceeded">>,
+        <<"agent-iterations">> => Iteration - 1
+    }};
+loop(Messages, Iteration, AgentOpts, Base) ->
+    #{model := Model, tools := Tools, llm_fun := LLMFun,
+      tool_fun := ToolFun, opts := Opts} = AgentOpts,
+    RequestBody = build_request_body(Messages, Tools, Model),
+    case LLMFun(RequestBody, Opts) of
+        {ok, ResponseBody} ->
+            case parse_response(ResponseBody) of
+                {tool_calls, AssistantMsg, ToolCalls} ->
+                    ?event(agent, {tool_calls, Iteration, length(ToolCalls)}),
+                    ToolResultMsgs = execute_tool_calls(ToolCalls, ToolFun, Opts),
+                    NewMessages = Messages ++ [AssistantMsg | ToolResultMsgs],
+                    loop(NewMessages, Iteration + 1, AgentOpts, Base);
+                {final_answer, Content} ->
+                    ?event(agent, {final_answer, Iteration}),
+                    {ok, Base#{
+                        <<"agent-answer">> => Content,
+                        <<"agent-iterations">> => Iteration
+                    }};
+                {error, ParseError} ->
+                    {ok, Base#{
+                        <<"agent-answer">> => <<"Error parsing LLM response.">>,
+                        <<"agent-error">> => ParseError,
+                        <<"agent-iterations">> => Iteration
+                    }}
+            end;
+        {error, LLMError} ->
+            {ok, Base#{
+                <<"agent-answer">> => <<"Error calling LLM.">>,
+                <<"agent-error">> => LLMError,
+                <<"agent-iterations">> => Iteration
+            }}
+    end.
+
+%%%===================================================================
+%%% LLM Interaction
+%%%===================================================================
+
+%% @doc Build the OpenAI-compatible request body.
+build_request_body(Messages, Tools, Model) ->
+    hb_json:encode(#{
+        <<"model">> => Model,
+        <<"messages">> => Messages,
+        <<"tools">> => Tools,
+        <<"tool_choice">> => <<"auto">>
+    }).
+
+%% @doc Default LLM call via inference@1.0.
+%% inference@1.0 relays to any OpenAI-compatible provider via relay@1.0,
+%% making local and remote LLM backends interchangeable from the agent's
+%% perspective. Supported Opts keys (consumed by inference@1.0/relay@1.0):
+%%   agent-api-peer: Base URL           (default: "http://localhost:8080")
+%%   agent-api-path: Completions path   (default: "/v1/chat/completions")
+%%   agent-api-key:  Bearer token       (optional)
+default_call_llm(RequestBody, Opts) ->
+    case hb_ao:resolve(
+        #{<<"device">>    => <<"inference@1.0">>,
+          <<"chat-mode">> => true},
+        #{<<"path">> => <<"completions">>,
+          <<"body">> => RequestBody},
+        Opts#{hashpath => ignore,
+              cache_control => [<<"no-store">>, <<"no-cache">>]}
+    ) of
+        {ok, Res} ->
+            {ok, hb_ao:get(<<"body">>, Res, <<>>, Opts)};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% @doc Parse an OpenAI chat completion response.
+%% Returns {tool_calls, AssistantMsg, ToolCalls} | {final_answer, Content} | {error, Reason}.
+parse_response(ResponseBody) when is_binary(ResponseBody) ->
+    try
+        Decoded = hb_json:decode(ResponseBody),
+        parse_response(Decoded)
+    catch
+        _:_ -> {error, <<"Failed to decode JSON response">>}
+    end;
+parse_response(Response) when is_map(Response) ->
+    Choices = maps:get(<<"choices">>, Response, []),
+    case Choices of
+        [FirstChoice | _] ->
+            Message = maps:get(<<"message">>, FirstChoice, #{}),
+            parse_assistant_message(Message);
+        [] ->
+            {error, <<"No choices in response">>}
+    end.
+
+%% @doc Parse the assistant message for tool_calls or final answer.
+parse_assistant_message(Message) ->
+    ToolCalls = maps:get(<<"tool_calls">>, Message, null),
+    Content = maps:get(<<"content">>, Message, null),
+    case ToolCalls of
+        null -> {final_answer, content_to_binary(Content)};
+        [] -> {final_answer, content_to_binary(Content)};
+        Calls when is_list(Calls) ->
+            %% Build assistant message to include in history
+            AssistantMsg = #{
+                <<"role">> => <<"assistant">>,
+                <<"content">> => Content,
+                <<"tool_calls">> => Calls
+            },
+            {tool_calls, AssistantMsg, Calls}
+    end.
+
+content_to_binary(null) -> <<>>;
+content_to_binary(B) when is_binary(B) -> B;
+content_to_binary(Other) -> hb_util:bin(Other).
+
+%%%===================================================================
+%%% Tool Execution
+%%%===================================================================
+
+%% @doc Execute a list of tool calls, returning tool result messages.
+execute_tool_calls(ToolCalls, ToolFun, Opts) ->
+    lists:map(
+        fun(ToolCall) ->
+            ToolCallId = maps:get(<<"id">>, ToolCall, <<>>),
+            Function = maps:get(<<"function">>, ToolCall, #{}),
+            FuncName = maps:get(<<"name">>, Function, <<>>),
+            ArgsJson = maps:get(<<"arguments">>, Function, <<"{}">>),
+            Args = try hb_json:decode(ArgsJson) catch _:_ -> #{} end,
+            Result = ToolFun(#{name => FuncName, args => Args}, Opts),
+            #{
+                <<"role">> => <<"tool">>,
+                <<"tool_call_id">> => ToolCallId,
+                <<"content">> => truncate_result(Result)
+            }
+        end,
+        ToolCalls
+    ).
+
+%% @doc Default tool executor. Dispatches by function name.
+default_execute_tool(#{name := <<"http_request">>, args := Args}, Opts) ->
+    execute_http_request(Args, Opts);
+default_execute_tool(#{name := <<"lookup_data">>, args := Args}, Opts) ->
+    execute_lookup(Args, Opts);
+default_execute_tool(#{name := <<"search_messages">>, args := Args}, Opts) ->
+    execute_search(Args, Opts);
+default_execute_tool(#{name := <<"get_arweave_tx">>, args := Args}, Opts) ->
+    execute_get_arweave_tx(Args, Opts);
+default_execute_tool(#{name := <<"bundle_item">>, args := Args}, Opts) ->
+    execute_bundle_item(Args, Opts);
+default_execute_tool(#{name := Name}, _Opts) ->
+    <<"Unknown tool: ", Name/binary>>.
+
+%% @doc Execute an HTTP request via relay@1.0.
+execute_http_request(Args, Opts) ->
+    Method = maps:get(<<"method">>, Args, <<"GET">>),
+    Url = maps:get(<<"url">>, Args, <<>>),
+    Body = maps:get(<<"body">>, Args, <<>>),
+    ContentType = maps:get(<<"content_type">>, Args, <<"text/plain">>),
+    case hb_ao:resolve(
+        #{<<"device">> => <<"relay@1.0">>,
+          <<"content-type">> => ContentType},
+        #{<<"path">> => <<"call">>,
+          <<"target">> => <<"payload">>,
+          <<"payload">> => #{
+              <<"path">> => Url,
+              <<"method">> => Method,
+              <<"body">> => Body,
+              <<"content-type">> => ContentType
+          }},
+        Opts#{hashpath => ignore,
+              cache_control => [<<"no-store">>, <<"no-cache">>]}
+    ) of
+        {ok, Res} ->
+            hb_ao:get(<<"body">>, Res, <<"No body">>, Opts);
+        {error, Reason} ->
+            iolist_to_binary(io_lib:format("HTTP request failed: ~p", [Reason]))
+    end.
+
+%% @doc Look up an item from the local cache by ID via lookup@1.0.
+execute_lookup(Args, Opts) ->
+    ID = maps:get(<<"id">>, Args, <<>>),
+    case hb_ao:resolve(
+        #{<<"device">> => <<"lookup@1.0">>},
+        #{<<"path">> => <<"read">>, <<"target">> => ID},
+        Opts#{hashpath => ignore}
+    ) of
+        {ok, Res} when is_map(Res) -> hb_json:encode(Res);
+        {ok, Res} when is_binary(Res) -> Res;
+        {ok, Res} -> hb_util:bin(Res);
+        {error, not_found} -> <<"Not found: ", ID/binary>>;
+        {error, Reason} ->
+            iolist_to_binary(io_lib:format("Lookup failed: ~p", [Reason]))
+    end.
+
+%% @doc Search the node cache for messages matching a key-value spec via query@1.0.
+execute_search(Args, Opts) ->
+    MatchSpec = maps:get(<<"match">>, Args, #{}),
+    ReturnType = maps:get(<<"return">>, Args, <<"paths">>),
+    %% Merge match keys into the request so query@1.0's `all' path picks them up.
+    Req = maps:merge(MatchSpec, #{<<"path">> => <<"all">>, <<"return">> => ReturnType}),
+    case hb_ao:resolve(
+        #{<<"device">> => <<"query@1.0">>},
+        Req,
+        Opts#{hashpath => ignore}
+    ) of
+        {ok, Results} -> hb_json:encode(Results);
+        {error, Reason} ->
+            iolist_to_binary(io_lib:format("Search failed: ~p", [Reason]))
+    end.
+
+%% @doc Fetch an Arweave transaction by TXID via arweave@2.9-pre.
+execute_get_arweave_tx(Args, Opts) ->
+    TXID = maps:get(<<"id">>, Args, <<>>),
+    case hb_ao:resolve(
+        #{<<"device">> => <<"arweave@2.9-pre">>},
+        #{<<"path">> => <<"tx">>, <<"tx">> => TXID},
+        Opts#{hashpath => ignore}
+    ) of
+        {ok, Res} when is_map(Res) -> hb_json:encode(Res);
+        {ok, Res} when is_binary(Res) -> Res;
+        {ok, Res} -> hb_util:bin(Res);
+        {error, not_found} -> <<"Transaction not found: ", TXID/binary>>;
+        {error, Reason} ->
+            iolist_to_binary(io_lib:format("Arweave TX fetch failed: ~p", [Reason]))
+    end.
+
+%% @doc Submit a data item to Arweave via the node's bundler@1.0.
+execute_bundle_item(Args, Opts) ->
+    Data = maps:get(<<"data">>, Args, <<>>),
+    ContentType = maps:get(<<"content_type">>, Args, <<"text/plain">>),
+    case hb_ao:resolve(
+        #{<<"device">> => <<"bundler@1.0">>},
+        #{<<"path">> => <<"item">>,
+          <<"data">> => Data,
+          <<"content-type">> => ContentType},
+        Opts#{hashpath => ignore}
+    ) of
+        {ok, Res} when is_binary(Res) -> Res;
+        {ok, Res} -> hb_util:bin(Res);
+        {error, Reason} ->
+            iolist_to_binary(io_lib:format("Bundle failed: ~p", [Reason]))
+    end.
+
+%% @doc Truncate tool results to avoid exceeding LLM context limits.
+truncate_result(Result) when is_binary(Result),
+                             byte_size(Result) > ?MAX_TOOL_RESULT_SIZE ->
+    <<Truncated:?MAX_TOOL_RESULT_SIZE/binary, _/binary>> = Result,
+    <<Truncated/binary, "\n... [truncated]">>;
+truncate_result(Result) when is_binary(Result) ->
+    Result;
+truncate_result(Result) ->
+    truncate_result(iolist_to_binary(io_lib:format("~p", [Result]))).
+
+%%%===================================================================
+%%% Configuration Helpers
+%%%===================================================================
+
+%% @doc Merge agent API config from a Source message into Opts.
+%% Keys already present in Opts are not overwritten.
+%% This allows Lua ao.resolve calls to pass config via Req/Base.
+merge_agent_config(Source, Opts) ->
+    Keys = [<<"agent-api-peer">>, <<"agent-api-path">>, <<"agent-api-key">>],
+    lists:foldl(fun(Key, Acc) ->
+        case maps:is_key(Key, Acc) of
+            true -> Acc;
+            false ->
+                case hb_ao:get(Key, Source, not_found, Opts#{hashpath => ignore}) of
+                    not_found -> Acc;
+                    Val -> Acc#{Key => Val}
+                end
+        end
+    end, Opts, Keys).
+
+%%%===================================================================
+%%% Default Configuration (hardcoded for MVP)
+%%%===================================================================
+
+default_system_prompt() ->
+    <<"You are a helpful AI assistant running on the AO network. "
+      "You have the following tools available:\n"
+      "- http_request: Make HTTP requests to any URL.\n"
+      "- lookup_data: Retrieve a cached message or data item by its ID.\n"
+      "- search_messages: Search the node cache for messages matching key-value criteria.\n"
+      "- get_arweave_tx: Fetch an Arweave transaction by its transaction ID.\n"
+      "- bundle_item: Submit data to be bundled and uploaded to Arweave.\n"
+      "When you have enough information to answer the user's question, "
+      "respond with a text message (do not call any tools). "
+      "Keep responses concise.">>.
+
+default_tools() ->
+    [tool_def(http_request), tool_def(lookup_data),
+     tool_def(search_messages), tool_def(get_arweave_tx),
+     tool_def(bundle_item)].
+
+tool_def(http_request) ->
+    #{
+        <<"type">> => <<"function">>,
+        <<"function">> => #{
+            <<"name">> => <<"http_request">>,
+            <<"description">> => <<"Make an HTTP request to a URL.">>,
+            <<"parameters">> => #{
+                <<"type">> => <<"object">>,
+                <<"properties">> => #{
+                    <<"url">> => #{
+                        <<"type">> => <<"string">>,
+                        <<"description">> => <<"The URL to request.">>
+                    },
+                    <<"method">> => #{
+                        <<"type">> => <<"string">>,
+                        <<"enum">> => [<<"GET">>, <<"POST">>, <<"PUT">>, <<"DELETE">>],
+                        <<"description">> => <<"HTTP method. Defaults to GET.">>
+                    },
+                    <<"body">> => #{
+                        <<"type">> => <<"string">>,
+                        <<"description">> => <<"Request body (for POST/PUT).">>
+                    },
+                    <<"content_type">> => #{
+                        <<"type">> => <<"string">>,
+                        <<"description">> =>
+                            <<"Content-Type header. Defaults to text/plain.">>
+                    }
+                },
+                <<"required">> => [<<"url">>]
+            }
+        }
+    };
+tool_def(lookup_data) ->
+    #{
+        <<"type">> => <<"function">>,
+        <<"function">> => #{
+            <<"name">> => <<"lookup_data">>,
+            <<"description">> =>
+                <<"Retrieve a message or data item from the node's local cache by its ID.">>,
+            <<"parameters">> => #{
+                <<"type">> => <<"object">>,
+                <<"properties">> => #{
+                    <<"id">> => #{
+                        <<"type">> => <<"string">>,
+                        <<"description">> => <<"The hash ID of the item to retrieve.">>
+                    }
+                },
+                <<"required">> => [<<"id">>]
+            }
+        }
+    };
+tool_def(search_messages) ->
+    #{
+        <<"type">> => <<"function">>,
+        <<"function">> => #{
+            <<"name">> => <<"search_messages">>,
+            <<"description">> =>
+                <<"Search the node's cache for messages matching key-value criteria.">>,
+            <<"parameters">> => #{
+                <<"type">> => <<"object">>,
+                <<"properties">> => #{
+                    <<"match">> => #{
+                        <<"type">> => <<"object">>,
+                        <<"description">> =>
+                            <<"JSON object of key-value pairs to match against cached messages.">>
+                    },
+                    <<"return">> => #{
+                        <<"type">> => <<"string">>,
+                        <<"enum">> => [<<"paths">>, <<"messages">>, <<"count">>],
+                        <<"description">> =>
+                            <<"What to return: paths (default), full messages, or count.">>
+                    }
+                },
+                <<"required">> => [<<"match">>]
+            }
+        }
+    };
+tool_def(get_arweave_tx) ->
+    #{
+        <<"type">> => <<"function">>,
+        <<"function">> => #{
+            <<"name">> => <<"get_arweave_tx">>,
+            <<"description">> =>
+                <<"Fetch an Arweave transaction header by its 43-character base64url transaction ID.">>,
+            <<"parameters">> => #{
+                <<"type">> => <<"object">>,
+                <<"properties">> => #{
+                    <<"id">> => #{
+                        <<"type">> => <<"string">>,
+                        <<"description">> => <<"The Arweave transaction ID.">>
+                    }
+                },
+                <<"required">> => [<<"id">>]
+            }
+        }
+    };
+tool_def(bundle_item) ->
+    #{
+        <<"type">> => <<"function">>,
+        <<"function">> => #{
+            <<"name">> => <<"bundle_item">>,
+            <<"description">> =>
+                <<"Submit a data item to be bundled and uploaded to Arweave.">>,
+            <<"parameters">> => #{
+                <<"type">> => <<"object">>,
+                <<"properties">> => #{
+                    <<"data">> => #{
+                        <<"type">> => <<"string">>,
+                        <<"description">> => <<"The data content to store on Arweave.">>
+                    },
+                    <<"content_type">> => #{
+                        <<"type">> => <<"string">>,
+                        <<"description">> =>
+                            <<"Content-Type of the data. Defaults to text/plain.">>
+                    }
+                },
+                <<"required">> => [<<"data">>]
+            }
+        }
+    }.
+
+%%%===================================================================
+%%% Tests
+%%%===================================================================
+
+%% Helper: create a mock LLM function that returns a sequence of responses.
+mock_llm_sequence(Responses) ->
+    Counter = atomics:new(1, [{signed, false}]),
+    fun(_RequestBody, _Opts) ->
+        Idx = atomics:add_get(Counter, 1, 1),
+        case Idx =< length(Responses) of
+            true -> lists:nth(Idx, Responses);
+            false -> {error, <<"No more mock responses">>}
+        end
+    end.
+
+%% Helper: build a mock OpenAI response with a text answer (no tool_calls).
+mock_text_response(Content) ->
+    {ok, hb_json:encode(#{
+        <<"choices">> => [#{
+            <<"message">> => #{
+                <<"role">> => <<"assistant">>,
+                <<"content">> => Content
+            }
+        }]
+    })}.
+
+%% Helper: build a mock OpenAI response with tool_calls.
+mock_tool_call_response(ToolCalls) ->
+    {ok, hb_json:encode(#{
+        <<"choices">> => [#{
+            <<"message">> => #{
+                <<"role">> => <<"assistant">>,
+                <<"content">> => null,
+                <<"tool_calls">> => ToolCalls
+            }
+        }]
+    })}.
+
+%% Helper: build a single tool_call structure.
+make_tool_call(Id, FuncName, ArgsMap) ->
+    #{
+        <<"id">> => Id,
+        <<"type">> => <<"function">>,
+        <<"function">> => #{
+            <<"name">> => FuncName,
+            <<"arguments">> => hb_json:encode(ArgsMap)
+        }
+    }.
+
+%% Helper: a mock tool function that records calls and returns a fixed result.
+mock_tool_fun(Result) ->
+    fun(_ToolInfo, _Opts) -> Result end.
+
+%% Helper: a mock tool function that records calls.
+mock_tool_fun_with_tracker(Result) ->
+    Tracker = ets:new(tool_calls_tracker, [bag, public]),
+    Fun = fun(ToolInfo, _Opts) ->
+        ets:insert(Tracker, {call, ToolInfo}),
+        Result
+    end,
+    {Fun, Tracker}.
+
+%% @doc LLM directly returns text answer, no tool calls.
+single_turn_no_tools_test() ->
+    LLMFun = mock_llm_sequence([
+        mock_text_response(<<"Hello! How can I help you?">>)
+    ]),
+    ToolFun = mock_tool_fun(<<"should not be called">>),
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Hi there">>},
+    Opts = #{
+        <<"agent-llm-fun">> => LLMFun,
+        <<"agent-tool-fun">> => ToolFun
+    },
+    {ok, Result} = run(Base, Req, Opts),
+    ?assertEqual(<<"Hello! How can I help you?">>,
+                 maps:get(<<"agent-answer">>, Result)),
+    ?assertEqual(1, maps:get(<<"agent-iterations">>, Result)).
+
+%% @doc LLM calls a tool, then returns final answer.
+single_tool_call_test() ->
+    ToolCall = make_tool_call(
+        <<"call_1">>,
+        <<"http_request">>,
+        #{<<"url">> => <<"https://example.com/api">>}
+    ),
+    LLMFun = mock_llm_sequence([
+        mock_tool_call_response([ToolCall]),
+        mock_text_response(<<"The result is 42.">>)
+    ]),
+    ToolFun = mock_tool_fun(<<"{\"value\": 42}">>),
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Get the value">>},
+    Opts = #{
+        <<"agent-llm-fun">> => LLMFun,
+        <<"agent-tool-fun">> => ToolFun
+    },
+    {ok, Result} = run(Base, Req, Opts),
+    ?assertEqual(<<"The result is 42.">>,
+                 maps:get(<<"agent-answer">>, Result)),
+    ?assertEqual(2, maps:get(<<"agent-iterations">>, Result)).
+
+%% @doc LLM returns multiple tool calls in a single response.
+multiple_tool_calls_test() ->
+    ToolCall1 = make_tool_call(
+        <<"call_1">>, <<"http_request">>,
+        #{<<"url">> => <<"https://api.example.com/a">>}
+    ),
+    ToolCall2 = make_tool_call(
+        <<"call_2">>, <<"http_request">>,
+        #{<<"url">> => <<"https://api.example.com/b">>}
+    ),
+    LLMFun = mock_llm_sequence([
+        mock_tool_call_response([ToolCall1, ToolCall2]),
+        mock_text_response(<<"Combined result.">>)
+    ]),
+    {ToolFun, Tracker} = mock_tool_fun_with_tracker(<<"ok">>),
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Fetch both">>},
+    Opts = #{
+        <<"agent-llm-fun">> => LLMFun,
+        <<"agent-tool-fun">> => ToolFun
+    },
+    {ok, Result} = run(Base, Req, Opts),
+    ?assertEqual(<<"Combined result.">>,
+                 maps:get(<<"agent-answer">>, Result)),
+    %% Verify both tools were called
+    Calls = ets:lookup(Tracker, call),
+    ?assertEqual(2, length(Calls)),
+    ets:delete(Tracker).
+
+%% @doc Max iterations reached, agent force-stops.
+max_iterations_test() ->
+    %% LLM always returns tool_calls, never a final answer
+    ToolCall = make_tool_call(
+        <<"call_loop">>, <<"http_request">>,
+        #{<<"url">> => <<"https://example.com">>}
+    ),
+    AlwaysToolCall = fun(_Body, _Opts) ->
+        mock_tool_call_response([ToolCall])
+    end,
+    ToolFun = mock_tool_fun(<<"result">>),
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Loop forever">>,
+            <<"agent-max-iterations">> => 3},
+    Opts = #{
+        <<"agent-llm-fun">> => AlwaysToolCall,
+        <<"agent-tool-fun">> => ToolFun
+    },
+    {ok, Result} = run(Base, Req, Opts),
+    ?assertEqual(<<"max_iterations_exceeded">>,
+                 maps:get(<<"agent-error">>, Result)),
+    ?assertEqual(3, maps:get(<<"agent-iterations">>, Result)).
+
+%% @doc Tool execution returns an error, which is passed back to LLM.
+tool_error_handling_test() ->
+    ToolCall = make_tool_call(
+        <<"call_err">>, <<"http_request">>,
+        #{<<"url">> => <<"https://fail.example.com">>}
+    ),
+    LLMFun = mock_llm_sequence([
+        mock_tool_call_response([ToolCall]),
+        mock_text_response(<<"Sorry, the request failed.">>)
+    ]),
+    ToolFun = mock_tool_fun(<<"HTTP request failed: timeout">>),
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Try failing URL">>},
+    Opts = #{
+        <<"agent-llm-fun">> => LLMFun,
+        <<"agent-tool-fun">> => ToolFun
+    },
+    {ok, Result} = run(Base, Req, Opts),
+    %% Agent should still complete despite tool error
+    ?assertEqual(<<"Sorry, the request failed.">>,
+                 maps:get(<<"agent-answer">>, Result)),
+    ?assertEqual(2, maps:get(<<"agent-iterations">>, Result)).
+
+%% @doc Verify conversation history is in correct OpenAI format.
+message_history_test() ->
+    ToolCall = make_tool_call(
+        <<"call_hist">>, <<"http_request">>,
+        #{<<"url">> => <<"https://example.com">>}
+    ),
+    %% Track what messages the LLM receives on 2nd call
+    MessageTracker = ets:new(msg_tracker, [set, public]),
+    LLMFun = fun(RequestBody, _Opts) ->
+        Decoded = hb_json:decode(RequestBody),
+        Messages = maps:get(<<"messages">>, Decoded, []),
+        ets:insert(MessageTracker, {length(Messages), Messages}),
+        case length(Messages) of
+            2 -> %% First call: [system, user]
+                mock_tool_call_response([ToolCall]);
+            _ -> %% Second call: should have full history
+                mock_text_response(<<"Done.">>)
+        end
+    end,
+    ToolFun = mock_tool_fun(<<"tool output">>),
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Test history">>},
+    Opts = #{
+        <<"agent-llm-fun">> => LLMFun,
+        <<"agent-tool-fun">> => ToolFun
+    },
+    {ok, _Result} = run(Base, Req, Opts),
+    %% Check 2nd call had correct history:
+    %% [system, user, assistant(tool_calls), tool(result)] = 4 messages
+    [{4, SecondCallMessages}] = ets:lookup(MessageTracker, 4),
+    %% Verify message roles in order
+    Roles = [maps:get(<<"role">>, M) || M <- SecondCallMessages],
+    ?assertEqual([<<"system">>, <<"user">>, <<"assistant">>, <<"tool">>], Roles),
+    %% Verify the tool message has the correct tool_call_id
+    ToolMsg = lists:last(SecondCallMessages),
+    ?assertEqual(<<"call_hist">>, maps:get(<<"tool_call_id">>, ToolMsg)),
+    ?assertEqual(<<"tool output">>, maps:get(<<"content">>, ToolMsg)),
+    ets:delete(MessageTracker).
+
+%% @doc truncate_result/1 correctly truncates long binaries.
+truncate_result_test() ->
+    Short = <<"short">>,
+    ?assertEqual(Short, truncate_result(Short)),
+    Long = binary:copy(<<"x">>, 5000),
+    Truncated = truncate_result(Long),
+    ?assert(byte_size(Truncated) < 5000),
+    ?assert(binary:match(Truncated, <<"[truncated]">>) =/= nomatch).
+
+%% @doc Unknown tool name returns a descriptive error binary.
+unknown_tool_test() ->
+    ToolCall = make_tool_call(
+        <<"call_unk">>, <<"unknown_func">>,
+        #{<<"arg">> => <<"val">>}
+    ),
+    LLMFun = mock_llm_sequence([
+        mock_tool_call_response([ToolCall]),
+        mock_text_response(<<"I don't know that tool.">>)
+    ]),
+    %% Use default_execute_tool which handles unknown tools
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Use unknown tool">>},
+    Opts = #{
+        <<"agent-llm-fun">> => LLMFun,
+        <<"agent-tool-fun">> => fun default_execute_tool/2
+    },
+    {ok, Result} = run(Base, Req, Opts),
+    ?assertEqual(<<"I don't know that tool.">>,
+                 maps:get(<<"agent-answer">>, Result)).
+
+%% @doc Test: Lua ao.resolve style call — config in Req, not Opts.
+%% Simulates: ao.resolve({path="/~agent@1.0/run", ["agent-api-peer"]=..., ...})
+lua_resolve_style_test() ->
+    LLMFun = mock_llm_sequence([
+        mock_text_response(<<"Paris">>)
+    ]),
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{
+        <<"path">> => <<"run">>,
+        <<"agent-user-prompt">> => <<"Capital of France?">>,
+        <<"agent-model">> => <<"test-model">>,
+        <<"agent-api-peer">> => <<"https://api.example.com">>,
+        <<"agent-api-path">> => <<"/v1/chat/completions">>,
+        <<"agent-api-key">> => <<"sk_test_key">>
+    },
+    Opts = #{
+        <<"agent-llm-fun">> => LLMFun,
+        <<"agent-tool-fun">> => fun default_execute_tool/2
+    },
+    {ok, Result} = run(Base, Req, Opts),
+    ?assertEqual(<<"Paris">>, maps:get(<<"agent-answer">>, Result)),
+    ?assertEqual(1, maps:get(<<"agent-iterations">>, Result)).
+
+%% @doc lookup_data tool call is routed with correct args.
+lookup_data_tool_test() ->
+    ToolCall = make_tool_call(<<"c_lookup">>, <<"lookup_data">>,
+                              #{<<"id">> => <<"deadbeef123">>}),
+    LLMFun = mock_llm_sequence([
+        mock_tool_call_response([ToolCall]),
+        mock_text_response(<<"Found the item.">>)
+    ]),
+    ToolFun = fun(#{name := <<"lookup_data">>, args := Args}, _Opts) ->
+        ?assertEqual(<<"deadbeef123">>, maps:get(<<"id">>, Args)),
+        <<"mock cached data">>
+    end,
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Look up the item">>},
+    Opts = #{<<"agent-llm-fun">> => LLMFun, <<"agent-tool-fun">> => ToolFun},
+    {ok, Result} = run(Base, Req, Opts),
+    ?assertEqual(<<"Found the item.">>, maps:get(<<"agent-answer">>, Result)),
+    ?assertEqual(2, maps:get(<<"agent-iterations">>, Result)).
+
+%% @doc search_messages tool call is routed with correct args.
+search_messages_tool_test() ->
+    ToolCall = make_tool_call(<<"c_search">>, <<"search_messages">>,
+                              #{<<"match">> => #{<<"type">> => <<"Process">>},
+                                <<"return">> => <<"paths">>}),
+    LLMFun = mock_llm_sequence([
+        mock_tool_call_response([ToolCall]),
+        mock_text_response(<<"Found 2 processes.">>)
+    ]),
+    ToolFun = fun(#{name := <<"search_messages">>, args := Args}, _Opts) ->
+        Match = maps:get(<<"match">>, Args),
+        ?assertEqual(<<"Process">>, maps:get(<<"type">>, Match)),
+        ?assertEqual(<<"paths">>, maps:get(<<"return">>, Args)),
+        <<"[\"/path/a\",\"/path/b\"]">>
+    end,
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Find all processes">>},
+    Opts = #{<<"agent-llm-fun">> => LLMFun, <<"agent-tool-fun">> => ToolFun},
+    {ok, Result} = run(Base, Req, Opts),
+    ?assertEqual(<<"Found 2 processes.">>, maps:get(<<"agent-answer">>, Result)).
+
+%% @doc get_arweave_tx tool call is routed with correct args.
+get_arweave_tx_tool_test() ->
+    TXID = <<"43characterbase64urlTXIDxxxxxxxxxxxxxxxx123">>,
+    ToolCall = make_tool_call(<<"c_tx">>, <<"get_arweave_tx">>,
+                              #{<<"id">> => TXID}),
+    LLMFun = mock_llm_sequence([
+        mock_tool_call_response([ToolCall]),
+        mock_text_response(<<"Transaction found.">>)
+    ]),
+    ToolFun = fun(#{name := <<"get_arweave_tx">>, args := Args}, _Opts) ->
+        ?assertEqual(TXID, maps:get(<<"id">>, Args)),
+        <<"{\"id\":\"", TXID/binary, "\"}">>
+    end,
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Get the Arweave TX">>},
+    Opts = #{<<"agent-llm-fun">> => LLMFun, <<"agent-tool-fun">> => ToolFun},
+    {ok, Result} = run(Base, Req, Opts),
+    ?assertEqual(<<"Transaction found.">>, maps:get(<<"agent-answer">>, Result)).
+
+%% @doc bundle_item tool call is routed with correct args.
+bundle_item_tool_test() ->
+    Data = <<"Hello Arweave">>,
+    ToolCall = make_tool_call(<<"c_bundle">>, <<"bundle_item">>,
+                              #{<<"data">> => Data,
+                                <<"content_type">> => <<"text/plain">>}),
+    LLMFun = mock_llm_sequence([
+        mock_tool_call_response([ToolCall]),
+        mock_text_response(<<"Data submitted to Arweave.">>)
+    ]),
+    ToolFun = fun(#{name := <<"bundle_item">>, args := Args}, _Opts) ->
+        ?assertEqual(Data, maps:get(<<"data">>, Args)),
+        ?assertEqual(<<"text/plain">>, maps:get(<<"content_type">>, Args)),
+        <<"Message queued.">>
+    end,
+    Base = #{<<"device">> => <<"agent@1.0">>},
+    Req = #{<<"path">> => <<"run">>,
+            <<"agent-user-prompt">> => <<"Store this to Arweave">>},
+    Opts = #{<<"agent-llm-fun">> => LLMFun, <<"agent-tool-fun">> => ToolFun},
+    {ok, Result} = run(Base, Req, Opts),
+    ?assertEqual(<<"Data submitted to Arweave.">>, maps:get(<<"agent-answer">>, Result)).
+
+%% @doc Integration test: real LLM API call via OpenRouter with tool use.
+%% Requires a valid OPENROUTER_API_KEY environment variable or direct substitution.
+%% Run with: rebar3 eunit --module=dev_agent --test=integration_real_api_test
+integration_real_api_test_() ->
+    {timeout, 120, fun() ->
+        application:ensure_all_started(gun),
+        ApiKey = list_to_binary(
+            os:getenv("OPENROUTER_API_KEY", "sk-or-v1-YOUR_KEY_HERE")),
+        Base = #{<<"device">> => <<"agent@1.0">>},
+        Req = #{
+            <<"path">> => <<"run">>,
+            <<"agent-user-prompt">> =>
+                <<"Use the http_request tool to GET https://httpbin.org/get "
+                  "and tell me what the 'origin' IP address is from the response.">>,
+            <<"agent-model">> => <<"openai/gpt-4o-mini">>,
+            <<"agent-max-iterations">> => 5
+        },
+        Opts = #{
+            <<"agent-api-peer">> => <<"https://openrouter.ai">>,
+            <<"agent-api-path">> => <<"/api/v1/chat/completions">>,
+            <<"agent-api-key">> => ApiKey,
+            protocol => http2
+        },
+        {ok, Result} = run(Base, Req, Opts),
+        Answer = maps:get(<<"agent-answer">>, Result),
+        Iterations = maps:get(<<"agent-iterations">>, Result),
+        ?debugFmt("~n=== Integration Test Result ===~n"
+                  "Answer: ~s~nIterations: ~p~nFull result: ~p~n",
+                  [Answer, Iterations, Result]),
+        %% Should have completed in more than 1 iteration (tool was called)
+        ?assert(Iterations >= 2),
+        %% Answer should contain meaningful content (not an error)
+        ?assert(byte_size(Answer) > 10),
+        ?assertNot(maps:is_key(<<"agent-error">>, Result))
+    end}.

--- a/src/dev_codec_http_auth.erl
+++ b/src/dev_codec_http_auth.erl
@@ -95,6 +95,11 @@ generate(_Msg, Req, Opts) ->
                 true -> {ok, Decoded};
                 false -> derive_key(Decoded, Req, Opts)
             end;
+        <<"Bearer ", Token/binary>> ->
+            case hb_maps:get(<<"raw">>, Req, false, Opts) of
+                true -> {ok, Token};
+                false -> {ok, Token}
+            end;
         undefined ->
             {error,
                 #{

--- a/src/dev_inference.erl
+++ b/src/dev_inference.erl
@@ -1,0 +1,305 @@
+%%% @doc Inference device with OpenAI-compatible API.
+%%% This module provides an interface to a local Python-based inference server.
+-module(dev_inference).
+-export([info/1, completions/3, chat/3, models/3, health/3, v1/3, stop/0]).
+-include_lib("eunit/include/eunit.hrl").
+-include("include/hb.hrl").
+
+-define(SERVER_PORT, "8080").
+
+%% Device API
+
+%% @doc Return information about the device.
+info(_Opts) ->
+    #{
+        exports => [<<"completions">>, <<"chat">>, <<"models">>, <<"health">>, <<"v1">>],
+        description => <<"Inference device with OpenAI-compatible API">>,
+        version => <<"1.0">>
+    }.
+
+%% @doc Stop the inference server process.
+stop() ->
+    case whereis(inference_server) of
+        undefined -> ok;
+        Pid -> 
+            Pid ! stop,
+            unregister(inference_server),
+            ok
+    end.
+
+%% @doc Handle completion requests.
+completions(Base, Req, Opts) ->
+    Path = case hb_ao:get(<<"chat-mode">>, Base, false, Opts) of
+        true -> <<"/v1/chat/completions">>;
+        false -> <<"/v1/completions">>
+    end,
+    do_inference_request(Base, Req, Opts, Path).
+
+%% @doc Handle chat completion requests.
+chat(Base, Req, Opts) ->
+    {ok, hb_util:deep_merge(
+        Base, 
+        Req#{
+            <<"device">> => <<"inference@1.0">>,
+            <<"chat-mode">> => true
+        }, 
+        Opts
+    )}.
+
+%% @doc Handle models request.
+models(_Base, _Req, _Opts) ->
+    Body = <<"{\"object\":\"list\",\"data\":[{\"id\":\"google/gemma-3-27b-it\",\"object\":\"model\",\"created\":1766123915,\"owned_by\":\"sglang\",\"root\":\"google/gemma-3-27b-it\",\"max_model_len\":16384}]}">>,
+    {ok, #{
+        <<"status">> => 200,
+        <<"content-type">> => <<"application/json">>,
+        <<"body">> => Body
+    }}.
+
+%% @doc Handle v1 API requests.
+v1(Base, Req, Opts) ->
+    {ok, hb_util:deep_merge(
+        Base, 
+        Req#{
+            <<"device">> => <<"inference@1.0">>
+        }, 
+        Opts
+    )}.
+
+%% @doc Check the health of the inference server.
+health(_Base, _Req, Opts) ->
+    forward_health_check(Opts).
+
+
+%% Internal functions
+
+forward_health_check(Opts) ->
+    Peer = iolist_to_binary(["http://localhost:", ?SERVER_PORT]),
+    
+    case hb_http_client:request(
+        #{
+            method => <<"GET">>,
+            peer => Peer,
+            path => <<"/health">>,
+            headers => #{},
+            body => <<>>
+        },
+        Opts
+    ) of
+        {ok, Status, _Headers, Body} when Status >= 200 andalso Status < 300 ->
+            {ok, #{
+                <<"status">> => <<"healthy">>,
+                <<"body">> => Body,
+                <<"timestamp">> => os:system_time(millisecond)
+            }};
+        {ok, Status, _Headers, Body} ->
+            {error, #{
+                <<"status">> => Status,
+                <<"message">> => <<"Backend unhealthy">>,
+                <<"body">> => Body
+            }};
+        {error, Details} ->
+            {error, #{
+                <<"status">> => 503,
+                <<"message">> => hb_util:bin(Details)
+            }}
+    end.
+
+do_inference_request(_Base, Req, Opts, Path) ->
+    Params = extract_inference_params(Req, Opts),
+    IsStream = case maps:get(<<"stream">>, Params, false) of
+        true -> true;
+        <<"true">> -> true;
+        _ -> false
+    end,
+    case IsStream of
+        true ->
+            Body = hb_json:encode(Params),
+            #{
+                <<"stream_generator">> => fun(Sender) -> 
+                    stream_from_backend(Sender, <<"POST">>, Path, Body, Opts) 
+                end
+            };
+        false ->
+            Body = prepare_request_body(Req, Opts),
+            Response = relay_to_backend(<<"POST">>, Path, Body, Opts),
+            
+            case should_include_attestation(Req, Opts) of
+                true -> add_attestation(Response, Req, Opts);
+                false -> format_response(Response, Req, Opts)
+            end
+    end.
+
+prepare_request_body(Req, Opts) ->
+    case hb_ao:get(<<"body">>, Req, not_found, Opts) of
+        not_found -> hb_json:encode(extract_inference_params(Req, Opts));
+        Body when is_binary(Body) -> Body;
+        Body when is_map(Body) -> hb_json:encode(Body)
+    end.
+
+should_include_attestation(Req, Opts) ->
+    case hb_ao:get(<<"tee">>, Req, false, Opts) of
+        <<"true">> -> true;
+        true -> true;
+        _ -> false
+    end.
+
+extract_inference_params(Req, Opts) ->
+    ParamKeys = [
+        <<"model">>, <<"prompt">>, <<"messages">>, <<"max_tokens">>,
+        <<"temperature">>, <<"top_p">>, <<"n">>, <<"stream">>,
+        <<"stop">>, <<"presence_penalty">>, <<"frequency_penalty">>,
+        <<"logit_bias">>, <<"user">>, <<"seed">>, <<"top_k">>,
+        <<"repetition_penalty">>, <<"length_penalty">>, <<"early_stopping">>,
+        <<"tools">>, <<"tool_choice">>
+    ],
+    Params = lists:foldl(
+        fun(Key, Acc) ->
+            case hb_ao:get(Key, Req, not_found, Opts) of
+                not_found -> Acc;
+                Value -> Acc#{Key => Value}
+            end
+        end,
+        #{},
+        ParamKeys
+    ),
+    hb_cache:ensure_all_loaded(Params, Opts).
+
+relay_to_backend(Method, DefaultPath, Body, Opts) ->
+    Peer = maps:get(<<"agent-api-peer">>, Opts, <<"http://localhost:8080">>),
+    Path = maps:get(<<"agent-api-path">>, Opts, DefaultPath),
+    Payload0 = #{
+        <<"path">>         => Path,
+        <<"method">>       => Method,
+        <<"body">>         => Body,
+        <<"content-type">> => <<"application/json">>
+    },
+    Payload = case maps:get(<<"agent-api-key">>, Opts, undefined) of
+        undefined -> Payload0;
+        ApiKey    -> Payload0#{<<"authorization">> => <<"Bearer ", ApiKey/binary>>}
+    end,
+    hb_ao:resolve(
+        #{<<"device">>       => <<"relay@1.0">>,
+          <<"content-type">> => <<"application/json">>,
+          <<"peer">>         => Peer},
+        #{<<"path">>   => <<"call">>,
+          <<"target">> => <<"payload">>,
+          <<"payload">> => Payload},
+        Opts#{hashpath => ignore, cache_control => [<<"no-store">>, <<"no-cache">>]}
+    ).
+
+format_response({ok, Res}, Req, Opts) ->
+    Body = hb_ao:get(<<"body">>, Res, Opts),
+    ?event(push, {format_response, Req, hb_ao:get(<<"type">>, Req)}),
+    %% Check if this is being called for scheduling (aos Send with resolve)
+    %% vs direct HTTP call. dev_push:maybe_evaluate_message sets force_message => true
+    case hb_ao:get(<<"type">>, Req) of
+        <<"Message">> ->
+            %% For scheduling: return only valid AO message fields (ANS-104 compatible)
+            {ok, #{
+                <<"data">> => Body,
+                <<"action">> => <<"Inference-Response">>
+            }};
+        _ ->
+            %% For direct HTTP: return full HTTP response format
+            {ok, #{
+                <<"status">> => hb_ao:get(<<"status">>, Res, 200, Opts),
+                <<"content-type">> => hb_ao:get(<<"content-type">>, Res, <<"application/json">>, Opts),
+                <<"body">> => Body
+            }}
+    end;
+format_response({error, Error}, Req, Opts) ->
+    case hb_ao:get(<<"type">>, Req) of
+        <<"Message">> ->
+            %% For scheduling: return AO message format
+            {error, #{
+                <<"data">> => hb_util:bin(Error),
+                <<"action">> => <<"Inference-Error">>
+            }};
+        _ ->
+            %% For direct HTTP: return HTTP error format
+            {error, #{
+                <<"status">> => 500,
+                <<"message">> => <<"Request failed">>,
+                <<"body">> => hb_util:bin(Error)
+            }}
+    end.
+
+add_attestation({ok, Res}, Req, Opts) ->
+    MergedData = #{
+        <<"request">> => hb_private:reset(Req),
+        <<"response">> => hb_private:reset(Res),
+        <<"timestamp">> => os:system_time(millisecond),
+        <<"nonce">> => hb_util:to_hex(crypto:strong_rand_bytes(32))
+    },
+    NonceHex = hb_util:to_hex(hb_crypto:sha256(hb_json:encode(MergedData))),
+    
+    %% Generate attestation - result contains evidences, claims, eat, verified
+    AttestationResult = case dev_sev_gpu:generate(#{}, #{nonce => NonceHex}, Opts) of
+        {ok, ResultJSON} -> 
+            case hb_json:decode(ResultJSON) of
+                Map when is_map(Map) -> Map;
+                _ -> #{}
+            end;
+        _ -> #{}
+    end,
+    
+    %% Merge attestation result with raw and nonce at same level
+    AttestationData = maps:merge(AttestationResult, #{
+        <<"raw">> => hb_json:encode(MergedData),
+        <<"nonce">> => NonceHex
+    }),
+    
+    ResponseBody = hb_ao:get(<<"body">>, Res, Opts),
+    DecodedBody = hb_json:decode(ResponseBody),
+    EnhancedBody = hb_json:encode(DecodedBody#{
+        <<"attestation">> => AttestationData,
+        <<"resolved_model">> => hb_opts:get(inference_opts, #{}, Opts)
+    }),
+    
+    %% Check context: scheduling (aos) vs direct HTTP
+    case hb_ao:get(<<"type">>, Req) of
+        <<"Message">> ->
+            %% For scheduling: return only valid AO message fields (ANS-104 compatible)
+            {ok, #{
+                <<"data">> => EnhancedBody,
+                <<"action">> => <<"Inference-Response">>
+            }};
+        _ ->
+            %% For direct HTTP: return full HTTP response format
+            {ok, #{
+                <<"status">> => hb_ao:get(<<"status">>, Res, 200, Opts),
+                <<"content-type">> => <<"application/json">>,
+                <<"body">> => EnhancedBody
+            }}
+    end;
+add_attestation({error, Error}, Req, Opts) ->
+    format_response({error, Error}, Req, Opts).
+
+stream_from_backend(Sender, Method, Path, Body, _Opts) ->
+    {ok, ConnPid} = gun:open("localhost", list_to_integer(?SERVER_PORT)),
+    {ok, _Protocol} = gun:await_up(ConnPid),
+    StreamRef = gun:request(ConnPid, Method, Path, [{<<"content-type">>, <<"application/json">>}], Body),
+    receive_stream(ConnPid, StreamRef, Sender).
+
+receive_stream(ConnPid, StreamRef, Sender) ->
+    receive
+        {gun_response, ConnPid, StreamRef, nofin, _Status, _Headers} ->
+            receive_stream(ConnPid, StreamRef, Sender);
+        {gun_response, ConnPid, StreamRef, fin, _Status, _Headers} ->
+            ok;
+        {gun_data, ConnPid, StreamRef, nofin, Data} ->
+            Sender(Data),
+            receive_stream(ConnPid, StreamRef, Sender);
+        {gun_data, ConnPid, StreamRef, fin, Data} ->
+            Sender(Data);
+        {gun_error, ConnPid, StreamRef, Reason} ->
+            ?event(inference, {stream_error, Reason}),
+            ok;
+        {gun_down, ConnPid, _Protocol, _Reason, _KilledStreams} ->
+             ok;
+        Other ->
+            ?event(inference, {unexpected_stream_msg, Other}),
+            receive_stream(ConnPid, StreamRef, Sender)
+    after 30000 ->
+        ok
+    end.

--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -372,6 +372,26 @@ message_to_status(_Item, _NodeMsg) ->
 %% @doc Sign the result of a device call if the node is configured to do so.
 maybe_sign({Status, Res}, NodeMsg) ->
     {Status, maybe_sign(Res, NodeMsg)};
+maybe_sign(Res = #{ <<"stream_generator">> := StreamGen }, NodeMsg) ->
+    Res#{
+        <<"stream_generator">> => fun(Sender) ->
+            WrappedSender = fun
+                (Data) when is_binary(Data) ->
+                    Sender(Data),
+                    put(stream_acc, <<(get_stream_acc())/binary, Data/binary>>);
+                (Other) ->
+                    Sender(Other)
+            end,
+            put(stream_acc, <<>>),
+            try
+                StreamGen(WrappedSender)
+            after
+                FinalBody = get_stream_acc(),
+                send_commitment(Sender, FinalBody, NodeMsg),
+                erase(stream_acc)
+            end
+        end
+    };
 maybe_sign(Res, NodeMsg) ->
     ?event({maybe_sign, Res}),
     case hb_opts:get(force_signed, false, NodeMsg) of
@@ -382,6 +402,19 @@ maybe_sign(Res, NodeMsg) ->
             end;
         false -> Res
     end.
+
+get_stream_acc() ->
+    case get(stream_acc) of
+        undefined -> <<>>;
+        Acc -> Acc
+    end.
+
+send_commitment(Sender, Res, NodeMsg) ->
+    CommittedRes = maybe_sign(Res, NodeMsg),
+    Sender(format_sse_event(<<"commitment">>, CommittedRes)).
+
+format_sse_event(Event, Data) ->
+    [<<"event: ">>, Event, <<"\n">>, <<"data: ">>, hb_json:encode(Data), <<"\n\n">>].
 
 %% @doc Check if the request in question is signed by a given `role' on the node.
 %% The `role' can be one of `operator' or `initiator'.

--- a/src/dev_sev_gpu.erl
+++ b/src/dev_sev_gpu.erl
@@ -1,0 +1,137 @@
+%%% @doc NVIDIA GPU TEE Attestation Device
+%%%
+%%% This module provides GPU attestation capabilities using the NVIDIA nvat SDK.
+%%% It uses Erlang NIFs to directly call the nvat C API for:
+%%% - Collecting GPU attestation evidence
+%%% - Verifying GPU attestation evidence locally
+%%%
+%%% The NIF handles SDK initialization internally, so no explicit setup is required.
+-module(dev_sev_gpu).
+-export([info/1, generate/3, verify/3]).
+-on_load(init/0).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(TEST_MOCK_NONCE, <<"da4a06c3604a5fac8aa0b4aaf5a6354cdd0dc7c193299bc3464f30b5cbfb931a">>).
+
+%% NIF stubs - these are replaced by the actual NIF functions when loaded
+-spec collect_evidence_nif(binary()) -> {ok, binary()} | {error, binary()}.
+collect_evidence_nif(_Nonce) -> erlang:nif_error(not_loaded).
+
+-spec verify_evidence_nif(binary()) -> {ok, binary()} | {error, binary()}.
+verify_evidence_nif(_EvidenceJSON) -> erlang:nif_error(not_loaded).
+
+%% NIF initialization
+init() ->
+    PrivDir = case code:priv_dir(hb) of
+        {error, bad_name} -> 
+            %% Fallback for development
+            "priv";
+        Dir -> Dir
+    end,
+    SoPath = filename:join(PrivDir, "dev_sev_gpu_nif"),
+    case erlang:load_nif(SoPath, 0) of
+        ok -> ok;
+        {error, {reload, _}} -> ok;
+        {error, Reason} -> 
+            ?event({nif_load_error, Reason}),
+            ok  %% Don't fail module load, but NIF calls will return not_loaded
+    end.
+
+info(_) -> 
+    #{exports => [<<"info">>, <<"generate">>, <<"verify">>]}.
+
+%% @doc Generate GPU attestation evidence.
+%%
+%% Collects attestation evidence from the GPU using NVML, verifies it locally,
+%% and returns a JSON object containing:
+%% - evidences: Serialized GPU evidence (for transport to verifier)
+%% - claims: Attestation claims from local verification
+%% - eat: Detached Entity Attestation Token
+%% - verified: Boolean indicating local verification success
+%%
+%% Input message M2 should contain:
+%% - nonce: Hex-encoded nonce for attestation freshness
+-spec generate(map(), map(), map()) -> {ok, binary()} | {error, term()}.
+generate(_M1, M2, Opts) ->
+    Nonce = hb_ao:get(nonce, M2, ?TEST_MOCK_NONCE, Opts),
+    case collect_evidence_nif(Nonce) of
+        {ok, ResultJSON} ->
+            {ok, ResultJSON};
+        {error, Reason} when is_binary(Reason) ->
+            {error, {nvat_error, Reason}};
+        {error, not_loaded} ->
+            {error, nif_not_loaded}
+    end.
+
+%% @doc Verify GPU attestation evidence.
+%%
+%% Verifies previously collected GPU evidence locally.
+%% The evidence JSON already contains the nonce from when it was collected.
+%%
+%% Input message M2 should contain:
+%% - body: The evidences JSON from a previous generate call
+%%
+%% Returns:
+%% - {ok, <<"true">>} if verification succeeds
+%% - {ok, <<"false">>} if verification fails
+%% - {error, Reason} on error
+-spec verify(map(), map(), map()) -> {ok, binary()} | {error, term()}.
+verify(_M1, M2, _Opts) ->
+    EvidenceJSON = maps:get(<<"body">>, M2, <<>>),
+    case verify_evidence_nif(EvidenceJSON) of
+        {ok, ResultJSON} ->
+            case hb_json:decode(ResultJSON) of
+                #{<<"valid">> := true} -> {ok, <<"true">>};
+                #{<<"valid">> := false} -> {ok, <<"false">>};
+                _ -> {ok, <<"false">>}
+            end;
+        {error, Reason} when is_binary(Reason) ->
+            {error, {nvat_error, Reason}};
+        {error, not_loaded} ->
+            {error, nif_not_loaded}
+    end.
+
+%% ============================================================================
+%% Unit Tests
+%% ============================================================================
+
+generate_test() ->
+    case generate(#{}, #{nonce => ?TEST_MOCK_NONCE}, #{}) of
+        {ok, ResultJSON} ->
+            ?assert(is_binary(ResultJSON)),
+            ?assert(byte_size(ResultJSON) > 0),
+            case hb_json:decode(ResultJSON) of
+                #{<<"evidences">> := _, <<"verified">> := true} ->
+                    ?assert(true);
+                _ ->
+                    ?assert(false)
+            end;
+        {error, _} ->
+            %% GPU not available or attestation not supported
+            ?assert(false)
+    end.
+
+verify_test() ->
+    case generate(#{}, #{nonce => ?TEST_MOCK_NONCE}, #{}) of
+        {ok, ResultJSON} ->
+            case hb_json:decode(ResultJSON) of
+                #{<<"evidences">> := Evidences} ->
+                    VerifyMsg = #{<<"body">> => hb_json:encode(Evidences)},
+                    case verify(#{}, VerifyMsg, #{}) of
+                        {ok, VerifyResultJSON} ->
+                            case hb_json:decode(VerifyResultJSON) of
+                                #{<<"verified">> := true} ->
+                                    ?assert(true);
+                                _ ->
+                                    ?assert(false)
+                            end;
+                        {error, _} ->
+                            ?assert(false)
+                    end;
+                _ ->
+                    ?assert(false)
+            end;
+        {error, _} ->
+            ?assert(false)
+    end.

--- a/src/hb_app.erl
+++ b/src/hb_app.erl
@@ -19,4 +19,6 @@ start(_StartType, _StartArgs) ->
     {ok, _} = hb_http_server:start().
 
 stop(_State) ->
+    % Stop inference server if it was started
+    catch dev_inference:stop(),
     ok.

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -469,49 +469,75 @@ reply(Req, TABMReq, BinStatus, RawMessage, Opts) when is_binary(BinStatus) ->
     reply(Req, TABMReq, binary_to_integer(BinStatus), RawMessage, Opts);
 reply(InitReq, TABMReq, RawStatus, RawMessage, Opts) ->
     KeyNormMessage = hb_ao:normalize_keys(RawMessage, Opts),
-    {ok, Req, Message} = reply_handle_cookies(InitReq, KeyNormMessage, Opts),
-    {Status, HeadersBeforeCors, EncodedBody} =
-        encode_reply(
-            RawStatus,
-            TABMReq,
-            Message,
-            Opts
-        ),
-    % Get the CORS request headers from the message, if they exist.
-    ReqHdr = cowboy_req:header(<<"access-control-request-headers">>, Req, <<"">>),
-    HeadersWithCors = add_cors_headers(HeadersBeforeCors, ReqHdr, Opts),
-    EncodedHeaders = hb_private:reset(HeadersWithCors),
-    ?event(http,
-        {http_replying,
-            {status, {explicit, Status}},
-            {path, hb_maps:get(<<"path">>, Req, undefined_path, Opts)},
-            {raw_message, RawMessage},
-            {enc_headers, {explicit, EncodedHeaders}},
-            {enc_body, EncodedBody}
-        }
-    ),
-    ReqBeforeStream = Req#{ resp_headers => EncodedHeaders },
-    PostStreamReq = cowboy_req:stream_reply(Status, #{}, ReqBeforeStream),
-    cowboy_req:stream_body(EncodedBody, nofin, PostStreamReq),
-    EndTime = os:system_time(millisecond),
-    ?event(http, {reply_headers, {explicit, PostStreamReq}}),
-    ?event(http_short,
-        {sent,
-            {status, Status},
-            {ip, {string, real_ip(Req, Opts)}},
-            {duration, EndTime - hb_maps:get(start_time, Req, undefined, Opts)},
-            {method, cowboy_req:method(Req)},
-            {path,
-                {string,
-                    uri_string:percent_decode(
-                        hb_maps:get(<<"path">>, TABMReq, <<"[NO PATH]">>, Opts)
-                    )
-                }
+    case maps:get(<<"stream_generator">>, KeyNormMessage, undefined) of
+        StreamFun when is_function(StreamFun, 1) ->
+            {ok, Req, _Message} = reply_handle_cookies(InitReq, KeyNormMessage, Opts),
+            Headers = #{
+                <<"content-type">> => <<"text/event-stream">>,
+                <<"cache-control">> => <<"no-cache">>,
+                <<"connection">> => <<"keep-alive">>
             },
-            {body_size, byte_size(EncodedBody)}
-        }
-    ),
-    {ok, PostStreamReq, no_state}.
+            ReqHdr = cowboy_req:header(<<"access-control-request-headers">>, Req, <<"">>),
+            HeadersWithCors = add_cors_headers(Headers, ReqHdr, Opts),
+            EncodedHeaders = hb_private:reset(HeadersWithCors),
+            ReqBeforeStream = Req#{ resp_headers => EncodedHeaders },
+            PostStreamReq = cowboy_req:stream_reply(RawStatus, #{}, ReqBeforeStream),
+            Sender = fun(Data) ->
+                cowboy_req:stream_body(Data, nofin, PostStreamReq)
+            end,
+            try
+                StreamFun(Sender)
+            catch
+                E:R:S ->
+                    ?event(http_error, {stream_error, E, R, S})
+            end,
+            cowboy_req:stream_body(<<>>, fin, PostStreamReq),
+            {ok, PostStreamReq, no_state};
+        _ ->
+            {ok, Req, Message} = reply_handle_cookies(InitReq, KeyNormMessage, Opts),
+            {Status, HeadersBeforeCors, EncodedBody} =
+                encode_reply(
+                    RawStatus,
+                    TABMReq,
+                    Message,
+                    Opts
+                ),
+            % Get the CORS request headers from the message, if they exist.
+            ReqHdr = cowboy_req:header(<<"access-control-request-headers">>, Req, <<"">>),
+            HeadersWithCors = add_cors_headers(HeadersBeforeCors, ReqHdr, Opts),
+            EncodedHeaders = hb_private:reset(HeadersWithCors),
+            ?event(http,
+                {http_replying,
+                    {status, {explicit, Status}},
+                    {path, hb_maps:get(<<"path">>, Req, undefined_path, Opts)},
+                    {raw_message, RawMessage},
+                    {enc_headers, {explicit, EncodedHeaders}},
+                    {enc_body, EncodedBody}
+                }
+            ),
+            ReqBeforeStream = Req#{ resp_headers => EncodedHeaders },
+            PostStreamReq = cowboy_req:stream_reply(Status, #{}, ReqBeforeStream),
+            cowboy_req:stream_body(EncodedBody, nofin, PostStreamReq),
+            EndTime = os:system_time(millisecond),
+            ?event(http, {reply_headers, {explicit, PostStreamReq}}),
+            ?event(http_short,
+                {sent,
+                    {status, Status},
+                    {ip, {string, real_ip(Req, Opts)}},
+                    {duration, EndTime - hb_maps:get(start_time, Req, undefined, Opts)},
+                    {method, cowboy_req:method(Req)},
+                    {path,
+                        {string,
+                            uri_string:percent_decode(
+                                hb_maps:get(<<"path">>, TABMReq, <<"[NO PATH]">>, Opts)
+                            )
+                        }
+                    },
+                    {body_size, byte_size(EncodedBody)}
+                }
+            ),
+            {ok, PostStreamReq, no_state}
+    end.
 
 %% @doc Handle replying with cookies if the message contains them. Returns the
 %% new Cowboy `Req` object, and the message with the cookies removed. Both
@@ -562,21 +588,16 @@ reply_handle_cookies(Req, Message, Opts) ->
 
 %% @doc Add permissive CORS headers to a message, if the message has not already
 %% specified CORS headers.
-add_cors_headers(Msg, ReqHdr, Opts) ->
+add_cors_headers(Msg, _ReqHdr, Opts) ->
     CorHeaders = #{
         <<"access-control-allow-origin">> => <<"*">>,
         <<"access-control-allow-methods">> => <<"GET, POST, PUT, DELETE, OPTIONS">>,
-        <<"access-control-expose-headers">> => <<"*">>
+        <<"access-control-expose-headers">> => <<"*">>,
+        <<"access-control-allow-headers">> => <<"*">>
     },
-     WithAllowHeaders = case ReqHdr of
-        <<>> -> CorHeaders;
-        _ -> CorHeaders#{
-             <<"access-control-allow-headers">> => ReqHdr
-        }
-    end,
     % Keys in the given message will overwrite the defaults listed below if 
     % included, due to `hb_maps:merge''s precidence order.
-    hb_maps:merge(WithAllowHeaders, Msg, Opts).
+    hb_maps:merge(CorHeaders, Msg, Opts).
 
 %% @doc Generate the headers and body for a HTTP response message.
 encode_reply(Status, TABMReq, Message, Opts) ->

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -351,7 +351,7 @@ init(Req, ServerID) ->
 %% @doc Helper to grab the full body of a HTTP request, even if it's chunked.
 read_body(Req) -> read_body(Req, <<>>).
 read_body(Req0, Acc) ->
-    case cowboy_req:read_body(Req0) of
+    case cowboy_req:read_body(Req0, #{length => 64000000, period => 60000}) of
         {ok, Data, _Req} -> {ok, << Acc/binary, Data/binary >>};
         {more, Data, Req} -> read_body(Req, << Acc/binary, Data/binary >>)
     end.

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -209,7 +209,10 @@ default_message() ->
             #{<<"name">> => <<"secret@1.0">>, <<"module">> => dev_secret},
             #{<<"name">> => <<"wasi@1.0">>, <<"module">> => dev_wasi},
             #{<<"name">> => <<"wasm-64@1.0">>, <<"module">> => dev_wasm},
-            #{<<"name">> => <<"whois@1.0">>, <<"module">> => dev_whois}
+            #{<<"name">> => <<"whois@1.0">>, <<"module">> => dev_whois},
+            #{<<"name">> => <<"sev_gpu@1.0">>, <<"module">> => dev_sev_gpu},
+            #{<<"name">> => <<"inference@1.0">>, <<"module">> => dev_inference},
+            #{<<"name">> => <<"agent@1.0">>, <<"module">> => dev_agent}
         ],
         %% Default execution cache control options
         cache_control => [<<"no-cache">>, <<"no-store">>],
@@ -286,6 +289,11 @@ default_message() ->
                 <<"node">> => #{ <<"prefix">> => <<"http://localhost:6363">> }
             },
             %% GraphQL: race all gateways, take the first 200.
+            #{
+                % Routes for the inference device to use a local inference server.
+                <<"template">> => <<"/v1/.*">>,
+                <<"node">> => #{ <<"prefix">> => <<"http://localhost:8080">> }
+            },
             #{
                 <<"template">> => <<"/graphql">>,
                 <<"nodes">> =>
@@ -574,6 +582,13 @@ default_message() ->
                 ]
         },
         scheduler_default_commitment_spec => <<"httpsig@1.0">>,
+        inference_opts => #{
+            <<"model_tx">> => <<"Ybz4a5jX1nX1_2KXJz6F5v8c1X9Yk9V6n0b-1cXoXoU">>,
+            <<"model_hash">> => <<"bf3fc475100aa8bafea66766f17bb468ff96e947">>,
+            <<"model_name">> => <<"Qwen/Qwen2.5-0.5B-Instruct">>,
+            <<"model_size">> => <<"27b">>,
+            <<"tensor_type">> => <<"BF16">>
+        },
         genesis_wasm_import_authorities =>
             [
                 <<"WjnS-s03HWsDSdMnyTdzB1eHZB2QheUWP_FVRVYxkXk">>


### PR DESCRIPTION
## Summary

This PR adds three new HyperBEAM devices along with supporting infrastructure.

---

## ~inference@1.0  (`src/dev_inference.erl`)

An OpenAI-compatible inference gateway that routes completion requests to a local **or** remote LLM backend via `relay@1.0`.

Key opts read at runtime:
| Opt | Default | Description |
|-----|---------|-------------|
| `agent-api-peer` | `http://localhost:8080` | Backend URL |
| `agent-api-path` | caller-supplied | API path (e.g. `/v1/chat/completions`) |
| `agent-api-key` | — | Optional Bearer token |

Works unchanged with local `llama.cpp`, OpenRouter, OpenAI, or any OpenAI-compatible endpoint.

---

## ~agent@1.0  (`src/dev_agent.erl`)

A [ReAct](https://arxiv.org/abs/2210.03629)-loop agent device.  Iteratively:
1. Calls LLM through `inference@1.0/completions`
2. Parses `tool_calls` from the response
3. Dispatches to built-in tools
4. Feeds results back as `tool` role messages
5. Repeats until the model emits a final answer

**Built-in tools:** `http_request`, `lookup_data`, `search_messages`, `get_arweave_tx`, `bundle_item`

All tools, the LLM call, and system prompt are overridable via `Run` key parameters.

**Architecture**
```
agent@1.0
    └─► inference@1.0 ──► relay@1.0 ──► local llama.cpp
                                    └──► remote provider (OpenRouter / OpenAI)
```

---

## ~sev_gpu@1.0  (`src/dev_sev_gpu.erl` + `native/dev_sev_gpu_nif/`)

SEV GPU device with NIF support for GPU-backed confidential compute.

---

## Supporting changes

- **`src/hb_opts.erl`** — register all three devices; add `/v1/.*` → `localhost:8080` route; `inference_opts` defaults
- **`src/hb_http.erl`** / **`src/hb_http_server.erl`** — HTTP layer improvements
- **`src/dev_meta.erl`**, **`src/dev_codec_http_auth.erl`**, **`src/hb_app.erl`** — supporting updates
- **`rebar.config`** / **`Makefile`** — build support for SEV GPU NIF
- **`docs/devices/agent-at-1-0.md`** — full device reference
- **`docs/dev_agent-testing.md`** — testing / debugging guide
- **`scripts/agent-test.lua`**, **`scripts/e2e-test.sh`** — test scripts
- **`mkdocs.yml`** — add `~agent@1.0` to Devices nav
- **`.gitignore`** — ignore `.agents/`, dev_sev_gpu logs