### PR TITLE
fix: dev_token_lib supply/2 3 & user_supply/3 balances sum fix

### DIFF
--- a/src/dev_token_lib.erl
+++ b/src/dev_token_lib.erl
@@ -156,7 +156,7 @@ unsubscribe(ProcMsg, Action, Target, Opts) ->
     push(
         ProcMsg,
         #{
-            <<"action">> => Action,
+            <<"action">> => <<"unsubscribe">>,
             <<"subscribe-action">> => Action,
             <<"subscribe-target">> => Target
         },

--- a/src/dev_token_lib.erl
+++ b/src/dev_token_lib.erl
@@ -264,7 +264,9 @@ balances(Prefix, ProcMsg, Opts) ->
 supply(ProcMsg, Opts) ->
     supply(now, ProcMsg, Opts).
 supply(Mode, ProcMsg, Opts) ->
-    lists:sum(maps:values(balances(Mode, ProcMsg, Opts))).
+    BalancesVal = maps:values(balances(Mode, ProcMsg, Opts)),
+    Balances = lists:filter(fun is_integer/1, BalancesVal),
+    lists:sum(Balances).
 
 %% @doc Calculate the supply of tokens in all sub-ledgers, from the balances of
 %% the root ledger.
@@ -276,14 +278,15 @@ subledger_supply(RootProc, AllProcs, Opts) ->
 user_supply(Proc, AllProcs, Opts) ->
     NormProcs = normalize_without_root(Proc, AllProcs),
     SubledgerIDs = maps:keys(NormProcs),
-    lists:sum(
+    Vals =
         maps:values(
             maps:without(
                 SubledgerIDs,
                 balances(now, Proc, Opts)
             )
-        )
-    ).
+        ),
+    NumericVals = lists:filter(fun is_number/1, Vals),
+    lists:sum(NumericVals).
 
 %% @doc Get the local expectation of a ledger's balances with peer ledgers.
 ledgers(ProcMsg, Opts) ->

--- a/src/dev_token_lib.erl
+++ b/src/dev_token_lib.erl
@@ -265,7 +265,7 @@ supply(ProcMsg, Opts) ->
     supply(now, ProcMsg, Opts).
 supply(Mode, ProcMsg, Opts) ->
     BalancesVal = maps:values(balances(Mode, ProcMsg, Opts)),
-    Balances = lists:filter(fun is_integer/1, BalancesVal),
+    Balances = lists:filter(fun is_number/1, BalancesVal),
     lists:sum(Balances).
 
 %% @doc Calculate the supply of tokens in all sub-ledgers, from the balances of

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -914,6 +914,26 @@ normalized_balance_normalizes_lazy_mint_test() ->
     ?assertEqual(7500, dev_token_lib:normalized_balance(Process, AliceAddr, Opts)),
     ?assertEqual(7500, balance(Process, AliceAddr, Opts)).
 
+%% @doc Ensure raw `dev_token_lib:supply/2` ignores trie metadata and returns
+%% the numeric sum of persisted balances.
+raw_supply_ignores_trie_metadata_test() ->
+    Opts = test_opts(),
+    Alice = ar_wallet:new(),
+    Bob = ar_wallet:new(),
+    Process =
+        generate_process(
+            #{},
+            #{
+                initial_balances => #{
+                    id(Alice) => 500,
+                    id(Bob) => 250
+                },
+                total_supply => 750
+            },
+            Opts
+        ),
+    ?assertEqual(750, dev_token_lib:supply(Process, Opts)).
+
 %% @doc Test that public global mint still advances pot accrual state even when
 %% no `subject' is provided.
 public_global_mint_still_drips_without_subject_test() ->


### PR DESCRIPTION
this PR fixe inconsistency bugs in dev_token_lib.erl

* `supply/2` - `supply/3` and `user_supply/3` did lists:sum on mapped values where they could contained trie@1.0 KVs when using supply (or other fns) on dev_token (or whatever device that uses dev_trie for balances). fixed that bu filtering by `is_numer/1` before sum, and added the post-fix repro test

* unsubscribe/4 was incorrectly passing `Action` for <<"action">> instead of only to `<<"subscribe-action">>` - fixed that:

```erl
        #{
            <<"action">> => <<"unsubscribe">>,
            <<"subscribe-action">> => Action,
            <<"subscribe-target">> => Target
        },
 ```