### PR TITLE
fix: treat only node-value trie nodes as terminal

### DIFF
--- a/src/dev_trie.erl
+++ b/src/dev_trie.erl
@@ -35,14 +35,12 @@ keys(Trie, Opts) ->
 
 collect_keys(TrieNode, Prefix, Opts, Acc) ->
     EdgeLabels = edges(TrieNode, Opts),
-    IsLeafTerminal = length(EdgeLabels) =:= 0,
     NodeValue = hb_maps:find(<<"node-value">>, TrieNode, Opts),
-    IsInteriorTerminal =
+    IsTerminal =
         case NodeValue of
             error -> false;
             _ -> true
         end,
-    IsTerminal = IsLeafTerminal orelse IsInteriorTerminal,
     NewAcc =
         case IsTerminal of
             true -> [Prefix|Acc];
@@ -523,6 +521,10 @@ basic_key_collection_test() ->
         ],
         keys(Trie, #{})
     ).
+
+initial_balances_trie_has_no_keys_test() ->
+    Trie = #{<<"device">> => <<"trie@1.0">>},
+    ?assertEqual([], keys(Trie, #{})).
 
 verify_test() ->
     Trie = hb_ao:set(


### PR DESCRIPTION
## finding
this PR fix a `dev_trie:keys/2` bug where edgeless trie nodes were incorrectly treated as terminal keys. before, `keys/2` considered any node with no child edges to be terminal, even if the node had no `node-value` and only contained trie metadata, so even a freshly initialized trie like `#{<<"device">> => <<"trie@1.0">>} ` led keys/2 to return `[<<>>]`  (one empty binary key) instead of `[]` (no keys).

that behavior was also inconsistent with trie get lookup: the same fresh trie that return an empty key through keys/2, with a direct `get(<<>>) `return `not_found`

## patch
keys/2 now treats a node as terminal only when `node-value` is present - implicit leaf keys are unchanged (non-map child-edge path)

all tests pass (also added initial_balances_trie_has_no_keys_test)

```shell
======================== EUnit ========================
module 'dev_trie'
  dev_trie: node_count_forwards_test...[0.042 s] ok
  dev_trie: node_count_backwards_test...[0.004 s] ok
  dev_trie: basic_topology_forwards_test...[0.004 s] ok
  dev_trie: basic_topology_backwards_test...[0.004 s] ok
  dev_trie: basic_retrievability_test...[0.006 s] ok
  dev_trie: basic_key_collection_test...[0.006 s] ok
  dev_trie: initial_balances_trie_has_no_keys_test...ok
  dev_trie: verify_test...[0.029 s] ok
  dev_trie: large_balance_table_test...[0.401 s] ok
  dev_trie: insertion_cases_test...[0.010 s] ok
  dev_trie: forwards_bulk_insertion_test...[0.011 s] ok
  dev_trie: backwards_bulk_insertion_test...[0.012 s] ok
  dev_trie: bulk_update_cases_test...[0.028 s] ok
  dev_trie: commitment_accumulation_test...[0.056 s] ok
  [done in 0.655 s]
=======================================================
  All 14 tests passed.
  ```