### PR TITLE
Copycat L3 indexer with parallel processing and parent lookups

### DIFF
--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -837,10 +837,19 @@ parent(Base, Request, Opts) ->
                 not_found ->
                     {error, not_found}
             catch
-                error:function_clause ->
-                    {error, not_found};
-                error:badarg ->
-                    {error, not_found}
+                error:Reason:Stacktrace ->
+                    ?event(error, 
+                        {parent_read_error, 
+                            {id, ID},
+                            {reason, Reason},
+                            {stacktrace, Stacktrace}
+                        }),
+                    {failure, 
+                        #{
+                            <<"status">> => 500, 
+                            <<"type">> => <<"parent_read_error">>
+                         }
+                    }
             end
     end.
 

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -809,7 +809,7 @@ parent(Base, Request, Opts) ->
             {error, not_found};
         ID ->
             StoreOpts = hb_store_arweave:store_from_opts(Opts),
-            try hb_store_arweave:read_parent(StoreOpts, ID) of
+            try hb_store_arweave:read_parent(StoreOpts, ID, Opts) of
                 {ok, [{Height, block} | _]} ->
                     Entry = #{
                         <<"type">> => <<"block">>,
@@ -1013,7 +1013,7 @@ to_message(Path = <<"/block/", _/binary>>, <<"GET">>, {ok, #{ <<"body">> := Body
             Opts
         ),
     CacheRes =
-        case hb_opts:get(arweave_index_blocks, true, Opts) of
+        case hb_opts:get(<<"arweave-index-blocks">>, true, Opts) of
             true -> dev_arweave_block_cache:write(Block, Opts);
             false -> skipped
         end,
@@ -1621,9 +1621,9 @@ head_raw_ans104_deserialize_throws_test_parallel() ->
         <<"index-store">> => [TestStore]
     },
     Opts = #{
-        store => [TestStore],
-        arweave_index_ids => true,
-        arweave_index_store => IndexStore
+        <<"store">> => [TestStore],
+        <<"arweave-index-ids">> => true,
+        <<"arweave-index-store">> => IndexStore
     },
     FakeID = <<"CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC">>,
     %% Same interior offset as bundle_header_garbage_guard_test_parallel.

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -5,7 +5,7 @@
 %%% `/arweave` route in the node's configuration message.
 -module(dev_arweave).
 -export([info/0]).
--export([tx/3, raw/3, chunk/3, block/3, current/3, status/3, price/3, tx_anchor/3]).
+-export([tx/3, raw/3, chunk/3, block/3, parent/3, current/3, status/3, price/3, tx_anchor/3]).
 -export([pending/3]).
 -export([post_tx_header/2, post_tx/3, post_tx/4, post_chunk/2]).
 %%% Helper functions
@@ -800,6 +800,48 @@ block({height, Height}, Opts) ->
                 #{ <<"route-by">> => Height },
                 Opts
             )
+    end.
+
+%% @doc Look up the parent (block or bundle) that contains an item.
+parent(Base, Request, Opts) ->
+    case find_key(<<"parent">>, Base, Request, Opts) of
+        not_found ->
+            {error, not_found};
+        ID ->
+            StoreOpts = hb_store_arweave:store_from_opts(Opts),
+            try hb_store_arweave:read_parent(StoreOpts, ID) of
+                {ok, [{Height, block} | _]} ->
+                    Entry = #{
+                        <<"type">> => <<"block">>,
+                        <<"height">> => Height
+                    },
+                    {ok, #{
+                        <<"content-type">> => <<"application/json">>,
+                        <<"body">> =>
+                            hb_json:encode(#{<<"parents">> => [Entry]})
+                    }};
+                {ok, [{ParentID, bundle} | _]} ->
+                    Entry = #{
+                        <<"type">> => <<"bundle">>,
+                        <<"id">> => hb_util:encode(ParentID)
+                    },
+                    {ok, #{
+                        <<"content-type">> => <<"application/json">>,
+                        <<"body">> =>
+                            hb_json:encode(#{<<"parents">> => [Entry]})
+                    }};
+                {error, Reason} ->
+                    ?event(warning,
+                        {parent_read_error, {id, ID}, {reason, Reason}}),
+                    {error, not_found};
+                not_found ->
+                    {error, not_found}
+            catch
+                error:function_clause ->
+                    {error, not_found};
+                error:badarg ->
+                    {error, not_found}
+            end
     end.
 
 %% @doc Retrieve the current block information from Arweave.

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -173,7 +173,16 @@ head_raw(Base, Request, Opts) ->
                                 <<"tx@1.0">> -> fun head_raw_tx/4;
                                 _ -> throw({invalid_codec_device, CodecDevice})
                             end,
-                        CodecFun(TXID, StartOffset, Length, Opts);
+                        try CodecFun(TXID, StartOffset, Length, Opts)
+                        catch _:Reason:Stacktrace ->
+                            %% This can be prone to serialization error. 
+                            %% Catch and output as an error.
+                            ?event(store_error, {head_raw, 
+                                {txid, TXID},
+                                {reason, Reason},
+                                {stacktrace, Stacktrace}}),
+                            {error, Reason}
+                        end;
                 not_found ->
                     ?event(
                         arweave,
@@ -1549,6 +1558,40 @@ head_raw_ans104_test_parallel() ->
     ?assertEqual(
         {ok, 575},
         hb_maps:find(<<"content-length">>, Result, Opts)
+    ).
+
+%% @doc Interior Arweave offset returns bytes that are not a valid ANS-104
+%% header, so head_raw_ans104/4 throws inside do_head_raw_ans104/5. The
+%% try-catch added to head_raw/3 must convert that throw into {error, _}.
+head_raw_ans104_deserialize_throws_test_parallel() ->
+    TestStore = hb_test_utils:test_store(hb_store_volatile, <<"head-raw-throws">>),
+    IndexStore = #{
+        <<"module">> => hb_store_arweave,
+        <<"index-store">> => [TestStore]
+    },
+    Opts = #{
+        store => [TestStore],
+        arweave_index_ids => true,
+        arweave_index_store => IndexStore
+    },
+    FakeID = <<"CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC">>,
+    %% Same interior offset as bundle_header_garbage_guard_test_parallel.
+    ProbeOffset = 376836336327208,
+    Size = 4096,
+    ok = hb_store_arweave:write_offset(
+        IndexStore, FakeID, <<"ans104@1.0">>, ProbeOffset - 1, Size
+    ),
+    ?assertMatch(
+        {error, _},
+        hb_ao:resolve(
+            #{ <<"device">> => <<"arweave@2.9">> },
+            #{
+                <<"path">> => <<"raw">>,
+                <<"raw">> => FakeID,
+                <<"method">> => <<"HEAD">>
+            },
+            Opts
+        )
     ).
 
 get_raw_range_tx_test_parallel() ->

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -1417,7 +1417,8 @@ index_test_tx(TXID, IndexStore, Opts) ->
             TXID,
             <<"tx@1.0">>,
             StartOffset,
-            Size
+            Size,
+            Opts
         ),
     ?assertMatch({ok, _}, hb_store_arweave:read_offset(IndexStore, TXID)),
     ok.
@@ -1630,7 +1631,7 @@ head_raw_ans104_deserialize_throws_test_parallel() ->
     ProbeOffset = 376836336327208,
     Size = 4096,
     ok = hb_store_arweave:write_offset(
-        IndexStore, FakeID, <<"ans104@1.0">>, ProbeOffset - 1, Size
+        IndexStore, FakeID, <<"ans104@1.0">>, ProbeOffset - 1, Size, Opts
     ),
     ?assertMatch(
         {error, _},

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -6,7 +6,7 @@
 %%% is provided, every block in the range is processed.
 -module(dev_copycat_arweave).
 -export([arweave/3]).
--export([add_owner_alias/3, resolve_owner_alias/2, set_memory_safe_cap/2, get_memory_safe_cap/1, set_depth_recursion_cap/2, get_depth_recursion_cap/1]).
+-export([add_owner_alias/3, resolve_owner_alias/2, set_depth_recursion_cap/2, get_depth_recursion_cap/1]).
 -include_lib("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -19,6 +19,7 @@
 % Note: this means that the children of L2 bundles are not indexed at
 % depth 2.
 -define(DEFAULT_BLOCK_DEPTH, 2).
+-define(DEFAULT_COPYCAT_MEMORY_BUDGET, 6 * 1024 * 1024 * 1024).
 
 % GET /~cron@1.0/once&cron-path=~copycat@1.0/arweave
 
@@ -81,10 +82,6 @@ arweave(_Base, Request, Opts) ->
             {error, <<"Unsupported mode `", (hb_util:bin(Mode))/binary,
                 "`. Supported modes are: write, list, inventory">>}
     end.
-%% @doc Set safe memory resource allocation cap for the in-memory
-%% bundle processing. in bytes.
-set_memory_safe_cap(Cap, Opts) when is_integer(Cap), Cap > 0 ->
-    Opts#{copycat_memory_cap => Cap}.
 %% @doc Set bundles descendant recursion cap, avoids recursion
 %% in very nested bundles (very rare).
 set_depth_recursion_cap(Cap, Opts) when is_integer(Cap), Cap > 0 ->
@@ -92,23 +89,14 @@ set_depth_recursion_cap(Cap, Opts) when is_integer(Cap), Cap > 0 ->
 %% @doc Get the set depth recursion cap from hb_opts.
 get_depth_recursion_cap(Opts) ->
     hb_opts:get(copycat_depth_recursion_cap, undefined, Opts).
-%% @doc Get the L1 TX data size that gets handled in-memory
-%% from hb_opts.
-get_memory_safe_cap(Opts) ->
-    hb_opts:get(copycat_memory_cap, undefined, Opts).
 
 %% @doc Return the effective per-TX memory cap, clamped to the global budget.
 %% Lazily initializes the budget pool on first call.
 effective_memory_cap(Opts) ->
     Budget = hb_opts:get(
-        copycat_memory_budget, 6 * 1024 * 1024 * 1024, Opts),
+        copycat_memory_budget, ?DEFAULT_COPYCAT_MEMORY_BUDGET, Opts),
     hb_copycat_budget:ensure_started(Budget),
-    PoolSize = hb_copycat_budget:get_budget(),
-    Cap = get_memory_safe_cap(Opts),
-    case Cap of
-        undefined -> PoolSize;
-        _ -> min(Cap, PoolSize)
-    end.
+    hb_copycat_budget:get_budget().
 
 %% @doc Return the store path for a block completion marker.
 block_indexed_path(Height) ->
@@ -361,9 +349,8 @@ parse_tag_filter(Key, Request, Opts) ->
 %% @doc Process the `id=...` copycat path for an already indexed L1 TX.
 %% applies L1-level owner/tag filters on the lightweight TX header first, then,
 %% if the TX passes and is a bundle, loads the full L1 payload once and indexes
-%% descendants in-memory (under the configured copycat_memory_cap) up to the
-%% requested safe depth (defaults to full recursion till the set
-%% copycat_depth_recursion_cap).
+%% descendants in-memory up to the requested safe depth (defaults to full recursion 
+%% till the set copycat_depth_recursion_cap).
 process_l1_request(TXID, Request, Opts) ->
     Depth = request_depth(Request, <<"safe_max">>, Opts),
     QueryL1Offset =
@@ -2399,13 +2386,6 @@ request_depth_clamping_test() ->
     ?assertEqual(6, request_depth(#{}, <<"safe_max">>, #{})),
     ok.
 
-memory_cap_setter_getter_test() ->
-    {_TestStore, _StoreOpts, Opts0} = setup_index_opts(),
-    ?assertEqual(6 * 1024 * 1024 * 1024, get_memory_safe_cap(Opts0)),
-    Opts1 = set_memory_safe_cap(1024, Opts0),
-    ?assertEqual(1024, get_memory_safe_cap(Opts1)),
-    ok.
-
 id_depth_1_test() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     {Block, TXID} = {1827942, <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>},
@@ -3024,21 +3004,6 @@ corrupt_item_ids_read_test() ->
     IDs = read_block_item_ids(Height, Opts),
     ?assertEqual(1, length(maps:get(<<"1">>, IDs))),
     ?assertEqual(<<"corrupt">>, maps:get(<<"2">>, IDs)),
-    ok.
-
-memory_cap_depth3_floors_to_2_test() ->
-    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
-    CappedOpts = set_memory_safe_cap(1, Opts),
-    Block = 1827942,
-    {ok, Block} =
-        hb_ao:resolve(
-            <<"~copycat@1.0/arweave&from=",
-                (hb_util:bin(Block))/binary, "&to=",
-                (hb_util:bin(Block))/binary, "&depth=3">>,
-            CappedOpts
-        ),
-    ?assert(is_block_indexed(Block, 2, CappedOpts)),
-    ?assertNot(is_block_indexed(Block, 3, CappedOpts)),
     ok.
 
 parent_encode_decode_test() ->

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -1,8 +1,9 @@
 %%% @doc A `~copycat@1.0' engine that fetches block data from an Arweave node for
 %%% replication. This engine works in _reverse_ chronological order by default.
 %%% If `to' is omitted, it keeps moving downward from `from' until it reaches a
-%%% block where at least one TX is already indexed, then stops. If `to' is
-%%% provided, every block in the range is processed.
+%%% block that is already indexed at the requested depth (checked via block
+%%% markers first, then legacy per-TX fallback for pre-marker indexes). If `to'
+%%% is provided, every block in the range is processed.
 -module(dev_copycat_arweave).
 -export([arweave/3]).
 -export([add_owner_alias/3, resolve_owner_alias/2, set_memory_safe_cap/2, get_memory_safe_cap/1, set_depth_recursion_cap/2, get_depth_recursion_cap/1]).
@@ -10,6 +11,9 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(ARWEAVE_DEVICE, <<"~arweave@2.9">>).
+-define(BLOCK_MARKER_PREFIX, <<"block/">>).
+-define(CUTOVER_KEY, <<"block/marker-cutover-height">>).
+-define(DEPTH_SENTINEL, 99999).
 % By default we'll index blocks to depth 2 which is:
 % - depth 1: L1 TXs
 % - depth 2: L2 bundles and dataitems
@@ -65,8 +69,14 @@ arweave(_Base, Request, Opts) ->
                 {error, unavailable} -> {error, unavailable};
                 {ok, {From, To}} -> list_index(From, To, Opts)
             end;
+        <<"list-items">> ->
+            case parse_range(Request, Opts) of
+                {error, unavailable} -> {error, unavailable};
+                {ok, {From, To}} -> list_items_index(From, To, Opts)
+            end;
         Mode ->
-            {error, <<"Unsupported mode `", (hb_util:bin(Mode))/binary, "`. Supported modes are: write, list">>}
+            {error, <<"Unsupported mode `", (hb_util:bin(Mode))/binary,
+                "`. Supported modes are: write, list, list-items">>}
     end.
 %% @doc Set safe memory resource allocation cap for the in-memory
 %% bundle processing. in bytes.
@@ -83,6 +93,156 @@ get_depth_recursion_cap(Opts) ->
 %% from hb_opts.
 get_memory_safe_cap(Opts) ->
     hb_opts:get(copycat_memory_cap, undefined, Opts).
+
+%% @doc Return the store path for a block completion marker.
+block_indexed_path(Height) ->
+    <<?BLOCK_MARKER_PREFIX/binary, (hb_util:bin(Height))/binary>>.
+
+%% @doc Return the store path for a per-block item index at a given depth.
+block_items_path(Height, Depth) ->
+    <<"block/", (hb_util:bin(Height))/binary,
+        "/items/", (hb_util:bin(Depth))/binary>>.
+
+%% @doc Encode a list of 32-byte raw IDs into a single binary.
+encode_item_ids(IDs) ->
+    << <<ID:32/binary>> || ID <- IDs >>.
+
+%% @doc Decode a binary of concatenated 32-byte IDs into a list.
+%% Rejects binaries whose size is not a multiple of 32.
+decode_item_ids(<<>>) -> [];
+decode_item_ids(Bin) when byte_size(Bin) rem 32 =/= 0 ->
+    {error, invalid_item_ids_binary};
+decode_item_ids(Bin) ->
+    decode_item_ids_acc(Bin, []).
+
+decode_item_ids_acc(<<>>, Acc) -> lists:reverse(Acc);
+decode_item_ids_acc(<<ID:32/binary, Rest/binary>>, Acc) ->
+    decode_item_ids_acc(Rest, [ID | Acc]).
+
+%% @doc Shift all depth keys in an item ID map by Offset.
+shift_item_ids(Map, Offset) ->
+    maps:fold(
+        fun(Depth, IDs, Acc) -> Acc#{Depth + Offset => IDs} end,
+        #{},
+        Map
+    ).
+
+%% @doc Merge a list of depth→ID-list maps in one pass per depth key.
+merge_all_item_ids(Maps) ->
+    AllKeys = lists:usort(lists:flatmap(fun maps:keys/1, Maps)),
+    maps:from_list([
+        {K, lists:append([maps:get(K, M, []) || M <- Maps])}
+    || K <- AllKeys]).
+
+%% @doc Merge two depth→ID-list maps by concatenating lists at each depth.
+merge_item_ids(A, B) ->
+    maps:fold(
+        fun(Depth, IDs, Acc) ->
+            Existing = maps:get(Depth, Acc, []),
+            Acc#{Depth => Existing ++ IDs}
+        end,
+        A,
+        B
+    ).
+
+%% @doc Read the stored marker depth for a block, or undefined if none.
+read_block_marker_depth(Height, Opts) ->
+    case hb_store_arweave:store_from_opts(Opts) of
+        no_store -> undefined;
+        #{ <<"index-store">> := Store } ->
+            case hb_store:read(Store, block_indexed_path(Height)) of
+                {ok, Bin} ->
+                    try binary_to_integer(Bin)
+                    catch _:_ -> undefined
+                    end;
+                not_found -> undefined
+            end
+    end.
+
+%% @doc Check if a block has been indexed at the given depth or deeper.
+is_block_indexed(undefined, _TargetDepth, _Opts) ->
+    false;
+is_block_indexed(Height, TargetDepth, Opts) ->
+    case read_block_marker_depth(Height, Opts) of
+        undefined -> false;
+        StoredDepth -> StoredDepth >= TargetDepth
+    end.
+
+%% @doc Write per-depth item ID lists for a block.
+%% Writes an entry for every depth from 1 through AchievedDepth (empty if
+%% no items at that level), plus any partial depths beyond AchievedDepth
+%% that were collected during indexing.
+write_block_item_ids(Height, AchievedDepth, ItemIDs, Opts) ->
+    case hb_store_arweave:store_from_opts(Opts) of
+        no_store -> ok;
+        #{ <<"index-store">> := Store } ->
+            MaxStoredDepth = case maps:keys(ItemIDs) of
+                [] -> AchievedDepth;
+                Keys -> max(AchievedDepth, lists:max(Keys))
+            end,
+            Results = lists:map(
+                fun(D) ->
+                    IDs = maps:get(D, ItemIDs, []),
+                    Bin = encode_item_ids(IDs),
+                    hb_store:write(
+                        Store,
+                        block_items_path(Height, D),
+                        Bin
+                    )
+                end,
+                lists:seq(1, MaxStoredDepth)
+            ),
+            case lists:all(fun(R) -> R =:= ok end, Results) of
+                true -> ok;
+                false ->
+                    ?event(copycat_short,
+                        {block_item_ids_write_failed,
+                            {height, Height}}),
+                    {error, item_ids_write_failed}
+            end
+    end.
+
+%% @doc Write a block completion marker with the achieved depth.
+mark_block_indexed(Height, Depth, Opts) ->
+    case hb_store_arweave:store_from_opts(Opts) of
+        no_store -> ok;
+        #{ <<"index-store">> := Store } ->
+            hb_store:write(
+                Store,
+                block_indexed_path(Height),
+                integer_to_binary(Depth)
+            )
+    end.
+
+%% @doc Read the persisted cutover height from the index store.
+read_cutover_height(Opts) ->
+    case hb_store_arweave:store_from_opts(Opts) of
+        no_store -> undefined;
+        #{ <<"index-store">> := Store } ->
+            case hb_store:read(Store, ?CUTOVER_KEY) of
+                {ok, Bin} -> hb_util:int(Bin);
+                not_found -> undefined
+            end
+    end.
+
+%% @doc Write the cutover height if not already set.
+ensure_cutover_height(Height, Opts) ->
+    case read_cutover_height(Opts) of
+        undefined ->
+            case hb_store_arweave:store_from_opts(Opts) of
+                no_store -> ok;
+                #{ <<"index-store">> := Store } ->
+                    hb_store:write(
+                        Store, ?CUTOVER_KEY, hb_util:bin(Height)),
+                    ?event(copycat_short,
+                        {marker_cutover_initialized,
+                            {height, Height}
+                        }
+                    )
+            end;
+        _ -> ok
+    end.
+
 %% @doc Normalize an owner address into the native ID form used for comparisons.
 normalize_owner_id(Addr) ->
     hb_util:native_id(hb_util:bin(Addr)).
@@ -403,18 +563,98 @@ list_index_blocks(Current, To, Opts, Acc) ->
                             list_index_blocks(Current - 1, To, Opts, Acc);
                         _ ->
                             BlockKey = hb_util:bin(Current),
-                            NewAcc = Acc#{
-                                BlockKey => #{
-                                    <<"indexed">> => IndexedTXs,
-                                    <<"not-indexed">> => NotIndexedTXs
-                                }
-                            },
+                            BlockInfo = assemble_block_info(
+                                Current, Block, Opts),
+                            WithItems = case maps:get(
+                                <<"depth">>, BlockInfo, undefined)
+                            of
+                                undefined -> BlockInfo;
+                                _ ->
+                                    BlockInfo#{
+                                        <<"items">> =>
+                                            read_block_item_counts(
+                                                Current, Opts)}
+                            end,
+                            NewAcc = Acc#{BlockKey => WithItems},
                             list_index_blocks(Current - 1, To, Opts, NewAcc)
                     end
             end;
         {error, _} ->
             list_index_blocks(Current - 1, To, Opts, Acc)
     end.
+
+%% @doc Build base block info with indexed/not-indexed TXs and optional depth.
+assemble_block_info(Height, Block, Opts) ->
+    TXIDs = hb_maps:get(<<"txs">>, Block, [], Opts),
+    {IndexedTXs, NotIndexedTXs} = classify_txs(TXIDs, Opts),
+    Base = #{
+        <<"indexed">> => IndexedTXs,
+        <<"not-indexed">> => NotIndexedTXs
+    },
+    case read_block_depth(Height, Opts) of
+        undefined -> Base;
+        Depth -> Base#{<<"depth">> => Depth}
+    end.
+
+%% @doc Read the achieved depth from a block marker.
+read_block_depth(Height, Opts) ->
+    read_block_marker_depth(Height, Opts).
+
+%% @doc Probe item entries upward from depth 1, applying TransformFun to each.
+probe_block_items(Height, Opts, TransformFun) ->
+    case hb_store_arweave:store_from_opts(Opts) of
+        no_store -> #{};
+        #{ <<"index-store">> := Store } ->
+            probe_block_items(Height, Store, 1, #{}, TransformFun)
+    end.
+
+probe_block_items(Height, Store, Depth, Acc, TransformFun) ->
+    case hb_store:read(Store, block_items_path(Height, Depth)) of
+        {ok, Bin} ->
+            Key = hb_util:bin(Depth),
+            probe_block_items(
+                Height, Store, Depth + 1,
+                Acc#{Key => TransformFun(Bin)}, TransformFun);
+        not_found ->
+            Acc
+    end.
+
+count_ids(Bin) when byte_size(Bin) rem 32 =:= 0 ->
+    byte_size(Bin) div 32;
+count_ids(_) -> <<"corrupt">>.
+
+decode_and_encode_ids(Bin) ->
+    case decode_item_ids(Bin) of
+        {error, _} -> <<"corrupt">>;
+        List -> [hb_util:encode(ID) || ID <- List]
+    end.
+
+read_block_item_counts(Height, Opts) ->
+    probe_block_items(Height, Opts, fun count_ids/1).
+
+read_block_item_ids(Height, Opts) ->
+    probe_block_items(Height, Opts, fun decode_and_encode_ids/1).
+
+%% @doc mode=list-items: return full item ID lists for a single block.
+list_items_index(From, To, _Opts) when From =/= To ->
+    {error, <<"mode=list-items requires from=to (single block only)">>};
+list_items_index(From, _To, Opts) ->
+    BlockKey = hb_util:bin(From),
+    BlockInfo = case fetch_block_header(From, Opts) of
+        {ok, Block} ->
+            Base = assemble_block_info(From, Block, Opts),
+            case maps:get(<<"depth">>, Base, undefined) of
+                undefined -> Base;
+                _ -> Base#{<<"items">> => read_block_item_ids(From, Opts)}
+            end;
+        {error, _} ->
+            #{<<"error">> => <<"block not found">>}
+    end,
+    JSON = hb_json:encode(#{BlockKey => BlockInfo}),
+    {ok, #{
+        <<"content-type">> => <<"application/json">>,
+        <<"body">> => JSON
+    }}.
 
 fetch_block_header(Height, Opts) ->
     ?event(debug_copycat, {fetching_block, Height}),
@@ -444,7 +684,8 @@ classify_txs(TXIDs, Opts) ->
 
 %% @doc Fetch blocks from an Arweave node while moving downward from `Current'.
 %% If `To' is provided, every block in [`To', `Current'] is processed. If `To'
-%% is omitted, stop at the first block where any TX is already indexed.
+%% is omitted, stop at the first block already indexed at the requested depth
+%% (via block markers above cutover, or legacy per-TX check below cutover).
 fetch_blocks(Current, To, TargetDepth, _Opts) 
         when is_integer(To), Current < To ->
     ?event(copycat_short,
@@ -458,7 +699,7 @@ fetch_blocks(Current, undefined, _TargetDepth, _Opts) when Current < 0 ->
     {ok, 0};
 fetch_blocks(Current, undefined, TargetDepth, Opts) ->
     BlockRes = fetch_block_header(Current, Opts),
-    case is_already_indexed(BlockRes, Opts) of
+    case is_already_indexed(BlockRes, TargetDepth, Opts) of
         true ->
             ?event(copycat_short,
                 {arweave_block_indexing_completed,
@@ -478,13 +719,36 @@ fetch_blocks(Current, To, TargetDepth, Opts) ->
     end),
     fetch_blocks(Current - 1, To, TargetDepth, Opts).
 
-%% @doc Determine whether a fetched block is considered indexed.
-%% A block is indexed when any TX from its `txs' list is in the index.
-is_already_indexed({ok, Block}, Opts) ->
-    TXIDs = hb_maps:get(<<"txs">>, Block, [], Opts),
-    lists:any(fun(TXID) -> is_tx_indexed(TXID, Opts) end, TXIDs);
-is_already_indexed({error, _}, _Opts) ->
+%% @doc Determine whether a fetched block is considered indexed at the
+%% requested depth. Checks block markers first. For blocks at or above
+%% the cutover height, the marker is authoritative. For blocks below
+%% the cutover, falls back to legacy per-TX check.
+is_already_indexed({ok, Block}, TargetDepth, Opts) ->
+    Height = hb_maps:get(<<"height">>, Block, undefined, Opts),
+    case is_block_indexed(Height, TargetDepth, Opts) of
+        true ->
+            true;
+        false ->
+            case is_post_cutover(Height, Opts) of
+                true ->
+                    false;
+                false ->
+                    TXIDs = hb_maps:get(<<"txs">>, Block, [], Opts),
+                    lists:any(
+                        fun(TXID) -> is_tx_indexed(TXID, Opts) end,
+                        TXIDs
+                    )
+            end
+    end;
+is_already_indexed({error, _}, _TargetDepth, _Opts) ->
     false.
+
+is_post_cutover(undefined, _Opts) -> false;
+is_post_cutover(Height, Opts) ->
+    case read_cutover_height(Opts) of
+        undefined -> false;
+        Cutover -> Height >= Cutover
+    end.
 
 fetch_and_process_block(Current, To, TargetDepth, Opts) ->
     BlockRes = fetch_block_header(Current, Opts),
@@ -512,17 +776,46 @@ process_block(BlockRes, Current, To, TargetDepth, Opts) ->
                     TotalTXs = maps:get(total_txs, Results, 0),
                     BundleTXs = maps:get(bundle_count, Results, 0),
                     SkippedTXs = maps:get(skipped_count, Results, 0),
-                    ?event(
-                        copycat_short,
-                        {arweave_block_indexed,
-                            {height, Current},
-                            {items_indexed, ItemsIndexed},
-                            {total_txs, TotalTXs},
-                            {bundle_txs, BundleTXs},
-                            {skipped_txs, SkippedTXs},
-                            {target, To}
-                        }
-                    )
+                    AchievedDepth = maps:get(
+                        achieved_depth, Results,
+                        max(2, TargetDepth)),
+                    ItemIDs = maps:get(item_ids, Results, #{}),
+                    maybe
+                        ok ?= write_block_item_ids(
+                            Current, AchievedDepth, ItemIDs, Opts),
+                        ok ?= mark_block_indexed(
+                            Current, AchievedDepth, Opts),
+                        ensure_cutover_height(Current, Opts),
+                        ?event(
+                            copycat_short,
+                            {arweave_block_indexed,
+                                {height, Current},
+                                {items_indexed, ItemsIndexed},
+                                {total_txs, TotalTXs},
+                                {bundle_txs, BundleTXs},
+                                {skipped_txs, SkippedTXs},
+                                {achieved_depth, AchievedDepth},
+                                {target, To}
+                            }
+                        )
+                    else
+                        {error, item_ids_write_failed} ->
+                            ?event(
+                                copycat_short,
+                                {arweave_block_metadata_failed,
+                                    {height, Current},
+                                    {target, To}
+                                }
+                            );
+                        _ ->
+                            ?event(
+                                copycat_short,
+                                {arweave_block_marker_failed,
+                                    {height, Current},
+                                    {target, To}
+                                }
+                            )
+                    end
             end;
         {error, _} = Error ->
             ?event(
@@ -560,15 +853,19 @@ maybe_index_block(Block, TargetDepth, Opts) ->
                     }};
                 {ok, TXs} ->
                     Height = hb_maps:get(<<"height">>, Block, 0, Opts),
+                    L1IDs = [TX#tx.id || TX <- TXs],
                     TXsWithData = ar_block:generate_size_tagged_list_from_txs(TXs, Height),
-                    % Filter out padding entries before processing
                     ValidTXs = lists:filter(
                         fun({{padding, _}, _}) -> false; (_) -> true end,
                         TXsWithData
                     ),
                     TXResults = process_block_txs(
                         ValidTXs, BlockStartOffset, TargetDepth, Opts),
-                    {block_cached, TXResults#{total_txs => TotalTXs}}
+                    ExistingIDs = maps:get(item_ids, TXResults, #{}),
+                    {block_cached, TXResults#{
+                        total_txs => TotalTXs,
+                        item_ids => ExistingIDs#{1 => L1IDs}
+                    }}
             end
     end.
 
@@ -582,8 +879,9 @@ parallel_map(Items, Fun, Opts) ->
 
 %% @doc Process a single transaction and return its contribution to the counters.
 %% Returns a map with keys: items_count, bundle_count, skipped_count
-process_block_tx({{padding, _PaddingRoot}, _EndOffset}, _BlockStartOffset, _TargetDepth, _Opts) ->
-    #{items_count => 0, bundle_count => 0, skipped_count => 0};
+process_block_tx({{padding, _PaddingRoot}, _EndOffset}, _BlockStartOffset, TargetDepth, _Opts) ->
+    #{items_count => 0, bundle_count => 0, skipped_count => 0,
+        achieved_depth => max(2, TargetDepth)};
 process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, Opts) ->
     IndexStore = hb_store_arweave:store_from_opts(Opts),
     TXID = hb_util:encode(TX#tx.id),
@@ -604,11 +902,17 @@ process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, 
         )
     end),
     case is_bundle_tx(TX, Opts) of
-        false -> #{items_count => 0, bundle_count => 0, skipped_count => 0};
+        false ->
+            #{items_count => 0, bundle_count => 0, skipped_count => 0,
+                achieved_depth => max(2, TargetDepth)};
         true when TargetDepth > 2 ->
-            % Indexing a block to depth 3 or greater means we need to load
-            % and recurse into each of the L1 TXs in the block.
-            maybe_process_l1_tx(TX#tx.id, #{}, TargetDepth - 1, false, Opts);
+            L1Result = process_l1_tx_direct(
+                TXStartOffset, TX#tx.data_size,
+                TargetDepth - 1, IndexStore, TXID, Opts),
+            L1Result#{
+                achieved_depth =>
+                    max(2, maps:get(achieved_depth, L1Result, 0))
+            };
         true ->
             % Lightweight processing of block transactions to depth 2. We
             % can avoid loading the full L1 TX data into memory, and instead
@@ -624,7 +928,6 @@ process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, 
             ),
             case BundleRes of
                 {ok, HeaderSize, BundleIndex} ->
-                    % Batch event tracking: measure total time and count for all write_offset calls
                     {TotalTime, {_, ItemsCount}} = timer:tc(fun() ->
                         lists:foldl(
                             fun({ItemID, Size}, {ItemStartOffset, ItemsCountAcc}) ->
@@ -641,14 +944,16 @@ process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, 
                             BundleIndex
                         )
                     end),
+                    L2IDs = [ItemID || {ItemID, _Size} <- BundleIndex],
                     ?event(debug_copycat,
                         {bundle_items_indexed,
                             {tx_id, {string, TXID}},
                             {items_count, ItemsCount}
                         }),
-                    % Single event increment for the batch
                     record_event_metrics(<<"item_indexed">>, ItemsCount, TotalTime),
-                    #{items_count => ItemsCount, bundle_count => 1, skipped_count => 0};
+                    #{items_count => ItemsCount, bundle_count => 1,
+                        skipped_count => 0, achieved_depth => 2,
+                        item_ids => #{2 => L2IDs}};
                 {error, Reason} ->
                     ?event(
                         copycat_short,
@@ -657,7 +962,8 @@ process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, 
                             {reason, Reason}
                         }
                     ),
-                    #{items_count => 0, bundle_count => 1, skipped_count => 1}
+                    #{items_count => 0, bundle_count => 1,
+                        skipped_count => 1, achieved_depth => 0}
             end
     end.
 
@@ -700,21 +1006,43 @@ process_block_txs(ValidTXs, BlockStartOffset, TargetDepth, Opts) ->
             TXWithData, BlockStartOffset, TargetDepth, Opts) end,
         Opts
     ),
-    lists:foldl(
+    Folded = lists:foldl(
         fun(Result, Acc) ->
             #{
-                items_count => maps:get(items_count, Result, 0) + maps:get(items_count, Acc, 0),
-                bundle_count => maps:get(bundle_count, Result, 0) + maps:get(bundle_count, Acc, 0),
-                skipped_count => maps:get(skipped_count, Result, 0) + maps:get(skipped_count, Acc, 0)
+                items_count =>
+                    maps:get(items_count, Result, 0)
+                        + maps:get(items_count, Acc, 0),
+                bundle_count =>
+                    maps:get(bundle_count, Result, 0)
+                        + maps:get(bundle_count, Acc, 0),
+                skipped_count =>
+                    maps:get(skipped_count, Result, 0)
+                        + maps:get(skipped_count, Acc, 0),
+                achieved_depth =>
+                    min(
+                        maps:get(achieved_depth, Result, ?DEPTH_SENTINEL),
+                        maps:get(achieved_depth, Acc, ?DEPTH_SENTINEL)
+                    )
             }
         end,
-        #{items_count => 0, bundle_count => 0, skipped_count => 0},
+        #{items_count => 0, bundle_count => 0, skipped_count => 0,
+            achieved_depth => ?DEPTH_SENTINEL},
         Results
-    ).
+    ),
+    MergedIDs = merge_all_item_ids(
+        [maps:get(item_ids, R, #{}) || R <- Results]),
+    Folded2 = Folded#{item_ids => MergedIDs},
+    case maps:get(achieved_depth, Folded2) of
+        ?DEPTH_SENTINEL ->
+            Folded2#{achieved_depth => max(2, TargetDepth)};
+        _ ->
+            Folded2
+    end.
 
 %% @doc Process a single indexed L1 TX candidate after lightweight filter checks.
 maybe_process_l1_tx(TXID, Filters, Depth, QueryL1Offset, Opts) ->
-    Skipped = #{items_count => 0, bundle_count => 0, skipped_count => 1},
+    Skipped = #{items_count => 0, bundle_count => 0, skipped_count => 1,
+        achieved_depth => 0},
     NormalizedTXID = hb_util:native_id(TXID),
     EncodedTXID = hb_util:encode(NormalizedTXID),
     IndexStore = hb_store_arweave:store_from_opts(Opts),
@@ -795,7 +1123,8 @@ maybe_process_l1_tx(TXID, Filters, Depth, QueryL1Offset, Opts) ->
             #{
                 items_count => 0,
                 bundle_count => 1,
-                skipped_count => 1
+                skipped_count => 1,
+                achieved_depth => 0
             };
         FilterReason ->
             ?event(
@@ -808,10 +1137,26 @@ maybe_process_l1_tx(TXID, Filters, Depth, QueryL1Offset, Opts) ->
             Skipped
     end.
 
+%% @doc Fast path for depth>2 block indexing. Skips offset lookup and
+%% header re-fetch since the caller already has both.
+process_l1_tx_direct(StartOffset, Length, Depth, IndexStore, EncodedTXID, Opts) ->
+    MemoryCap = get_memory_safe_cap(Opts),
+    case MemoryCap =/= undefined andalso Length > MemoryCap of
+        true ->
+            ?event(copycat_short,
+                {arweave_bundle_skipped,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {reason, memory_safe_cap_exceeded}
+                }
+            ),
+            #{items_count => 0, bundle_count => 1,
+                skipped_count => 1, achieved_depth => 0};
+        false ->
+            process_l1_tx(
+                StartOffset, Length, Depth, IndexStore, EncodedTXID, Opts)
+    end.
+
 %% @doc Load the L1 TX data into memory and index it.
-%% 
-%% TODO: process_l1_tx and process_block_tx are very similar and can/should
-%% be merged.
 process_l1_tx(
         StartOffset, Length, Depth, IndexStore, EncodedTXID, Opts) ->
     case observe_copycat_l1_stage(
@@ -836,7 +1181,7 @@ process_l1_tx(
                 end
             ),
             case IndexRes of
-                {ok, ItemsCount} ->
+                {ok, ItemsCount, AchievedDepth, BundleIDs} ->
                     record_event_metrics(
                         <<"item_indexed">>,
                         ItemsCount,
@@ -845,7 +1190,9 @@ process_l1_tx(
                     #{
                         items_count => ItemsCount,
                         bundle_count => 1,
-                        skipped_count => 0
+                        skipped_count => 0,
+                        achieved_depth => 1 + AchievedDepth,
+                        item_ids => shift_item_ids(BundleIDs, 1)
                     };
                 {error, Reason} ->
                     ?event(
@@ -858,7 +1205,8 @@ process_l1_tx(
                     #{
                         items_count => 0,
                         bundle_count => 1,
-                        skipped_count => 1
+                        skipped_count => 1,
+                        achieved_depth => 0
                     }
             end;
         {error, Reason} ->
@@ -872,7 +1220,8 @@ process_l1_tx(
             #{
                 items_count => 0,
                 bundle_count => 1,
-                skipped_count => 1
+                skipped_count => 1,
+                achieved_depth => 0
             };
         not_found ->
             ?event(
@@ -885,7 +1234,8 @@ process_l1_tx(
             #{
                 items_count => 0,
                 bundle_count => 1,
-                skipped_count => 1
+                skipped_count => 1,
+                achieved_depth => 0
             }
     end.
 %% @doc Ensure the root L1 TX offset exists locally before `id=...` indexing.
@@ -963,7 +1313,7 @@ query_l1_tx_offset(TXID, IndexStore, Opts) ->
 
 index_full_bundle_bytes(_BundleData, _BundleStartOffset, Depth, _Store, _Opts)
         when Depth =< 0 ->
-    {ok, 0};
+    {ok, 0, 0, #{}};
 index_full_bundle_bytes(BundleData, BundleStartOffset, Depth, Store, Opts) ->
     case ar_bundles:decode_bundle_header(BundleData) of
         invalid_bundle_header ->
@@ -977,13 +1327,25 @@ index_full_bundle_bytes(BundleData, BundleStartOffset, Depth, Store, Opts) ->
                 Depth,
                 Store,
                 Opts,
-                0
+                0,
+                ?DEPTH_SENTINEL,
+                [],
+                #{}
             )
     end.
 
 %% @doc Index bundle children from decoded bundle bytes and recurse descendants in-memory.
-index_full_bundle_items([], _ItemsBin, _ItemStartOffset, _Depth, _Store, _Opts, Count) ->
-    {ok, Count};
+%% Returns {ok, Count, MinAchievedDepth, ItemIDs} or {error, Reason}.
+%% ItemIDs is a map of relative-depth => list of raw 32-byte IDs.
+index_full_bundle_items(
+        [], _ItemsBin, _ItemStartOffset, Depth, _Store, _Opts,
+        Count, MinDepth, ThisLevelIDs, DescIDs) ->
+    FinalDepth = case MinDepth of
+        ?DEPTH_SENTINEL -> Depth;
+        _ -> 1 + MinDepth
+    end,
+    AllIDs = DescIDs#{1 => lists:reverse(ThisLevelIDs)},
+    {ok, Count, FinalDepth, AllIDs};
 index_full_bundle_items(
     [{ItemID, Size} | Rest],
     ItemsBin,
@@ -991,29 +1353,32 @@ index_full_bundle_items(
     Depth,
     Store,
     Opts,
-    Count
+    Count,
+    MinDepth,
+    ThisLevelIDs,
+    DescIDs
 ) when byte_size(ItemsBin) >= Size ->
     ItemBinary = binary:part(ItemsBin, 0, Size),
+    EncodedItemID = hb_util:encode(ItemID),
+    ParseResult = validate_and_flag_item_id(
+        ItemBinary, ItemID, EncodedItemID, Store),
     hb_store_arweave:write_offset(
         Store,
-        hb_util:encode(ItemID),
+        EncodedItemID,
         <<"ans104@1.0">>,
         ItemStartOffset,
         Size
     ),
-    DescendantCount =
-        case Depth > 1 of
-            true ->
-                index_full_bundle_descendants(
-                    ItemBinary,
-                    ItemStartOffset,
-                    Depth - 1,
-                    Store,
-                    Opts
-                );
-            false ->
-                0
+    {DescendantCount, ItemAchievedDepth, ChildIDs} =
+        case {Depth > 1, ParseResult} of
+            {true, {ok, HeaderSize, ParsedItem}} ->
+                index_full_bundle_descendants_parsed(
+                    ParsedItem, HeaderSize,
+                    ItemStartOffset, Depth - 1, Store, Opts);
+            _ ->
+                {0, Depth - 1, #{}}
         end,
+    ShiftedChildIDs = shift_item_ids(ChildIDs, 1),
     index_full_bundle_items(
         Rest,
         binary:part(ItemsBin, Size, byte_size(ItemsBin) - Size),
@@ -1021,38 +1386,78 @@ index_full_bundle_items(
         Depth,
         Store,
         Opts,
-        Count + 1 + DescendantCount
+        Count + 1 + DescendantCount,
+        min(MinDepth, ItemAchievedDepth),
+        [ItemID | ThisLevelIDs],
+        merge_item_ids(DescIDs, ShiftedChildIDs)
     );
-index_full_bundle_items(_BundleIndex, _ItemsBin, _ItemStartOffset, _Depth, _Store, _Opts, _Count) ->
+index_full_bundle_items(
+        _BundleIndex, _ItemsBin, _ItemStartOffset, _Depth,
+        _Store, _Opts, _Count, _MinDepth, _ThisLevelIDs, _DescIDs) ->
     {error, invalid_bundle_header}.
 
-%% @doc Recurse into a nested bundle data item from in-memory bytes.
-index_full_bundle_descendants(_ItemBinary, _ItemStartOffset, Depth, _Store, _Opts)
+%% @doc Recurse into a nested data item using an already-parsed header.
+%% Returns {Count, AchievedDepth, ItemIDs}.
+index_full_bundle_descendants_parsed(
+        _ParsedItem, _HeaderSize, _ItemStartOffset, Depth, _Store, _Opts)
         when Depth =< 0 ->
-    0;
-index_full_bundle_descendants(ItemBinary, ItemStartOffset, Depth, Store, Opts) ->
-    try ar_bundles:deserialize_header(ItemBinary) of
-        {ok, HeaderSize, HeaderTX} ->
-            case is_bundle_tx(HeaderTX, Opts) of
-                true ->
-                    case index_full_bundle_bytes(
-                        HeaderTX#tx.data,
-                        ItemStartOffset + HeaderSize,
-                        Depth,
-                        Store,
-                        Opts
-                    ) of
-                        {ok, Count} -> Count;
-                        _ -> 0
-                    end;
-                false ->
-                    0
+    {0, 0, #{}};
+index_full_bundle_descendants_parsed(
+        ParsedItem, HeaderSize, ItemStartOffset, Depth, Store, Opts) ->
+    case is_bundle_tx(ParsedItem, Opts) of
+        true ->
+            case index_full_bundle_bytes(
+                ParsedItem#tx.data,
+                ItemStartOffset + HeaderSize,
+                Depth,
+                Store,
+                Opts
+            ) of
+                {ok, Count, ChildDepth, ChildIDs} ->
+                    {Count, ChildDepth, ChildIDs};
+                _ ->
+                    {0, 0, #{}}
             end;
+        false ->
+            {0, Depth, #{}}
+    end.
+
+%% @doc Validate an item ID by hashing the signature from the deserialized
+%% header. Returns {ok, HeaderSize, ParsedItem} on successful parse, or
+%% error if deserialization fails. Mismatch flags are written but don't
+%% prevent the item from being indexed.
+validate_and_flag_item_id(ItemBinary, DeclaredID, EncodedDeclaredID, Store) ->
+    try ar_bundles:deserialize_header(ItemBinary) of
+        {ok, HeaderSize, ParsedItem} ->
+            ComputedID = crypto:hash(sha256, ParsedItem#tx.signature),
+            case ComputedID =:= DeclaredID of
+                true ->
+                    ok;
+                false ->
+                    case Store of
+                        #{ <<"index-store">> := IndexStore } ->
+                            hb_store:write(
+                                IndexStore,
+                                hb_store_arweave_offset:mismatch_path(
+                                    DeclaredID),
+                                ComputedID
+                            );
+                        _ -> ok
+                    end,
+                    ?event(copycat_short,
+                        {item_id_mismatch,
+                            {declared_id, {explicit, EncodedDeclaredID}},
+                            {computed_id,
+                                {explicit, hb_util:encode(ComputedID)}}
+                        }
+                    )
+            end,
+            {ok, HeaderSize, ParsedItem};
         _ ->
-            0
+            error
     catch
         _:_ ->
-            0
+            error
     end.
 
 %% @doc Check whether a TX header indicates bundle content.
@@ -1542,6 +1947,9 @@ auto_stop_on_indexed_block_test_parallel() ->
     ?assert(has_any_indexed_tx(Higher1, Opts)),
     ?assert(has_any_indexed_tx(IndexedBlock, Opts)),
     ?assertNot(has_any_indexed_tx(IndexedBlock-1, Opts)),
+    ?assert(is_block_indexed(IndexedBlock, 2, Opts)),
+    ?assert(is_block_indexed(Higher1, 2, Opts)),
+    ?assert(is_block_indexed(Higher2, 2, Opts)),
     ok.
 
 explicit_to_reindexes_all_test_parallel() ->
@@ -1609,6 +2017,8 @@ auto_stop_partial_index_test_parallel() ->
     ?assert(has_any_indexed_tx(HigherBlock, Opts)),
     ?assert(has_any_indexed_tx(Block, Opts)),
     ?assertNot(has_any_indexed_tx(Block-1, Opts)),
+    ?assert(is_block_indexed(HigherBlock, 2, Opts)),
+    ?assertNot(is_block_indexed(Block, 2, Opts)),
     ok.
 
 negative_parse_range_test_parallel() ->
@@ -2177,3 +2587,330 @@ assert_indexed_range(From, To, _Opts) when From < To ->
 assert_indexed_range(From, To, Opts) ->
     ?assert(has_any_indexed_tx(From, Opts)),
     assert_indexed_range(From - 1, To, Opts).
+
+block_marker_depth_2_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    Block = 1827942,
+    {ok, Block} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=",
+                (hb_util:bin(Block))/binary, "&to=",
+                (hb_util:bin(Block))/binary>>,
+            Opts
+        ),
+    ?assert(is_block_indexed(Block, 2, Opts)),
+    ?assertNot(is_block_indexed(Block, 3, Opts)),
+    ok.
+
+depth_1_normalizes_to_2_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    TX1 = #tx{
+        format = 2,
+        id = crypto:strong_rand_bytes(32),
+        data_size = 100,
+        tags = []
+    },
+    TX2 = #tx{
+        format = 2,
+        id = crypto:strong_rand_bytes(32),
+        data_size = 200,
+        tags = []
+    },
+    Tuples = [
+        {{TX1, <<>>}, 100},
+        {{TX2, <<>>}, 300}
+    ],
+    Result = process_block_txs(Tuples, 0, 1, Opts),
+    ?assertEqual(2, maps:get(achieved_depth, Result)),
+    Height = 88888888,
+    mark_block_indexed(Height, maps:get(achieved_depth, Result), Opts),
+    ?assert(is_block_indexed(Height, 1, Opts)),
+    ?assert(is_block_indexed(Height, 2, Opts)),
+    ?assertNot(is_block_indexed(Height, 3, Opts)),
+    ok.
+
+block_marker_cutover_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    LowerBlock = 1827941,
+    UpperBlock = 1827942,
+    {ok, UpperBlock} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=",
+                (hb_util:bin(UpperBlock))/binary, "&to=",
+                (hb_util:bin(UpperBlock))/binary>>,
+            Opts
+        ),
+    Cutover = read_cutover_height(Opts),
+    ?assertNotEqual(undefined, Cutover),
+    ?assert(is_block_indexed(UpperBlock, 2, Opts)),
+    ?assertNot(is_block_indexed(LowerBlock, 2, Opts)),
+    ok.
+
+achieved_depth_block_depth_3_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    Block = 1827942,
+    {ok, Block} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=",
+                (hb_util:bin(Block))/binary, "&to=",
+                (hb_util:bin(Block))/binary, "&depth=3">>,
+            Opts
+        ),
+    ?assert(is_block_indexed(Block, 3, Opts)),
+    ok.
+
+invalid_bundle_bytes_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    StoreOpts = hb_store_arweave:store_from_opts(Opts),
+    ?assertEqual(
+        {error, invalid_bundle_header},
+        index_full_bundle_bytes(<<"not a bundle">>, 0, 2, StoreOpts, Opts)
+    ),
+    ok.
+
+small_block_depth_3_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    Block = 1889322,
+    {ok, Block} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=",
+                (hb_util:bin(Block))/binary, "&to=",
+                (hb_util:bin(Block))/binary, "&depth=3">>,
+            Opts
+        ),
+    ?assert(is_block_indexed(Block, 3, Opts)),
+    #{ <<"index-store">> := Store } = hb_store_arweave:store_from_opts(Opts),
+    {ok, L1Bin} = hb_store:read(Store, block_items_path(Block, 1)),
+    ?assert(length(decode_item_ids(L1Bin)) > 0),
+    {ok, L2Bin} = hb_store:read(Store, block_items_path(Block, 2)),
+    ?assert(length(decode_item_ids(L2Bin)) > 0),
+    {ok, L3Bin} = hb_store:read(Store, block_items_path(Block, 3)),
+    L3IDs = decode_item_ids(L3Bin),
+    ?assertEqual(3, length(L3IDs)),
+    assert_item_read(
+        <<"npAzk_BomjWBQQr_xnmlhdxjyl97EJnNv_MAaXffs1s">>,
+        Opts),
+    ok.
+
+no_mismatch_flags_on_valid_bundles_test() ->
+    {_TestStore, StoreOpts, Opts} = setup_index_opts(),
+    Block = 1827942,
+    {ok, Block} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=",
+                (hb_util:bin(Block))/binary, "&to=",
+                (hb_util:bin(Block))/binary, "&depth=3">>,
+            Opts
+        ),
+    #{ <<"index-store">> := IndexStore } = StoreOpts,
+    ItemID = hb_util:native_id(
+        <<"54K1ehEIKZxGSusgZzgbGYaHfllwWQ09-S9-eRUJg5Y">>),
+    ?assertEqual(
+        not_found,
+        hb_store:read(
+            IndexStore,
+            hb_store_arweave_offset:mismatch_path(ItemID)
+        )
+    ),
+    ok.
+
+mismatch_path_encoding_test() ->
+    ID = crypto:strong_rand_bytes(32),
+    Path = hb_store_arweave_offset:mismatch_path(ID),
+    ?assert(binary:match(Path, <<"mismatch/">>) =/= nomatch),
+    ok.
+
+exact_marker_depth_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    Block = 1827942,
+    {ok, Block} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=",
+                (hb_util:bin(Block))/binary, "&to=",
+                (hb_util:bin(Block))/binary, "&depth=3">>,
+            Opts
+        ),
+    #{ <<"index-store">> := Store } =
+        hb_store_arweave:store_from_opts(Opts),
+    {ok, StoredBin} =
+        hb_store:read(Store, block_indexed_path(Block)),
+    StoredDepth = binary_to_integer(StoredBin),
+    ?assertEqual(3, StoredDepth),
+    ok.
+
+fabricated_mismatch_test() ->
+    {_TestStore, StoreOpts, _Opts} = setup_index_opts(),
+    {Priv, Pub} = ar_wallet:new(),
+    Target = crypto:strong_rand_bytes(32),
+    Anchor = crypto:strong_rand_bytes(32),
+    Item = ar_bundles:sign_item(
+        ar_bundles:new_item(Target, Anchor, [], <<"test data">>),
+        {Priv, Pub}
+    ),
+    ItemBinary = ar_bundles:serialize(Item),
+    RealID = crypto:hash(sha256, Item#tx.signature),
+    FakeID = crypto:strong_rand_bytes(32),
+    EncodedFakeID = hb_util:encode(FakeID),
+    validate_and_flag_item_id(ItemBinary, FakeID, EncodedFakeID, StoreOpts),
+    #{ <<"index-store">> := IndexStore } = StoreOpts,
+    {ok, StoredActualID} =
+        hb_store:read(
+            IndexStore,
+            hb_store_arweave_offset:mismatch_path(FakeID)
+        ),
+    ?assertEqual(RealID, StoredActualID),
+    ?assertEqual(
+        not_found,
+        hb_store:read(
+            IndexStore,
+            hb_store_arweave_offset:mismatch_path(RealID)
+        )
+    ),
+    ok.
+
+block_item_ids_depth_2_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    {ok, 1827942} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=1827942&to=1827942">>,
+            Opts
+        ),
+    #{ <<"index-store">> := Store } = hb_store_arweave:store_from_opts(Opts),
+    {ok, L1Bin} = hb_store:read(Store, block_items_path(1827942, 1)),
+    L1IDs = decode_item_ids(L1Bin),
+    ?assert(length(L1IDs) > 0),
+    {ok, L2Bin} = hb_store:read(Store, block_items_path(1827942, 2)),
+    L2IDs = decode_item_ids(L2Bin),
+    ?assert(length(L2IDs) > 0),
+    L2Encoded = [hb_util:encode(ID) || ID <- L2IDs],
+    Pos54K = index_of(<<"54K1ehEIKZxGSusgZzgbGYaHfllwWQ09-S9-eRUJg5Y">>, L2Encoded),
+    PosOBK = index_of(<<"OBKr-7UrmjxFD-h-qP-XLuvCgtyuO_IDpBMgIytvusA">>, L2Encoded),
+    ?assert(is_integer(Pos54K)),
+    ?assert(is_integer(PosOBK)),
+    ?assert(Pos54K < PosOBK),
+    ?assertEqual(not_found, hb_store:read(Store, block_items_path(1827942, 3))),
+    ok.
+
+block_item_ids_depth_3_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    {ok, 1827942} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=1827942&to=1827942&depth=3">>,
+            Opts
+        ),
+    #{ <<"index-store">> := Store } = hb_store_arweave:store_from_opts(Opts),
+    {ok, L1Bin} = hb_store:read(Store, block_items_path(1827942, 1)),
+    L1Count = length(decode_item_ids(L1Bin)),
+    ?assertEqual(5, L1Count),
+    {ok, L2Bin} = hb_store:read(Store, block_items_path(1827942, 2)),
+    L2Count = length(decode_item_ids(L2Bin)),
+    ?assert(L2Count > 0),
+    {ok, L3Bin} = hb_store:read(Store, block_items_path(1827942, 3)),
+    L3Count = length(decode_item_ids(L3Bin)),
+    ?assert(L3Count >= 1),
+    L3IDs = decode_item_ids(L3Bin),
+    L3Encoded = [hb_util:encode(ID) || ID <- L3IDs],
+    ?assert(lists:member(
+        <<"8aJrRWtHcJvJ61qsH6agGkemzrtLw3W22xFrpCGAnTM">>, L3Encoded)),
+    ok.
+
+list_index_with_items_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    {ok, 1827942} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=1827942&to=1827942">>,
+            Opts
+        ),
+    {ok, ListResult} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=1827942&to=1827942&mode=list">>,
+            Opts
+        ),
+    Body = hb_json:decode(hb_maps:get(<<"body">>, ListResult)),
+    BlockInfo = maps:get(<<"1827942">>, Body),
+    ?assert(is_integer(maps:get(<<"depth">>, BlockInfo))),
+    Items = maps:get(<<"items">>, BlockInfo),
+    ?assert(maps:get(<<"1">>, Items) > 0),
+    ?assert(maps:get(<<"2">>, Items) > 0),
+    ok.
+
+list_items_single_block_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    {ok, 1827942} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=1827942&to=1827942">>,
+            Opts
+        ),
+    {ok, ListResult} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=1827942&to=1827942&mode=list-items">>,
+            Opts
+        ),
+    Body = hb_json:decode(hb_maps:get(<<"body">>, ListResult)),
+    BlockInfo = maps:get(<<"1827942">>, Body),
+    Items = maps:get(<<"items">>, BlockInfo),
+    L1Items = maps:get(<<"1">>, Items),
+    ?assert(is_list(L1Items)),
+    ?assert(length(L1Items) > 0),
+    L2Items = maps:get(<<"2">>, Items),
+    ?assert(is_list(L2Items)),
+    ?assert(length(L2Items) > 0),
+    {ok, Block} = fetch_block_header(1827942, Opts),
+    BlockTXIDs = hb_maps:get(<<"txs">>, Block, [], Opts),
+    ?assertEqual(BlockTXIDs, L1Items),
+    ?assert(lists:member(
+        <<"54K1ehEIKZxGSusgZzgbGYaHfllwWQ09-S9-eRUJg5Y">>, L2Items)),
+    ok.
+
+list_items_rejects_range_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    {error, _} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=1827942&to=1827940&mode=list-items">>,
+            Opts
+        ),
+    ok.
+
+decode_item_ids_validation_test() ->
+    ?assertEqual([], decode_item_ids(<<>>)),
+    GoodBin = <<0:256, 1:256>>,
+    ?assertEqual(2, length(decode_item_ids(GoodBin))),
+    BadBin = <<0:240>>,
+    ?assertEqual({error, invalid_item_ids_binary}, decode_item_ids(BadBin)),
+    ok.
+
+corrupt_item_ids_read_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    #{ <<"index-store">> := Store } = hb_store_arweave:store_from_opts(Opts),
+    Height = 99999999,
+    hb_store:write(Store, block_indexed_path(Height), <<"2">>),
+    hb_store:write(Store, block_items_path(Height, 1), <<0:256>>),
+    hb_store:write(Store, block_items_path(Height, 2), <<0:240>>),
+    Counts = read_block_item_counts(Height, Opts),
+    ?assertEqual(1, maps:get(<<"1">>, Counts)),
+    ?assertEqual(<<"corrupt">>, maps:get(<<"2">>, Counts)),
+    IDs = read_block_item_ids(Height, Opts),
+    ?assertEqual(1, length(maps:get(<<"1">>, IDs))),
+    ?assertEqual(<<"corrupt">>, maps:get(<<"2">>, IDs)),
+    ok.
+
+memory_cap_depth3_floors_to_2_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    CappedOpts = set_memory_safe_cap(1, Opts),
+    Block = 1827942,
+    {ok, Block} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=",
+                (hb_util:bin(Block))/binary, "&to=",
+                (hb_util:bin(Block))/binary, "&depth=3">>,
+            CappedOpts
+        ),
+    ?assert(is_block_indexed(Block, 2, CappedOpts)),
+    ?assertNot(is_block_indexed(Block, 3, CappedOpts)),
+    ok.
+
+index_of(Elem, List) -> index_of(Elem, List, 1).
+
+index_of(_Elem, [], _N) -> not_found;
+index_of(Elem, [Elem | _], N) -> N;
+index_of(Elem, [_ | Rest], N) -> index_of(Elem, Rest, N + 1).

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -169,12 +169,12 @@ read_block_marker_depth(Height, Opts) ->
     case hb_store_arweave:store_from_opts(Opts) of
         no_store -> undefined;
         #{ <<"index-store">> := Store } ->
-            case hb_store:read(Store, block_indexed_path(Height)) of
+            case hb_store:read(Store, block_indexed_path(Height), Opts) of
                 {ok, Bin} ->
                     try binary_to_integer(Bin)
                     catch _:_ -> undefined
                     end;
-                not_found -> undefined
+                {error, not_found} -> undefined
             end
     end.
 
@@ -230,9 +230,9 @@ mark_block_indexed(Height, Depth, Opts) ->
 %% @doc Read the persisted cutover height from the index store.
 read_cutover_height(Opts) ->
     Store = get_index_store(Opts),
-    case hb_store:read(Store, ?CUTOVER_KEY) of
+    case hb_store:read(Store, ?CUTOVER_KEY, Opts) of
         {ok, Bin} -> hb_util:int(Bin);
-        not_found -> undefined
+        {error, not_found} -> undefined
     end.
 
 %% @doc Write the cutover height if not already set.
@@ -532,7 +532,7 @@ is_tx_indexed(TXID, Opts) ->
     Store = get_index_store(Opts),
     case hb_store:read(Store, hb_store_arweave_offset:path(TXID), Opts) of
         {ok, _} -> true;
-        not_found -> false
+        {error, not_found} -> false
     end.
 
 %% @doc List indexed blocks and transactions in the given range.
@@ -608,17 +608,17 @@ probe_block_items(Height, Opts, TransformFun) ->
     case hb_store_arweave:store_from_opts(Opts) of
         no_store -> #{};
         #{ <<"index-store">> := Store } ->
-            probe_block_items(Height, Store, 1, #{}, TransformFun)
+            probe_block_items(Height, Store, 1, #{}, TransformFun, Opts)
     end.
 
-probe_block_items(Height, Store, Depth, Acc, TransformFun) ->
-    case hb_store:read(Store, block_items_path(Height, Depth)) of
+probe_block_items(Height, Store, Depth, Acc, TransformFun, Opts) ->
+    case hb_store:read(Store, block_items_path(Height, Depth), Opts) of
         {ok, Bin} ->
             Key = hb_util:bin(Depth),
             probe_block_items(
                 Height, Store, Depth + 1,
-                Acc#{Key => TransformFun(Bin)}, TransformFun);
-        not_found ->
+                Acc#{Key => TransformFun(Bin)}, TransformFun, Opts);
+        {error, not_found} ->
             Acc
     end.
 
@@ -2785,11 +2785,11 @@ small_block_depth_3_test() ->
         ),
     ?assert(is_block_indexed(Block, 3, Opts)),
     #{ <<"index-store">> := Store } = hb_store_arweave:store_from_opts(Opts),
-    {ok, L1Bin} = hb_store:read(Store, block_items_path(Block, 1)),
+    {ok, L1Bin} = hb_store:read(Store, block_items_path(Block, 1), Opts),
     ?assert(length(decode_item_ids(L1Bin)) > 0),
-    {ok, L2Bin} = hb_store:read(Store, block_items_path(Block, 2)),
+    {ok, L2Bin} = hb_store:read(Store, block_items_path(Block, 2), Opts),
     ?assert(length(decode_item_ids(L2Bin)) > 0),
-    {ok, L3Bin} = hb_store:read(Store, block_items_path(Block, 3)),
+    {ok, L3Bin} = hb_store:read(Store, block_items_path(Block, 3), Opts),
     L3IDs = decode_item_ids(L3Bin),
     ?assertEqual(3, length(L3IDs)),
     assert_item_read(
@@ -2814,7 +2814,8 @@ no_mismatch_flags_on_valid_bundles_test() ->
         not_found,
         hb_store:read(
             IndexStore,
-            hb_store_arweave_offset:mismatch_path(ItemID)
+            hb_store_arweave_offset:mismatch_path(ItemID),
+            Opts
         )
     ),
     ok.
@@ -2838,13 +2839,13 @@ exact_marker_depth_test() ->
     #{ <<"index-store">> := Store } =
         hb_store_arweave:store_from_opts(Opts),
     {ok, StoredBin} =
-        hb_store:read(Store, block_indexed_path(Block)),
+        hb_store:read(Store, block_indexed_path(Block), Opts),
     StoredDepth = binary_to_integer(StoredBin),
     ?assertEqual(3, StoredDepth),
     ok.
 
 fabricated_mismatch_test() ->
-    {_TestStore, StoreOpts, _Opts} = setup_index_opts(),
+    {_TestStore, StoreOpts, Opts} = setup_index_opts(),
     {Priv, Pub} = ar_wallet:new(),
     Target = crypto:strong_rand_bytes(32),
     Anchor = crypto:strong_rand_bytes(32),
@@ -2861,14 +2862,16 @@ fabricated_mismatch_test() ->
     {ok, StoredActualID} =
         hb_store:read(
             IndexStore,
-            hb_store_arweave_offset:mismatch_path(FakeID)
+            hb_store_arweave_offset:mismatch_path(FakeID),
+            Opts
         ),
     ?assertEqual(RealID, StoredActualID),
     ?assertEqual(
         not_found,
         hb_store:read(
             IndexStore,
-            hb_store_arweave_offset:mismatch_path(RealID)
+            hb_store_arweave_offset:mismatch_path(RealID),
+            Opts
         )
     ),
     ok.
@@ -2881,10 +2884,10 @@ block_item_ids_depth_2_test() ->
             Opts
         ),
     #{ <<"index-store">> := Store } = hb_store_arweave:store_from_opts(Opts),
-    {ok, L1Bin} = hb_store:read(Store, block_items_path(1827942, 1)),
+    {ok, L1Bin} = hb_store:read(Store, block_items_path(1827942, 1), Opts),
     L1IDs = decode_item_ids(L1Bin),
     ?assert(length(L1IDs) > 0),
-    {ok, L2Bin} = hb_store:read(Store, block_items_path(1827942, 2)),
+    {ok, L2Bin} = hb_store:read(Store, block_items_path(1827942, 2), Opts),
     L2IDs = decode_item_ids(L2Bin),
     ?assert(length(L2IDs) > 0),
     L2Encoded = [hb_util:encode(ID) || ID <- L2IDs],
@@ -2893,7 +2896,7 @@ block_item_ids_depth_2_test() ->
     ?assert(is_integer(Pos54K)),
     ?assert(is_integer(PosOBK)),
     ?assert(Pos54K < PosOBK),
-    ?assertEqual(not_found, hb_store:read(Store, block_items_path(1827942, 3))),
+    ?assertEqual(not_found, hb_store:read(Store, block_items_path(1827942, 3), Opts)),
     ok.
 
 block_item_ids_depth_3_test() ->
@@ -2904,13 +2907,13 @@ block_item_ids_depth_3_test() ->
             Opts
         ),
     #{ <<"index-store">> := Store } = hb_store_arweave:store_from_opts(Opts),
-    {ok, L1Bin} = hb_store:read(Store, block_items_path(1827942, 1)),
+    {ok, L1Bin} = hb_store:read(Store, block_items_path(1827942, 1), Opts),
     L1Count = length(decode_item_ids(L1Bin)),
     ?assertEqual(5, L1Count),
-    {ok, L2Bin} = hb_store:read(Store, block_items_path(1827942, 2)),
+    {ok, L2Bin} = hb_store:read(Store, block_items_path(1827942, 2), Opts),
     L2Count = length(decode_item_ids(L2Bin)),
     ?assert(L2Count > 0),
-    {ok, L3Bin} = hb_store:read(Store, block_items_path(1827942, 3)),
+    {ok, L3Bin} = hb_store:read(Store, block_items_path(1827942, 3), Opts),
     L3Count = length(decode_item_ids(L3Bin)),
     ?assert(L3Count >= 1),
     L3IDs = decode_item_ids(L3Bin),

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -53,12 +53,16 @@ arweave(_Base, Request, Opts) ->
                             }}                         
                     end;
                 error ->
-                    TargetDepth = request_depth(Request, ?DEFAULT_BLOCK_DEPTH, Opts),
                     case parse_range(Request, Opts) of
-                        {error, unavailable} -> {error, unavailable};
+                        {error, unavailable} ->
+                            {error, unavailable};
                         {ok, {From, To}} ->
+                            TargetDepth = request_depth(
+                                Request, ?DEFAULT_BLOCK_DEPTH, Opts),
                             ?event(copycat_short,
-                                {indexing_blocks, {from, From}, {to, To}, {depth, TargetDepth}}
+                                {indexing_blocks,
+                                    {from, From}, {to, To},
+                                    {depth, TargetDepth}}
                             ),
                             fetch_blocks(From, To, TargetDepth, Opts)
                     end

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -11,7 +11,6 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(ARWEAVE_DEVICE, <<"~arweave@2.9">>).
--define(BLOCK_MARKER_PREFIX, <<"block/">>).
 -define(CUTOVER_KEY, <<"block/marker-cutover-height">>).
 -define(DEPTH_SENTINEL, 99999).
 % By default we'll index blocks to depth 2 which is:
@@ -69,14 +68,14 @@ arweave(_Base, Request, Opts) ->
                 {error, unavailable} -> {error, unavailable};
                 {ok, {From, To}} -> list_index(From, To, Opts)
             end;
-        <<"list-items">> ->
+        <<"inventory">> ->
             case parse_range(Request, Opts) of
                 {error, unavailable} -> {error, unavailable};
-                {ok, {From, To}} -> list_items_index(From, To, Opts)
+                {ok, {From, To}} -> inventory_index(From, To, Opts)
             end;
         Mode ->
             {error, <<"Unsupported mode `", (hb_util:bin(Mode))/binary,
-                "`. Supported modes are: write, list, list-items">>}
+                "`. Supported modes are: write, list, inventory">>}
     end.
 %% @doc Set safe memory resource allocation cap for the in-memory
 %% bundle processing. in bytes.
@@ -94,9 +93,22 @@ get_depth_recursion_cap(Opts) ->
 get_memory_safe_cap(Opts) ->
     hb_opts:get(copycat_memory_cap, undefined, Opts).
 
+%% @doc Return the effective per-TX memory cap, clamped to the global budget.
+%% Lazily initializes the budget pool on first call.
+effective_memory_cap(Opts) ->
+    Budget = hb_opts:get(
+        copycat_memory_budget, 6 * 1024 * 1024 * 1024, Opts),
+    hb_copycat_budget:ensure_started(Budget),
+    PoolSize = hb_copycat_budget:get_budget(),
+    Cap = get_memory_safe_cap(Opts),
+    case Cap of
+        undefined -> PoolSize;
+        _ -> min(Cap, PoolSize)
+    end.
+
 %% @doc Return the store path for a block completion marker.
 block_indexed_path(Height) ->
-    <<?BLOCK_MARKER_PREFIX/binary, (hb_util:bin(Height))/binary>>.
+    <<"block/", (hb_util:bin(Height))/binary, "/depth">>.
 
 %% @doc Return the store path for a per-block item index at a given depth.
 block_items_path(Height, Depth) ->
@@ -635,26 +647,36 @@ read_block_item_counts(Height, Opts) ->
 read_block_item_ids(Height, Opts) ->
     probe_block_items(Height, Opts, fun decode_and_encode_ids/1).
 
-%% @doc mode=list-items: return full item ID lists for a single block.
-list_items_index(From, To, _Opts) when From =/= To ->
-    {error, <<"mode=list-items requires from=to (single block only)">>};
-list_items_index(From, _To, Opts) ->
-    BlockKey = hb_util:bin(From),
-    BlockInfo = case fetch_block_header(From, Opts) of
-        {ok, Block} ->
-            Base = assemble_block_info(From, Block, Opts),
-            case maps:get(<<"depth">>, Base, undefined) of
-                undefined -> Base;
-                _ -> Base#{<<"items">> => read_block_item_ids(From, Opts)}
-            end;
-        {error, _} ->
-            #{<<"error">> => <<"block not found">>}
-    end,
-    JSON = hb_json:encode(#{BlockKey => BlockInfo}),
+%% @doc mode=inventory: return per-depth item ID lists from the local index store.
+%% Supports range queries. The inventory read itself is local-only (no network).
+%% Note: range parsing may call latest_height/1 if from/to are omitted or negative.
+inventory_index(From, undefined, Opts) ->
+    inventory_index(From, 0, Opts);
+inventory_index(From, To, _Opts) when From < To ->
+    {ok, #{
+        <<"content-type">> => <<"application/json">>,
+        <<"body">> => hb_json:encode(#{})
+    }};
+inventory_index(From, To, Opts) ->
+    Result = inventory_local(From, To, Opts, #{}),
+    JSON = hb_json:encode(Result),
     {ok, #{
         <<"content-type">> => <<"application/json">>,
         <<"body">> => JSON
     }}.
+
+inventory_local(Current, To, _Opts, Acc) when Current < To -> Acc;
+inventory_local(Current, To, Opts, Acc) ->
+    case read_block_depth(Current, Opts) of
+        undefined ->
+            inventory_local(Current - 1, To, Opts, Acc);
+        Depth ->
+            ItemIDs = read_block_item_ids(Current, Opts),
+            BlockKey = hb_util:bin(Current),
+            BlockInfo = #{<<"depth">> => Depth, <<"items">> => ItemIDs},
+            inventory_local(Current - 1, To, Opts,
+                Acc#{BlockKey => BlockInfo})
+    end.
 
 fetch_block_header(Height, Opts) ->
     ?event(debug_copycat, {fetching_block, Height}),
@@ -686,7 +708,7 @@ classify_txs(TXIDs, Opts) ->
 %% If `To' is provided, every block in [`To', `Current'] is processed. If `To'
 %% is omitted, stop at the first block already indexed at the requested depth
 %% (via block markers above cutover, or legacy per-TX check below cutover).
-fetch_blocks(Current, To, TargetDepth, _Opts) 
+fetch_blocks(Current, To, TargetDepth, _Opts)
         when is_integer(To), Current < To ->
     ?event(copycat_short,
         {arweave_block_indexing_completed,
@@ -698,26 +720,97 @@ fetch_blocks(Current, To, TargetDepth, _Opts)
 fetch_blocks(Current, undefined, _TargetDepth, _Opts) when Current < 0 ->
     {ok, 0};
 fetch_blocks(Current, undefined, TargetDepth, Opts) ->
-    BlockRes = fetch_block_header(Current, Opts),
-    case is_already_indexed(BlockRes, TargetDepth, Opts) of
-        true ->
+    BlockWorkers = block_workers(Opts),
+    fetch_blocks_open_ended(Current, TargetDepth, BlockWorkers, Opts);
+fetch_blocks(Current, To, TargetDepth, Opts) ->
+    BlockWorkers = block_workers(Opts),
+    fetch_blocks_ranged(Current, To, TargetDepth, BlockWorkers, Opts).
+
+block_workers(Opts) ->
+    max(1, hb_opts:get(arweave_block_workers, 3, Opts)).
+
+%% @doc Process a known range of blocks in parallel batches.
+fetch_blocks_ranged(Current, To, TargetDepth, _Workers, _Opts)
+        when Current < To ->
+    ?event(copycat_short,
+        {arweave_block_indexing_completed,
+            {reached_target, To},
+            {target_depth, TargetDepth}
+        }
+    ),
+    {ok, To};
+fetch_blocks_ranged(Current, To, TargetDepth, Workers, Opts) ->
+    BatchEnd = max(To, Current - Workers + 1),
+    Heights = lists:seq(Current, BatchEnd, -1),
+    hb_pmap:parallel_map(
+        Heights,
+        fun(H) ->
+            observe_event(<<"block_indexed">>, fun() ->
+                fetch_and_process_block(H, To, TargetDepth, Opts)
+            end)
+        end,
+        Workers
+    ),
+    fetch_blocks_ranged(BatchEnd - 1, To, TargetDepth, Workers, Opts).
+
+%% @doc Process blocks until an already-indexed block is found.
+%% Fetches headers in parallel, stops at the first indexed block,
+%% then processes the unindexed prefix in parallel.
+fetch_blocks_open_ended(Current, _TargetDepth, _Workers, _Opts)
+        when Current < 0 ->
+    {ok, 0};
+fetch_blocks_open_ended(Current, TargetDepth, Workers, Opts) ->
+    BatchEnd = max(0, Current - Workers + 1),
+    Heights = lists:seq(Current, BatchEnd, -1),
+    HeaderResults = hb_pmap:parallel_map(
+        Heights,
+        fun(H) -> {H, fetch_block_header(H, Opts)} end,
+        Workers
+    ),
+    case find_indexed_prefix(HeaderResults, TargetDepth, Opts) of
+        {all_unindexed, ToProcess} ->
+            process_prefetched_blocks(
+                ToProcess, TargetDepth, Workers, Opts),
+            fetch_blocks_open_ended(
+                BatchEnd - 1, TargetDepth, Workers, Opts);
+        {stop_at, StopHeight, ToProcess} ->
+            process_prefetched_blocks(
+                ToProcess, TargetDepth, Workers, Opts),
             ?event(copycat_short,
                 {arweave_block_indexing_completed,
-                    {stop_at_indexed_block, Current}
+                    {stop_at_indexed_block, StopHeight}
                 }
             ),
-            {ok, Current};
+            {ok, StopHeight}
+    end.
+
+%% @doc Walk header results in order, return the unindexed prefix and
+%% either the stop height or all_unindexed.
+find_indexed_prefix(HeaderResults, TargetDepth, Opts) ->
+    find_indexed_prefix(HeaderResults, TargetDepth, Opts, []).
+
+find_indexed_prefix([], _TargetDepth, _Opts, Acc) ->
+    {all_unindexed, lists:reverse(Acc)};
+find_indexed_prefix([{H, BlockRes} | Rest], TargetDepth, Opts, Acc) ->
+    case is_already_indexed(BlockRes, TargetDepth, Opts) of
+        true ->
+            {stop_at, H, lists:reverse(Acc)};
         false ->
+            find_indexed_prefix(
+                Rest, TargetDepth, Opts, [{H, BlockRes} | Acc])
+    end.
+
+%% @doc Process a list of {Height, BlockRes} tuples in parallel.
+process_prefetched_blocks(Blocks, TargetDepth, Workers, Opts) ->
+    hb_pmap:parallel_map(
+        Blocks,
+        fun({H, BlockRes}) ->
             observe_event(<<"block_indexed">>, fun() ->
-                process_block(BlockRes, Current, undefined, TargetDepth, Opts)
-            end),
-            fetch_blocks(Current - 1, undefined, TargetDepth, Opts)
-    end;
-fetch_blocks(Current, To, TargetDepth, Opts) ->
-    observe_event(<<"block_indexed">>, fun() ->
-        fetch_and_process_block(Current, To, TargetDepth, Opts)
-    end),
-    fetch_blocks(Current - 1, To, TargetDepth, Opts).
+                process_block(BlockRes, H, undefined, TargetDepth, Opts)
+            end)
+        end,
+        Workers
+    ).
 
 %% @doc Determine whether a fetched block is considered indexed at the
 %% requested depth. Checks block markers first. For blocks at or above
@@ -1077,12 +1170,13 @@ maybe_process_l1_tx(TXID, Filters, Depth, QueryL1Offset, Opts) ->
                 true -> bundle;
                 false -> not_bundle
             end,
-        within_memory_cap ?=
-            case Length =< get_memory_safe_cap(Opts) of
-                true -> within_memory_cap;
-                false -> memory_safe_cap_exceeded
+        within_effective_cap ?=
+            case Length =< effective_memory_cap(Opts) of
+                true -> within_effective_cap;
+                false -> effective_cap_exceeded
             end,
-        process_l1_tx(
+        ok ?= hb_copycat_budget:lease(Length),
+        try process_l1_tx(
             StartOffset,
             Length,
             Depth,
@@ -1090,6 +1184,9 @@ maybe_process_l1_tx(TXID, Filters, Depth, QueryL1Offset, Opts) ->
             EncodedTXID,
             Opts
         )
+        after
+            hb_copycat_budget:release(Length)
+        end
     else
         {error, Reason} ->
             ?event(
@@ -1112,12 +1209,12 @@ maybe_process_l1_tx(TXID, Filters, Depth, QueryL1Offset, Opts) ->
                 }
             ),
             Skipped;
-        memory_safe_cap_exceeded ->
+        effective_cap_exceeded ->
             ?event(
                 copycat_short,
                 {arweave_bundle_skipped,
                     {tx_id, {explicit, EncodedTXID}},
-                    {reason, memory_safe_cap_exceeded}
+                    {reason, effective_cap_exceeded}
                 }
             ),
             #{
@@ -1140,20 +1237,26 @@ maybe_process_l1_tx(TXID, Filters, Depth, QueryL1Offset, Opts) ->
 %% @doc Fast path for depth>2 block indexing. Skips offset lookup and
 %% header re-fetch since the caller already has both.
 process_l1_tx_direct(StartOffset, Length, Depth, IndexStore, EncodedTXID, Opts) ->
-    MemoryCap = get_memory_safe_cap(Opts),
-    case MemoryCap =/= undefined andalso Length > MemoryCap of
+    EffectiveCap = effective_memory_cap(Opts),
+    case Length > EffectiveCap of
         true ->
             ?event(copycat_short,
                 {arweave_bundle_skipped,
                     {tx_id, {explicit, EncodedTXID}},
-                    {reason, memory_safe_cap_exceeded}
+                    {reason, effective_cap_exceeded}
                 }
             ),
             #{items_count => 0, bundle_count => 1,
                 skipped_count => 1, achieved_depth => 0};
         false ->
-            process_l1_tx(
-                StartOffset, Length, Depth, IndexStore, EncodedTXID, Opts)
+            ok = hb_copycat_budget:lease(Length),
+            try
+                process_l1_tx(
+                    StartOffset, Length, Depth,
+                    IndexStore, EncodedTXID, Opts)
+            after
+                hb_copycat_budget:release(Length)
+            end
     end.
 
 %% @doc Load the L1 TX data into memory and index it.
@@ -2834,20 +2937,21 @@ list_index_with_items_test() ->
     ?assert(maps:get(<<"2">>, Items) > 0),
     ok.
 
-list_items_single_block_test() ->
+inventory_single_block_test() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     {ok, 1827942} =
         hb_ao:resolve(
             <<"~copycat@1.0/arweave&from=1827942&to=1827942">>,
             Opts
         ),
-    {ok, ListResult} =
+    {ok, InvResult} =
         hb_ao:resolve(
-            <<"~copycat@1.0/arweave&from=1827942&to=1827942&mode=list-items">>,
+            <<"~copycat@1.0/arweave&from=1827942&to=1827942&mode=inventory">>,
             Opts
         ),
-    Body = hb_json:decode(hb_maps:get(<<"body">>, ListResult)),
+    Body = hb_json:decode(hb_maps:get(<<"body">>, InvResult)),
     BlockInfo = maps:get(<<"1827942">>, Body),
+    ?assert(is_integer(maps:get(<<"depth">>, BlockInfo))),
     Items = maps:get(<<"items">>, BlockInfo),
     L1Items = maps:get(<<"1">>, Items),
     ?assert(is_list(L1Items)),
@@ -2855,20 +2959,26 @@ list_items_single_block_test() ->
     L2Items = maps:get(<<"2">>, Items),
     ?assert(is_list(L2Items)),
     ?assert(length(L2Items) > 0),
-    {ok, Block} = fetch_block_header(1827942, Opts),
-    BlockTXIDs = hb_maps:get(<<"txs">>, Block, [], Opts),
-    ?assertEqual(BlockTXIDs, L1Items),
+    ?assertEqual(5, length(L1Items)),
     ?assert(lists:member(
         <<"54K1ehEIKZxGSusgZzgbGYaHfllwWQ09-S9-eRUJg5Y">>, L2Items)),
     ok.
 
-list_items_rejects_range_test() ->
-    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
-    {error, _} =
-        hb_ao:resolve(
-            <<"~copycat@1.0/arweave&from=1827942&to=1827940&mode=list-items">>,
-            Opts
-        ),
+inventory_range_test() ->
+    {_TestStore, StoreOpts, Opts} = setup_index_opts(),
+    #{ <<"index-store">> := Store } = StoreOpts,
+    hb_store:write(Store, block_indexed_path(77777777), <<"2">>),
+    hb_store:write(Store, block_items_path(77777777, 1), <<0:256>>),
+    hb_store:write(Store, block_items_path(77777777, 2), <<>>),
+    hb_store:write(Store, block_indexed_path(77777778), <<"2">>),
+    hb_store:write(Store, block_items_path(77777778, 1), <<1:256>>),
+    hb_store:write(Store, block_items_path(77777778, 2), <<>>),
+    {ok, InvResult} = inventory_index(77777778, 77777777, Opts),
+    Body = hb_json:decode(hb_maps:get(<<"body">>, InvResult)),
+    ?assert(maps:is_key(<<"77777777">>, Body)),
+    ?assert(maps:is_key(<<"77777778">>, Body)),
+    ?assertEqual(2, maps:get(<<"depth">>, maps:get(<<"77777777">>, Body))),
+    ?assertEqual(2, maps:get(<<"depth">>, maps:get(<<"77777778">>, Body))),
     ok.
 
 decode_item_ids_validation_test() ->

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -390,24 +390,33 @@ process_l1_request(TXID, Request, Opts) ->
     observe_copycat_l1_stage(
         <<"l1_request_total">>,
         fun() ->
-            maybe
-                {ok, OwnerFilters} ?= parse_owner_filter(Request, Opts),
-                {ok, IncludeTag} ?= parse_tag_filter(<<"include-tag">>, Request, Opts),
-                {ok, ExcludeTag} ?= parse_tag_filter(<<"exclude-tag">>, Request, Opts),
-                {ok,
-                    maybe_process_l1_tx(
-                        TXID,
-                        OwnerFilters#{
-                            include_tag => IncludeTag,
-                            exclude_tag => ExcludeTag
-                        },
-                        Depth,
-                        QueryL1Offset,
-                        Opts
-                    )}
-            else
-                {error, _} = Error ->
-                    Error
+            try
+                maybe
+                    {ok, OwnerFilters} ?= parse_owner_filter(Request, Opts),
+                    {ok, IncludeTag} ?= parse_tag_filter(<<"include-tag">>, Request, Opts),
+                    {ok, ExcludeTag} ?= parse_tag_filter(<<"exclude-tag">>, Request, Opts),
+                    {ok,
+                        maybe_process_l1_tx(
+                            TXID,
+                            OwnerFilters#{
+                                include_tag => IncludeTag,
+                                exclude_tag => ExcludeTag
+                            },
+                            Depth,
+                            QueryL1Offset,
+                            Opts
+                        )}
+                else
+                    {error, _} = Error ->
+                        Error
+                end
+            catch
+                _:Reason:Stacktrace ->
+                    ?event(copycat_short,
+                        {error,
+                            {reason, Reason},
+                            {stacktrace, Stacktrace}}),
+                    {error, Reason}
             end
         end
     ).
@@ -1019,7 +1028,7 @@ process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, 
     end),
     #{ <<"index-store">> := ParentStore } = IndexStore,
     write_parent(TX#tx.id, BlockHeight, block, ParentStore),
-    case is_bundle_tx(TX, Opts) of
+    try is_bundle_tx(TX, Opts) of
         false ->
             #{items_count => 0, bundle_count => 0, skipped_count => 0,
                 achieved_depth => max(2, TargetDepth)};
@@ -1084,6 +1093,14 @@ process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, 
                     #{items_count => 0, bundle_count => 1,
                         skipped_count => 1, achieved_depth => 0}
             end
+    catch
+        _:Reason:Stacktrace ->
+            ?event(copycat_short,
+                {arweave_bundle_skipped,
+                    {tx, {explicit, TX#tx.id}},
+                    {reason, Reason},
+                    {stacktrace, Stacktrace}}),
+            #{items_count => 0, bundle_count => 0, skipped_count => 1, achieved_depth => 0}
     end.
 
 download_bundle_header(EndOffset, Size, Opts) ->
@@ -1598,6 +1615,7 @@ validate_and_flag_item_id(ItemBinary, DeclaredID, EncodedDeclaredID, Store) ->
     end.
 
 %% @doc Check whether a TX header indicates bundle content.
+%% NOTE: This function can throw if transaction tags aren't properly formated
 is_bundle_tx(TX, _Opts) ->
     dev_arweave_common:type(TX) =/= binary.
 

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -115,6 +115,21 @@ block_items_path(Height, Depth) ->
     <<"block/", (hb_util:bin(Height))/binary,
         "/items/", (hb_util:bin(Depth))/binary>>.
 
+%% @doc Return the store path for a parent index entry.
+parent_path(ItemID) when byte_size(ItemID) =:= 32 ->
+    <<"parent/", ItemID/binary>>.
+
+%% @doc Encode a parent entry for storage.
+encode_parent_entry(Height, block) when is_integer(Height) ->
+    <<0, Height:64/big-unsigned>>;
+encode_parent_entry(ParentID, bundle) when byte_size(ParentID) =:= 32 ->
+    <<1, ParentID:32/binary>>.
+
+%% @doc Write a parent entry for an item to the index store.
+write_parent(ItemID, ParentData, Type, Store) ->
+    Entry = encode_parent_entry(ParentData, Type),
+    hb_store:write(Store, parent_path(ItemID), Entry).
+
 %% @doc Encode a list of 32-byte raw IDs into a single binary.
 encode_item_ids(IDs) ->
     << <<ID:32/binary>> || ID <- IDs >>.
@@ -745,9 +760,13 @@ fetch_blocks_ranged(Current, To, TargetDepth, Workers, Opts) ->
     hb_pmap:parallel_map(
         Heights,
         fun(H) ->
-            observe_event(<<"block_indexed">>, fun() ->
-                fetch_and_process_block(H, To, TargetDepth, Opts)
-            end)
+            case is_block_indexed(H, TargetDepth, Opts) of
+                true -> ok;
+                false ->
+                    observe_event(<<"block_indexed">>, fun() ->
+                        fetch_and_process_block(H, To, TargetDepth, Opts)
+                    end)
+            end
         end,
         Workers
     ),
@@ -953,7 +972,7 @@ maybe_index_block(Block, TargetDepth, Opts) ->
                         TXsWithData
                     ),
                     TXResults = process_block_txs(
-                        ValidTXs, BlockStartOffset, TargetDepth, Opts),
+                        ValidTXs, BlockStartOffset, TargetDepth, Height, Opts),
                     ExistingIDs = maps:get(item_ids, TXResults, #{}),
                     {block_cached, TXResults#{
                         total_txs => TotalTXs,
@@ -972,10 +991,10 @@ parallel_map(Items, Fun, Opts) ->
 
 %% @doc Process a single transaction and return its contribution to the counters.
 %% Returns a map with keys: items_count, bundle_count, skipped_count
-process_block_tx({{padding, _PaddingRoot}, _EndOffset}, _BlockStartOffset, TargetDepth, _Opts) ->
+process_block_tx({{padding, _PaddingRoot}, _EndOffset}, _BlockStartOffset, TargetDepth, _BlockHeight, _Opts) ->
     #{items_count => 0, bundle_count => 0, skipped_count => 0,
         achieved_depth => max(2, TargetDepth)};
-process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, Opts) ->
+process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, BlockHeight, Opts) ->
     IndexStore = hb_store_arweave:store_from_opts(Opts),
     TXID = hb_util:encode(TX#tx.id),
     TXEndOffset = BlockStartOffset + EndOffset,
@@ -994,6 +1013,8 @@ process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, 
             TX#tx.data_size
         )
     end),
+    #{ <<"index-store">> := ParentStore } = IndexStore,
+    write_parent(TX#tx.id, BlockHeight, block, ParentStore),
     case is_bundle_tx(TX, Opts) of
         false ->
             #{items_count => 0, bundle_count => 0, skipped_count => 0,
@@ -1001,7 +1022,7 @@ process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, 
         true when TargetDepth > 2 ->
             L1Result = process_l1_tx_direct(
                 TXStartOffset, TX#tx.data_size,
-                TargetDepth - 1, IndexStore, TXID, Opts),
+                TargetDepth - 1, IndexStore, TXID, TX#tx.id, Opts),
             L1Result#{
                 achieved_depth =>
                     max(2, maps:get(achieved_depth, L1Result, 0))
@@ -1031,6 +1052,7 @@ process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, 
                                     ItemStartOffset,
                                     Size
                                 ),
+                                write_parent(ItemID, TX#tx.id, bundle, ParentStore),
                                 {ItemStartOffset + Size, ItemsCountAcc + 1}
                             end,
                             {TXStartOffset + HeaderSize, 0},
@@ -1092,11 +1114,11 @@ header_chunk(HeaderSize, FirstChunk, StartOffset, Opts) ->
 %% When arweave_index_workers <= 1, processes sequentially (one worker at a time).
 %% When arweave_index_workers > 1, processes in parallel with the specified concurrency limit.
 %% Returns a map with keys: items_count, bundle_count, skipped_count.
-process_block_txs(ValidTXs, BlockStartOffset, TargetDepth, Opts) ->
+process_block_txs(ValidTXs, BlockStartOffset, TargetDepth, BlockHeight, Opts) ->
     Results = parallel_map(
         ValidTXs,
         fun(TXWithData) -> process_block_tx(
-            TXWithData, BlockStartOffset, TargetDepth, Opts) end,
+            TXWithData, BlockStartOffset, TargetDepth, BlockHeight, Opts) end,
         Opts
     ),
     Folded = lists:foldl(
@@ -1182,6 +1204,7 @@ maybe_process_l1_tx(TXID, Filters, Depth, QueryL1Offset, Opts) ->
             Depth,
             IndexStore,
             EncodedTXID,
+            hb_util:decode(EncodedTXID),
             Opts
         )
         after
@@ -1236,7 +1259,7 @@ maybe_process_l1_tx(TXID, Filters, Depth, QueryL1Offset, Opts) ->
 
 %% @doc Fast path for depth>2 block indexing. Skips offset lookup and
 %% header re-fetch since the caller already has both.
-process_l1_tx_direct(StartOffset, Length, Depth, IndexStore, EncodedTXID, Opts) ->
+process_l1_tx_direct(StartOffset, Length, Depth, IndexStore, EncodedTXID, ParentID, Opts) ->
     EffectiveCap = effective_memory_cap(Opts),
     case Length > EffectiveCap of
         true ->
@@ -1253,7 +1276,7 @@ process_l1_tx_direct(StartOffset, Length, Depth, IndexStore, EncodedTXID, Opts) 
             try
                 process_l1_tx(
                     StartOffset, Length, Depth,
-                    IndexStore, EncodedTXID, Opts)
+                    IndexStore, EncodedTXID, ParentID, Opts)
             after
                 hb_copycat_budget:release(Length)
             end
@@ -1261,7 +1284,7 @@ process_l1_tx_direct(StartOffset, Length, Depth, IndexStore, EncodedTXID, Opts) 
 
 %% @doc Load the L1 TX data into memory and index it.
 process_l1_tx(
-        StartOffset, Length, Depth, IndexStore, EncodedTXID, Opts) ->
+        StartOffset, Length, Depth, IndexStore, EncodedTXID, ParentID, Opts) ->
     case observe_copycat_l1_stage(
         <<"l1_read_chunks">>,
         fun() -> hb_store_arweave:read_chunks(StartOffset, Length, Opts) end
@@ -1277,6 +1300,7 @@ process_l1_tx(
                                 StartOffset,
                                 Depth,
                                 IndexStore,
+                                ParentID,
                                 Opts
                             )
                         end
@@ -1414,10 +1438,10 @@ query_l1_tx_offset(TXID, IndexStore, Opts) ->
             {error, not_found}
     end.
 
-index_full_bundle_bytes(_BundleData, _BundleStartOffset, Depth, _Store, _Opts)
+index_full_bundle_bytes(_BundleData, _BundleStartOffset, Depth, _Store, _ParentID, _Opts)
         when Depth =< 0 ->
     {ok, 0, 0, #{}};
-index_full_bundle_bytes(BundleData, BundleStartOffset, Depth, Store, Opts) ->
+index_full_bundle_bytes(BundleData, BundleStartOffset, Depth, Store, ParentID, Opts) ->
     case ar_bundles:decode_bundle_header(BundleData) of
         invalid_bundle_header ->
             {error, invalid_bundle_header};
@@ -1429,6 +1453,7 @@ index_full_bundle_bytes(BundleData, BundleStartOffset, Depth, Store, Opts) ->
                 BundleStartOffset + HeaderSize,
                 Depth,
                 Store,
+                ParentID,
                 Opts,
                 0,
                 ?DEPTH_SENTINEL,
@@ -1441,7 +1466,7 @@ index_full_bundle_bytes(BundleData, BundleStartOffset, Depth, Store, Opts) ->
 %% Returns {ok, Count, MinAchievedDepth, ItemIDs} or {error, Reason}.
 %% ItemIDs is a map of relative-depth => list of raw 32-byte IDs.
 index_full_bundle_items(
-        [], _ItemsBin, _ItemStartOffset, Depth, _Store, _Opts,
+        [], _ItemsBin, _ItemStartOffset, Depth, _Store, _ParentID, _Opts,
         Count, MinDepth, ThisLevelIDs, DescIDs) ->
     FinalDepth = case MinDepth of
         ?DEPTH_SENTINEL -> Depth;
@@ -1455,6 +1480,7 @@ index_full_bundle_items(
     ItemStartOffset,
     Depth,
     Store,
+    ParentID,
     Opts,
     Count,
     MinDepth,
@@ -1472,12 +1498,14 @@ index_full_bundle_items(
         ItemStartOffset,
         Size
     ),
+    #{ <<"index-store">> := IdxStore } = Store,
+    write_parent(ItemID, ParentID, bundle, IdxStore),
     {DescendantCount, ItemAchievedDepth, ChildIDs} =
         case {Depth > 1, ParseResult} of
             {true, {ok, HeaderSize, ParsedItem}} ->
                 index_full_bundle_descendants_parsed(
                     ParsedItem, HeaderSize,
-                    ItemStartOffset, Depth - 1, Store, Opts);
+                    ItemStartOffset, Depth - 1, Store, ItemID, Opts);
             _ ->
                 {0, Depth - 1, #{}}
         end,
@@ -1488,6 +1516,7 @@ index_full_bundle_items(
         ItemStartOffset + Size,
         Depth,
         Store,
+        ParentID,
         Opts,
         Count + 1 + DescendantCount,
         min(MinDepth, ItemAchievedDepth),
@@ -1496,17 +1525,17 @@ index_full_bundle_items(
     );
 index_full_bundle_items(
         _BundleIndex, _ItemsBin, _ItemStartOffset, _Depth,
-        _Store, _Opts, _Count, _MinDepth, _ThisLevelIDs, _DescIDs) ->
+        _Store, _ParentID, _Opts, _Count, _MinDepth, _ThisLevelIDs, _DescIDs) ->
     {error, invalid_bundle_header}.
 
 %% @doc Recurse into a nested data item using an already-parsed header.
 %% Returns {Count, AchievedDepth, ItemIDs}.
 index_full_bundle_descendants_parsed(
-        _ParsedItem, _HeaderSize, _ItemStartOffset, Depth, _Store, _Opts)
+        _ParsedItem, _HeaderSize, _ItemStartOffset, Depth, _Store, _ParentID, _Opts)
         when Depth =< 0 ->
     {0, 0, #{}};
 index_full_bundle_descendants_parsed(
-        ParsedItem, HeaderSize, ItemStartOffset, Depth, Store, Opts) ->
+        ParsedItem, HeaderSize, ItemStartOffset, Depth, Store, ParentID, Opts) ->
     case is_bundle_tx(ParsedItem, Opts) of
         true ->
             case index_full_bundle_bytes(
@@ -1514,6 +1543,7 @@ index_full_bundle_descendants_parsed(
                 ItemStartOffset + HeaderSize,
                 Depth,
                 Store,
+                ParentID,
                 Opts
             ) of
                 {ok, Count, ChildDepth, ChildIDs} ->
@@ -2723,7 +2753,7 @@ depth_1_normalizes_to_2_test() ->
         {{TX1, <<>>}, 100},
         {{TX2, <<>>}, 300}
     ],
-    Result = process_block_txs(Tuples, 0, 1, Opts),
+    Result = process_block_txs(Tuples, 0, 1, 88888888, Opts),
     ?assertEqual(2, maps:get(achieved_depth, Result)),
     Height = 88888888,
     mark_block_indexed(Height, maps:get(achieved_depth, Result), Opts),
@@ -2767,7 +2797,7 @@ invalid_bundle_bytes_test() ->
     StoreOpts = hb_store_arweave:store_from_opts(Opts),
     ?assertEqual(
         {error, invalid_bundle_header},
-        index_full_bundle_bytes(<<"not a bundle">>, 0, 2, StoreOpts, Opts)
+        index_full_bundle_bytes(<<"not a bundle">>, 0, 2, StoreOpts, <<0:256>>, Opts)
     ),
     ok.
 
@@ -3017,6 +3047,190 @@ memory_cap_depth3_floors_to_2_test() ->
         ),
     ?assert(is_block_indexed(Block, 2, CappedOpts)),
     ?assertNot(is_block_indexed(Block, 3, CappedOpts)),
+    ok.
+
+parent_encode_decode_test() ->
+    BlockEntry = encode_parent_entry(12345, block),
+    ?assertEqual(<<0, 12345:64/big-unsigned>>, BlockEntry),
+    BundleID = crypto:strong_rand_bytes(32),
+    BundleEntry = encode_parent_entry(BundleID, bundle),
+    ?assertEqual(<<1, BundleID:32/binary>>, BundleEntry),
+    Combined = <<BlockEntry/binary, BundleEntry/binary>>,
+    Decoded = hb_store_arweave:decode_parent_entries(Combined),
+    ?assertEqual([{12345, block}, {BundleID, bundle}], Decoded),
+    ok.
+
+parent_not_found_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    StoreOpts2 = hb_store_arweave:store_from_opts(Opts),
+    UnknownID = crypto:strong_rand_bytes(32),
+    ?assertEqual(not_found, hb_store_arweave:read_parent(StoreOpts2, UnknownID)),
+    ok.
+
+parent_depth_2_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    Block = 1827942,
+    {ok, Block} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=",
+                (hb_util:bin(Block))/binary, "&to=",
+                (hb_util:bin(Block))/binary, "&depth=2">>,
+            Opts
+        ),
+    StoreOpts2 = hb_store_arweave:store_from_opts(Opts),
+    {ok, InvResult} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=",
+                (hb_util:bin(Block))/binary, "&to=",
+                (hb_util:bin(Block))/binary, "&mode=inventory">>,
+            Opts
+        ),
+    Body = hb_json:decode(hb_maps:get(<<"body">>, InvResult)),
+    BlockInfo = maps:get(hb_util:bin(Block), Body),
+    L1Items = maps:get(<<"1">>, maps:get(<<"items">>, BlockInfo)),
+    L1ID = hb_util:decode(hd(L1Items)),
+    {ok, [{Block, block}]} = hb_store_arweave:read_parent(StoreOpts2, L1ID),
+    L2Items = maps:get(<<"2">>, maps:get(<<"items">>, BlockInfo)),
+    case L2Items of
+        [] -> ok;
+        [FirstL2 | _] ->
+            L2ID = hb_util:decode(FirstL2),
+            {ok, [{L2Parent, bundle}]} =
+                hb_store_arweave:read_parent(StoreOpts2, L2ID),
+            ?assert(lists:member(
+                hb_util:encode(L2Parent), L1Items))
+    end,
+    ok.
+
+parent_depth_3_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    Block = 1889322,
+    {ok, Block} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=",
+                (hb_util:bin(Block))/binary, "&to=",
+                (hb_util:bin(Block))/binary, "&depth=3">>,
+            Opts
+        ),
+    StoreOpts2 = hb_store_arweave:store_from_opts(Opts),
+    {ok, InvResult} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=",
+                (hb_util:bin(Block))/binary, "&to=",
+                (hb_util:bin(Block))/binary, "&mode=inventory">>,
+            Opts
+        ),
+    Body = hb_json:decode(hb_maps:get(<<"body">>, InvResult)),
+    BlockInfo = maps:get(hb_util:bin(Block), Body),
+    L3Items = maps:get(<<"3">>, maps:get(<<"items">>, BlockInfo)),
+    ?assert(length(L3Items) > 0),
+    L2Items = maps:get(<<"2">>, maps:get(<<"items">>, BlockInfo)),
+    L3ID = hb_util:decode(hd(L3Items)),
+    {ok, [{L3Parent, bundle}]} =
+        hb_store_arweave:read_parent(StoreOpts2, L3ID),
+    ?assert(lists:member(hb_util:encode(L3Parent), L2Items)),
+    ok.
+
+parent_corrupt_data_test() ->
+    ?assertEqual([], hb_store_arweave:decode_parent_entries(<<>>)),
+    ?assertEqual(
+        {error, corrupt_parent_data},
+        hb_store_arweave:decode_parent_entries(<<5, 1, 2, 3>>)),
+    Truncated = <<0, 1, 2, 3>>,
+    ?assertEqual(
+        {error, corrupt_parent_data},
+        hb_store_arweave:decode_parent_entries(Truncated)),
+    ValidThenCorrupt = <<0, 100:64/big-unsigned, 99>>,
+    ?assertEqual(
+        {error, corrupt_parent_data},
+        hb_store_arweave:decode_parent_entries(ValidThenCorrupt)),
+    ok.
+
+parent_endpoint_block_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    Block = 1827942,
+    {ok, Block} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=",
+                (hb_util:bin(Block))/binary, "&to=",
+                (hb_util:bin(Block))/binary, "&depth=2">>,
+            Opts
+        ),
+    {ok, InvResult} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=",
+                (hb_util:bin(Block))/binary, "&to=",
+                (hb_util:bin(Block))/binary, "&mode=inventory">>,
+            Opts
+        ),
+    InvBody = hb_json:decode(hb_maps:get(<<"body">>, InvResult)),
+    BlockInfo = maps:get(hb_util:bin(Block), InvBody),
+    L1Items = maps:get(<<"1">>, maps:get(<<"items">>, BlockInfo)),
+    L1EncodedID = hd(L1Items),
+    {ok, ParentResult} =
+        hb_ao:resolve(
+            <<"~arweave@2.9/parent=", L1EncodedID/binary>>,
+            Opts
+        ),
+    ?assertEqual(
+        <<"application/json">>,
+        hb_maps:get(<<"content-type">>, ParentResult)),
+    Body = hb_json:decode(hb_maps:get(<<"body">>, ParentResult)),
+    Parents = maps:get(<<"parents">>, Body),
+    ?assertEqual(1, length(Parents)),
+    [Entry] = Parents,
+    ?assertEqual(<<"block">>, maps:get(<<"type">>, Entry)),
+    ?assertEqual(Block, maps:get(<<"height">>, Entry)),
+    ok.
+
+parent_endpoint_bundle_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    Block = 1827942,
+    {ok, Block} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=",
+                (hb_util:bin(Block))/binary, "&to=",
+                (hb_util:bin(Block))/binary, "&depth=2">>,
+            Opts
+        ),
+    {ok, InvResult} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=",
+                (hb_util:bin(Block))/binary, "&to=",
+                (hb_util:bin(Block))/binary, "&mode=inventory">>,
+            Opts
+        ),
+    InvBody = hb_json:decode(hb_maps:get(<<"body">>, InvResult)),
+    BlockInfo = maps:get(hb_util:bin(Block), InvBody),
+    L1Items = maps:get(<<"1">>, maps:get(<<"items">>, BlockInfo)),
+    L2Items = maps:get(<<"2">>, maps:get(<<"items">>, BlockInfo)),
+    ?assert(length(L2Items) > 0),
+    L2EncodedID = hd(L2Items),
+    {ok, ParentResult} =
+        hb_ao:resolve(
+            <<"~arweave@2.9/parent=", L2EncodedID/binary>>,
+            Opts
+        ),
+    ?assertEqual(
+        <<"application/json">>,
+        hb_maps:get(<<"content-type">>, ParentResult)),
+    Body = hb_json:decode(hb_maps:get(<<"body">>, ParentResult)),
+    [Entry] = maps:get(<<"parents">>, Body),
+    ?assertEqual(<<"bundle">>, maps:get(<<"type">>, Entry)),
+    ParentID = maps:get(<<"id">>, Entry),
+    ?assert(lists:member(ParentID, L1Items)),
+    ok.
+
+parent_endpoint_not_found_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    FakeID = <<"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA">>,
+    ?assertEqual(
+        {error, not_found},
+        hb_ao:resolve(
+            <<"~arweave@2.9/parent=", FakeID/binary>>,
+            Opts
+        )
+    ),
     ok.
 
 index_of(Elem, List) -> index_of(Elem, List, 1).

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -1099,28 +1099,6 @@ download_bundle_header(EndOffset, Size, Opts) ->
         dev_arweave:bundle_header(EndOffset - Size, Opts)
     end).
 
-header_chunk(invalid_bundle_header, _FirstChunk, _StartOffset, _Opts) ->
-    {error, invalid_bundle_header};
-header_chunk(HeaderSize, FirstChunk, _StartOffset, _Opts)
-        when HeaderSize =< byte_size(FirstChunk) ->
-    {ok, FirstChunk};
-header_chunk(HeaderSize, FirstChunk, StartOffset, Opts) ->
-    Res =
-        hb_ao:resolve(
-            <<
-                ?ARWEAVE_DEVICE/binary,
-                "/chunk&offset=",
-                (hb_util:bin(StartOffset + byte_size(FirstChunk)))/binary,
-                "&length=",
-                (hb_util:bin(HeaderSize - byte_size(FirstChunk)))/binary
-            >>,
-            Opts
-        ),
-    case Res of
-        {ok, OtherChunks} -> {ok, <<FirstChunk/binary, OtherChunks/binary>>};
-        Other -> Other
-    end.
-
 %% @doc Process transactions: spawn workers and manage the worker pool.
 %% This function processes transactions in parallel using parallel_map.
 %% When arweave_index_workers <= 1, processes sequentially (one worker at a time).

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -12,8 +12,8 @@
 -define(ARWEAVE_DEVICE, <<"~arweave@2.9">>).
 -define(DEPTH_L1_OFFSETS, 1).
 -define(DEPTH_RECURSION_CAP, 4).
-%% 1GB in bytes
--define(MEMORY_SAFE_CAP, 1024 * 1024 * 1024).
+%% 6GB in bytes
+-define(MEMORY_SAFE_CAP, 6 * 1024 * 1024 * 1024).
 
 % GET /~cron@1.0/once&cron-path=~copycat@1.0/arweave
 
@@ -169,6 +169,10 @@ parse_tag_filter(Key, Request, Opts) ->
 %% (defaults to full recursion till the set copycat_depth_recursion_cap).
 process_l1_request(TXID, Request, Opts) ->
     Depth = request_depth(Request, <<"safe_max">>, Opts),
+    LoadL1Offset =
+        hb_util:bool(
+            hb_maps:get(<<"load-l1-offset">>, Request, false, Opts)
+        ),
     case parse_owner_filter(Request, Opts) of
         {error, _} = Error ->
             Error;
@@ -185,6 +189,7 @@ process_l1_request(TXID, Request, Opts) ->
                                 process_l1_candidate(
                                     TXID,
                                     OwnerFilters#{
+                                        load_l1_offset => LoadL1Offset,
                                         include_tag => IncludeTag,
                                         exclude_tag => ExcludeTag
                                     },
@@ -652,7 +657,14 @@ process_l1_candidate(TXID, Filters, Depth, Opts) ->
     NormalizedTXID = hb_util:native_id(TXID),
     EncodedTXID = hb_util:encode(NormalizedTXID),
     IndexStore = hb_store_arweave:store_from_opts(Opts),
-    case hb_store_arweave:read_offset(IndexStore, NormalizedTXID) of
+    LoadL1Offset = maps:get(load_l1_offset, Filters, false),
+    case ensure_l1_tx_offset(
+        NormalizedTXID,
+        EncodedTXID,
+        IndexStore,
+        LoadL1Offset,
+        Opts
+    ) of
         {ok,
             #{
                 <<"codec-device">> := <<"tx@1.0">>,
@@ -783,15 +795,76 @@ process_l1_candidate(TXID, Filters, Depth, Opts) ->
                 }
             ),
             Skipped;
-        not_found ->
+        {error, Reason} ->
             ?event(
                 copycat_short,
                 {arweave_tx_skipped,
                     {tx_id, {explicit, EncodedTXID}},
-                    {reason, missing_offset}
+                    {reason, Reason}
                 }
             ),
             Skipped
+    end.
+%% @doc Ensure the root L1 TX offset exists locally before `id=...` indexing.
+%% if the offset is missing and `load_l1_offset` is enabled, fetches the TX
+%% offset metadata from Arweave, writes it to the local offset store, and
+%% retries the local lookup.
+ensure_l1_tx_offset(_TXID, _EncodedTXID, IndexStore, _LoadL1Offset, _Opts)
+        when is_map(IndexStore) =:= false ->
+    {error, missing_offset};
+ensure_l1_tx_offset(TXID, EncodedTXID, IndexStore, LoadL1Offset, Opts) ->
+    case hb_store_arweave:read_offset(IndexStore, TXID) of
+        {ok, _} = OffsetRes ->
+            OffsetRes;
+        not_found when LoadL1Offset ->
+            ?event(
+                copycat_short,
+                {arweave_tx_offset_loading,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {source, network}
+                }
+            ),
+            case load_l1_tx_offset(EncodedTXID, IndexStore, Opts) of
+                ok ->
+                    case hb_store_arweave:read_offset(IndexStore, TXID) of
+                        {ok, _} = OffsetRes ->
+                            OffsetRes;
+                        not_found ->
+                            {error, missing_offset}
+                    end;
+                {error, Reason} ->
+                    {error, Reason}
+            end;
+        not_found ->
+            {error, missing_offset}
+    end.
+
+load_l1_tx_offset(TXID, IndexStore, Opts) ->
+    case hb_http:request(
+        #{
+            <<"path">> => <<"/arweave/tx/", TXID/binary, "/offset">>,
+            <<"method">> => <<"GET">>
+        },
+        Opts
+    ) of
+        {ok, #{ <<"body">> := OffsetBody }} ->
+            OffsetMsg = hb_json:decode(OffsetBody),
+            EndOffset = hb_util:int(maps:get(<<"offset">>, OffsetMsg)),
+            Size = hb_util:int(maps:get(<<"size">>, OffsetMsg)),
+            StartOffset = EndOffset - Size,
+            ok =
+                hb_store_arweave:write_offset(
+                    IndexStore,
+                    TXID,
+                    <<"tx@1.0">>,
+                    StartOffset,
+                    Size
+                ),
+            ok;
+        {error, Reason} ->
+            {error, Reason};
+        not_found ->
+            {error, not_found}
     end.
 
 index_bundle_bytes(_BundleData, _BundleStartOffset, Depth, _Store, _Opts)

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -1033,13 +1033,25 @@ process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, 
             #{items_count => 0, bundle_count => 0, skipped_count => 0,
                 achieved_depth => max(2, TargetDepth)};
         true when TargetDepth > 2 ->
-            L1Result = process_l1_tx_direct(
-                TXStartOffset, TX#tx.data_size,
-                TargetDepth - 1, IndexStore, TXID, TX#tx.id, Opts),
-            L1Result#{
-                achieved_depth =>
-                    max(2, maps:get(achieved_depth, L1Result, 0))
-            };
+            %% Retry to perseve bundle count
+            try 
+                L1Result = process_l1_tx_direct(
+                    TXStartOffset, TX#tx.data_size,
+                    TargetDepth - 1, IndexStore, TXID, TX#tx.id, Opts),
+                L1Result#{
+                    achieved_depth =>
+                        max(2, maps:get(achieved_depth, L1Result, 0))
+                }
+            catch 
+                _:Reason:Stacktrace ->
+                    ?event(copycat_short,
+                        {arweave_bundle_skipped,
+                            {tx, {explicit, TX#tx.id}},
+                            {reason, Reason},
+                            {stacktrace, Stacktrace}}),
+                    #{items_count => 0, bundle_count => 1,
+                        skipped_count => 1, achieved_depth => 0}
+            end;
         true ->
             % Lightweight processing of block transactions to depth 2. We
             % can avoid loading the full L1 TX data into memory, and instead

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -85,16 +85,20 @@ arweave(_Base, Request, Opts) ->
 %% @doc Set bundles descendant recursion cap, avoids recursion
 %% in very nested bundles (very rare).
 set_depth_recursion_cap(Cap, Opts) when is_integer(Cap), Cap > 0 ->
-    Opts#{copycat_depth_recursion_cap => Cap}.
+    Opts#{<<"copycat_depth_recursion_cap">> => Cap}.
 %% @doc Get the set depth recursion cap from hb_opts.
 get_depth_recursion_cap(Opts) ->
-    hb_opts:get(copycat_depth_recursion_cap, undefined, Opts).
+    hb_opts:get(<<"copycat_depth_recursion_cap">>, undefined, Opts).
 
 %% @doc Return the effective per-TX memory cap, clamped to the global budget.
 %% Lazily initializes the budget pool on first call.
 effective_memory_cap(Opts) ->
-    Budget = hb_opts:get(
-        copycat_memory_budget, ?DEFAULT_COPYCAT_MEMORY_BUDGET, Opts),
+    Budget = 
+        hb_opts:get(
+        <<"copycat_memory_budget">>, 
+        ?DEFAULT_COPYCAT_MEMORY_BUDGET, 
+        Opts
+    ),
     hb_copycat_budget:ensure_started(Budget),
     hb_copycat_budget:get_budget().
 
@@ -118,9 +122,9 @@ encode_parent_entry(ParentID, bundle) when byte_size(ParentID) =:= 32 ->
     <<1, ParentID:32/binary>>.
 
 %% @doc Write a parent entry for an item to the index store.
-write_parent(ItemID, ParentData, Type, Store) ->
+write_parent(ItemID, ParentData, Type, Store, Opts) ->
     Entry = encode_parent_entry(ParentData, Type),
-    hb_store:write(Store, parent_path(ItemID), Entry).
+    hb_store:write(Store, #{parent_path(ItemID) => Entry}, Opts).
 
 %% @doc Encode a list of 32-byte raw IDs into a single binary.
 encode_item_ids(IDs) ->
@@ -203,8 +207,8 @@ write_block_item_ids(Height, AchievedDepth, ItemIDs, Opts) ->
             Bin = encode_item_ids(IDs),
             hb_store:write(
                 Store,
-                block_items_path(Height, D),
-                Bin
+                #{block_items_path(Height, D) => Bin},
+                Opts
             )
         end,
         lists:seq(1, MaxStoredDepth)
@@ -223,8 +227,8 @@ mark_block_indexed(Height, Depth, Opts) ->
     Store = get_index_store(Opts),
     hb_store:write(
         Store,
-        block_indexed_path(Height),
-        integer_to_binary(Depth)
+        #{block_indexed_path(Height) => integer_to_binary(Depth)},
+        Opts
     ).
 
 %% @doc Read the persisted cutover height from the index store.
@@ -240,7 +244,7 @@ ensure_cutover_height(Height, Opts) ->
     case read_cutover_height(Opts) of
         undefined ->
             Store = get_index_store(Opts),
-            hb_store:write(Store, ?CUTOVER_KEY, hb_util:bin(Height)),
+            hb_store:write(Store, #{?CUTOVER_KEY => hb_util:bin(Height)}, Opts),
             ?event(copycat_short, {marker_cutover_initialized, {height, Height}});
         _ -> ok
     end.
@@ -252,14 +256,14 @@ normalize_owner_id(Addr) ->
 %% @doc Adds an address to the owners aliases cache in Opts, mapping
 %% Alias -> native address for fast lookup and once per address computation.
 add_owner_alias(Addr, Alias, Opts) when is_binary(Alias) -> 
-    ExistingAliases = hb_opts:get(owner_aliases, #{}, Opts),
-    Opts#{ owner_aliases => ExistingAliases#{ Alias => normalize_owner_id(Addr) }};
+    ExistingAliases = hb_opts:get(<<"owner_aliases">>, #{}, Opts),
+    Opts#{ <<"owner_aliases">> => ExistingAliases#{ Alias => normalize_owner_id(Addr) }};
 add_owner_alias(_Addr, Alias, _Opts) ->
     throw({invalid_owner_alias, Alias}).
 
 %% @doc Retrieve the address of a given alias.
 resolve_owner_alias(Alias, Opts) when is_binary(Alias) ->
-    Aliases = hb_opts:get(owner_aliases, #{}, Opts),
+    Aliases = hb_opts:get(<<"owner_aliases">>, #{}, Opts),
     case hb_maps:find(Alias, Aliases) of
         {ok, Addr} -> {ok, Addr};
         error -> {error, {owner_alias_not_found, Alias}}
@@ -718,7 +722,7 @@ fetch_blocks(Current, To, TargetDepth, Opts) ->
     fetch_blocks_ranged(Current, To, TargetDepth, BlockWorkers, Opts).
 
 block_workers(Opts) ->
-    max(1, hb_opts:get(arweave_block_workers, 3, Opts)).
+    max(1, hb_opts:get(<<"arweave_block_workers">>, 3, Opts)).
 
 %% @doc Process a known range of blocks in parallel batches.
 fetch_blocks_ranged(Current, To, TargetDepth, _Workers, _Opts)
@@ -921,7 +925,7 @@ process_block(BlockRes, Current, To, TargetDepth, Opts) ->
 %% @doc Index the IDs of all transactions in the block if configured to do so.
 maybe_index_block(Block, TargetDepth, Opts) ->
     TotalTXs = length(hb_maps:get(<<"txs">>, Block, [], Opts)),
-    case hb_opts:get(arweave_index_ids, true, Opts) of
+    case hb_opts:get(<<"arweave-index-ids">>, true, Opts) of
         false -> 
             {block_skipped, #{
                 items_count => 0,
@@ -993,7 +997,7 @@ process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, 
         )
     end),
     #{ <<"index-store">> := IndexStore } = ArweaveStore,
-    ok = write_parent(TX#tx.id, BlockHeight, block, IndexStore),
+    ok = write_parent(TX#tx.id, BlockHeight, block, IndexStore, Opts),
     try is_bundle_tx(TX, Opts) of
         false ->
             #{items_count => 0, bundle_count => 0, skipped_count => 0,
@@ -1043,7 +1047,7 @@ process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, 
                                     ItemStartOffset,
                                     Size
                                 ),
-                                ok = write_parent(ItemID, TX#tx.id, bundle, IndexStore),
+                                ok = write_parent(ItemID, TX#tx.id, bundle, IndexStore, Opts),
                                 {ItemStartOffset + Size, ItemsCountAcc + 1}
                             end,
                             {TXStartOffset + HeaderSize, 0},
@@ -1475,7 +1479,7 @@ index_full_bundle_items(
         ItemStartOffset,
         Size
     ),
-    ok = write_parent(ItemID, ParentID, bundle, IndexStore),
+    ok = write_parent(ItemID, ParentID, bundle, IndexStore, Opts),
     {DescendantCount, ItemAchievedDepth, ChildIDs} =
         case {Depth > 1, ParseResult} of
             {true, {ok, HeaderSize, ParsedItem}} ->
@@ -1545,9 +1549,8 @@ validate_and_flag_item_id(ItemBinary, DeclaredID, EncodedDeclaredID, IndexStore)
                 false ->
                     ok = hb_store:write(
                         IndexStore,
-                        hb_store_arweave_offset:mismatch_path(
-                            DeclaredID),
-                        ComputedID
+                        #{hb_store_arweave_offset:mismatch_path(DeclaredID) => ComputedID},
+                        #{}
                     ),
                     ?event(copycat_short,
                         {item_id_mismatch,
@@ -1807,25 +1810,27 @@ invalid_bundle_header_test_parallel() ->
         download_bundle_header(EndOffset, Size, Opts)),
     ok.
 
-invalid_bundle_test_parallel() ->
-    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
-    Block = 1307606,
-    {ok, Block} =
-        hb_ao:resolve(
-            <<"~copycat@1.0/arweave&from=", (hb_util:bin(Block))/binary, "&to=", (hb_util:bin(Block))/binary>>,
+invalid_bundle_test_parallel_() ->
+    {timeout, 60, fun() ->
+        {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+        Block = 1307606,
+        {ok, Block} =
+            hb_ao:resolve(
+                <<"~copycat@1.0/arweave&from=", (hb_util:bin(Block))/binary, "&to=", (hb_util:bin(Block))/binary>>,
+                Opts
+            ),
+        assert_bundle_read(
+            <<"8S12ZqO6-_icGkeuH8mFq6x9q7OIoXOqFRGH5k-wshg">>,
+            [
+                {<<"gintz-t6q_kdeP_IBQVGnp9fgFzs-pPGGehXW-V7ZRk">>, <<"1">>}
+            ],
             Opts
         ),
-    assert_bundle_read(
-        <<"8S12ZqO6-_icGkeuH8mFq6x9q7OIoXOqFRGH5k-wshg">>,
-        [
-            {<<"gintz-t6q_kdeP_IBQVGnp9fgFzs-pPGGehXW-V7ZRk">>, <<"1">>}
-        ],
-        Opts
-    ),
-    % L1 TX with bundle tags, but data is not a valid bundle. The L1 TX
-    % should still be indexed.
-    assert_item_read(<<"cGNURX2IUt98VKVIeXSfYe6eulNwPEqijaQfvatzd_o">>, Opts),
-    ok.
+        % L1 TX with bundle tags, but data is not a valid bundle. The L1 TX
+        % should still be indexed.
+        assert_item_read(<<"cGNURX2IUt98VKVIeXSfYe6eulNwPEqijaQfvatzd_o">>, Opts),
+        ok
+    end}.
 
 block_with_large_integer_test_parallel() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
@@ -2116,7 +2121,7 @@ auto_stop_partial_index_test_parallel() ->
     TXIDs = hb_maps:get(<<"txs">>, BlockData, [], Opts),
     ?assert(length(TXIDs) > 0),
     [OneTXID | _] = TXIDs,
-    hb_store_arweave:write_offset(StoreOpts, OneTXID, <<"tx@1.0">>, 0, 0),
+    ok = hb_store_arweave:write_offset(StoreOpts, OneTXID, <<"tx@1.0">>, 0, 0),
     {ok, Block} =
         hb_ao:resolve(
             <<
@@ -2256,7 +2261,7 @@ negative_from_index_test_parallel() ->
     ?assertNot(has_any_indexed_tx(NextBlock + 1, Opts)),
     ok.
 
-owner_alias_roundtrip_test() ->
+owner_alias_roundtrip_test_parallel() ->
     Opts1 =
         add_owner_alias(
             <<"FPjbN7EVwP3XwQJx8qnKqJDYa4TLJ0Y8gu4AaiUuW1c">>,
@@ -2645,7 +2650,10 @@ assert_bundle_read(BundleID, ExpectedItems, Opts) ->
 assert_item_read(ItemID, Opts) ->
     ?event(debug_test, {resolving, {explicit, ItemID}}),
     ReadResult = hb_store_arweave:read(
-        hb_store_arweave:store_from_opts(Opts), ItemID),
+        hb_store_arweave:store_from_opts(Opts), 
+        #{<<"read">> => ItemID}, 
+        Opts
+    ),
     ?assertMatch({ok, _}, ReadResult, ItemID),
     {ok, Item} = ReadResult,
     ?event(debug_test, {item, Item}),
@@ -2655,8 +2663,11 @@ assert_item_read(ItemID, Opts) ->
 
 assert_item_not_read(ItemID, Opts) ->
     ReadResult = hb_store_arweave:read(
-        hb_store_arweave:store_from_opts(Opts), ItemID),
-    ?assertEqual(not_found, ReadResult),
+        hb_store_arweave:store_from_opts(Opts), 
+        #{<<"read">> => ItemID}, 
+        Opts
+    ),
+    ?assertEqual({error, not_found}, ReadResult),
     ok.
 
 has_any_indexed_tx(Height, Opts) ->
@@ -2811,7 +2822,7 @@ no_mismatch_flags_on_valid_bundles_test() ->
     ItemID = hb_util:native_id(
         <<"54K1ehEIKZxGSusgZzgbGYaHfllwWQ09-S9-eRUJg5Y">>),
     ?assertEqual(
-        not_found,
+       {error, not_found},
         hb_store:read(
             IndexStore,
             hb_store_arweave_offset:mismatch_path(ItemID),
@@ -2867,7 +2878,7 @@ fabricated_mismatch_test() ->
         ),
     ?assertEqual(RealID, StoredActualID),
     ?assertEqual(
-        not_found,
+       {error, not_found},
         hb_store:read(
             IndexStore,
             hb_store_arweave_offset:mismatch_path(RealID),
@@ -2896,7 +2907,7 @@ block_item_ids_depth_2_test() ->
     ?assert(is_integer(Pos54K)),
     ?assert(is_integer(PosOBK)),
     ?assert(Pos54K < PosOBK),
-    ?assertEqual(not_found, hb_store:read(Store, block_items_path(1827942, 3), Opts)),
+    ?assertEqual({error, not_found}, hb_store:read(Store, block_items_path(1827942, 3), Opts)),
     ok.
 
 block_item_ids_depth_3_test() ->
@@ -2972,12 +2983,12 @@ inventory_single_block_test() ->
 inventory_range_test() ->
     {_TestStore, StoreOpts, Opts} = setup_index_opts(),
     #{ <<"index-store">> := Store } = StoreOpts,
-    hb_store:write(Store, block_indexed_path(77777777), <<"2">>),
-    hb_store:write(Store, block_items_path(77777777, 1), <<0:256>>),
-    hb_store:write(Store, block_items_path(77777777, 2), <<>>),
-    hb_store:write(Store, block_indexed_path(77777778), <<"2">>),
-    hb_store:write(Store, block_items_path(77777778, 1), <<1:256>>),
-    hb_store:write(Store, block_items_path(77777778, 2), <<>>),
+    ok = hb_store:write(Store, #{block_indexed_path(77777777) => <<"2">>}, Opts),
+    ok = hb_store:write(Store, #{block_items_path(77777777, 1) => <<0:256>>}, Opts),
+    ok = hb_store:write(Store, #{block_items_path(77777777, 2) => <<>>}, Opts),
+    ok = hb_store:write(Store, #{block_indexed_path(77777778) => <<"2">>}, Opts),
+    ok = hb_store:write(Store, #{block_items_path(77777778, 1) => <<1:256>>}, Opts),
+    ok = hb_store:write(Store, #{block_items_path(77777778, 2) => <<>>}, Opts),
     {ok, InvResult} = inventory_index(77777778, 77777777, Opts),
     Body = hb_json:decode(hb_maps:get(<<"body">>, InvResult)),
     ?assert(maps:is_key(<<"77777777">>, Body)),
@@ -2998,9 +3009,9 @@ corrupt_item_ids_read_test() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     #{ <<"index-store">> := Store } = hb_store_arweave:store_from_opts(Opts),
     Height = 99999999,
-    hb_store:write(Store, block_indexed_path(Height), <<"2">>),
-    hb_store:write(Store, block_items_path(Height, 1), <<0:256>>),
-    hb_store:write(Store, block_items_path(Height, 2), <<0:240>>),
+    ok = hb_store:write(Store, #{block_indexed_path(Height) => <<"2">>}, Opts),
+    ok = hb_store:write(Store, #{block_items_path(Height, 1) => <<0:256>>}, Opts),
+    ok = hb_store:write(Store, #{block_items_path(Height, 2) => <<0:240>>}, Opts),
     Counts = read_block_item_counts(Height, Opts),
     ?assertEqual(1, maps:get(<<"1">>, Counts)),
     ?assertEqual(<<"corrupt">>, maps:get(<<"2">>, Counts)),
@@ -3024,7 +3035,11 @@ parent_not_found_test() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     StoreOpts2 = hb_store_arweave:store_from_opts(Opts),
     UnknownID = crypto:strong_rand_bytes(32),
-    ?assertEqual(not_found, hb_store_arweave:read_parent(StoreOpts2, UnknownID)),
+    ?assertEqual(
+       not_found, 
+       hb_store_arweave:read_parent(StoreOpts2, UnknownID, Opts),
+       Opts
+    ),
     ok.
 
 parent_depth_2_test() ->
@@ -3049,14 +3064,14 @@ parent_depth_2_test() ->
     BlockInfo = maps:get(hb_util:bin(Block), Body),
     L1Items = maps:get(<<"1">>, maps:get(<<"items">>, BlockInfo)),
     L1ID = hb_util:decode(hd(L1Items)),
-    {ok, [{Block, block}]} = hb_store_arweave:read_parent(StoreOpts2, L1ID),
+    {ok, [{Block, block}]} = hb_store_arweave:read_parent(StoreOpts2, L1ID, Opts),
     L2Items = maps:get(<<"2">>, maps:get(<<"items">>, BlockInfo)),
     case L2Items of
         [] -> ok;
         [FirstL2 | _] ->
             L2ID = hb_util:decode(FirstL2),
             {ok, [{L2Parent, bundle}]} =
-                hb_store_arweave:read_parent(StoreOpts2, L2ID),
+                hb_store_arweave:read_parent(StoreOpts2, L2ID, Opts),
             ?assert(lists:member(
                 hb_util:encode(L2Parent), L1Items))
     end,
@@ -3087,7 +3102,7 @@ parent_depth_3_test() ->
     L2Items = maps:get(<<"2">>, maps:get(<<"items">>, BlockInfo)),
     L3ID = hb_util:decode(hd(L3Items)),
     {ok, [{L3Parent, bundle}]} =
-        hb_store_arweave:read_parent(StoreOpts2, L3ID),
+        hb_store_arweave:read_parent(StoreOpts2, L3ID, Opts),
     ?assert(lists:member(hb_util:encode(L3Parent), L2Items)),
     ok.
 

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -6,7 +6,7 @@
 %%% is provided, every block in the range is processed.
 -module(dev_copycat_arweave).
 -export([arweave/3]).
--export([add_owner_alias/3, resolve_owner_alias/2, set_depth_recursion_cap/2, get_depth_recursion_cap/1]).
+-export([set_depth_recursion_cap/2, get_depth_recursion_cap/1]).
 -include_lib("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -474,7 +474,7 @@ has_tag_pair(#tx{tags = Tags}, #{name := Name, value := Value}) ->
                 LowerValue -> true;
                 _ -> false
             end
-end;
+    end;
 has_tag_pair(_, _) ->
     false.
 %% @doc Parse the range from the request.
@@ -999,7 +999,7 @@ process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, 
             #{items_count => 0, bundle_count => 0, skipped_count => 0,
                 achieved_depth => max(2, TargetDepth)};
         true when TargetDepth > 2 ->
-            %% Retry to perseve bundle count
+            %% Retry to preserve bundle count
             try 
                 L1Result = process_l1_tx_direct(
                     TXStartOffset, TX#tx.data_size,
@@ -1741,7 +1741,7 @@ block_depth_3_test() ->
             <<"~copycat@1.0/arweave&from=1827942&to=1827942&depth=3">>,
             Opts
         ),
-    % L3 item read when doing depth=2
+    % L3 item read when doing depth=3
     assert_item_read(
         <<"8aJrRWtHcJvJ61qsH6agGkemzrtLw3W22xFrpCGAnTM">>,
         Opts),

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -196,25 +196,30 @@ process_l1_request(TXID, Request, Opts) ->
         hb_util:bool(
             hb_maps:get(<<"query-l1-offset">>, Request, false, Opts)
         ),
-    maybe
-        {ok, OwnerFilters} ?= parse_owner_filter(Request, Opts),
-        {ok, IncludeTag} ?= parse_tag_filter(<<"include-tag">>, Request, Opts),
-        {ok, ExcludeTag} ?= parse_tag_filter(<<"exclude-tag">>, Request, Opts),
-        {ok,
-            maybe_process_l1_tx(
-                TXID,
-                OwnerFilters#{
-                    include_tag => IncludeTag,
-                    exclude_tag => ExcludeTag
-                },
-                Depth,
-                QueryL1Offset,
-                Opts
-            )}
-    else
-        {error, _} = Error ->
-            Error
-    end.
+    observe_copycat_l1_stage(
+        <<"l1_request_total">>,
+        fun() ->
+            maybe
+                {ok, OwnerFilters} ?= parse_owner_filter(Request, Opts),
+                {ok, IncludeTag} ?= parse_tag_filter(<<"include-tag">>, Request, Opts),
+                {ok, ExcludeTag} ?= parse_tag_filter(<<"exclude-tag">>, Request, Opts),
+                {ok,
+                    maybe_process_l1_tx(
+                        TXID,
+                        OwnerFilters#{
+                            include_tag => IncludeTag,
+                            exclude_tag => ExcludeTag
+                        },
+                        Depth,
+                        QueryL1Offset,
+                        Opts
+                    )}
+            else
+                {error, _} = Error ->
+                    Error
+            end
+        end
+    ).
 %% @doc Parse the requested recursion depth and clamp it to the configured
 %% safe cap. Depth is relative so depth 1 is always one level below the
 %% root specified in the request (either a block or an L1 TX ID).
@@ -716,8 +721,7 @@ maybe_process_l1_tx(TXID, Filters, Depth, QueryL1Offset, Opts) ->
     ?event(copycat_short,
         {indexing_l1_tx, {tx_id, {explicit, EncodedTXID}},
         {depth, Depth},
-        {query_l1_offset, QueryL1Offset},
-        {filters, Filters}
+        {query_l1_offset, QueryL1Offset}
     }),
     maybe
         {ok,
@@ -726,12 +730,17 @@ maybe_process_l1_tx(TXID, Filters, Depth, QueryL1Offset, Opts) ->
                 <<"start-offset">> := StartOffset,
                 <<"length">> := Length
             }} ?=
-            ensure_l1_tx_offset(
-                NormalizedTXID,
-                EncodedTXID,
-                IndexStore,
-                QueryL1Offset,
-                Opts
+            observe_copycat_l1_stage(
+                <<"l1_offset_lookup">>,
+                fun() ->
+                    ensure_l1_tx_offset(
+                        NormalizedTXID,
+                        EncodedTXID,
+                        IndexStore,
+                        QueryL1Offset,
+                        Opts
+                    )
+                end
             ),
         {ok, TX} ?= resolve_tx_header(EncodedTXID, Opts),
         pass ?= l1_filter_reason(TX, Filters),
@@ -805,16 +814,24 @@ maybe_process_l1_tx(TXID, Filters, Depth, QueryL1Offset, Opts) ->
 %% be merged.
 process_l1_tx(
         StartOffset, Length, Depth, IndexStore, EncodedTXID, Opts) ->
-    case hb_store_arweave:read_chunks(StartOffset, Length, Opts) of
+    case observe_copycat_l1_stage(
+        <<"l1_read_chunks">>,
+        fun() -> hb_store_arweave:read_chunks(StartOffset, Length, Opts) end
+    ) of
         {ok, BundleData} ->
             {TotalTime, IndexRes} = timer:tc(
                 fun() ->
-                    index_full_bundle_bytes(
-                        BundleData,
-                        StartOffset,
-                        Depth,
-                        IndexStore,
-                        Opts
+                    observe_copycat_l1_stage(
+                        <<"l1_full_bundle_index">>,
+                        fun() ->
+                            index_full_bundle_bytes(
+                                BundleData,
+                                StartOffset,
+                                Depth,
+                                IndexStore,
+                                Opts
+                            )
+                        end
                     )
                 end
             ),
@@ -908,26 +925,35 @@ ensure_l1_tx_offset(TXID, EncodedTXID, IndexStore, QueryL1Offset, Opts) ->
 query_l1_tx_offset(TXID, IndexStore, Opts) ->
     % TODO: move this into dev_arweave - I think? Unless it's possible to
     % query this already via one of the existing ~arweave@2.9 paths?
-    case hb_http:request(
-        #{
-            <<"path">> => <<"/arweave/tx/", TXID/binary, "/offset">>,
-            <<"method">> => <<"GET">>
-        },
-        Opts
+    case observe_copycat_l1_stage(
+        <<"l1_offset_query_http">>,
+        fun() ->
+            hb_http:request(
+                #{
+                    <<"path">> => <<"/arweave/tx/", TXID/binary, "/offset">>,
+                    <<"method">> => <<"GET">>
+                },
+                Opts
+            )
+        end
     ) of
         {ok, #{ <<"body">> := OffsetBody }} ->
             OffsetMsg = hb_json:decode(OffsetBody),
             EndOffset = hb_util:int(maps:get(<<"offset">>, OffsetMsg)),
             Size = hb_util:int(maps:get(<<"size">>, OffsetMsg)),
             StartOffset = EndOffset - Size,
-            ok =
-                hb_store_arweave:write_offset(
-                    IndexStore,
-                    TXID,
-                    <<"tx@1.0">>,
-                    StartOffset,
-                    Size
-                ),
+            ok = observe_copycat_l1_stage(
+                <<"l1_offset_query_store_write">>,
+                fun() ->
+                    hb_store_arweave:write_offset(
+                        IndexStore,
+                        TXID,
+                        <<"tx@1.0">>,
+                        StartOffset,
+                        Size
+                    )
+                end
+            ),
             ok;
         {error, Reason} ->
             {error, Reason};
@@ -1097,14 +1123,23 @@ resolve_tx_header(TXID, Opts) ->
 
 %% @doc Record event metrics (count and duration) using hb_event:increment.
 record_event_metrics(MetricName, Count, Duration) ->
-    hb_event:increment(<<"arweave_block_count">>, MetricName, #{}, Count),
-    hb_event:increment(<<"arweave_block_duration">>, MetricName, #{}, Duration).
+    hb_event:increment(arweave_block_count, MetricName, #{}, Count),
+    hb_event:increment(arweave_block_duration, MetricName, #{}, Duration).
+
+record_copycat_l1_metrics(MetricName, Count, Duration) ->
+    hb_event:increment(copycat_l1_count, MetricName, #{}, Count),
+    hb_event:increment(copycat_l1_duration, MetricName, #{}, Duration).
 
 %% @doc Track an operation's execution time and count using hb_event:increment.
 %% Always tracks both count and duration, regardless of success/failure.
 observe_event(MetricName, Fun) ->
     {Time, Result} = timer:tc(Fun),
     record_event_metrics(MetricName, 1, Time),
+    Result.
+
+observe_copycat_l1_stage(MetricName, Fun) ->
+    {Time, Result} = timer:tc(Fun),
+    record_copycat_l1_metrics(MetricName, 1, Time),
     Result.
 
 %%% Tests

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -11,14 +11,11 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(ARWEAVE_DEVICE, <<"~arweave@2.9">>).
--define(CUTOVER_KEY, <<"block/marker-cutover-height">>).
 -define(DEPTH_SENTINEL, 99999).
-% By default we'll index blocks to depth 2 which is:
-% - depth 1: L1 TXs
-% - depth 2: L2 bundles and dataitems
-% Note: this means that the children of L2 bundles are not indexed at
-% depth 2.
--define(DEFAULT_BLOCK_DEPTH, 2).
+%% `full` uses the copycat-depth-recursion-cap option 
+%% as a safe depth to go to. This can be changed to an 
+%% integer value.
+-define(DEFAULT_BLOCK_DEPTH, <<"full">>).
 -define(DEFAULT_COPYCAT_MEMORY_BUDGET, 6 * 1024 * 1024 * 1024).
 
 % GET /~cron@1.0/once&cron-path=~copycat@1.0/arweave
@@ -51,7 +48,7 @@ arweave(_Base, Request, Opts) ->
                                 bundle_count => 0,
                                 skipped_count => 0,
                                 <<"body">> => 0
-                            }}                         
+                            }}
                     end;
                 error ->
                     case parse_range(Request, Opts) of
@@ -85,62 +82,22 @@ arweave(_Base, Request, Opts) ->
 %% @doc Set bundles descendant recursion cap, avoids recursion
 %% in very nested bundles (very rare).
 set_depth_recursion_cap(Cap, Opts) when is_integer(Cap), Cap > 0 ->
-    Opts#{<<"copycat_depth_recursion_cap">> => Cap}.
+    Opts#{<<"copycat-depth-recursion-cap">> => Cap}.
 %% @doc Get the set depth recursion cap from hb_opts.
 get_depth_recursion_cap(Opts) ->
-    hb_opts:get(<<"copycat_depth_recursion_cap">>, undefined, Opts).
+    hb_opts:get(<<"copycat-depth-recursion-cap">>, undefined, Opts).
 
 %% @doc Return the effective per-TX memory cap, clamped to the global budget.
 %% Lazily initializes the budget pool on first call.
 effective_memory_cap(Opts) ->
     Budget = 
         hb_opts:get(
-        <<"copycat_memory_budget">>, 
+        <<"copycat-memory-budget">>, 
         ?DEFAULT_COPYCAT_MEMORY_BUDGET, 
         Opts
     ),
     hb_copycat_budget:ensure_started(Budget),
     hb_copycat_budget:get_budget().
-
-%% @doc Return the store path for a block completion marker.
-block_indexed_path(Height) ->
-    <<"block/", (hb_util:bin(Height))/binary, "/depth">>.
-
-%% @doc Return the store path for a per-block item index at a given depth.
-block_items_path(Height, Depth) ->
-    <<"block/", (hb_util:bin(Height))/binary,
-        "/items/", (hb_util:bin(Depth))/binary>>.
-
-%% @doc Return the store path for a parent index entry.
-parent_path(ItemID) when byte_size(ItemID) =:= 32 ->
-    <<"parent/", ItemID/binary>>.
-
-%% @doc Encode a parent entry for storage.
-encode_parent_entry(Height, block) when is_integer(Height) ->
-    <<0, Height:64/big-unsigned>>;
-encode_parent_entry(ParentID, bundle) when byte_size(ParentID) =:= 32 ->
-    <<1, ParentID:32/binary>>.
-
-%% @doc Write a parent entry for an item to the index store.
-write_parent(ItemID, ParentData, Type, Store, Opts) ->
-    Entry = encode_parent_entry(ParentData, Type),
-    hb_store:write(Store, #{parent_path(ItemID) => Entry}, Opts).
-
-%% @doc Encode a list of 32-byte raw IDs into a single binary.
-encode_item_ids(IDs) ->
-    << <<ID:32/binary>> || ID <- IDs >>.
-
-%% @doc Decode a binary of concatenated 32-byte IDs into a list.
-%% Rejects binaries whose size is not a multiple of 32.
-decode_item_ids(<<>>) -> [];
-decode_item_ids(Bin) when byte_size(Bin) rem 32 =/= 0 ->
-    {error, invalid_item_ids_binary};
-decode_item_ids(Bin) ->
-    decode_item_ids_acc(Bin, []).
-
-decode_item_ids_acc(<<>>, Acc) -> lists:reverse(Acc);
-decode_item_ids_acc(<<ID:32/binary, Rest/binary>>, Acc) ->
-    decode_item_ids_acc(Rest, [ID | Acc]).
 
 %% @doc Shift all depth keys in an item ID map by Offset.
 shift_item_ids(Map, Offset) ->
@@ -167,87 +124,6 @@ merge_item_ids(A, B) ->
         A,
         B
     ).
-
-%% @doc Read the stored marker depth for a block, or undefined if none.
-read_block_marker_depth(Height, Opts) ->
-    case hb_store_arweave:store_from_opts(Opts) of
-        no_store -> undefined;
-        #{ <<"index-store">> := Store } ->
-            case hb_store:read(Store, block_indexed_path(Height), Opts) of
-                {ok, Bin} ->
-                    try binary_to_integer(Bin)
-                    catch _:_ -> undefined
-                    end;
-                {error, not_found} -> undefined
-            end
-    end.
-
-%% @doc Check if a block has been indexed at the given depth or deeper.
-is_block_indexed(undefined, _TargetDepth, _Opts) ->
-    false;
-is_block_indexed(Height, TargetDepth, Opts) ->
-    case read_block_marker_depth(Height, Opts) of
-        undefined -> false;
-        StoredDepth -> StoredDepth >= TargetDepth
-    end.
-
-%% @doc Write per-depth item ID lists for a block.
-%% Writes an entry for every depth from 1 through AchievedDepth (empty if
-%% no items at that level), plus any partial depths beyond AchievedDepth
-%% that were collected during indexing.
-write_block_item_ids(Height, AchievedDepth, ItemIDs, Opts) ->
-    Store = get_index_store(Opts),
-    MaxStoredDepth = case maps:keys(ItemIDs) of
-        [] -> AchievedDepth;
-        Keys -> max(AchievedDepth, lists:max(Keys))
-    end,
-    Results = lists:map(
-        fun(D) ->
-            IDs = maps:get(D, ItemIDs, []),
-            Bin = encode_item_ids(IDs),
-            hb_store:write(
-                Store,
-                #{block_items_path(Height, D) => Bin},
-                Opts
-            )
-        end,
-        lists:seq(1, MaxStoredDepth)
-    ),
-    case lists:all(fun(R) -> R =:= ok end, Results) of
-        true -> ok;
-        false ->
-            ?event(copycat_short,
-                {block_item_ids_write_failed,
-                    {height, Height}}),
-            {error, item_ids_write_failed}
-    end.
-
-%% @doc Write a block completion marker with the achieved depth.
-mark_block_indexed(Height, Depth, Opts) ->
-    Store = get_index_store(Opts),
-    hb_store:write(
-        Store,
-        #{block_indexed_path(Height) => integer_to_binary(Depth)},
-        Opts
-    ).
-
-%% @doc Read the persisted cutover height from the index store.
-read_cutover_height(Opts) ->
-    Store = get_index_store(Opts),
-    case hb_store:read(Store, ?CUTOVER_KEY, Opts) of
-        {ok, Bin} -> hb_util:int(Bin);
-        {error, not_found} -> undefined
-    end.
-
-%% @doc Write the cutover height if not already set.
-ensure_cutover_height(Height, Opts) ->
-    case read_cutover_height(Opts) of
-        undefined ->
-            Store = get_index_store(Opts),
-            hb_store:write(Store, #{?CUTOVER_KEY => hb_util:bin(Height)}, Opts),
-            ?event(copycat_short, {marker_cutover_initialized, {height, Height}});
-        _ -> ok
-    end.
 
 %% @doc Normalize an owner address into the native ID form used for comparisons.
 normalize_owner_id(Addr) ->
@@ -354,9 +230,9 @@ parse_tag_filter(Key, Request, Opts) ->
 %% applies L1-level owner/tag filters on the lightweight TX header first, then,
 %% if the TX passes and is a bundle, loads the full L1 payload once and indexes
 %% descendants in-memory up to the requested safe depth (defaults to full recursion 
-%% till the set copycat_depth_recursion_cap).
+%% till the set copycat-depth-recursion-cap).
 process_l1_request(TXID, Request, Opts) ->
-    Depth = request_depth(Request, <<"safe_max">>, Opts),
+    Depth = request_depth(Request, <<"full">>, Opts),
     QueryL1Offset =
         hb_util:bool(
             hb_maps:get(<<"query-l1-offset">>, Request, false, Opts)
@@ -398,12 +274,12 @@ process_l1_request(TXID, Request, Opts) ->
 %% safe cap. Depth is relative so depth 1 is always one level below the
 %% root specified in the request (either a block or an L1 TX ID).
 %% 
-%% `safe_max` resolves to the current copycat depth recursion cap.
+%% `full` resolves to the current copycat depth recursion cap.
 request_depth(Request, Default, Opts) ->
     MaxRecursionCap = get_depth_recursion_cap(Opts),
     RequestedDepth =
         case hb_maps:get(<<"depth">>, Request, Default, Opts) of
-            <<"safe_max">> -> MaxRecursionCap;
+            <<"full">> -> MaxRecursionCap;
             Value -> hb_util:int(Value)
         end,
     erlang:min(
@@ -531,14 +407,6 @@ latest_height(Opts) ->
         {error, Reason} -> {error, Reason}
     end.
 
-%% @doc Check if a transaction ID is indexed in the arweave index store.
-is_tx_indexed(TXID, Opts) ->
-    Store = get_index_store(Opts),
-    case hb_store:read(Store, hb_store_arweave_offset:path(TXID), Opts) of
-        {ok, _} -> true;
-        {error, not_found} -> false
-    end.
-
 %% @doc List indexed blocks and transactions in the given range.
 %% Returns JSON with block heights as keys, each containing indexed and not-indexed lists.
 list_index(From, undefined, Opts) ->
@@ -583,7 +451,7 @@ list_index_blocks(Current, To, Opts, Acc) ->
                                 _ ->
                                     BlockInfo#{
                                         <<"items">> =>
-                                            read_block_item_counts(
+                                            hb_store_arweave:read_block_item_counts(
                                                 Current, Opts)}
                             end,
                             NewAcc = Acc#{BlockKey => WithItems},
@@ -602,45 +470,10 @@ assemble_block_info(Height, Block, Opts) ->
         <<"indexed">> => IndexedTXs,
         <<"not-indexed">> => NotIndexedTXs
     },
-    case read_block_marker_depth(Height, Opts) of
+    case hb_store_arweave:read_block_marker_depth(Height, Opts) of
         undefined -> Base;
         Depth -> Base#{<<"depth">> => Depth}
     end.
-
-%% @doc Probe item entries upward from depth 1, applying TransformFun to each.
-probe_block_items(Height, Opts, TransformFun) ->
-    case hb_store_arweave:store_from_opts(Opts) of
-        no_store -> #{};
-        #{ <<"index-store">> := Store } ->
-            probe_block_items(Height, Store, 1, #{}, TransformFun, Opts)
-    end.
-
-probe_block_items(Height, Store, Depth, Acc, TransformFun, Opts) ->
-    case hb_store:read(Store, block_items_path(Height, Depth), Opts) of
-        {ok, Bin} ->
-            Key = hb_util:bin(Depth),
-            probe_block_items(
-                Height, Store, Depth + 1,
-                Acc#{Key => TransformFun(Bin)}, TransformFun, Opts);
-        {error, not_found} ->
-            Acc
-    end.
-
-count_ids(Bin) when byte_size(Bin) rem 32 =:= 0 ->
-    byte_size(Bin) div 32;
-count_ids(_) -> <<"corrupt">>.
-
-decode_and_encode_ids(Bin) ->
-    case decode_item_ids(Bin) of
-        {error, _} -> <<"corrupt">>;
-        List -> [hb_util:encode(ID) || ID <- List]
-    end.
-
-read_block_item_counts(Height, Opts) ->
-    probe_block_items(Height, Opts, fun count_ids/1).
-
-read_block_item_ids(Height, Opts) ->
-    probe_block_items(Height, Opts, fun decode_and_encode_ids/1).
 
 %% @doc mode=inventory: return per-depth item ID lists from the local index store.
 %% Supports range queries. The inventory read itself is local-only (no network).
@@ -662,11 +495,11 @@ inventory_index(From, To, Opts) ->
 
 inventory_local(Current, To, _Opts, Acc) when Current < To -> Acc;
 inventory_local(Current, To, Opts, Acc) ->
-    case read_block_marker_depth(Current, Opts) of
+    case hb_store_arweave:read_block_marker_depth(Current, Opts) of
         undefined ->
             inventory_local(Current - 1, To, Opts, Acc);
         Depth ->
-            ItemIDs = read_block_item_ids(Current, Opts),
+            ItemIDs = hb_store_arweave:read_block_item_ids(Current, Opts),
             BlockKey = hb_util:bin(Current),
             BlockInfo = #{<<"depth">> => Depth, <<"items">> => ItemIDs},
             inventory_local(Current - 1, To, Opts,
@@ -690,7 +523,7 @@ fetch_block_header(Height, Opts) ->
 classify_txs(TXIDs, Opts) ->
     lists:foldl(
         fun(TXID, {IndexedAcc, NotIndexedAcc}) ->
-            case is_tx_indexed(TXID, Opts) of
+                case hb_store_arweave:is_tx_indexed(TXID, Opts) of
                 true -> {[TXID | IndexedAcc], NotIndexedAcc};
                 false -> {IndexedAcc, [TXID | NotIndexedAcc]}
             end
@@ -722,7 +555,7 @@ fetch_blocks(Current, To, TargetDepth, Opts) ->
     fetch_blocks_ranged(Current, To, TargetDepth, BlockWorkers, Opts).
 
 block_workers(Opts) ->
-    max(1, hb_opts:get(<<"arweave_block_workers">>, 3, Opts)).
+    max(1, hb_opts:get(<<"arweave-block-workers">>, 3, Opts)).
 
 %% @doc Process a known range of blocks in parallel batches.
 fetch_blocks_ranged(Current, To, TargetDepth, _Workers, _Opts)
@@ -740,7 +573,7 @@ fetch_blocks_ranged(Current, To, TargetDepth, Workers, Opts) ->
     hb_pmap:parallel_map(
         Heights,
         fun(H) ->
-            case is_block_indexed(H, TargetDepth, Opts) of
+                case hb_store_arweave:is_block_indexed(H, TargetDepth, Opts) of
                 true -> ok;
                 false ->
                     observe_event(<<"block_indexed">>, fun() ->
@@ -817,30 +650,23 @@ process_prefetched_blocks(Blocks, TargetDepth, Workers, Opts) ->
 %% the cutover, falls back to legacy per-TX check.
 is_already_indexed({ok, Block}, TargetDepth, Opts) ->
     Height = hb_maps:get(<<"height">>, Block, undefined, Opts),
-    case is_block_indexed(Height, TargetDepth, Opts) of
+    case hb_store_arweave:is_block_indexed(Height, TargetDepth, Opts) of
         true ->
             true;
         false ->
-            case is_post_cutover(Height, Opts) of
+            case hb_store_arweave:is_post_cutover(Height, Opts) of
                 true ->
                     false;
                 false ->
                     TXIDs = hb_maps:get(<<"txs">>, Block, [], Opts),
                     lists:any(
-                        fun(TXID) -> is_tx_indexed(TXID, Opts) end,
+                        fun(TXID) -> hb_store_arweave:is_tx_indexed(TXID, Opts) end,
                         TXIDs
                     )
             end
     end;
 is_already_indexed({error, _}, _TargetDepth, _Opts) ->
     false.
-
-is_post_cutover(undefined, _Opts) -> false;
-is_post_cutover(Height, Opts) ->
-    case read_cutover_height(Opts) of
-        undefined -> false;
-        Cutover -> Height >= Cutover
-    end.
 
 fetch_and_process_block(Current, To, TargetDepth, Opts) ->
     BlockRes = fetch_block_header(Current, Opts),
@@ -873,11 +699,11 @@ process_block(BlockRes, Current, To, TargetDepth, Opts) ->
                         max(2, TargetDepth)),
                     ItemIDs = maps:get(item_ids, Results, #{}),
                     maybe
-                        ok ?= write_block_item_ids(
+                        ok ?= hb_store_arweave:write_block_item_ids(
                             Current, AchievedDepth, ItemIDs, Opts),
-                        ok ?= mark_block_indexed(
+                        ok ?= hb_store_arweave:mark_block_indexed(
                             Current, AchievedDepth, Opts),
-                        ensure_cutover_height(Current, Opts),
+                        hb_store_arweave:ensure_cutover_height(Current, Opts),
                         ?event(
                             copycat_short,
                             {arweave_block_indexed,
@@ -993,11 +819,12 @@ process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, 
             TXID,
             <<"tx@1.0">>,
             TXStartOffset,
-            TX#tx.data_size
+            TX#tx.data_size,
+            Opts
         )
     end),
     #{ <<"index-store">> := IndexStore } = ArweaveStore,
-    ok = write_parent(TX#tx.id, BlockHeight, block, IndexStore, Opts),
+    ok = hb_store_arweave:write_parent(TX#tx.id, BlockHeight, block, IndexStore, Opts),
     try is_bundle_tx(TX, Opts) of
         false ->
             #{items_count => 0, bundle_count => 0, skipped_count => 0,
@@ -1045,9 +872,10 @@ process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, 
                                     hb_util:encode(ItemID),
                                     <<"ans104@1.0">>,
                                     ItemStartOffset,
-                                    Size
+                                    Size,
+                                    Opts
                                 ),
-                                ok = write_parent(ItemID, TX#tx.id, bundle, IndexStore, Opts),
+                                ok = hb_store_arweave:write_parent(ItemID, TX#tx.id, bundle, IndexStore, Opts),
                                 {ItemStartOffset + Size, ItemsCountAcc + 1}
                             end,
                             {TXStartOffset + HeaderSize, 0},
@@ -1381,8 +1209,6 @@ ensure_l1_tx_offset(TXID, EncodedTXID, IndexStore, QueryL1Offset, Opts) ->
     end.
 
 query_l1_tx_offset(TXID, IndexStore, Opts) ->
-    % TODO: move this into dev_arweave - I think? Unless it's possible to
-    % query this already via one of the existing ~arweave@2.9 paths?
     case observe_copycat_l1_stage(
         <<"l1_offset_query_http">>,
         fun() ->
@@ -1408,7 +1234,8 @@ query_l1_tx_offset(TXID, IndexStore, Opts) ->
                         TXID,
                         <<"tx@1.0">>,
                         StartOffset,
-                        Size
+                        Size,
+                        Opts
                     )
                 end
             ),
@@ -1477,9 +1304,10 @@ index_full_bundle_items(
         EncodedItemID,
         <<"ans104@1.0">>,
         ItemStartOffset,
-        Size
+        Size,
+        Opts
     ),
-    ok = write_parent(ItemID, ParentID, bundle, IndexStore, Opts),
+    ok = hb_store_arweave:write_parent(ItemID, ParentID, bundle, IndexStore, Opts),
     {DescendantCount, ItemAchievedDepth, ChildIDs} =
         case {Depth > 1, ParseResult} of
             {true, {ok, HeaderSize, ParsedItem}} ->
@@ -1656,12 +1484,6 @@ observe_copycat_l1_stage(MetricName, Fun) ->
     record_copycat_l1_metrics(MetricName, 1, Time),
     Result.
 
-get_index_store(Opts) ->
-    case hb_store_arweave:store_from_opts(Opts) of
-        #{ <<"index-store">> := Store } -> Store;
-        _ -> throw(no_index_store_available)
-    end.
-
 %%% Tests
 
 index_ids_test_parallel() ->
@@ -1673,7 +1495,7 @@ index_ids_test_parallel() ->
     {_TestStore, StoreOpts, Opts} = setup_index_opts(),
     {ok, 1827942} =
         hb_ao:resolve(
-            <<"~copycat@1.0/arweave&from=1827942&to=1827942">>,
+            <<"~copycat@1.0/arweave&from=1827942&to=1827942&depth=2">>,
             Opts
         ),
     ?assertMatch(
@@ -2064,9 +1886,9 @@ auto_stop_on_indexed_block_test_parallel() ->
     ?assert(has_any_indexed_tx(Higher1, Opts)),
     ?assert(has_any_indexed_tx(IndexedBlock, Opts)),
     ?assertNot(has_any_indexed_tx(IndexedBlock-1, Opts)),
-    ?assert(is_block_indexed(IndexedBlock, 2, Opts)),
-    ?assert(is_block_indexed(Higher1, 2, Opts)),
-    ?assert(is_block_indexed(Higher2, 2, Opts)),
+    ?assert(hb_store_arweave:is_block_indexed(IndexedBlock, 2, Opts)),
+    ?assert(hb_store_arweave:is_block_indexed(Higher1, 2, Opts)),
+    ?assert(hb_store_arweave:is_block_indexed(Higher2, 2, Opts)),
     ok.
 
 explicit_to_reindexes_all_test_parallel() ->
@@ -2121,7 +1943,7 @@ auto_stop_partial_index_test_parallel() ->
     TXIDs = hb_maps:get(<<"txs">>, BlockData, [], Opts),
     ?assert(length(TXIDs) > 0),
     [OneTXID | _] = TXIDs,
-    ok = hb_store_arweave:write_offset(StoreOpts, OneTXID, <<"tx@1.0">>, 0, 0),
+    ok = hb_store_arweave:write_offset(StoreOpts, OneTXID, <<"tx@1.0">>, 0, 0, Opts),
     {ok, Block} =
         hb_ao:resolve(
             <<
@@ -2134,8 +1956,8 @@ auto_stop_partial_index_test_parallel() ->
     ?assert(has_any_indexed_tx(HigherBlock, Opts)),
     ?assert(has_any_indexed_tx(Block, Opts)),
     ?assertNot(has_any_indexed_tx(Block-1, Opts)),
-    ?assert(is_block_indexed(HigherBlock, 2, Opts)),
-    ?assertNot(is_block_indexed(Block, 2, Opts)),
+    ?assert(hb_store_arweave:is_block_indexed(HigherBlock, 2, Opts)),
+    ?assertNot(hb_store_arweave:is_block_indexed(Block, 2, Opts)),
     ok.
 
 negative_parse_range_test_parallel() ->
@@ -2372,23 +2194,23 @@ l1_filter_reason_test() ->
 
 request_depth_clamping_test() ->
     {_TestStore, _StoreOpts, Opts0} = setup_index_opts(),
-    ?assertEqual(6, request_depth(#{}, <<"safe_max">>, Opts0)),
+    ?assertEqual(6, request_depth(#{}, <<"full">>, Opts0)),
     ?assertEqual(
         2,
-        request_depth(#{<<"depth">> => <<"2">>}, <<"safe_max">>, Opts0)
+        request_depth(#{<<"depth">> => <<"2">>}, <<"full">>, Opts0)
     ),
     ?assertEqual(
         1,
-        request_depth(#{<<"depth">> => <<"0">>}, <<"safe_max">>, Opts0)
+        request_depth(#{<<"depth">> => <<"0">>}, <<"full">>, Opts0)
     ),
     ?assertEqual(
         6,
-        request_depth(#{<<"depth">> => <<"999">>}, <<"safe_max">>, Opts0)
+        request_depth(#{<<"depth">> => <<"999">>}, <<"full">>, Opts0)
     ),
     Opts1 = set_depth_recursion_cap(2, Opts0),
-    ?assertEqual(2, request_depth(#{}, <<"safe_max">>, Opts1)),
+    ?assertEqual(2, request_depth(#{}, <<"full">>, Opts1)),
     % no recursion cap set, use default from hb_opts
-    ?assertEqual(6, request_depth(#{}, <<"safe_max">>, #{})),
+    ?assertEqual(6, request_depth(#{}, <<"full">>, #{})),
     ok.
 
 id_depth_1_test() ->
@@ -2674,7 +2496,7 @@ has_any_indexed_tx(Height, Opts) ->
     case fetch_block_header(Height, Opts) of
         {ok, Block} ->
             TXIDs = hb_maps:get(<<"txs">>, Block, [], Opts),
-            lists:any(fun(TXID) -> is_tx_indexed(TXID, Opts) end, TXIDs);
+            lists:any(fun(TXID) -> hb_store_arweave:is_tx_indexed(TXID, Opts) end, TXIDs);
         {error, _} ->
             false
     end.
@@ -2704,18 +2526,18 @@ assert_indexed_range(From, To, Opts) ->
     ?assert(has_any_indexed_tx(From, Opts)),
     assert_indexed_range(From - 1, To, Opts).
 
-block_marker_depth_2_test() ->
+block_marker_default_depth_test() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     Block = 1827942,
     {ok, Block} =
         hb_ao:resolve(
             <<"~copycat@1.0/arweave&from=",
                 (hb_util:bin(Block))/binary, "&to=",
-                (hb_util:bin(Block))/binary>>,
+                (hb_util:bin(Block))/binary, "&depth=2">>,
             Opts
         ),
-    ?assert(is_block_indexed(Block, 2, Opts)),
-    ?assertNot(is_block_indexed(Block, 3, Opts)),
+    ?assert(hb_store_arweave:is_block_indexed(Block, 2, Opts)),
+    ?assertNot(hb_store_arweave:is_block_indexed(Block, 3, Opts)),
     ok.
 
 depth_1_normalizes_to_2_test() ->
@@ -2739,10 +2561,10 @@ depth_1_normalizes_to_2_test() ->
     Result = process_block_txs(Tuples, 0, 1, 88888888, Opts),
     ?assertEqual(2, maps:get(achieved_depth, Result)),
     Height = 88888888,
-    mark_block_indexed(Height, maps:get(achieved_depth, Result), Opts),
-    ?assert(is_block_indexed(Height, 1, Opts)),
-    ?assert(is_block_indexed(Height, 2, Opts)),
-    ?assertNot(is_block_indexed(Height, 3, Opts)),
+    hb_store_arweave:mark_block_indexed(Height, maps:get(achieved_depth, Result), Opts),
+    ?assert(hb_store_arweave:is_block_indexed(Height, 1, Opts)),
+    ?assert(hb_store_arweave:is_block_indexed(Height, 2, Opts)),
+    ?assertNot(hb_store_arweave:is_block_indexed(Height, 3, Opts)),
     ok.
 
 block_marker_cutover_test() ->
@@ -2756,11 +2578,26 @@ block_marker_cutover_test() ->
                 (hb_util:bin(UpperBlock))/binary>>,
             Opts
         ),
-    Cutover = read_cutover_height(Opts),
+    Cutover = hb_store_arweave:read_cutover_height(Opts),
     ?assertNotEqual(undefined, Cutover),
-    ?assert(is_block_indexed(UpperBlock, 2, Opts)),
-    ?assertNot(is_block_indexed(LowerBlock, 2, Opts)),
+    ?assert(hb_store_arweave:is_block_indexed(UpperBlock, 2, Opts)),
+    ?assertNot(hb_store_arweave:is_block_indexed(LowerBlock, 2, Opts)),
     ok.
+
+achieved_depth_block_depth_2_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    Block = 1827942,
+    {ok, Block} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=",
+                (hb_util:bin(Block))/binary, "&to=",
+                (hb_util:bin(Block))/binary, "&depth=2">>,
+            Opts
+        ),
+    ?assert(hb_store_arweave:is_block_indexed(Block, 2, Opts)),
+    ?assertNot(hb_store_arweave:is_block_indexed(Block, 3, Opts)),
+    ok.
+
 
 achieved_depth_block_depth_3_test() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
@@ -2772,7 +2609,7 @@ achieved_depth_block_depth_3_test() ->
                 (hb_util:bin(Block))/binary, "&depth=3">>,
             Opts
         ),
-    ?assert(is_block_indexed(Block, 3, Opts)),
+    ?assert(hb_store_arweave:is_block_indexed(Block, 3, Opts)),
     ok.
 
 invalid_bundle_bytes_test() ->
@@ -2794,14 +2631,14 @@ small_block_depth_3_test() ->
                 (hb_util:bin(Block))/binary, "&depth=3">>,
             Opts
         ),
-    ?assert(is_block_indexed(Block, 3, Opts)),
+    ?assert(hb_store_arweave:is_block_indexed(Block, 3, Opts)),
     #{ <<"index-store">> := Store } = hb_store_arweave:store_from_opts(Opts),
-    {ok, L1Bin} = hb_store:read(Store, block_items_path(Block, 1), Opts),
-    ?assert(length(decode_item_ids(L1Bin)) > 0),
-    {ok, L2Bin} = hb_store:read(Store, block_items_path(Block, 2), Opts),
-    ?assert(length(decode_item_ids(L2Bin)) > 0),
-    {ok, L3Bin} = hb_store:read(Store, block_items_path(Block, 3), Opts),
-    L3IDs = decode_item_ids(L3Bin),
+    {ok, L1Bin} = hb_store:read(Store, hb_store_arweave:block_items_path(Block, 1), Opts),
+    ?assert(length(hb_store_arweave:decode_item_ids(L1Bin)) > 0),
+    {ok, L2Bin} = hb_store:read(Store, hb_store_arweave:block_items_path(Block, 2), Opts),
+    ?assert(length(hb_store_arweave:decode_item_ids(L2Bin)) > 0),
+    {ok, L3Bin} = hb_store:read(Store, hb_store_arweave:block_items_path(Block, 3), Opts),
+    L3IDs = hb_store_arweave:decode_item_ids(L3Bin),
     ?assertEqual(3, length(L3IDs)),
     assert_item_read(
         <<"npAzk_BomjWBQQr_xnmlhdxjyl97EJnNv_MAaXffs1s">>,
@@ -2850,7 +2687,7 @@ exact_marker_depth_test() ->
     #{ <<"index-store">> := Store } =
         hb_store_arweave:store_from_opts(Opts),
     {ok, StoredBin} =
-        hb_store:read(Store, block_indexed_path(Block), Opts),
+    hb_store:read(Store, hb_store_arweave:block_indexed_path(Block), Opts),
     StoredDepth = binary_to_integer(StoredBin),
     ?assertEqual(3, StoredDepth),
     ok.
@@ -2891,15 +2728,15 @@ block_item_ids_depth_2_test() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     {ok, 1827942} =
         hb_ao:resolve(
-            <<"~copycat@1.0/arweave&from=1827942&to=1827942">>,
+            <<"~copycat@1.0/arweave&from=1827942&to=1827942&depth=2">>,
             Opts
         ),
     #{ <<"index-store">> := Store } = hb_store_arweave:store_from_opts(Opts),
-    {ok, L1Bin} = hb_store:read(Store, block_items_path(1827942, 1), Opts),
-    L1IDs = decode_item_ids(L1Bin),
+    {ok, L1Bin} = hb_store:read(Store, hb_store_arweave:block_items_path(1827942, 1), Opts),
+    L1IDs = hb_store_arweave:decode_item_ids(L1Bin),
     ?assert(length(L1IDs) > 0),
-    {ok, L2Bin} = hb_store:read(Store, block_items_path(1827942, 2), Opts),
-    L2IDs = decode_item_ids(L2Bin),
+    {ok, L2Bin} = hb_store:read(Store, hb_store_arweave:block_items_path(1827942, 2), Opts),
+    L2IDs = hb_store_arweave:decode_item_ids(L2Bin),
     ?assert(length(L2IDs) > 0),
     L2Encoded = [hb_util:encode(ID) || ID <- L2IDs],
     Pos54K = index_of(<<"54K1ehEIKZxGSusgZzgbGYaHfllwWQ09-S9-eRUJg5Y">>, L2Encoded),
@@ -2907,7 +2744,7 @@ block_item_ids_depth_2_test() ->
     ?assert(is_integer(Pos54K)),
     ?assert(is_integer(PosOBK)),
     ?assert(Pos54K < PosOBK),
-    ?assertEqual({error, not_found}, hb_store:read(Store, block_items_path(1827942, 3), Opts)),
+    ?assertEqual({error, not_found}, hb_store:read(Store, hb_store_arweave:block_items_path(1827942, 3), Opts)),
     ok.
 
 block_item_ids_depth_3_test() ->
@@ -2918,16 +2755,16 @@ block_item_ids_depth_3_test() ->
             Opts
         ),
     #{ <<"index-store">> := Store } = hb_store_arweave:store_from_opts(Opts),
-    {ok, L1Bin} = hb_store:read(Store, block_items_path(1827942, 1), Opts),
-    L1Count = length(decode_item_ids(L1Bin)),
+    {ok, L1Bin} = hb_store:read(Store, hb_store_arweave:block_items_path(1827942, 1), Opts),
+    L1Count = length(hb_store_arweave:decode_item_ids(L1Bin)),
     ?assertEqual(5, L1Count),
-    {ok, L2Bin} = hb_store:read(Store, block_items_path(1827942, 2), Opts),
-    L2Count = length(decode_item_ids(L2Bin)),
+    {ok, L2Bin} = hb_store:read(Store, hb_store_arweave:block_items_path(1827942, 2), Opts),
+    L2Count = length(hb_store_arweave:decode_item_ids(L2Bin)),
     ?assert(L2Count > 0),
-    {ok, L3Bin} = hb_store:read(Store, block_items_path(1827942, 3), Opts),
-    L3Count = length(decode_item_ids(L3Bin)),
+    {ok, L3Bin} = hb_store:read(Store, hb_store_arweave:block_items_path(1827942, 3), Opts),
+    L3Count = length(hb_store_arweave:decode_item_ids(L3Bin)),
     ?assert(L3Count >= 1),
-    L3IDs = decode_item_ids(L3Bin),
+    L3IDs = hb_store_arweave:decode_item_ids(L3Bin),
     L3Encoded = [hb_util:encode(ID) || ID <- L3IDs],
     ?assert(lists:member(
         <<"8aJrRWtHcJvJ61qsH6agGkemzrtLw3W22xFrpCGAnTM">>, L3Encoded)),
@@ -2983,63 +2820,18 @@ inventory_single_block_test() ->
 inventory_range_test() ->
     {_TestStore, StoreOpts, Opts} = setup_index_opts(),
     #{ <<"index-store">> := Store } = StoreOpts,
-    ok = hb_store:write(Store, #{block_indexed_path(77777777) => <<"2">>}, Opts),
-    ok = hb_store:write(Store, #{block_items_path(77777777, 1) => <<0:256>>}, Opts),
-    ok = hb_store:write(Store, #{block_items_path(77777777, 2) => <<>>}, Opts),
-    ok = hb_store:write(Store, #{block_indexed_path(77777778) => <<"2">>}, Opts),
-    ok = hb_store:write(Store, #{block_items_path(77777778, 1) => <<1:256>>}, Opts),
-    ok = hb_store:write(Store, #{block_items_path(77777778, 2) => <<>>}, Opts),
+    ok = hb_store:write(Store, #{hb_store_arweave:block_indexed_path(77777777) => <<"2">>}, Opts),
+    ok = hb_store:write(Store, #{hb_store_arweave:block_items_path(77777777, 1) => <<0:256>>}, Opts),
+    ok = hb_store:write(Store, #{hb_store_arweave:block_items_path(77777777, 2) => <<>>}, Opts),
+    ok = hb_store:write(Store, #{hb_store_arweave:block_indexed_path(77777778) => <<"2">>}, Opts),
+    ok = hb_store:write(Store, #{hb_store_arweave:block_items_path(77777778, 1) => <<1:256>>}, Opts),
+    ok = hb_store:write(Store, #{hb_store_arweave:block_items_path(77777778, 2) => <<>>}, Opts),
     {ok, InvResult} = inventory_index(77777778, 77777777, Opts),
     Body = hb_json:decode(hb_maps:get(<<"body">>, InvResult)),
     ?assert(maps:is_key(<<"77777777">>, Body)),
     ?assert(maps:is_key(<<"77777778">>, Body)),
     ?assertEqual(2, maps:get(<<"depth">>, maps:get(<<"77777777">>, Body))),
     ?assertEqual(2, maps:get(<<"depth">>, maps:get(<<"77777778">>, Body))),
-    ok.
-
-decode_item_ids_validation_test() ->
-    ?assertEqual([], decode_item_ids(<<>>)),
-    GoodBin = <<0:256, 1:256>>,
-    ?assertEqual(2, length(decode_item_ids(GoodBin))),
-    BadBin = <<0:240>>,
-    ?assertEqual({error, invalid_item_ids_binary}, decode_item_ids(BadBin)),
-    ok.
-
-corrupt_item_ids_read_test() ->
-    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
-    #{ <<"index-store">> := Store } = hb_store_arweave:store_from_opts(Opts),
-    Height = 99999999,
-    ok = hb_store:write(Store, #{block_indexed_path(Height) => <<"2">>}, Opts),
-    ok = hb_store:write(Store, #{block_items_path(Height, 1) => <<0:256>>}, Opts),
-    ok = hb_store:write(Store, #{block_items_path(Height, 2) => <<0:240>>}, Opts),
-    Counts = read_block_item_counts(Height, Opts),
-    ?assertEqual(1, maps:get(<<"1">>, Counts)),
-    ?assertEqual(<<"corrupt">>, maps:get(<<"2">>, Counts)),
-    IDs = read_block_item_ids(Height, Opts),
-    ?assertEqual(1, length(maps:get(<<"1">>, IDs))),
-    ?assertEqual(<<"corrupt">>, maps:get(<<"2">>, IDs)),
-    ok.
-
-parent_encode_decode_test() ->
-    BlockEntry = encode_parent_entry(12345, block),
-    ?assertEqual(<<0, 12345:64/big-unsigned>>, BlockEntry),
-    BundleID = crypto:strong_rand_bytes(32),
-    BundleEntry = encode_parent_entry(BundleID, bundle),
-    ?assertEqual(<<1, BundleID:32/binary>>, BundleEntry),
-    Combined = <<BlockEntry/binary, BundleEntry/binary>>,
-    Decoded = hb_store_arweave:decode_parent_entries(Combined),
-    ?assertEqual([{12345, block}, {BundleID, bundle}], Decoded),
-    ok.
-
-parent_not_found_test() ->
-    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
-    StoreOpts2 = hb_store_arweave:store_from_opts(Opts),
-    UnknownID = crypto:strong_rand_bytes(32),
-    ?assertEqual(
-       not_found, 
-       hb_store_arweave:read_parent(StoreOpts2, UnknownID, Opts),
-       Opts
-    ),
     ok.
 
 parent_depth_2_test() ->

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -10,7 +10,12 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(ARWEAVE_DEVICE, <<"~arweave@2.9">>).
--define(DEPTH_L1_OFFSETS, 1).
+% By default we'll index blocks to depth 2 which is:
+% - depth 1: L1 TXs
+% - depth 2: L2 bundles and dataitems
+% Note: this means that the children of L2 bundles are not indexed at
+% depth 2.
+-define(DEFAULT_BLOCK_DEPTH, 2).
 
 % GET /~cron@1.0/once&cron-path=~copycat@1.0/arweave
 
@@ -23,16 +28,11 @@ arweave(_Base, Request, Opts) ->
             case hb_maps:find(<<"id">>, Request, Opts) of
                 {ok, TXID} -> process_l1_request(TXID, Request, Opts);
                 error ->
-                    BlockDepth = request_depth(Request, ?DEPTH_L1_OFFSETS, Opts),
+                    TargetDepth = request_depth(Request, ?DEFAULT_BLOCK_DEPTH, Opts),
                     case parse_range(Request, Opts) of
                         {error, unavailable} -> {error, unavailable};
                         {ok, {From, To}} ->
-                            fetch_blocks(
-                                Request,
-                                From,
-                                To,
-                                Opts#{copycat_block_depth => BlockDepth}
-                            )
+                            fetch_blocks(From, To, TargetDepth, Opts)
                     end
             end;
         <<"list">> ->
@@ -65,15 +65,15 @@ normalize_owner_id(Addr) ->
 %% @doc Adds an address to the owners aliases cache in Opts, mapping
 %% Alias -> native address for fast lookup and once per address computation.
 add_owner_alias(Addr, Alias, Opts) when is_binary(Alias) -> 
-    ExistingAliases = maps:get(owner_aliases, Opts, #{}),
+    ExistingAliases = hb_opts:get(owner_aliases, #{}, Opts),
     Opts#{ owner_aliases => ExistingAliases#{ Alias => normalize_owner_id(Addr) }};
 add_owner_alias(_Addr, Alias, _Opts) ->
     throw({invalid_owner_alias, Alias}).
 
 %% @doc Retrieve the address of a given alias.
 resolve_owner_alias(Alias, Opts) when is_binary(Alias) ->
-    Aliases = maps:get(owner_aliases, Opts, #{}),
-    case maps:find(Alias, Aliases) of
+    Aliases = hb_opts:get(owner_aliases, #{}, Opts),
+    case hb_maps:find(Alias, Aliases) of
         {ok, Addr} -> {ok, Addr};
         error -> {error, {owner_alias_not_found, Alias}}
     end;
@@ -82,29 +82,28 @@ resolve_owner_alias(Alias, _Opts) ->
 %% @doc Parse include/exclude owner filters from the request.
 %% Supports direct owner values and owner aliases.
 parse_owner_filter(Request, Opts) ->
-    case resolve_owner_filter_value(
-        <<"include-owner">>,
-        <<"include-owner-alias">>,
-        Request,
-        Opts
-    ) of
-        {error, _} = Error ->
-            Error;
-        {ok, IncludeOwner} ->
-            case resolve_owner_filter_value(
+    maybe
+        {ok, IncludeOwner} ?=
+            resolve_owner_filter_value(
+                <<"include-owner">>,
+                <<"include-owner-alias">>,
+                Request,
+                Opts
+            ),
+        {ok, ExcludeOwner} ?=
+            resolve_owner_filter_value(
                 <<"exclude-owner">>,
                 <<"exclude-owner-alias">>,
                 Request,
                 Opts
-            ) of
-                {error, _} = Error ->
-                    Error;
-                {ok, ExcludeOwner} ->
-                    {ok, #{
-                        include_owner => IncludeOwner,
-                        exclude_owner => ExcludeOwner
-                    }}
-            end
+            ),
+        {ok, #{
+            include_owner => IncludeOwner,
+            exclude_owner => ExcludeOwner
+        }}
+    else
+        {error, _} = Error ->
+            Error
     end.
 %% @doc Resolve one owner filter value from either a direct owner param or
 %% a comma-separated owner alias param. Alias takes precedence.
@@ -163,41 +162,38 @@ parse_tag_filter(Key, Request, Opts) ->
 %% @doc Process the `id=...` copycat path for an already indexed L1 TX.
 %% applies L1-level owner/tag filters on the lightweight TX header first, then,
 %% if the TX passes and is a bundle, loads the full L1 payload once and indexes
-%% descendants in-memory (under the configured copycat_memory_cap) up to the requested safe depth
-%% (defaults to full recursion till the set copycat_depth_recursion_cap).
+%% descendants in-memory (under the configured copycat_memory_cap) up to the
+%% requested safe depth (defaults to full recursion till the set
+%% copycat_depth_recursion_cap).
 process_l1_request(TXID, Request, Opts) ->
     Depth = request_depth(Request, <<"safe_max">>, Opts),
-    LoadL1Offset =
+    QueryL1Offset =
         hb_util:bool(
-            hb_maps:get(<<"load-l1-offset">>, Request, false, Opts)
+            hb_maps:get(<<"query-l1-offset">>, Request, false, Opts)
         ),
-    case parse_owner_filter(Request, Opts) of
+    maybe
+        {ok, OwnerFilters} ?= parse_owner_filter(Request, Opts),
+        {ok, IncludeTag} ?= parse_tag_filter(<<"include-tag">>, Request, Opts),
+        {ok, ExcludeTag} ?= parse_tag_filter(<<"exclude-tag">>, Request, Opts),
+        {ok,
+            maybe_process_l1_tx(
+                TXID,
+                OwnerFilters#{
+                    include_tag => IncludeTag,
+                    exclude_tag => ExcludeTag
+                },
+                Depth,
+                QueryL1Offset,
+                Opts
+            )}
+    else
         {error, _} = Error ->
-            Error;
-        {ok, OwnerFilters} ->
-            case parse_tag_filter(<<"include-tag">>, Request, Opts) of
-                {error, _} = Error ->
-                    Error;
-                {ok, IncludeTag} ->
-                    case parse_tag_filter(<<"exclude-tag">>, Request, Opts) of
-                        {error, _} = Error ->
-                            Error;
-                        {ok, ExcludeTag} ->
-                            {ok,
-                                process_l1_candidate(
-                                    TXID,
-                                    OwnerFilters#{
-                                        load_l1_offset => LoadL1Offset,
-                                        include_tag => IncludeTag,
-                                        exclude_tag => ExcludeTag
-                                    },
-                                    Depth,
-                                    Opts
-                                )}
-                    end
-            end
+            Error
     end.
-%% @doc Parse the requested recursion depth and clamp it to the configured safe cap.
+%% @doc Parse the requested recursion depth and clamp it to the configured
+%% safe cap. Depth is relative so depth 1 is always one level below the
+%% root specified in the request (either a block or an L1 TX ID).
+%% 
 %% `safe_max` resolves to the current copycat depth recursion cap.
 request_depth(Request, Default, Opts) ->
     MaxRecursionCap = get_depth_recursion_cap(Opts),
@@ -208,10 +204,7 @@ request_depth(Request, Default, Opts) ->
         end,
     erlang:min(
         MaxRecursionCap,
-        erlang:max(
-            ?DEPTH_L1_OFFSETS,
-            RequestedDepth
-        )
+        erlang:max(1, RequestedDepth)
     ).
 %% @doc Return the first matching L1 filter reason for a TX header, or `pass`.
 l1_filter_reason(TX, Filters) ->
@@ -220,39 +213,14 @@ l1_filter_reason(TX, Filters) ->
     IncludeTag = maps:get(include_tag, Filters, undefined),
     ExcludeTag = maps:get(exclude_tag, Filters, undefined),
     Owner = ar_tx:get_owner_address(TX),
-    case owner_matches_filter(Owner, IncludeOwner) of
-        false when IncludeOwner =/= undefined ->
-            include_owner_mismatch;
-        _ ->
-            case owner_matches_filter(Owner, ExcludeOwner) of
-                true ->
-                    exclude_owner_match;
-                false ->
-                    case IncludeTag of
-                        undefined ->
-                            case ExcludeTag of
-                                undefined -> pass;
-                                _ ->
-                                    case has_tag_pair(TX, ExcludeTag) of
-                                        true -> exclude_tag_match;
-                                        false -> pass
-                                    end
-                            end;
-                        _ ->
-                            case has_tag_pair(TX, IncludeTag) of
-                                false -> include_tag_mismatch;
-                                true ->
-                                    case ExcludeTag of
-                                        undefined -> pass;
-                                        _ ->
-                                            case has_tag_pair(TX, ExcludeTag) of
-                                                true -> exclude_tag_match;
-                                                false -> pass
-                                            end
-                                    end
-                            end
-                    end
-            end
+    maybe
+        pass ?= maybe_include_owner(Owner, IncludeOwner),
+        pass ?= maybe_exclude_owner(Owner, ExcludeOwner),
+        pass ?= maybe_include_tag(TX, IncludeTag),
+        pass ?= maybe_exclude_tag(TX, ExcludeTag),
+        pass
+    else
+        Reason -> Reason
     end.
 %% @doc Match an owner against an undefined, single-owner, or multi-owner filter.
 owner_matches_filter(_Owner, undefined) ->
@@ -261,6 +229,38 @@ owner_matches_filter(Owner, Owners) when is_list(Owners) ->
     lists:member(Owner, Owners);
 owner_matches_filter(Owner, FilterOwner) ->
     Owner =:= FilterOwner.
+
+maybe_include_owner(_Owner, undefined) ->
+    pass;
+maybe_include_owner(Owner, IncludeOwner) ->
+    case owner_matches_filter(Owner, IncludeOwner) of
+        true -> pass;
+        false -> include_owner_mismatch
+    end.
+
+maybe_exclude_owner(_Owner, undefined) ->
+    pass;
+maybe_exclude_owner(Owner, ExcludeOwner) ->
+    case owner_matches_filter(Owner, ExcludeOwner) of
+        true -> exclude_owner_match;
+        false -> pass
+    end.
+
+maybe_include_tag(_TX, undefined) ->
+    pass;
+maybe_include_tag(TX, IncludeTag) ->
+    case has_tag_pair(TX, IncludeTag) of
+        true -> pass;
+        false -> include_tag_mismatch
+    end.
+
+maybe_exclude_tag(_TX, undefined) ->
+    pass;
+maybe_exclude_tag(TX, ExcludeTag) ->
+    case has_tag_pair(TX, ExcludeTag) of
+        true -> exclude_tag_match;
+        false -> pass
+    end.
 
 has_tag_pair(#tx{tags = Tags}, #{name := Name, value := Value}) ->
     TagValue = dev_arweave_common:tagfind(Name, Tags, not_found),
@@ -418,38 +418,38 @@ classify_txs(TXIDs, Opts) ->
 %% @doc Fetch blocks from an Arweave node while moving downward from `Current'.
 %% If `To' is provided, every block in [`To', `Current'] is processed. If `To'
 %% is omitted, stop at the first block where any TX is already indexed.
-fetch_blocks(Req, Current, To, _Opts) when is_integer(To), Current < To ->
+fetch_blocks(Current, To, TargetDepth, _Opts) 
+        when is_integer(To), Current < To ->
     ?event(copycat_short,
         {arweave_block_indexing_completed,
             {reached_target, To},
-            {initial_request, Req}
+            {target_depth, TargetDepth}
         }
     ),
     {ok, To};
-fetch_blocks(_Req, Current, undefined, _Opts) when Current < 0 ->
+fetch_blocks(Current, undefined, _TargetDepth, _Opts) when Current < 0 ->
     {ok, 0};
-fetch_blocks(Req, Current, undefined, Opts) ->
+fetch_blocks(Current, undefined, TargetDepth, Opts) ->
     BlockRes = fetch_block_header(Current, Opts),
     case is_already_indexed(BlockRes, Opts) of
         true ->
             ?event(copycat_short,
                 {arweave_block_indexing_completed,
-                    {stop_at_indexed_block, Current},
-                    {initial_request, Req}
+                    {stop_at_indexed_block, Current}
                 }
             ),
             {ok, Current};
         false ->
             observe_event(<<"block_indexed">>, fun() ->
-                process_block(BlockRes, Current, undefined, Opts)
+                process_block(BlockRes, Current, undefined, TargetDepth, Opts)
             end),
-            fetch_blocks(Req, Current - 1, undefined, Opts)
+            fetch_blocks(Current - 1, undefined, TargetDepth, Opts)
     end;
-fetch_blocks(Req, Current, To, Opts) ->
+fetch_blocks(Current, To, TargetDepth, Opts) ->
     observe_event(<<"block_indexed">>, fun() ->
-        fetch_and_process_block(Current, To, Opts)
+        fetch_and_process_block(Current, To, TargetDepth, Opts)
     end),
-    fetch_blocks(Req, Current - 1, To, Opts).
+    fetch_blocks(Current - 1, To, TargetDepth, Opts).
 
 %% @doc Determine whether a fetched block is considered indexed.
 %% A block is indexed when any TX from its `txs' list is in the index.
@@ -459,17 +459,17 @@ is_already_indexed({ok, Block}, Opts) ->
 is_already_indexed({error, _}, _Opts) ->
     false.
 
-fetch_and_process_block(Current, To, Opts) ->
+fetch_and_process_block(Current, To, TargetDepth, Opts) ->
     BlockRes = fetch_block_header(Current, Opts),
-    process_block(BlockRes, Current, To, Opts).
+    process_block(BlockRes, Current, To, TargetDepth, Opts).
 
 %% @doc Process a block.
-process_block(BlockRes, Current, To, Opts) ->
+process_block(BlockRes, Current, To, TargetDepth, Opts) ->
     case BlockRes of
         {ok, Block} ->
             ?event(debug_copycat, {{processing_block, Current},
                 {indep_hash, hb_maps:get(<<"indep_hash">>, Block, <<>>)}}),
-            case maybe_index_ids(Block, Opts) of
+            case maybe_index_block(Block, TargetDepth, Opts) of
                 {block_skipped, Results} ->
                     TotalTXs = maps:get(total_txs, Results, 0),
                     ?event(
@@ -508,7 +508,7 @@ process_block(BlockRes, Current, To, Opts) ->
     end.
 
 %% @doc Index the IDs of all transactions in the block if configured to do so.
-maybe_index_ids(Block, Opts) ->
+maybe_index_block(Block, TargetDepth, Opts) ->
     TotalTXs = length(hb_maps:get(<<"txs">>, Block, [], Opts)),
     case hb_opts:get(arweave_index_ids, true, Opts) of
         false -> 
@@ -539,7 +539,8 @@ maybe_index_ids(Block, Opts) ->
                         fun({{padding, _}, _}) -> false; (_) -> true end,
                         TXsWithData
                     ),
-                    TXResults = process_txs(ValidTXs, BlockStartOffset, Opts),
+                    TXResults = process_block_txs(
+                        ValidTXs, BlockStartOffset, TargetDepth, Opts),
                     {block_cached, TXResults#{total_txs => TotalTXs}}
             end
     end.
@@ -554,10 +555,9 @@ parallel_map(Items, Fun, Opts) ->
 
 %% @doc Process a single transaction and return its contribution to the counters.
 %% Returns a map with keys: items_count, bundle_count, skipped_count
-process_tx({{padding, _PaddingRoot}, _EndOffset}, _BlockStartOffset, _Opts) ->
+process_block_tx({{padding, _PaddingRoot}, _EndOffset}, _BlockStartOffset, _TargetDepth, _Opts) ->
     #{items_count => 0, bundle_count => 0, skipped_count => 0};
-process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
-    Depth = get_block_depth(Opts),
+process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, Opts) ->
     IndexStore = hb_store_arweave:store_from_opts(Opts),
     TXID = hb_util:encode(TX#tx.id),
     TXEndOffset = BlockStartOffset + EndOffset,
@@ -578,8 +578,10 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
     end),
     case is_bundle_tx(TX, Opts) of
         false -> #{items_count => 0, bundle_count => 0, skipped_count => 0};
-        true when Depth > ?DEPTH_L1_OFFSETS ->
-            process_l1_candidate(TX#tx.id, #{}, Depth, Opts);
+        true when TargetDepth > 2 ->
+            % Indexing a block to depth 3 or greater means we need to load
+            % and recurse into each of the L1 TXs in the block.
+            maybe_process_l1_tx(TX#tx.id, #{}, TargetDepth - 1, false, Opts);
         true ->
             % Lightweight processing of block transactions to depth 2. We
             % can avoid loading the full L1 TX data into memory, and instead
@@ -637,10 +639,11 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
 %% When arweave_index_workers <= 1, processes sequentially (one worker at a time).
 %% When arweave_index_workers > 1, processes in parallel with the specified concurrency limit.
 %% Returns a map with keys: items_count, bundle_count, skipped_count.
-process_txs(ValidTXs, BlockStartOffset, Opts) ->
+process_txs(ValidTXs, BlockStartOffset, TargetDepth, Opts) ->
     Results = parallel_map(
         ValidTXs,
-        fun(TXWithData) -> process_tx(TXWithData, BlockStartOffset, Opts) end,
+        fun(TXWithData) -> process_tx(
+            TXWithData, BlockStartOffset, TargetDepth, Opts) end,
         Opts
     ),
     lists:foldl(
@@ -656,17 +659,16 @@ process_txs(ValidTXs, BlockStartOffset, Opts) ->
     ).
 
 %% @doc Process a single indexed L1 TX candidate after lightweight filter checks.
-process_l1_candidate(TXID, Filters, Depth, Opts) ->
+process_l1_candidate(TXID, Filters, Depth, ReadL1Offset, Opts) ->
     Skipped = #{items_count => 0, bundle_count => 0, skipped_count => 1},
     NormalizedTXID = hb_util:native_id(TXID),
     EncodedTXID = hb_util:encode(NormalizedTXID),
     IndexStore = hb_store_arweave:store_from_opts(Opts),
-    LoadL1Offset = maps:get(load_l1_offset, Filters, false),
     case ensure_l1_tx_offset(
         NormalizedTXID,
         EncodedTXID,
         IndexStore,
-        LoadL1Offset,
+        ReadL1Offset,
         Opts
     ) of
         {ok,
@@ -816,11 +818,11 @@ process_l1_candidate(TXID, Filters, Depth, Opts) ->
 ensure_l1_tx_offset(_TXID, _EncodedTXID, IndexStore, _LoadL1Offset, _Opts)
         when is_map(IndexStore) =:= false ->
     {error, missing_offset};
-ensure_l1_tx_offset(TXID, EncodedTXID, IndexStore, LoadL1Offset, Opts) ->
+ensure_l1_tx_offset(TXID, EncodedTXID, IndexStore, ReadL1Offset, Opts) ->
     case hb_store_arweave:read_offset(IndexStore, TXID) of
         {ok, _} = OffsetRes ->
             OffsetRes;
-        not_found when LoadL1Offset ->
+        not_found when ReadL1Offset ->
             ?event(
                 copycat_short,
                 {arweave_tx_offset_loading,
@@ -891,10 +893,342 @@ index_bundle_bytes(BundleData, BundleStartOffset, Depth, Store, Opts) ->
             )
     end.
 
+%% @doc Lightweight bundle indexing. This function only loads the bundle header
+%% and writes the index based solely on the header. For a more rigorous and
+%% deeper indexing, see the index_full_bundle_xxx functions.
+index_bundle_header(TXID, TXEndOffset, TXDataSize, TXStartOffset, IndexStore, Opts) ->
+    BundleRes = download_bundle_header(TXEndOffset, TXDataSize, Opts),
+    case BundleRes of
+        {ok, {BundleIndex, HeaderSize}} ->
+            % Batch event tracking: measure total time and count for
+            % all write_offset calls
+            {TotalTime, {_, ItemsCount}} = timer:tc(fun() ->
+                lists:foldl(
+                    fun({ItemID, Size}, {ItemStartOffset, ItemsCountAcc}) ->
+                        hb_store_arweave:write_offset(
+                            IndexStore,
+                            hb_util:encode(ItemID),
+                            <<"ans104@1.0">>,
+                            ItemStartOffset,
+                            Size
+                        ),
+                        {ItemStartOffset + Size, ItemsCountAcc + 1}
+                    end,
+                    {TXStartOffset + HeaderSize, 0},
+                    BundleIndex
+                )
+            end),
+            % Single event increment for the batch
+            record_event_metrics(<<"item_indexed">>, ItemsCount, TotalTime),
+            #{items_count => ItemsCount, bundle_count => 1, skipped_count => 0};
+        {error, Reason} ->
+            ?event(
+                copycat_short,
+                {arweave_bundle_skipped,
+                    {tx_id, {explicit, TXID}},
+                    {reason, Reason}
+                }
+            ),
+            #{items_count => 0, bundle_count => 1, skipped_count => 1}
+    end.
+
+download_bundle_header(EndOffset, Size, Opts) ->
+    observe_event(<<"bundle_header">>, fun() ->
+        dev_arweave:bundle_header(EndOffset - Size, Opts)
+    end).
+
+header_chunk(invalid_bundle_header, _FirstChunk, _StartOffset, _Opts) ->
+    {error, invalid_bundle_header};
+header_chunk(HeaderSize, FirstChunk, _StartOffset, _Opts)
+        when HeaderSize =< byte_size(FirstChunk) ->
+    {ok, FirstChunk};
+header_chunk(HeaderSize, FirstChunk, StartOffset, Opts) ->
+    Res =
+        hb_ao:resolve(
+            <<
+                ?ARWEAVE_DEVICE/binary,
+                "/chunk&offset=",
+                (hb_util:bin(StartOffset + byte_size(FirstChunk)))/binary,
+                "&length=",
+                (hb_util:bin(HeaderSize - byte_size(FirstChunk)))/binary
+            >>,
+            Opts
+        ),
+    case Res of
+        {ok, OtherChunks} -> {ok, <<FirstChunk/binary, OtherChunks/binary>>};
+        Other -> Other
+    end.
+
+%% @doc Process transactions: spawn workers and manage the worker pool.
+%% This function processes transactions in parallel using parallel_map.
+%% When arweave_index_workers <= 1, processes sequentially (one worker at a time).
+%% When arweave_index_workers > 1, processes in parallel with the specified concurrency limit.
+%% Returns a map with keys: items_count, bundle_count, skipped_count.
+process_block_txs(ValidTXs, BlockStartOffset, TargetDepth, Opts) ->
+    Results = parallel_map(
+        ValidTXs,
+        fun(TXWithData) -> process_block_tx(
+            TXWithData, BlockStartOffset, TargetDepth, Opts) end,
+        Opts
+    ),
+    lists:foldl(
+        fun(Result, Acc) ->
+            #{
+                items_count => maps:get(items_count, Result, 0) + maps:get(items_count, Acc, 0),
+                bundle_count => maps:get(bundle_count, Result, 0) + maps:get(bundle_count, Acc, 0),
+                skipped_count => maps:get(skipped_count, Result, 0) + maps:get(skipped_count, Acc, 0)
+            }
+        end,
+        #{items_count => 0, bundle_count => 0, skipped_count => 0},
+        Results
+    ).
+
+%% @doc Process a single indexed L1 TX candidate after lightweight filter checks.
+maybe_process_l1_tx(TXID, Filters, Depth, QueryL1Offset, Opts) ->
+    Skipped = #{items_count => 0, bundle_count => 0, skipped_count => 1},
+    NormalizedTXID = hb_util:native_id(TXID),
+    EncodedTXID = hb_util:encode(NormalizedTXID),
+    IndexStore = hb_store_arweave:store_from_opts(Opts),
+    maybe
+        {ok,
+            #{
+                <<"codec-device">> := <<"tx@1.0">>,
+                <<"start-offset">> := StartOffset,
+                <<"length">> := Length
+            }} ?=
+            ensure_l1_tx_offset(
+                NormalizedTXID,
+                EncodedTXID,
+                IndexStore,
+                QueryL1Offset,
+                Opts
+            ),
+        {ok, TX} ?= resolve_tx_header(EncodedTXID, Opts),
+        pass ?= l1_filter_reason(TX, Filters),
+        bundle ?=
+            case is_bundle_tx(TX, Opts) of
+                true -> bundle;
+                false -> not_bundle
+            end,
+        within_memory_cap ?=
+            case Length =< get_memory_safe_cap(Opts) of
+                true -> within_memory_cap;
+                false -> memory_safe_cap_exceeded
+            end,
+        process_l1_tx(
+            StartOffset,
+            Length,
+            Depth,
+            IndexStore,
+            EncodedTXID,
+            Opts
+        )
+    else
+        {error, Reason} ->
+            ?event(
+                copycat_short,
+                {arweave_tx_skipped,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {reason, Reason}
+                }
+            ),
+            Skipped;
+        error ->
+            % event already logged in resolve_tx_header
+            Skipped;
+        not_bundle ->
+            ?event(
+                copycat_short,
+                {arweave_tx_skipped,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {reason, not_bundle}
+                }
+            ),
+            Skipped;
+        memory_safe_cap_exceeded ->
+            ?event(
+                copycat_short,
+                {arweave_bundle_skipped,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {reason, memory_safe_cap_exceeded}
+                }
+            ),
+            #{
+                items_count => 0,
+                bundle_count => 1,
+                skipped_count => 1
+            };
+        FilterReason ->
+            ?event(
+                copycat_short,
+                {arweave_tx_skipped,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {reason, FilterReason}
+                }
+            ),
+            Skipped
+    end.
+
+%% @doc Load the L1 TX data into memory and index it.
+%% 
+%% TODO: process_l1_tx and process_block_tx are very similar and can/should
+%% be merged.
+process_l1_tx(
+        StartOffset, Length, Depth, IndexStore, EncodedTXID, Opts) ->
+    case hb_store_arweave:read_chunks(StartOffset, Length, Opts) of
+        {ok, BundleData} ->
+            {TotalTime, IndexRes} = timer:tc(
+                fun() ->
+                    index_full_bundle_bytes(
+                        BundleData,
+                        StartOffset,
+                        Depth,
+                        IndexStore,
+                        Opts
+                    )
+                end
+            ),
+            case IndexRes of
+                {ok, ItemsCount} ->
+                    record_event_metrics(
+                        <<"item_indexed">>,
+                        ItemsCount,
+                        TotalTime
+                    ),
+                    #{
+                        items_count => ItemsCount,
+                        bundle_count => 1,
+                        skipped_count => 0
+                    };
+                {error, Reason} ->
+                    ?event(
+                        copycat_short,
+                        {arweave_bundle_skipped,
+                            {tx_id, {explicit, EncodedTXID}},
+                            {reason, Reason}
+                        }
+                    ),
+                    #{
+                        items_count => 0,
+                        bundle_count => 1,
+                        skipped_count => 1
+                    }
+            end;
+        {error, Reason} ->
+            ?event(
+                copycat_short,
+                {arweave_bundle_skipped,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {reason, Reason}
+                }
+            ),
+            #{
+                items_count => 0,
+                bundle_count => 1,
+                skipped_count => 1
+            };
+        not_found ->
+            ?event(
+                copycat_short,
+                {arweave_bundle_skipped,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {reason, not_found}
+                }
+            ),
+            #{
+                items_count => 0,
+                bundle_count => 1,
+                skipped_count => 1
+            }
+    end.
+%% @doc Ensure the root L1 TX offset exists locally before `id=...` indexing.
+%% if the offset is missing and `query_l1_offset` is enabled, fetches the TX
+%% offset metadata from Arweave, writes it to the local offset store, and
+%% retries the local lookup.
+ensure_l1_tx_offset(_TXID, _EncodedTXID, IndexStore, _LoadL1Offset, _Opts)
+        when is_map(IndexStore) =:= false ->
+    {error, missing_offset};
+ensure_l1_tx_offset(TXID, EncodedTXID, IndexStore, QueryL1Offset, Opts) ->
+    case hb_store_arweave:read_offset(IndexStore, TXID) of
+        {ok, _} = OffsetRes ->
+            OffsetRes;
+        not_found when QueryL1Offset ->
+            ?event(
+                copycat_short,
+                {arweave_tx_querying_offset,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {source, network}
+                }
+            ),
+            case query_l1_tx_offset(EncodedTXID, IndexStore, Opts) of
+                ok ->
+                    case hb_store_arweave:read_offset(IndexStore, TXID) of
+                        {ok, _} = OffsetRes ->
+                            OffsetRes;
+                        not_found ->
+                            {error, missing_offset}
+                    end;
+                {error, Reason} ->
+                    {error, Reason}
+            end;
+        not_found ->
+            {error, missing_offset}
+    end.
+
+query_l1_tx_offset(TXID, IndexStore, Opts) ->
+    % TODO: move this into dev_arweave - I think? Unless it's possible to
+    % query this already via one of the existing ~arweave@2.9 paths?
+    case hb_http:request(
+        #{
+            <<"path">> => <<"/arweave/tx/", TXID/binary, "/offset">>,
+            <<"method">> => <<"GET">>
+        },
+        Opts
+    ) of
+        {ok, #{ <<"body">> := OffsetBody }} ->
+            OffsetMsg = hb_json:decode(OffsetBody),
+            EndOffset = hb_util:int(maps:get(<<"offset">>, OffsetMsg)),
+            Size = hb_util:int(maps:get(<<"size">>, OffsetMsg)),
+            StartOffset = EndOffset - Size,
+            ok =
+                hb_store_arweave:write_offset(
+                    IndexStore,
+                    TXID,
+                    <<"tx@1.0">>,
+                    StartOffset,
+                    Size
+                ),
+            ok;
+        {error, Reason} ->
+            {error, Reason};
+        not_found ->
+            {error, not_found}
+    end.
+
+index_full_bundle_bytes(_BundleData, _BundleStartOffset, Depth, _Store, _Opts)
+        when Depth =< 0 ->
+    {ok, 0};
+index_full_bundle_bytes(BundleData, BundleStartOffset, Depth, Store, Opts) ->
+    case ar_bundles:decode_bundle_header(BundleData) of
+        invalid_bundle_header ->
+            {error, invalid_bundle_header};
+        {ItemsBin, BundleIndex} ->
+            HeaderSize = byte_size(BundleData) - byte_size(ItemsBin),
+            index_full_bundle_items(
+                BundleIndex,
+                ItemsBin,
+                BundleStartOffset + HeaderSize,
+                Depth,
+                Store,
+                Opts,
+                0
+            )
+    end.
+
 %% @doc Index bundle children from decoded bundle bytes and recurse descendants in-memory.
-index_bundle_items([], _ItemsBin, _ItemStartOffset, _Depth, _Store, _Opts, Count) ->
+index_full_bundle_items([], _ItemsBin, _ItemStartOffset, _Depth, _Store, _Opts, Count) ->
     {ok, Count};
-index_bundle_items(
+index_full_bundle_items(
     [{ItemID, Size} | Rest],
     ItemsBin,
     ItemStartOffset,
@@ -914,7 +1248,7 @@ index_bundle_items(
     DescendantCount =
         case Depth > 1 of
             true ->
-                index_bundle_descendants(
+                index_full_bundle_descendants(
                     ItemBinary,
                     ItemStartOffset,
                     Depth - 1,
@@ -924,7 +1258,7 @@ index_bundle_items(
             false ->
                 0
         end,
-    index_bundle_items(
+    index_full_bundle_items(
         Rest,
         binary:part(ItemsBin, Size, byte_size(ItemsBin) - Size),
         ItemStartOffset + Size,
@@ -933,19 +1267,19 @@ index_bundle_items(
         Opts,
         Count + 1 + DescendantCount
     );
-index_bundle_items(_BundleIndex, _ItemsBin, _ItemStartOffset, _Depth, _Store, _Opts, _Count) ->
+index_full_bundle_items(_BundleIndex, _ItemsBin, _ItemStartOffset, _Depth, _Store, _Opts, _Count) ->
     {error, invalid_bundle_header}.
 
 %% @doc Recurse into a nested bundle data item from in-memory bytes.
-index_bundle_descendants(_ItemBinary, _ItemStartOffset, Depth, _Store, _Opts)
+index_full_bundle_descendants(_ItemBinary, _ItemStartOffset, Depth, _Store, _Opts)
         when Depth =< 0 ->
     0;
-index_bundle_descendants(ItemBinary, ItemStartOffset, Depth, Store, Opts) ->
+index_full_bundle_descendants(ItemBinary, ItemStartOffset, Depth, Store, Opts) ->
     try ar_bundles:deserialize_header(ItemBinary) of
         {ok, HeaderSize, HeaderTX} ->
             case is_bundle_tx(HeaderTX, Opts) of
                 true ->
-                    case index_bundle_bytes(
+                    case index_full_bundle_bytes(
                         HeaderTX#tx.data,
                         ItemStartOffset + HeaderSize,
                         Depth,
@@ -968,12 +1302,6 @@ index_bundle_descendants(ItemBinary, ItemStartOffset, Depth, Store, Opts) ->
 %% @doc Check whether a TX header indicates bundle content.
 is_bundle_tx(TX, _Opts) ->
     dev_arweave_common:type(TX) =/= binary.
-
-%% @doc Download and decode a bundle header from chunk data.
-download_bundle_header(EndOffset, Size, Opts) ->
-    observe_event(<<"bundle_header">>, fun() ->
-        dev_arweave:bundle_header(EndOffset - Size, Size, Opts)
-    end).
 
 resolve_tx_headers(TXIDs, Opts) ->
     Results = parallel_map(
@@ -1119,7 +1447,23 @@ index_ids_test_parallel() ->
         ],
         Opts
     ),
+    % L3 item not read when doing L1 depth=1
+    assert_item_not_read(<<"8aJrRWtHcJvJ61qsH6agGkemzrtLw3W22xFrpCGAnTM">>, Opts),
    ok.
+
+block_depth_3_test() ->
+    %% Test block: https://viewblock.io/arweave/block/1827942
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    {ok, 1827942} =
+        hb_ao:resolve(
+            <<"~copycat@1.0/arweave&from=1827942&to=1827942&depth=3">>,
+            Opts
+        ),
+    % L3 item read when doing depth=2
+    assert_item_read(
+        <<"8aJrRWtHcJvJ61qsH6agGkemzrtLw3W22xFrpCGAnTM">>,
+        Opts),
+    ok.
 
 %% @doc Test a bundle header that fits in a single chunk.
 small_bundle_header_test_parallel() ->
@@ -1625,6 +1969,345 @@ negative_from_index_test_parallel() ->
     ?assertNot(has_any_indexed_tx(NextBlock + 1, Opts)),
     ok.
 
+owner_alias_roundtrip_test() ->
+    Opts1 =
+        add_owner_alias(
+            <<"FPjbN7EVwP3XwQJx8qnKqJDYa4TLJ0Y8gu4AaiUuW1c">>,
+            <<"turbo">>,
+            #{}
+        ),
+    Opts2 =
+        add_owner_alias(
+            <<"JNC6vBhU4sAK5T49VL4k79vNer0tZjM8fI1gpqUQK5g">>,
+            <<"redstone">>,
+            Opts1
+        ),
+    ?assertEqual(
+        {ok, normalize_owner_id(<<"FPjbN7EVwP3XwQJx8qnKqJDYa4TLJ0Y8gu4AaiUuW1c">>)},
+        resolve_owner_alias(<<"turbo">>, Opts2)
+    ),
+    ?assertEqual(
+        {ok, normalize_owner_id(<<"JNC6vBhU4sAK5T49VL4k79vNer0tZjM8fI1gpqUQK5g">>)},
+        resolve_owner_alias(<<"redstone">>, Opts2)
+    ),
+    ?assertEqual(
+        {error, {owner_alias_not_found, <<"unknown">>}},
+        resolve_owner_alias(<<"unknown">>, Opts2)
+    ),
+    ok.
+
+parse_tag_filter_test() ->
+    ?assertEqual(
+        {ok, #{name => <<"App-Name">>, value => <<"ao">>}},
+        parse_tag_filter(<<"include-tag">>, #{<<"include-tag">> => <<"App-Name:ao">>}, #{})
+    ),
+    ?assertEqual(
+        {ok, undefined},
+        parse_tag_filter(<<"include-tag">>, #{}, #{})
+    ),
+    ?assertEqual(
+        {error, invalid_tag_filter},
+        parse_tag_filter(<<"include-tag">>, #{<<"include-tag">> => <<"App-Name">>}, #{})
+    ),
+    ?assertEqual(
+        {error, invalid_tag_filter},
+        parse_tag_filter(<<"include-tag">>, #{<<"include-tag">> => <<":ao">>}, #{})
+    ),
+    ?assertEqual(
+        {error, invalid_tag_filter},
+        parse_tag_filter(<<"include-tag">>, #{<<"include-tag">> => <<"App-Name:">>}, #{})
+    ),
+    ok.
+
+l1_filter_reason_test() ->
+    Owner = <<"owner-1">>,
+    OtherOwner = <<"owner-2">>,
+    TX = #tx{
+        owner = <<"non-default-owner">>,
+        owner_address = Owner,
+        tags = [
+            {<<"App-Name">>, <<"ao">>},
+            {<<"Bundler-App-Name">>, <<"Redstone">>}
+        ]
+    },
+    IncludeTag = #{name => <<"App-Name">>, value => <<"ao">>},
+    ExcludeTag = #{name => <<"Bundler-App-Name">>, value => <<"Redstone">>},
+    ?assertEqual(pass, l1_filter_reason(TX, #{})),
+    ?assertEqual(pass, l1_filter_reason(TX, #{include_owner => Owner})),
+    ?assertEqual(
+        include_owner_mismatch,
+        l1_filter_reason(TX, #{include_owner => OtherOwner})
+    ),
+    ?assertEqual(
+        exclude_owner_match,
+        l1_filter_reason(TX, #{exclude_owner => Owner})
+    ),
+    ?assertEqual(
+        pass,
+        l1_filter_reason(TX, #{exclude_owner => OtherOwner})
+    ),
+    ?assertEqual(pass, l1_filter_reason(TX, #{include_tag => IncludeTag})),
+    ?assertEqual(
+        include_tag_mismatch,
+        l1_filter_reason(
+            TX,
+            #{include_tag => #{name => <<"Content-Type">>, value => <<"text/plain">>}}
+        )
+    ),
+    ?assertEqual(
+        exclude_tag_match,
+        l1_filter_reason(TX, #{exclude_tag => ExcludeTag})
+    ),
+    ?assertEqual(
+        pass,
+        l1_filter_reason(
+            TX,
+            #{exclude_tag => #{name => <<"Content-Type">>, value => <<"text/plain">>}}
+        )
+    ),
+    ?assertEqual(
+        exclude_tag_match,
+        l1_filter_reason(
+            TX,
+            #{include_tag => IncludeTag, exclude_tag => ExcludeTag}
+        )
+    ),
+    ?assertEqual(
+        pass,
+        l1_filter_reason(TX, #{include_owner => [OtherOwner, Owner]})
+    ),
+    ok.
+
+request_depth_clamping_test() ->
+    {_TestStore, _StoreOpts, Opts0} = setup_index_opts(),
+    ?assertEqual(6, request_depth(#{}, <<"safe_max">>, Opts0)),
+    ?assertEqual(
+        2,
+        request_depth(#{<<"depth">> => <<"2">>}, <<"safe_max">>, Opts0)
+    ),
+    ?assertEqual(
+        1,
+        request_depth(#{<<"depth">> => <<"0">>}, <<"safe_max">>, Opts0)
+    ),
+    ?assertEqual(
+        6,
+        request_depth(#{<<"depth">> => <<"999">>}, <<"safe_max">>, Opts0)
+    ),
+    Opts1 = set_depth_recursion_cap(2, Opts0),
+    ?assertEqual(2, request_depth(#{}, <<"safe_max">>, Opts1)),
+    % no recursion cap set, use default from hb_opts
+    ?assertEqual(6, request_depth(#{}, <<"safe_max">>, #{})),
+    ok.
+
+memory_cap_setter_getter_test() ->
+    {_TestStore, _StoreOpts, Opts0} = setup_index_opts(),
+    ?assertEqual(6 * 1024 * 1024 * 1024, get_memory_safe_cap(Opts0)),
+    Opts1 = set_memory_safe_cap(1024, Opts0),
+    ?assertEqual(1024, get_memory_safe_cap(Opts1)),
+    ok.
+
+id_depth_1_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    {Block, TXID} = {1827942, <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>},
+    ok = index_l1_offsets(Block, Opts),
+    {ok, Result} =
+        hb_ao:resolve(
+            <<
+                "~copycat@1.0/arweave&"
+                "id=", TXID/binary, "&"
+                "mode=write&"
+                "depth=1"
+            >>,
+            Opts
+        ),
+    ?assertEqual(26, maps:get(items_count, Result)),
+    ?assertEqual(1, maps:get(bundle_count, Result)),
+    ?assertEqual(0, maps:get(skipped_count, Result)),
+
+    assert_bundle_read(
+        <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>,
+        [
+            {<<"54K1ehEIKZxGSusgZzgbGYaHfllwWQ09-S9-eRUJg5Y">>, <<"1">>},
+            {<<"MgatoEjlO_YtdbxFi9Q7Hxbs0YQVcChddhSS7FsdeIg">>, <<"19">>},
+            {<<"z-oKJfhMq5qoVFrljEfiBKgumaJmCWVxNJaavR5aPE8">>, <<"26">>}
+        ],
+        Opts
+    ),
+    % L3 item not read when doing L1 depth=1
+    assert_item_not_read(<<"8aJrRWtHcJvJ61qsH6agGkemzrtLw3W22xFrpCGAnTM">>, Opts),
+    ok.
+
+id_depth_2_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    {Block, TXID} = {1827942, <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>},
+    ok = index_l1_offsets(Block, Opts),
+    {ok, Result} =
+        hb_ao:resolve(
+            <<
+                "~copycat@1.0/arweave&"
+                "id=", TXID/binary, "&"
+                "mode=write&"
+                "depth=2"
+            >>,
+            Opts
+        ),
+    ?assertEqual(52, maps:get(items_count, Result)),
+    ?assertEqual(1, maps:get(bundle_count, Result)),
+    ?assertEqual(0, maps:get(skipped_count, Result)),
+
+    assert_bundle_read(
+        <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>,
+        [
+            {<<"54K1ehEIKZxGSusgZzgbGYaHfllwWQ09-S9-eRUJg5Y">>, <<"1">>},
+            {<<"MgatoEjlO_YtdbxFi9Q7Hxbs0YQVcChddhSS7FsdeIg">>, <<"19">>},
+            {<<"z-oKJfhMq5qoVFrljEfiBKgumaJmCWVxNJaavR5aPE8">>, <<"26">>}
+        ],
+        Opts
+    ),
+    % L2 bundle and L3 children should be read when doing L1 with depth=2
+    assert_bundle_read(
+        <<"54K1ehEIKZxGSusgZzgbGYaHfllwWQ09-S9-eRUJg5Y">>,
+        [
+            {<<"iS5R3iSKaCdcXG2nlKWsbdT1_uhQe54nMsgYK-ivEcE">>, <<"1">>},
+            {<<"8aJrRWtHcJvJ61qsH6agGkemzrtLw3W22xFrpCGAnTM">>, <<"2">>}
+        ],
+        Opts
+    ),
+    ok.
+
+id_exclude_tag_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    {Block, TXID} = {1827942, <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>},
+    ok = index_l1_offsets(Block, Opts),
+    {ok, Result} =
+        hb_ao:resolve(
+            <<
+                "~copycat@1.0/arweave&"
+                "id=", TXID/binary, "&"
+                "mode=write&"
+                "exclude-tag=App-Name:ArDrive%20Turbo&"
+                "depth=2"
+            >>,
+            Opts
+        ),
+    ?assertEqual(0, maps:get(items_count, Result)),
+    ?assertEqual(0, maps:get(bundle_count, Result)),
+    ?assertEqual(1, maps:get(skipped_count, Result)),
+    assert_item_not_read(<<"iS5R3iSKaCdcXG2nlKWsbdT1_uhQe54nMsgYK-ivEcE">>, Opts),
+    ok.
+
+id_include_owner_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    {Block, TXID} = {1827942, <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>},
+    ok = index_l1_offsets(Block, Opts),
+    {ok, Included} =
+        hb_ao:resolve(
+            <<
+                "~copycat@1.0/arweave&"
+                "id=", TXID/binary, "&"
+                "mode=write&"
+                "include-owner=JNC6vBhjHY1EPwV3pEeNmrsgFMxH5d38_LHsZ7jful8"
+            >>,
+            Opts
+        ),
+    ?assertEqual(52, maps:get(items_count, Included)),
+    ?assertEqual(1, maps:get(bundle_count, Included)),
+    ?assertEqual(0, maps:get(skipped_count, Included)),
+    {ok, Skipped} =
+        hb_ao:resolve(
+            <<
+                "~copycat@1.0/arweave&"
+                "id=", TXID/binary, "&"
+                "mode=write&"
+                "include-owner=FPjbN7EVwP3XwQJx8qnKqJDYa4TLJ0Y8gu4AaiUuW1c"
+            >>,
+            Opts
+        ),
+    ?assertEqual(0, maps:get(items_count, Skipped)),
+    ?assertEqual(0, maps:get(bundle_count, Skipped)),
+    ?assertEqual(1, maps:get(skipped_count, Skipped)).
+
+id_missing_offset_without_load_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    {_Block, TXID} = {1827942, <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>},
+    {ok, Result} =
+        hb_ao:resolve(
+            <<
+                "~copycat@1.0/arweave&"
+                "id=", TXID/binary, "&"
+                "mode=write"
+            >>,
+            Opts
+        ),
+    ?assertEqual(0, maps:get(items_count, Result)),
+    ?assertEqual(0, maps:get(bundle_count, Result)),
+    ?assertEqual(1, maps:get(skipped_count, Result)),
+    assert_item_not_read(<<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>, Opts),
+    ok.
+
+id_missing_offset_with_load_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
+    {_Block, TXID} = {1827942, <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>},
+    {ok, Result} =
+        hb_ao:resolve(
+            <<
+                "~copycat@1.0/arweave&"
+                "id=", TXID/binary, "&"
+                "mode=write&"
+                "query-l1-offset=true&"
+                "depth=2"
+            >>,
+            Opts
+        ),
+    ?assertEqual(52, maps:get(items_count, Result)),
+    ?assertEqual(1, maps:get(bundle_count, Result)),
+    ?assertEqual(0, maps:get(skipped_count, Result)),
+
+    assert_bundle_read(
+        <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>,
+        [
+            {<<"54K1ehEIKZxGSusgZzgbGYaHfllwWQ09-S9-eRUJg5Y">>, <<"1">>},
+            {<<"MgatoEjlO_YtdbxFi9Q7Hxbs0YQVcChddhSS7FsdeIg">>, <<"19">>},
+            {<<"z-oKJfhMq5qoVFrljEfiBKgumaJmCWVxNJaavR5aPE8">>, <<"26">>}
+        ],
+        Opts
+    ),
+    % L2 bundle and L3 children should be read when doing L1 with depth=2
+    assert_bundle_read(
+        <<"54K1ehEIKZxGSusgZzgbGYaHfllwWQ09-S9-eRUJg5Y">>,
+        [
+            {<<"iS5R3iSKaCdcXG2nlKWsbdT1_uhQe54nMsgYK-ivEcE">>, <<"1">>},
+            {<<"8aJrRWtHcJvJ61qsH6agGkemzrtLw3W22xFrpCGAnTM">>, <<"2">>}
+        ],
+        Opts
+    ),
+    ok.
+
+parse_owner_filter_unknown_alias_test() ->
+    ?assertEqual(
+        {error, {owner_alias_not_found, <<"nonexistent">>}},
+        parse_owner_filter(
+            #{<<"include-owner-alias">> => <<"nonexistent">>},
+            #{}
+        )
+    ),
+    ok.
+
+index_l1_offsets(Block, Opts) ->
+    BlockBin = hb_util:bin(Block),
+    {ok, Block} =
+        hb_ao:resolve(
+            <<
+                "~copycat@1.0/arweave&"
+                "from=", BlockBin/binary, "&"
+                "to=", BlockBin/binary, "&"
+                "mode=write&"
+                "depth=1"
+            >>,
+            Opts
+        ),
+    ok.
+
 setup_index_opts() ->
     TestStore = hb_test_utils:test_store(),
     StoreOpts = #{ <<"index-store">> => [TestStore] },
@@ -1674,7 +2357,9 @@ assert_bundle_read(BundleID, ExpectedItems, Opts) ->
     lists:foreach(
         fun({{_ItemID, Index}, Item}) ->
             QueriedItem = hb_ao:get(Index, Bundle, Opts),
-            ?assertEqual(hb_maps:without(?AO_CORE_KEYS, Item), hb_maps:without(?AO_CORE_KEYS, QueriedItem))
+            ?assertEqual(
+                hb_maps:without(?AO_CORE_KEYS, Item),
+                hb_maps:without(?AO_CORE_KEYS, QueriedItem))
         end,
         lists:zip(ExpectedItems, ReadItems)
     ),
@@ -1682,13 +2367,20 @@ assert_bundle_read(BundleID, ExpectedItems, Opts) ->
 
 assert_item_read(ItemID, Opts) ->
     ?event(debug_test, {resolving, {explicit, ItemID}}),
-    Resolved = hb_ao:resolve(ItemID, Opts),
-    ?assertMatch({ok, _}, Resolved, ItemID),
-    {ok, Item} = Resolved,
+    ReadResult = hb_store_arweave:read(
+        hb_store_arweave:store_from_opts(Opts), ItemID),
+    ?assertMatch({ok, _}, ReadResult, ItemID),
+    {ok, Item} = ReadResult,
     ?event(debug_test, {item, Item}),
     ?assert(hb_message:verify(Item, all, Opts)),
     ?assertEqual(ItemID, hb_message:id(Item, signed)),
     Item.
+
+assert_item_not_read(ItemID, Opts) ->
+    ReadResult = hb_store_arweave:read(
+        hb_store_arweave:store_from_opts(Opts), ItemID),
+    ?assertEqual(not_found, ReadResult),
+    ok.
 
 has_any_indexed_tx(Height, Opts) ->
     case fetch_block_header(Height, Opts) of

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -11,9 +11,6 @@
 
 -define(ARWEAVE_DEVICE, <<"~arweave@2.9">>).
 -define(DEPTH_L1_OFFSETS, 1).
--define(DEPTH_RECURSION_CAP, 4).
-%% 6GB in bytes
--define(MEMORY_SAFE_CAP, 6 * 1024 * 1024 * 1024).
 
 % GET /~cron@1.0/once&cron-path=~copycat@1.0/arweave
 
@@ -26,9 +23,16 @@ arweave(_Base, Request, Opts) ->
             case hb_maps:find(<<"id">>, Request, Opts) of
                 {ok, TXID} -> process_l1_request(TXID, Request, Opts);
                 error ->
+                    BlockDepth = request_depth(Request, ?DEPTH_L1_OFFSETS, Opts),
                     case parse_range(Request, Opts) of
                         {error, unavailable} -> {error, unavailable};
-                        {ok, {From, To}} -> fetch_blocks(Request, From, To, Opts)
+                        {ok, {From, To}} ->
+                            fetch_blocks(
+                                Request,
+                                From,
+                                To,
+                                Opts#{copycat_block_depth => BlockDepth}
+                            )
                     end
             end;
         <<"list">> ->
@@ -47,19 +51,13 @@ set_memory_safe_cap(Cap, Opts) when is_integer(Cap), Cap > 0 ->
 %% in very nested bundles (very rare).
 set_depth_recursion_cap(Cap, Opts) when is_integer(Cap), Cap > 0 ->
     Opts#{copycat_depth_recursion_cap => Cap}.
-%% @doc Get the set depth recursion cap. if not set, defaults to ?DEPTH_RECURSION_CAP
+%% @doc Get the set depth recursion cap from hb_opts.
 get_depth_recursion_cap(Opts) ->
-    case maps:get(copycat_depth_recursion_cap, Opts, not_found) of
-        not_found -> ?DEPTH_RECURSION_CAP;
-        Cap -> Cap
-    end.
+    hb_opts:get(copycat_depth_recursion_cap, undefined, Opts).
 %% @doc Get the L1 TX data size that gets handled in-memory
-%% defaults to ?MEMORY_SAFE_CAP if not set.
+%% from hb_opts.
 get_memory_safe_cap(Opts) ->
-    case maps:get(copycat_memory_cap, Opts, not_found) of
-        not_found -> ?MEMORY_SAFE_CAP;
-        Cap -> Cap
-    end.
+    hb_opts:get(copycat_memory_cap, undefined, Opts).
 %% @doc Normalize an owner address into the native ID form used for comparisons.
 normalize_owner_id(Addr) ->
     hb_util:native_id(hb_util:bin(Addr)).
@@ -165,7 +163,7 @@ parse_tag_filter(Key, Request, Opts) ->
 %% @doc Process the `id=...` copycat path for an already indexed L1 TX.
 %% applies L1-level owner/tag filters on the lightweight TX header first, then,
 %% if the TX passes and is a bundle, loads the full L1 payload once and indexes
-%% descendants in-memory (under the ?MEMORY_SAFE_CAP limit) up to the requested safe depth
+%% descendants in-memory (under the configured copycat_memory_cap) up to the requested safe depth
 %% (defaults to full recursion till the set copycat_depth_recursion_cap).
 process_l1_request(TXID, Request, Opts) ->
     Depth = request_depth(Request, <<"safe_max">>, Opts),
@@ -319,6 +317,9 @@ normalize_height(Height, Opts) ->
         false ->
             {ok, RequestedHeight}
     end.
+
+get_block_depth(Opts) ->
+    maps:get(copycat_block_depth, Opts, ?DEPTH_L1_OFFSETS).
 
 latest_height(Opts) ->
     case hb_ao:resolve(
@@ -556,6 +557,7 @@ parallel_map(Items, Fun, Opts) ->
 process_tx({{padding, _PaddingRoot}, _EndOffset}, _BlockStartOffset, _Opts) ->
     #{items_count => 0, bundle_count => 0, skipped_count => 0};
 process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
+    Depth = get_block_depth(Opts),
     IndexStore = hb_store_arweave:store_from_opts(Opts),
     TXID = hb_util:encode(TX#tx.id),
     TXEndOffset = BlockStartOffset + EndOffset,
@@ -576,6 +578,8 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
     end),
     case is_bundle_tx(TX, Opts) of
         false -> #{items_count => 0, bundle_count => 0, skipped_count => 0};
+        true when Depth > ?DEPTH_L1_OFFSETS ->
+            process_l1_candidate(TX#tx.id, #{}, Depth, Opts);
         true ->
             % Lightweight processing of block transactions to depth 2. We
             % can avoid loading the full L1 TX data into memory, and instead

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -5,10 +5,15 @@
 %%% provided, every block in the range is processed.
 -module(dev_copycat_arweave).
 -export([arweave/3]).
+-export([add_owner_alias/3, resolve_owner_alias/2, set_memory_safe_cap/2, get_memory_safe_cap/1, set_depth_recursion_cap/2, get_depth_recursion_cap/1]).
 -include_lib("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 -define(ARWEAVE_DEVICE, <<"~arweave@2.9">>).
+-define(DEPTH_L1_OFFSETS, 1).
+-define(DEPTH_RECURSION_CAP, 4).
+%% 1GB in bytes
+-define(MEMORY_SAFE_CAP, 1024 * 1024 * 1024).
 
 % GET /~cron@1.0/once&cron-path=~copycat@1.0/arweave
 
@@ -16,18 +21,259 @@
 %% latest known block towards the Genesis block. If no range is provided, we
 %% fetch blocks from the latest known block towards the Genesis block.
 arweave(_Base, Request, Opts) ->
-    case parse_range(Request, Opts) of
-        {error, unavailable} ->
-            {error, unavailable};
-        {ok, {From, To}} ->
-            case hb_maps:get(<<"mode">>, Request, <<"write">>, Opts) of
-                <<"write">> -> fetch_blocks(Request, From, To, Opts);
-                <<"list">> -> list_index(From, To, Opts);
-                Mode ->
-                    {error, <<"Unsupported mode `", (hb_util:bin(Mode))/binary, "`. Supported modes are: write, list">>}
+    case hb_maps:get(<<"mode">>, Request, <<"write">>, Opts) of
+        <<"write">> ->
+            case hb_maps:find(<<"id">>, Request, Opts) of
+                {ok, TXID} -> process_l1_request(TXID, Request, Opts);
+                error ->
+                    case parse_range(Request, Opts) of
+                        {error, unavailable} -> {error, unavailable};
+                        {ok, {From, To}} -> fetch_blocks(Request, From, To, Opts)
+                    end
+            end;
+        <<"list">> ->
+            case parse_range(Request, Opts) of
+                {error, unavailable} -> {error, unavailable};
+                {ok, {From, To}} -> list_index(From, To, Opts)
+            end;
+        Mode ->
+            {error, <<"Unsupported mode `", (hb_util:bin(Mode))/binary, "`. Supported modes are: write, list">>}
+    end.
+%% @doc Set safe memory resource allocation cap for the in-memory
+%% bundle processing. in bytes.
+set_memory_safe_cap(Cap, Opts) when is_integer(Cap), Cap > 0 ->
+    Opts#{copycat_memory_cap => Cap}.
+%% @doc Set bundles descendant recursion cap, avoids recursion
+%% in very nested bundles (very rare).
+set_depth_recursion_cap(Cap, Opts) when is_integer(Cap), Cap > 0 ->
+    Opts#{copycat_depth_recursion_cap => Cap}.
+%% @doc Get the set depth recursion cap. if not set, defaults to ?DEPTH_RECURSION_CAP
+get_depth_recursion_cap(Opts) ->
+    case maps:get(copycat_depth_recursion_cap, Opts, not_found) of
+        not_found -> ?DEPTH_RECURSION_CAP;
+        Cap -> Cap
+    end.
+%% @doc Get the L1 TX data size that gets handled in-memory
+%% defaults to ?MEMORY_SAFE_CAP if not set.
+get_memory_safe_cap(Opts) ->
+    case maps:get(copycat_memory_cap, Opts, not_found) of
+        not_found -> ?MEMORY_SAFE_CAP;
+        Cap -> Cap
+    end.
+%% @doc Normalize an owner address into the native ID form used for comparisons.
+normalize_owner_id(Addr) ->
+    hb_util:native_id(hb_util:bin(Addr)).
+
+%% @doc Adds an address to the owners aliases cache in Opts, mapping
+%% Alias -> native address for fast lookup and once per address computation.
+add_owner_alias(Addr, Alias, Opts) when is_binary(Alias) -> 
+    ExistingAliases = maps:get(owner_aliases, Opts, #{}),
+    Opts#{ owner_aliases => ExistingAliases#{ Alias => normalize_owner_id(Addr) }};
+add_owner_alias(_Addr, Alias, _Opts) ->
+    throw({invalid_owner_alias, Alias}).
+
+%% @doc Retrieve the address of a given alias.
+resolve_owner_alias(Alias, Opts) when is_binary(Alias) ->
+    Aliases = maps:get(owner_aliases, Opts, #{}),
+    case maps:find(Alias, Aliases) of
+        {ok, Addr} -> {ok, Addr};
+        error -> {error, {owner_alias_not_found, Alias}}
+    end;
+resolve_owner_alias(Alias, _Opts) ->
+    {error, {invalid_owner_alias, Alias}}.
+%% @doc Parse include/exclude owner filters from the request.
+%% Supports direct owner values and owner aliases.
+parse_owner_filter(Request, Opts) ->
+    case resolve_owner_filter_value(
+        <<"include-owner">>,
+        <<"include-owner-alias">>,
+        Request,
+        Opts
+    ) of
+        {error, _} = Error ->
+            Error;
+        {ok, IncludeOwner} ->
+            case resolve_owner_filter_value(
+                <<"exclude-owner">>,
+                <<"exclude-owner-alias">>,
+                Request,
+                Opts
+            ) of
+                {error, _} = Error ->
+                    Error;
+                {ok, ExcludeOwner} ->
+                    {ok, #{
+                        include_owner => IncludeOwner,
+                        exclude_owner => ExcludeOwner
+                    }}
             end
     end.
+%% @doc Resolve one owner filter value from either a direct owner param or
+%% a comma-separated owner alias param. Alias takes precedence.
+resolve_owner_filter_value(OwnerKey, AliasKey, Request, Opts) ->
+    case hb_maps:find(AliasKey, Request, Opts) of
+        {ok, Alias} ->
+            resolve_owner_aliases(Alias, Opts);
+        error ->
+            case hb_maps:find(OwnerKey, Request, Opts) of
+                {ok, Owner} ->
+                    {ok, normalize_owner_id(Owner)};
+                error ->
+                    {ok, undefined}
+            end
+    end.
+%% @doc Resolve one or more comma-separated owner aliases into normalized owner IDs.
+resolve_owner_aliases(Alias, Opts) ->
+    case
+        lists:filter(
+            fun(Part) -> byte_size(Part) > 0 end,
+            binary:split(hb_util:bin(Alias), <<",">>, [global])
+        )
+    of
+        [SingleAlias] ->
+            case resolve_owner_alias(SingleAlias, Opts) of
+                {ok, Addr} -> {ok, normalize_owner_id(Addr)};
+                {error, _} = Error -> Error
+            end;
+        Aliases ->
+            resolve_owner_aliases(Aliases, Opts, [])
+    end.
+%% @doc Resolve a list of owner aliases into normalized owner IDs.
+resolve_owner_aliases([], _Opts, Acc) ->
+    {ok, lists:reverse(Acc)};
+resolve_owner_aliases([Alias | Rest], Opts, Acc) ->
+    case resolve_owner_alias(Alias, Opts) of
+        {ok, Addr} ->
+            resolve_owner_aliases(Rest, Opts, [normalize_owner_id(Addr) | Acc]);
+        {error, _} = Error ->
+            Error
+    end.
+%% @doc Parse an L1 tag filter from `Name:Value` form.
+parse_tag_filter(Key, Request, Opts) ->
+    case hb_maps:find(Key, Request, Opts) of
+        {ok, Tag} ->
+            case binary:split(hb_util:bin(Tag), <<":">>, [global]) of
+                [Name, Value]
+                        when byte_size(Name) > 0 andalso byte_size(Value) > 0 ->
+                    {ok, #{name => Name, value => Value}};
+                _ ->
+                    {error, invalid_tag_filter}
+            end;
+        error ->
+            {ok, undefined}
+    end.
+%% @doc Process the `id=...` copycat path for an already indexed L1 TX.
+%% applies L1-level owner/tag filters on the lightweight TX header first, then,
+%% if the TX passes and is a bundle, loads the full L1 payload once and indexes
+%% descendants in-memory (under the ?MEMORY_SAFE_CAP limit) up to the requested safe depth
+%% (defaults to full recursion till the set copycat_depth_recursion_cap).
+process_l1_request(TXID, Request, Opts) ->
+    Depth = request_depth(Request, <<"safe_max">>, Opts),
+    case parse_owner_filter(Request, Opts) of
+        {error, _} = Error ->
+            Error;
+        {ok, OwnerFilters} ->
+            case parse_tag_filter(<<"include-tag">>, Request, Opts) of
+                {error, _} = Error ->
+                    Error;
+                {ok, IncludeTag} ->
+                    case parse_tag_filter(<<"exclude-tag">>, Request, Opts) of
+                        {error, _} = Error ->
+                            Error;
+                        {ok, ExcludeTag} ->
+                            {ok,
+                                process_l1_candidate(
+                                    TXID,
+                                    OwnerFilters#{
+                                        include_tag => IncludeTag,
+                                        exclude_tag => ExcludeTag
+                                    },
+                                    Depth,
+                                    Opts
+                                )}
+                    end
+            end
+    end.
+%% @doc Parse the requested recursion depth and clamp it to the configured safe cap.
+%% `safe_max` resolves to the current copycat depth recursion cap.
+request_depth(Request, Default, Opts) ->
+    MaxRecursionCap = get_depth_recursion_cap(Opts),
+    RequestedDepth =
+        case hb_maps:get(<<"depth">>, Request, Default, Opts) of
+            <<"safe_max">> -> MaxRecursionCap;
+            Value -> hb_util:int(Value)
+        end,
+    erlang:min(
+        MaxRecursionCap,
+        erlang:max(
+            ?DEPTH_L1_OFFSETS,
+            RequestedDepth
+        )
+    ).
+%% @doc Return the first matching L1 filter reason for a TX header, or `pass`.
+l1_filter_reason(TX, Filters) ->
+    IncludeOwner = maps:get(include_owner, Filters, undefined),
+    ExcludeOwner = maps:get(exclude_owner, Filters, undefined),
+    IncludeTag = maps:get(include_tag, Filters, undefined),
+    ExcludeTag = maps:get(exclude_tag, Filters, undefined),
+    Owner = ar_tx:get_owner_address(TX),
+    case owner_matches_filter(Owner, IncludeOwner) of
+        false when IncludeOwner =/= undefined ->
+            include_owner_mismatch;
+        _ ->
+            case owner_matches_filter(Owner, ExcludeOwner) of
+                true ->
+                    exclude_owner_match;
+                false ->
+                    case IncludeTag of
+                        undefined ->
+                            case ExcludeTag of
+                                undefined -> pass;
+                                _ ->
+                                    case has_tag_pair(TX, ExcludeTag) of
+                                        true -> exclude_tag_match;
+                                        false -> pass
+                                    end
+                            end;
+                        _ ->
+                            case has_tag_pair(TX, IncludeTag) of
+                                false -> include_tag_mismatch;
+                                true ->
+                                    case ExcludeTag of
+                                        undefined -> pass;
+                                        _ ->
+                                            case has_tag_pair(TX, ExcludeTag) of
+                                                true -> exclude_tag_match;
+                                                false -> pass
+                                            end
+                                    end
+                            end
+                    end
+            end
+    end.
+%% @doc Match an owner against an undefined, single-owner, or multi-owner filter.
+owner_matches_filter(_Owner, undefined) ->
+    false;
+owner_matches_filter(Owner, Owners) when is_list(Owners) ->
+    lists:member(Owner, Owners);
+owner_matches_filter(Owner, FilterOwner) ->
+    Owner =:= FilterOwner.
 
+has_tag_pair(#tx{tags = Tags}, #{name := Name, value := Value}) ->
+    TagValue = dev_arweave_common:tagfind(Name, Tags, not_found),
+    case TagValue of
+        not_found ->
+            false;
+        _ ->
+            LowerTagValue = hb_util:to_lower(TagValue),
+            LowerValue = hb_util:to_lower(Value),
+            case LowerTagValue of
+                LowerValue -> true;
+                _ -> false
+            end
+end;
+has_tag_pair(_, _) ->
+    false.
 %% @doc Parse the range from the request.
 parse_range(Request, Opts) ->
     maybe
@@ -399,6 +645,248 @@ process_txs(ValidTXs, BlockStartOffset, Opts) ->
         #{items_count => 0, bundle_count => 0, skipped_count => 0},
         Results
     ).
+
+%% @doc Process a single indexed L1 TX candidate after lightweight filter checks.
+process_l1_candidate(TXID, Filters, Depth, Opts) ->
+    Skipped = #{items_count => 0, bundle_count => 0, skipped_count => 1},
+    NormalizedTXID = hb_util:native_id(TXID),
+    EncodedTXID = hb_util:encode(NormalizedTXID),
+    IndexStore = hb_store_arweave:store_from_opts(Opts),
+    case hb_store_arweave:read_offset(IndexStore, NormalizedTXID) of
+        {ok,
+            #{
+                <<"codec-device">> := <<"tx@1.0">>,
+                <<"start-offset">> := StartOffset,
+                <<"length">> := Length
+            }} ->
+            case resolve_tx_header(EncodedTXID, Opts) of
+                {ok, TX} ->
+                    case l1_filter_reason(TX, Filters) of
+                        pass ->
+                            case is_bundle_tx(TX, Opts) of
+                                false ->
+                                    ?event(
+                                        copycat_short,
+                                        {arweave_tx_skipped,
+                                            {tx_id, {explicit, EncodedTXID}},
+                                            {reason, not_bundle}
+                                }
+                                    ),
+                                    Skipped;
+                                true ->
+                                    case Length =< get_memory_safe_cap(Opts) of
+                                        false ->
+                                            ?event(
+                                                copycat_short,
+                                                {arweave_bundle_skipped,
+                                                    {tx_id, {explicit, EncodedTXID}},
+                                                    {reason, memory_safe_cap_exceeded}
+                                                }
+                                            ),
+                                            #{
+                                                items_count => 0,
+                                                bundle_count => 1,
+                                                skipped_count => 1
+                                            };
+                                        true ->
+                                            case hb_store_arweave:read_chunks(
+                                                StartOffset,
+                                                Length,
+                                                Opts
+                                            ) of
+                                                {ok, BundleData} ->
+                                                    {TotalTime, IndexRes} = timer:tc(
+                                                        fun() ->
+                                                            index_bundle_bytes(
+                                                                BundleData,
+                                                                StartOffset,
+                                                                Depth,
+                                                                IndexStore,
+                                                                Opts
+                                                            )
+                                                        end
+                                                    ),
+                                                    case IndexRes of
+                                                        {ok, ItemsCount} ->
+                                                            record_event_metrics(
+                                                                <<"item_indexed">>,
+                                                                ItemsCount,
+                                                                TotalTime
+                                                            ),
+                                                            #{
+                                                                items_count => ItemsCount,
+                                                                bundle_count => 1,
+                                                                skipped_count => 0
+                                                            };
+                                                        {error, Reason} ->
+                                                            ?event(
+                                                                copycat_short,
+                                                                {arweave_bundle_skipped,
+                                                                    {tx_id, {explicit, EncodedTXID}},
+                                                                    {reason, Reason}
+                                                                }
+                                                            ),
+                                                            #{
+                                                                items_count => 0,
+                                                                bundle_count => 1,
+                                                                skipped_count => 1
+                                                            }
+                                                    end;
+                                                {error, Reason} ->
+                                                    ?event(
+                                                        copycat_short,
+                                                        {arweave_bundle_skipped,
+                                                            {tx_id, {explicit, EncodedTXID}},
+                                                            {reason, Reason}
+                                                        }
+                                                    ),
+                                                    #{
+                                                        items_count => 0,
+                                                        bundle_count => 1,
+                                                        skipped_count => 1
+                                                    };
+                                                not_found ->
+                                                    ?event(
+                                                        copycat_short,
+                                                        {arweave_bundle_skipped,
+                                                            {tx_id, {explicit, EncodedTXID}},
+                                                            {reason, not_found}
+                                                        }
+                                                    ),
+                                                    #{
+                                                        items_count => 0,
+                                                        bundle_count => 1,
+                                                        skipped_count => 1
+                                                    }
+                                            end
+                                    end
+                            end;
+                        FilterReason ->
+                            ?event(
+                                copycat_short,
+                                {arweave_tx_skipped,
+                                    {tx_id, {explicit, EncodedTXID}},
+                                    {reason, FilterReason}
+                                }
+                            ),
+                            Skipped
+                    end;
+                error ->
+                    Skipped
+            end;
+        {ok, _OtherOffset} ->
+            ?event(
+                copycat_short,
+                {arweave_tx_skipped,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {reason, not_tx}
+                }
+            ),
+            Skipped;
+        not_found ->
+            ?event(
+                copycat_short,
+                {arweave_tx_skipped,
+                    {tx_id, {explicit, EncodedTXID}},
+                    {reason, missing_offset}
+                }
+            ),
+            Skipped
+    end.
+
+index_bundle_bytes(_BundleData, _BundleStartOffset, Depth, _Store, _Opts)
+        when Depth =< 0 ->
+    {ok, 0};
+index_bundle_bytes(BundleData, BundleStartOffset, Depth, Store, Opts) ->
+    case ar_bundles:decode_bundle_header(BundleData) of
+        invalid_bundle_header ->
+            {error, invalid_bundle_header};
+        {ItemsBin, BundleIndex} ->
+            HeaderSize = byte_size(BundleData) - byte_size(ItemsBin),
+            index_bundle_items(
+                BundleIndex,
+                ItemsBin,
+                BundleStartOffset + HeaderSize,
+                Depth,
+                Store,
+                Opts,
+                0
+            )
+    end.
+
+%% @doc Index bundle children from decoded bundle bytes and recurse descendants in-memory.
+index_bundle_items([], _ItemsBin, _ItemStartOffset, _Depth, _Store, _Opts, Count) ->
+    {ok, Count};
+index_bundle_items(
+    [{ItemID, Size} | Rest],
+    ItemsBin,
+    ItemStartOffset,
+    Depth,
+    Store,
+    Opts,
+    Count
+) when byte_size(ItemsBin) >= Size ->
+    ItemBinary = binary:part(ItemsBin, 0, Size),
+    hb_store_arweave:write_offset(
+        Store,
+        hb_util:encode(ItemID),
+        <<"ans104@1.0">>,
+        ItemStartOffset,
+        Size
+    ),
+    DescendantCount =
+        case Depth > 1 of
+            true ->
+                index_bundle_descendants(
+                    ItemBinary,
+                    ItemStartOffset,
+                    Depth - 1,
+                    Store,
+                    Opts
+                );
+            false ->
+                0
+        end,
+    index_bundle_items(
+        Rest,
+        binary:part(ItemsBin, Size, byte_size(ItemsBin) - Size),
+        ItemStartOffset + Size,
+        Depth,
+        Store,
+        Opts,
+        Count + 1 + DescendantCount
+    );
+index_bundle_items(_BundleIndex, _ItemsBin, _ItemStartOffset, _Depth, _Store, _Opts, _Count) ->
+    {error, invalid_bundle_header}.
+
+%% @doc Recurse into a nested bundle data item from in-memory bytes.
+index_bundle_descendants(_ItemBinary, _ItemStartOffset, Depth, _Store, _Opts)
+        when Depth =< 0 ->
+    0;
+index_bundle_descendants(ItemBinary, ItemStartOffset, Depth, Store, Opts) ->
+    try ar_bundles:deserialize_header(ItemBinary) of
+        {ok, HeaderSize, HeaderTX} ->
+            case is_bundle_tx(HeaderTX, Opts) of
+                true ->
+                    case index_bundle_bytes(
+                        HeaderTX#tx.data,
+                        ItemStartOffset + HeaderSize,
+                        Depth,
+                        Store,
+                        Opts
+                    ) of
+                        {ok, Count} -> Count;
+                        _ -> 0
+                    end;
+                false ->
+                    0
+            end;
+        _ ->
+            0
+    catch
+        _:_ ->
+            0
+    end.
 
 %% @doc Check whether a TX header indicates bundle content.
 is_bundle_tx(TX, _Opts) ->

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -204,73 +204,56 @@ is_block_indexed(Height, TargetDepth, Opts) ->
 %% no items at that level), plus any partial depths beyond AchievedDepth
 %% that were collected during indexing.
 write_block_item_ids(Height, AchievedDepth, ItemIDs, Opts) ->
-    case hb_store_arweave:store_from_opts(Opts) of
-        no_store -> ok;
-        #{ <<"index-store">> := Store } ->
-            MaxStoredDepth = case maps:keys(ItemIDs) of
-                [] -> AchievedDepth;
-                Keys -> max(AchievedDepth, lists:max(Keys))
-            end,
-            Results = lists:map(
-                fun(D) ->
-                    IDs = maps:get(D, ItemIDs, []),
-                    Bin = encode_item_ids(IDs),
-                    hb_store:write(
-                        Store,
-                        block_items_path(Height, D),
-                        Bin
-                    )
-                end,
-                lists:seq(1, MaxStoredDepth)
-            ),
-            case lists:all(fun(R) -> R =:= ok end, Results) of
-                true -> ok;
-                false ->
-                    ?event(copycat_short,
-                        {block_item_ids_write_failed,
-                            {height, Height}}),
-                    {error, item_ids_write_failed}
-            end
+    Store = get_index_store(Opts),
+    MaxStoredDepth = case maps:keys(ItemIDs) of
+        [] -> AchievedDepth;
+        Keys -> max(AchievedDepth, lists:max(Keys))
+    end,
+    Results = lists:map(
+        fun(D) ->
+            IDs = maps:get(D, ItemIDs, []),
+            Bin = encode_item_ids(IDs),
+            hb_store:write(
+                Store,
+                block_items_path(Height, D),
+                Bin
+            )
+        end,
+        lists:seq(1, MaxStoredDepth)
+    ),
+    case lists:all(fun(R) -> R =:= ok end, Results) of
+        true -> ok;
+        false ->
+            ?event(copycat_short,
+                {block_item_ids_write_failed,
+                    {height, Height}}),
+            {error, item_ids_write_failed}
     end.
 
 %% @doc Write a block completion marker with the achieved depth.
 mark_block_indexed(Height, Depth, Opts) ->
-    case hb_store_arweave:store_from_opts(Opts) of
-        no_store -> ok;
-        #{ <<"index-store">> := Store } ->
-            hb_store:write(
-                Store,
-                block_indexed_path(Height),
-                integer_to_binary(Depth)
-            )
-    end.
+    Store = get_index_store(Opts),
+    hb_store:write(
+        Store,
+        block_indexed_path(Height),
+        integer_to_binary(Depth)
+    ).
 
 %% @doc Read the persisted cutover height from the index store.
 read_cutover_height(Opts) ->
-    case hb_store_arweave:store_from_opts(Opts) of
-        no_store -> undefined;
-        #{ <<"index-store">> := Store } ->
-            case hb_store:read(Store, ?CUTOVER_KEY) of
-                {ok, Bin} -> hb_util:int(Bin);
-                not_found -> undefined
-            end
+    Store = get_index_store(Opts),
+    case hb_store:read(Store, ?CUTOVER_KEY) of
+        {ok, Bin} -> hb_util:int(Bin);
+        not_found -> undefined
     end.
 
 %% @doc Write the cutover height if not already set.
 ensure_cutover_height(Height, Opts) ->
     case read_cutover_height(Opts) of
         undefined ->
-            case hb_store_arweave:store_from_opts(Opts) of
-                no_store -> ok;
-                #{ <<"index-store">> := Store } ->
-                    hb_store:write(
-                        Store, ?CUTOVER_KEY, hb_util:bin(Height)),
-                    ?event(copycat_short,
-                        {marker_cutover_initialized,
-                            {height, Height}
-                        }
-                    )
-            end;
+            Store = get_index_store(Opts),
+            hb_store:write(Store, ?CUTOVER_KEY, hb_util:bin(Height)),
+            ?event(copycat_short, {marker_cutover_initialized, {height, Height}});
         _ -> ok
     end.
 
@@ -559,13 +542,10 @@ latest_height(Opts) ->
 
 %% @doc Check if a transaction ID is indexed in the arweave index store.
 is_tx_indexed(TXID, Opts) ->
-    case hb_store_arweave:store_from_opts(Opts) of
-        no_store -> false;
-        #{ <<"index-store">> := Store } ->
-            case hb_store:read(Store, hb_store_arweave_offset:path(TXID), Opts) of
-                {ok, _} -> true;
-                {error, not_found} -> false
-            end
+    Store = get_index_store(Opts),
+    case hb_store:read(Store, hb_store_arweave_offset:path(TXID), Opts) of
+        {ok, _} -> true;
+        not_found -> false
     end.
 
 %% @doc List indexed blocks and transactions in the given range.
@@ -596,7 +576,7 @@ list_index_blocks(Current, To, Opts, Acc) ->
                 [] ->
                     list_index_blocks(Current - 1, To, Opts, Acc);
                 _ ->
-                    {IndexedTXs, NotIndexedTXs} = classify_txs(TXIDs, Opts),
+                    {IndexedTXs, _NotIndexedTXs} = classify_txs(TXIDs, Opts),
                     case IndexedTXs of
                         [] ->
                             % Do not include blocks with no locally indexed TXs.
@@ -631,14 +611,10 @@ assemble_block_info(Height, Block, Opts) ->
         <<"indexed">> => IndexedTXs,
         <<"not-indexed">> => NotIndexedTXs
     },
-    case read_block_depth(Height, Opts) of
+    case read_block_marker_depth(Height, Opts) of
         undefined -> Base;
         Depth -> Base#{<<"depth">> => Depth}
     end.
-
-%% @doc Read the achieved depth from a block marker.
-read_block_depth(Height, Opts) ->
-    read_block_marker_depth(Height, Opts).
 
 %% @doc Probe item entries upward from depth 1, applying TransformFun to each.
 probe_block_items(Height, Opts, TransformFun) ->
@@ -695,7 +671,7 @@ inventory_index(From, To, Opts) ->
 
 inventory_local(Current, To, _Opts, Acc) when Current < To -> Acc;
 inventory_local(Current, To, Opts, Acc) ->
-    case read_block_depth(Current, Opts) of
+    case read_block_marker_depth(Current, Opts) of
         undefined ->
             inventory_local(Current - 1, To, Opts, Acc);
         Depth ->
@@ -931,15 +907,18 @@ process_block(BlockRes, Current, To, TargetDepth, Opts) ->
                                     {height, Current},
                                     {target, To}
                                 }
-                            );
-                        _ ->
+                            ),
+                            throw(item_ids_write_failed);
+                        Error ->
                             ?event(
                                 copycat_short,
                                 {arweave_block_marker_failed,
                                     {height, Current},
-                                    {target, To}
+                                    {target, To},
+                                    {error, Error}
                                 }
-                            )
+                            ),
+                            throw({writing_to_index_store, Error})
                     end
             end;
         {error, _} = Error ->
@@ -1008,7 +987,7 @@ process_block_tx({{padding, _PaddingRoot}, _EndOffset}, _BlockStartOffset, Targe
     #{items_count => 0, bundle_count => 0, skipped_count => 0,
         achieved_depth => max(2, TargetDepth)};
 process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, BlockHeight, Opts) ->
-    IndexStore = hb_store_arweave:store_from_opts(Opts),
+    ArweaveStore = hb_store_arweave:store_from_opts(Opts),
     TXID = hb_util:encode(TX#tx.id),
     TXEndOffset = BlockStartOffset + EndOffset,
     TXStartOffset = TXEndOffset - TX#tx.data_size,
@@ -1017,17 +996,17 @@ process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, 
         {offset, TXStartOffset},
         {size, TX#tx.data_size}
     }),
-    observe_event(<<"item_indexed">>, fun() ->
+    ok = observe_event(<<"item_indexed">>, fun() ->
         hb_store_arweave:write_offset(
-            IndexStore,
+            ArweaveStore,
             TXID,
             <<"tx@1.0">>,
             TXStartOffset,
             TX#tx.data_size
         )
     end),
-    #{ <<"index-store">> := ParentStore } = IndexStore,
-    write_parent(TX#tx.id, BlockHeight, block, ParentStore),
+    #{ <<"index-store">> := IndexStore } = ArweaveStore,
+    ok = write_parent(TX#tx.id, BlockHeight, block, IndexStore),
     try is_bundle_tx(TX, Opts) of
         false ->
             #{items_count => 0, bundle_count => 0, skipped_count => 0,
@@ -1037,7 +1016,7 @@ process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, 
             try 
                 L1Result = process_l1_tx_direct(
                     TXStartOffset, TX#tx.data_size,
-                    TargetDepth - 1, IndexStore, TXID, TX#tx.id, Opts),
+                    TargetDepth - 1, ArweaveStore, TXID, TX#tx.id, Opts),
                 L1Result#{
                     achieved_depth =>
                         max(2, maps:get(achieved_depth, L1Result, 0))
@@ -1070,14 +1049,14 @@ process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, 
                     {TotalTime, {_, ItemsCount}} = timer:tc(fun() ->
                         lists:foldl(
                             fun({ItemID, Size}, {ItemStartOffset, ItemsCountAcc}) ->
-                                hb_store_arweave:write_offset(
-                                    IndexStore,
+                                ok = hb_store_arweave:write_offset(
+                                    ArweaveStore,
                                     hb_util:encode(ItemID),
                                     <<"ans104@1.0">>,
                                     ItemStartOffset,
                                     Size
                                 ),
-                                write_parent(ItemID, TX#tx.id, bundle, ParentStore),
+                                ok = write_parent(ItemID, TX#tx.id, bundle, IndexStore),
                                 {ItemStartOffset + Size, ItemsCountAcc + 1}
                             end,
                             {TXStartOffset + HeaderSize, 0},
@@ -1512,7 +1491,7 @@ index_full_bundle_items(
     ItemsBin,
     ItemStartOffset,
     Depth,
-    Store,
+    #{ <<"index-store">> := IndexStore } = Store,
     ParentID,
     Opts,
     Count,
@@ -1523,16 +1502,15 @@ index_full_bundle_items(
     ItemBinary = binary:part(ItemsBin, 0, Size),
     EncodedItemID = hb_util:encode(ItemID),
     ParseResult = validate_and_flag_item_id(
-        ItemBinary, ItemID, EncodedItemID, Store),
-    hb_store_arweave:write_offset(
+        ItemBinary, ItemID, EncodedItemID, IndexStore),
+    ok = hb_store_arweave:write_offset(
         Store,
         EncodedItemID,
         <<"ans104@1.0">>,
         ItemStartOffset,
         Size
     ),
-    #{ <<"index-store">> := IdxStore } = Store,
-    write_parent(ItemID, ParentID, bundle, IdxStore),
+    ok = write_parent(ItemID, ParentID, bundle, IndexStore),
     {DescendantCount, ItemAchievedDepth, ChildIDs} =
         case {Depth > 1, ParseResult} of
             {true, {ok, HeaderSize, ParsedItem}} ->
@@ -1592,7 +1570,7 @@ index_full_bundle_descendants_parsed(
 %% header. Returns {ok, HeaderSize, ParsedItem} on successful parse, or
 %% error if deserialization fails. Mismatch flags are written but don't
 %% prevent the item from being indexed.
-validate_and_flag_item_id(ItemBinary, DeclaredID, EncodedDeclaredID, Store) ->
+validate_and_flag_item_id(ItemBinary, DeclaredID, EncodedDeclaredID, IndexStore) ->
     try ar_bundles:deserialize_header(ItemBinary) of
         {ok, HeaderSize, ParsedItem} ->
             ComputedID = crypto:hash(sha256, ParsedItem#tx.signature),
@@ -1600,16 +1578,12 @@ validate_and_flag_item_id(ItemBinary, DeclaredID, EncodedDeclaredID, Store) ->
                 true ->
                     ok;
                 false ->
-                    case Store of
-                        #{ <<"index-store">> := IndexStore } ->
-                            hb_store:write(
-                                IndexStore,
-                                hb_store_arweave_offset:mismatch_path(
-                                    DeclaredID),
-                                ComputedID
-                            );
-                        _ -> ok
-                    end,
+                    ok = hb_store:write(
+                        IndexStore,
+                        hb_store_arweave_offset:mismatch_path(
+                            DeclaredID),
+                        ComputedID
+                    ),
                     ?event(copycat_short,
                         {item_id_mismatch,
                             {declared_id, {explicit, EncodedDeclaredID}},
@@ -1713,6 +1687,12 @@ observe_copycat_l1_stage(MetricName, Fun) ->
     {Time, Result} = timer:tc(Fun),
     record_copycat_l1_metrics(MetricName, 1, Time),
     Result.
+
+get_index_store(Opts) ->
+    case hb_store_arweave:store_from_opts(Opts) of
+        #{ <<"index-store">> := Store } -> Store;
+        _ -> throw(no_index_store_available)
+    end.
 
 %%% Tests
 
@@ -2918,8 +2898,8 @@ fabricated_mismatch_test() ->
     RealID = crypto:hash(sha256, Item#tx.signature),
     FakeID = crypto:strong_rand_bytes(32),
     EncodedFakeID = hb_util:encode(FakeID),
-    validate_and_flag_item_id(ItemBinary, FakeID, EncodedFakeID, StoreOpts),
     #{ <<"index-store">> := IndexStore } = StoreOpts,
+    validate_and_flag_item_id(ItemBinary, FakeID, EncodedFakeID, IndexStore),
     {ok, StoredActualID} =
         hb_store:read(
             IndexStore,

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -26,12 +26,37 @@ arweave(_Base, Request, Opts) ->
     case hb_maps:get(<<"mode">>, Request, <<"write">>, Opts) of
         <<"write">> ->
             case hb_maps:find(<<"id">>, Request, Opts) of
-                {ok, TXID} -> process_l1_request(TXID, Request, Opts);
+                {ok, TXID} ->
+                    case process_l1_request(TXID, Request, Opts) of
+                        {ok, Stats} when is_map(Stats) ->
+                            ?event(
+                                copycat_short,
+                                {arweave_tx_indexed,
+                                    {id, {explicit, TXID}},
+                                    {items_indexed, maps:get(items_count, Stats, 0)},
+                                    {bundle_txs, maps:get(bundle_count, Stats, 0)},
+                                    {skipped_txs, maps:get(skipped_count, Stats, 0)}
+                                }
+                            ),
+                            {ok, Stats#{
+                                <<"body">> => maps:get(items_count, Stats, 0)
+                            }};
+                        _ -> 
+                            {ok, #{
+                                items_count => 0,
+                                bundle_count => 0,
+                                skipped_count => 0,
+                                <<"body">> => 0
+                            }}                         
+                    end;
                 error ->
                     TargetDepth = request_depth(Request, ?DEFAULT_BLOCK_DEPTH, Opts),
                     case parse_range(Request, Opts) of
                         {error, unavailable} -> {error, unavailable};
                         {ok, {From, To}} ->
+                            ?event(copycat_short,
+                                {indexing_blocks, {from, From}, {to, To}, {depth, TargetDepth}}
+                            ),
                             fetch_blocks(From, To, TargetDepth, Opts)
                     end
             end;
@@ -317,9 +342,6 @@ normalize_height(Height, Opts) ->
         false ->
             {ok, RequestedHeight}
     end.
-
-get_block_depth(Opts) ->
-    maps:get(copycat_block_depth, Opts, ?DEPTH_L1_OFFSETS).
 
 latest_height(Opts) ->
     case hb_ao:resolve(
@@ -634,304 +656,6 @@ process_block_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, 
             end
     end.
 
-%% @doc Process transactions: spawn workers and manage the worker pool.
-%% This function processes transactions in parallel using parallel_map.
-%% When arweave_index_workers <= 1, processes sequentially (one worker at a time).
-%% When arweave_index_workers > 1, processes in parallel with the specified concurrency limit.
-%% Returns a map with keys: items_count, bundle_count, skipped_count.
-process_txs(ValidTXs, BlockStartOffset, TargetDepth, Opts) ->
-    Results = parallel_map(
-        ValidTXs,
-        fun(TXWithData) -> process_tx(
-            TXWithData, BlockStartOffset, TargetDepth, Opts) end,
-        Opts
-    ),
-    lists:foldl(
-        fun(Result, Acc) ->
-            #{
-                items_count => maps:get(items_count, Result, 0) + maps:get(items_count, Acc, 0),
-                bundle_count => maps:get(bundle_count, Result, 0) + maps:get(bundle_count, Acc, 0),
-                skipped_count => maps:get(skipped_count, Result, 0) + maps:get(skipped_count, Acc, 0)
-            }
-        end,
-        #{items_count => 0, bundle_count => 0, skipped_count => 0},
-        Results
-    ).
-
-%% @doc Process a single indexed L1 TX candidate after lightweight filter checks.
-process_l1_candidate(TXID, Filters, Depth, ReadL1Offset, Opts) ->
-    Skipped = #{items_count => 0, bundle_count => 0, skipped_count => 1},
-    NormalizedTXID = hb_util:native_id(TXID),
-    EncodedTXID = hb_util:encode(NormalizedTXID),
-    IndexStore = hb_store_arweave:store_from_opts(Opts),
-    case ensure_l1_tx_offset(
-        NormalizedTXID,
-        EncodedTXID,
-        IndexStore,
-        ReadL1Offset,
-        Opts
-    ) of
-        {ok,
-            #{
-                <<"codec-device">> := <<"tx@1.0">>,
-                <<"start-offset">> := StartOffset,
-                <<"length">> := Length
-            }} ->
-            case resolve_tx_header(EncodedTXID, Opts) of
-                {ok, TX} ->
-                    case l1_filter_reason(TX, Filters) of
-                        pass ->
-                            case is_bundle_tx(TX, Opts) of
-                                false ->
-                                    ?event(
-                                        copycat_short,
-                                        {arweave_tx_skipped,
-                                            {tx_id, {explicit, EncodedTXID}},
-                                            {reason, not_bundle}
-                                }
-                                    ),
-                                    Skipped;
-                                true ->
-                                    case Length =< get_memory_safe_cap(Opts) of
-                                        false ->
-                                            ?event(
-                                                copycat_short,
-                                                {arweave_bundle_skipped,
-                                                    {tx_id, {explicit, EncodedTXID}},
-                                                    {reason, memory_safe_cap_exceeded}
-                                                }
-                                            ),
-                                            #{
-                                                items_count => 0,
-                                                bundle_count => 1,
-                                                skipped_count => 1
-                                            };
-                                        true ->
-                                            case hb_store_arweave:read_chunks(
-                                                StartOffset,
-                                                Length,
-                                                Opts
-                                            ) of
-                                                {ok, BundleData} ->
-                                                    {TotalTime, IndexRes} = timer:tc(
-                                                        fun() ->
-                                                            index_bundle_bytes(
-                                                                BundleData,
-                                                                StartOffset,
-                                                                Depth,
-                                                                IndexStore,
-                                                                Opts
-                                                            )
-                                                        end
-                                                    ),
-                                                    case IndexRes of
-                                                        {ok, ItemsCount} ->
-                                                            record_event_metrics(
-                                                                <<"item_indexed">>,
-                                                                ItemsCount,
-                                                                TotalTime
-                                                            ),
-                                                            #{
-                                                                items_count => ItemsCount,
-                                                                bundle_count => 1,
-                                                                skipped_count => 0
-                                                            };
-                                                        {error, Reason} ->
-                                                            ?event(
-                                                                copycat_short,
-                                                                {arweave_bundle_skipped,
-                                                                    {tx_id, {explicit, EncodedTXID}},
-                                                                    {reason, Reason}
-                                                                }
-                                                            ),
-                                                            #{
-                                                                items_count => 0,
-                                                                bundle_count => 1,
-                                                                skipped_count => 1
-                                                            }
-                                                    end;
-                                                {error, Reason} ->
-                                                    ?event(
-                                                        copycat_short,
-                                                        {arweave_bundle_skipped,
-                                                            {tx_id, {explicit, EncodedTXID}},
-                                                            {reason, Reason}
-                                                        }
-                                                    ),
-                                                    #{
-                                                        items_count => 0,
-                                                        bundle_count => 1,
-                                                        skipped_count => 1
-                                                    };
-                                                not_found ->
-                                                    ?event(
-                                                        copycat_short,
-                                                        {arweave_bundle_skipped,
-                                                            {tx_id, {explicit, EncodedTXID}},
-                                                            {reason, not_found}
-                                                        }
-                                                    ),
-                                                    #{
-                                                        items_count => 0,
-                                                        bundle_count => 1,
-                                                        skipped_count => 1
-                                                    }
-                                            end
-                                    end
-                            end;
-                        FilterReason ->
-                            ?event(
-                                copycat_short,
-                                {arweave_tx_skipped,
-                                    {tx_id, {explicit, EncodedTXID}},
-                                    {reason, FilterReason}
-                                }
-                            ),
-                            Skipped
-                    end;
-                error ->
-                    Skipped
-            end;
-        {ok, _OtherOffset} ->
-            ?event(
-                copycat_short,
-                {arweave_tx_skipped,
-                    {tx_id, {explicit, EncodedTXID}},
-                    {reason, not_tx}
-                }
-            ),
-            Skipped;
-        {error, Reason} ->
-            ?event(
-                copycat_short,
-                {arweave_tx_skipped,
-                    {tx_id, {explicit, EncodedTXID}},
-                    {reason, Reason}
-                }
-            ),
-            Skipped
-    end.
-%% @doc Ensure the root L1 TX offset exists locally before `id=...` indexing.
-%% if the offset is missing and `load_l1_offset` is enabled, fetches the TX
-%% offset metadata from Arweave, writes it to the local offset store, and
-%% retries the local lookup.
-ensure_l1_tx_offset(_TXID, _EncodedTXID, IndexStore, _LoadL1Offset, _Opts)
-        when is_map(IndexStore) =:= false ->
-    {error, missing_offset};
-ensure_l1_tx_offset(TXID, EncodedTXID, IndexStore, ReadL1Offset, Opts) ->
-    case hb_store_arweave:read_offset(IndexStore, TXID) of
-        {ok, _} = OffsetRes ->
-            OffsetRes;
-        not_found when ReadL1Offset ->
-            ?event(
-                copycat_short,
-                {arweave_tx_offset_loading,
-                    {tx_id, {explicit, EncodedTXID}},
-                    {source, network}
-                }
-            ),
-            case load_l1_tx_offset(EncodedTXID, IndexStore, Opts) of
-                ok ->
-                    case hb_store_arweave:read_offset(IndexStore, TXID) of
-                        {ok, _} = OffsetRes ->
-                            OffsetRes;
-                        not_found ->
-                            {error, missing_offset}
-                    end;
-                {error, Reason} ->
-                    {error, Reason}
-            end;
-        not_found ->
-            {error, missing_offset}
-    end.
-
-load_l1_tx_offset(TXID, IndexStore, Opts) ->
-    case hb_http:request(
-        #{
-            <<"path">> => <<"/arweave/tx/", TXID/binary, "/offset">>,
-            <<"method">> => <<"GET">>
-        },
-        Opts
-    ) of
-        {ok, #{ <<"body">> := OffsetBody }} ->
-            OffsetMsg = hb_json:decode(OffsetBody),
-            EndOffset = hb_util:int(maps:get(<<"offset">>, OffsetMsg)),
-            Size = hb_util:int(maps:get(<<"size">>, OffsetMsg)),
-            StartOffset = EndOffset - Size,
-            ok =
-                hb_store_arweave:write_offset(
-                    IndexStore,
-                    TXID,
-                    <<"tx@1.0">>,
-                    StartOffset,
-                    Size
-                ),
-            ok;
-        {error, Reason} ->
-            {error, Reason};
-        not_found ->
-            {error, not_found}
-    end.
-
-index_bundle_bytes(_BundleData, _BundleStartOffset, Depth, _Store, _Opts)
-        when Depth =< 0 ->
-    {ok, 0};
-index_bundle_bytes(BundleData, BundleStartOffset, Depth, Store, Opts) ->
-    case ar_bundles:decode_bundle_header(BundleData) of
-        invalid_bundle_header ->
-            {error, invalid_bundle_header};
-        {ItemsBin, BundleIndex} ->
-            HeaderSize = byte_size(BundleData) - byte_size(ItemsBin),
-            index_bundle_items(
-                BundleIndex,
-                ItemsBin,
-                BundleStartOffset + HeaderSize,
-                Depth,
-                Store,
-                Opts,
-                0
-            )
-    end.
-
-%% @doc Lightweight bundle indexing. This function only loads the bundle header
-%% and writes the index based solely on the header. For a more rigorous and
-%% deeper indexing, see the index_full_bundle_xxx functions.
-index_bundle_header(TXID, TXEndOffset, TXDataSize, TXStartOffset, IndexStore, Opts) ->
-    BundleRes = download_bundle_header(TXEndOffset, TXDataSize, Opts),
-    case BundleRes of
-        {ok, {BundleIndex, HeaderSize}} ->
-            % Batch event tracking: measure total time and count for
-            % all write_offset calls
-            {TotalTime, {_, ItemsCount}} = timer:tc(fun() ->
-                lists:foldl(
-                    fun({ItemID, Size}, {ItemStartOffset, ItemsCountAcc}) ->
-                        hb_store_arweave:write_offset(
-                            IndexStore,
-                            hb_util:encode(ItemID),
-                            <<"ans104@1.0">>,
-                            ItemStartOffset,
-                            Size
-                        ),
-                        {ItemStartOffset + Size, ItemsCountAcc + 1}
-                    end,
-                    {TXStartOffset + HeaderSize, 0},
-                    BundleIndex
-                )
-            end),
-            % Single event increment for the batch
-            record_event_metrics(<<"item_indexed">>, ItemsCount, TotalTime),
-            #{items_count => ItemsCount, bundle_count => 1, skipped_count => 0};
-        {error, Reason} ->
-            ?event(
-                copycat_short,
-                {arweave_bundle_skipped,
-                    {tx_id, {explicit, TXID}},
-                    {reason, Reason}
-                }
-            ),
-            #{items_count => 0, bundle_count => 1, skipped_count => 1}
-    end.
-
 download_bundle_header(EndOffset, Size, Opts) ->
     observe_event(<<"bundle_header">>, fun() ->
         dev_arweave:bundle_header(EndOffset - Size, Opts)
@@ -989,6 +713,12 @@ maybe_process_l1_tx(TXID, Filters, Depth, QueryL1Offset, Opts) ->
     NormalizedTXID = hb_util:native_id(TXID),
     EncodedTXID = hb_util:encode(NormalizedTXID),
     IndexStore = hb_store_arweave:store_from_opts(Opts),
+    ?event(copycat_short,
+        {indexing_l1_tx, {tx_id, {explicit, EncodedTXID}},
+        {depth, Depth},
+        {query_l1_offset, QueryL1Offset},
+        {filters, Filters}
+    }),
     maybe
         {ok,
             #{
@@ -1449,7 +1179,7 @@ index_ids_test_parallel() ->
     ),
     % L3 item not read when doing L1 depth=1
     assert_item_not_read(<<"8aJrRWtHcJvJ61qsH6agGkemzrtLw3W22xFrpCGAnTM">>, Opts),
-   ok.
+    ok.
 
 block_depth_3_test() ->
     %% Test block: https://viewblock.io/arweave/block/1827942
@@ -2123,7 +1853,6 @@ id_depth_1_test() ->
     ?assertEqual(26, maps:get(items_count, Result)),
     ?assertEqual(1, maps:get(bundle_count, Result)),
     ?assertEqual(0, maps:get(skipped_count, Result)),
-
     assert_bundle_read(
         <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>,
         [
@@ -2154,7 +1883,6 @@ id_depth_2_test() ->
     ?assertEqual(52, maps:get(items_count, Result)),
     ?assertEqual(1, maps:get(bundle_count, Result)),
     ?assertEqual(0, maps:get(skipped_count, Result)),
-
     assert_bundle_read(
         <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>,
         [
@@ -2262,7 +1990,6 @@ id_missing_offset_with_load_test() ->
     ?assertEqual(52, maps:get(items_count, Result)),
     ?assertEqual(1, maps:get(bundle_count, Result)),
     ?assertEqual(0, maps:get(skipped_count, Result)),
-
     assert_bundle_read(
         <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>,
         [

--- a/src/dev_match.erl
+++ b/src/dev_match.erl
@@ -93,7 +93,7 @@ write(IDs, Base, Opts) ->
                 fun(RawKey, Value) ->
                     Key = hb_ao:normalize_key(RawKey),
                     ValuePath = value_path(Value, Opts),
-                    ok = hb_store:group(Store, address(Key, ValuePath), Opts),
+                    hb_store:group(Store, address(Key, ValuePath), Opts),
                     lists:foreach(
                         fun(ID) ->
                             Address = address(Key, ValuePath, ID),

--- a/src/hb_cache.erl
+++ b/src/hb_cache.erl
@@ -278,7 +278,7 @@ do_write_message(Bin, Store, Opts) when is_binary(Bin) ->
     % Write the binary in the store at its calculated content-hash.
     % Return the path.
     Path = generate_binary_path(Bin, Opts),
-    ok = hb_store:write(Store, #{ Path => Bin }, Opts),
+    hb_store:write(Store, #{ Path => Bin }, Opts),
     %lists:map(fun(ID) -> hb_store:make_link(Store, Path, ID) end, AllIDs),
     {ok, Path};
 do_write_message(List, Store, Opts) when is_list(List) ->
@@ -296,7 +296,7 @@ do_write_message(Msg, Store, Opts) when is_map(Msg) ->
     MsgHashpathAlg = hb_path:hashpath_alg(Msg, Opts),
     ?event(debug_cache, {writing_message, {id, UncommittedID}, {alt_ids, AltIDs}, {original, Msg}}),
     % Write all of the keys of the message into the store.
-    ok = hb_store:group(Store, UncommittedID, Opts),
+    hb_store:group(Store, UncommittedID, Opts),
     maps:map(
         fun(Key, Value) ->
             write_key(UncommittedID, Key, MsgHashpathAlg, Value, Store, Opts)
@@ -363,7 +363,7 @@ write_key(Base, Key, HPAlg, Value, Store, Opts) ->
             Opts
         ),
     {ok, Path} = do_write_message(Value, Store, Opts),
-    ok = hb_store:link(Store, #{ KeyHashPath => Path }, Opts),
+    hb_store:link(Store, #{ KeyHashPath => Path }, Opts),
     {ok, Path}.
 
 %% @doc The `structured@1.0` encoder does not typically encode `commitments`,

--- a/src/hb_copycat_budget.erl
+++ b/src/hb_copycat_budget.erl
@@ -198,4 +198,4 @@ concurrent_leases_test() ->
     ok.
 
 reset_to_default() ->
-    reset(hb_opts:get(<<"copycat_memory_budget">>, 6 * 1024 * 1024 * 1024, #{})).
+    reset(hb_opts:get(<<"copycat-memory-budget">>, 6 * 1024 * 1024 * 1024, #{})).

--- a/src/hb_copycat_budget.erl
+++ b/src/hb_copycat_budget.erl
@@ -1,0 +1,192 @@
+%%% @doc Atomics-based byte budget pool for copycat memory throttling.
+%%% Controls how many bytes of TX data can be held in memory simultaneously
+%%% across all copycat workers. Uses persistent_term for constant-time access.
+-module(hb_copycat_budget).
+-export([ensure_started/1, reset/1, lease/1, release/1, get_budget/0, stats/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(PERSISTENT_KEY, hb_copycat_budget).
+-define(IDX_LEASED, 1).
+-define(IDX_PEAK, 2).
+-define(IDX_BUDGET, 3).
+-define(IDX_RETRIES, 4).
+-define(RETRY_SLEEP_MS, 50).
+
+-define(INIT_LOCK, hb_copycat_budget_init).
+
+ensure_started(Budget) when is_integer(Budget), Budget > 0 ->
+    case persistent_term:get(?PERSISTENT_KEY, undefined) of
+        undefined ->
+            init_with_lock(Budget);
+        _Ref ->
+            ok
+    end.
+
+init_with_lock(Budget) ->
+    try register(?INIT_LOCK, self()) of
+        true ->
+            try
+                case persistent_term:get(?PERSISTENT_KEY, undefined) of
+                    undefined ->
+                        Ref = atomics:new(4, [{signed, true}]),
+                        atomics:put(Ref, ?IDX_BUDGET, Budget),
+                        persistent_term:put(?PERSISTENT_KEY, Ref);
+                    _AlreadySet ->
+                        ok
+                end
+            after
+                unregister(?INIT_LOCK)
+            end,
+            ok
+    catch
+        error:badarg ->
+            await_init(Budget)
+    end.
+
+await_init(Budget) ->
+    case persistent_term:get(?PERSISTENT_KEY, undefined) of
+        undefined ->
+            case whereis(?INIT_LOCK) of
+                undefined ->
+                    init_with_lock(Budget);
+                _Pid ->
+                    timer:sleep(1),
+                    await_init(Budget)
+            end;
+        _Ref ->
+            ok
+    end.
+
+reset(Budget) when is_integer(Budget), Budget > 0 ->
+    Ref = atomics:new(4, [{signed, true}]),
+    atomics:put(Ref, ?IDX_BUDGET, Budget),
+    persistent_term:put(?PERSISTENT_KEY, Ref),
+    ok.
+
+lease(Size) when is_integer(Size), Size > 0 ->
+    Ref = persistent_term:get(?PERSISTENT_KEY),
+    lease_loop(Ref, Size).
+
+lease_loop(Ref, Size) ->
+    Current = atomics:get(Ref, ?IDX_LEASED),
+    Budget = atomics:get(Ref, ?IDX_BUDGET),
+    case Current + Size > Budget of
+        true ->
+            atomics:add(Ref, ?IDX_RETRIES, 1),
+            timer:sleep(?RETRY_SLEEP_MS),
+            lease_loop(Ref, Size);
+        false ->
+            case atomics:compare_exchange(Ref, ?IDX_LEASED, Current, Current + Size) of
+                ok ->
+                    update_peak(Ref, Current + Size),
+                    ok;
+                _Changed ->
+                    lease_loop(Ref, Size)
+            end
+    end.
+
+release(Size) when is_integer(Size), Size > 0 ->
+    Ref = persistent_term:get(?PERSISTENT_KEY),
+    atomics:sub(Ref, ?IDX_LEASED, Size),
+    ok.
+
+get_budget() ->
+    case persistent_term:get(?PERSISTENT_KEY, undefined) of
+        undefined -> undefined;
+        Ref -> atomics:get(Ref, ?IDX_BUDGET)
+    end.
+
+stats() ->
+    case persistent_term:get(?PERSISTENT_KEY, undefined) of
+        undefined ->
+            not_started;
+        Ref ->
+            #{
+                leased => atomics:get(Ref, ?IDX_LEASED),
+                peak => atomics:get(Ref, ?IDX_PEAK),
+                budget => atomics:get(Ref, ?IDX_BUDGET),
+                retries => atomics:get(Ref, ?IDX_RETRIES)
+            }
+    end.
+
+update_peak(Ref, NewLeased) ->
+    Peak = atomics:get(Ref, ?IDX_PEAK),
+    case NewLeased =< Peak of
+        true -> ok;
+        false ->
+            case atomics:compare_exchange(Ref, ?IDX_PEAK, Peak, NewLeased) of
+                ok -> ok;
+                _Changed -> update_peak(Ref, NewLeased)
+            end
+    end.
+
+%%% Tests
+
+lease_release_cycle_test() ->
+    reset(1000),
+    ?assertEqual(1000, get_budget()),
+    ok = lease(400),
+    #{leased := 400, peak := 400, budget := 1000} = stats(),
+    ok = lease(300),
+    #{leased := 700, peak := 700} = stats(),
+    ok = release(400),
+    #{leased := 300, peak := 700} = stats(),
+    ok = release(300),
+    #{leased := 0, peak := 700} = stats(),
+    reset_to_default(),
+    ok.
+
+blocks_when_over_budget_test() ->
+    reset(100),
+    ok = lease(100),
+    Parent = self(),
+    Ref = make_ref(),
+    Pid = spawn(fun() ->
+        Parent ! {Ref, trying},
+        ok = lease(50),
+        Parent ! {Ref, got_lease}
+    end),
+    receive {Ref, trying} -> ok end,
+    timer:sleep(120),
+    receive
+        {Ref, got_lease} -> error(should_have_blocked)
+    after 0 -> ok
+    end,
+    release(60),
+    receive
+        {Ref, got_lease} -> ok
+    after 500 ->
+        exit(Pid, kill),
+        error(lease_never_granted)
+    end,
+    release(50),
+    #{leased := 40} = stats(),
+    release(40),
+    reset_to_default(),
+    ok.
+
+concurrent_leases_test() ->
+    Budget = 1000,
+    reset(Budget),
+    Parent = self(),
+    NumWorkers = 20,
+    LeaseSize = 200,
+    Pids = [spawn(fun() ->
+        ok = lease(LeaseSize),
+        timer:sleep(10),
+        release(LeaseSize),
+        Parent ! {done, self()}
+    end) || _ <- lists:seq(1, NumWorkers)],
+    lists:foreach(fun(Pid) ->
+        receive {done, Pid} -> ok
+        after 5000 -> error({timeout, Pid})
+        end
+    end, Pids),
+    #{leased := 0, peak := Peak, budget := Budget} = stats(),
+    ?assert(Peak =< Budget),
+    ?assert(Peak > 0),
+    reset_to_default(),
+    ok.
+
+reset_to_default() ->
+    reset(hb_opts:get(copycat_memory_budget, 6 * 1024 * 1024 * 1024, #{})).

--- a/src/hb_copycat_budget.erl
+++ b/src/hb_copycat_budget.erl
@@ -198,4 +198,4 @@ concurrent_leases_test() ->
     ok.
 
 reset_to_default() ->
-    reset(hb_opts:get(copycat_memory_budget, 6 * 1024 * 1024 * 1024, #{})).
+    reset(hb_opts:get(<<"copycat_memory_budget">>, 6 * 1024 * 1024 * 1024, #{})).

--- a/src/hb_copycat_budget.erl
+++ b/src/hb_copycat_budget.erl
@@ -28,7 +28,7 @@ init_with_lock(Budget) ->
             try
                 case persistent_term:get(?PERSISTENT_KEY, undefined) of
                     undefined ->
-                        Ref = atomics:new(4, [{signed, true}]),
+                        Ref = atomics:new(4, [{signed, false}]),
                         atomics:put(Ref, ?IDX_BUDGET, Budget),
                         persistent_term:put(?PERSISTENT_KEY, Ref);
                     _AlreadySet ->
@@ -58,7 +58,7 @@ await_init(Budget) ->
     end.
 
 reset(Budget) when is_integer(Budget), Budget > 0 ->
-    Ref = atomics:new(4, [{signed, true}]),
+    Ref = atomics:new(4, [{signed, false}]),
     atomics:put(Ref, ?IDX_BUDGET, Budget),
     persistent_term:put(?PERSISTENT_KEY, Ref),
     ok.

--- a/src/hb_copycat_budget.erl
+++ b/src/hb_copycat_budget.erl
@@ -4,6 +4,7 @@
 -module(hb_copycat_budget).
 -export([ensure_started/1, reset/1, lease/1, release/1, get_budget/0, stats/0]).
 -include_lib("eunit/include/eunit.hrl").
+-include("include/hb.hrl").
 
 -define(PERSISTENT_KEY, hb_copycat_budget).
 -define(IDX_LEASED, 1).
@@ -11,6 +12,7 @@
 -define(IDX_BUDGET, 3).
 -define(IDX_RETRIES, 4).
 -define(RETRY_SLEEP_MS, 50).
+-define(LEASE_LOOP_MAX_RETRIES, 100).
 
 -define(INIT_LOCK, hb_copycat_budget_init).
 
@@ -65,23 +67,30 @@ reset(Budget) when is_integer(Budget), Budget > 0 ->
 
 lease(Size) when is_integer(Size), Size > 0 ->
     Ref = persistent_term:get(?PERSISTENT_KEY),
-    lease_loop(Ref, Size).
+    lease_loop(Ref, Size, 0).
 
-lease_loop(Ref, Size) ->
+lease_loop(Ref, Size, ?LEASE_LOOP_MAX_RETRIES) -> 
+    ?event(error, 
+        {lease_loop_max_retries_exhausted, 
+            {ref, Ref},
+            {size, Size},
+            {max_retries, ?LEASE_LOOP_MAX_RETRIES}}),
+    throw(exhausted_lease_loop_max_retires);
+lease_loop(Ref, Size, Retries) ->
     Current = atomics:get(Ref, ?IDX_LEASED),
     Budget = atomics:get(Ref, ?IDX_BUDGET),
     case Current + Size > Budget of
         true ->
             atomics:add(Ref, ?IDX_RETRIES, 1),
             timer:sleep(?RETRY_SLEEP_MS),
-            lease_loop(Ref, Size);
+            lease_loop(Ref, Size, Retries + 1);
         false ->
             case atomics:compare_exchange(Ref, ?IDX_LEASED, Current, Current + Size) of
                 ok ->
                     update_peak(Ref, Current + Size),
                     ok;
                 _Changed ->
-                    lease_loop(Ref, Size)
+                    lease_loop(Ref, Size, Retries + 1)
             end
     end.
 

--- a/src/hb_event.erl
+++ b/src/hb_event.erl
@@ -7,7 +7,6 @@
 -export([log_event/6]).
 -export([setup_logger/0]).
 -export([increment/3, increment/4, increment_callers/1]).
--include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 -define(OVERLOAD_QUEUE_LENGTH, 10_000).
@@ -363,28 +362,10 @@ check_overload(Last, N) ->
             case erlang:process_info(self(), message_queue_len) of
                 {message_queue_len, Len} when Len > ?OVERLOAD_QUEUE_LENGTH ->
                     {memory, MemorySize} = erlang:process_info(self(), memory),
-                    case rand:uniform(max(1000, Len - ?OVERLOAD_QUEUE_LENGTH)) of
-                        1 ->
-                            ?debug_print(
-                                {warning,
-                                    prometheus_event_queue_overloading,
-                                    {queue, Len},
-                                    {last_event, Last},
-                                    {memory_bytes, MemorySize}
-                                }
-                            );
-                        _ -> ignored
-                    end,
+                    % If the size of this process is too large, exit such that
+                    % we can be restarted by the next caller.
                     case MemorySize of
                         MemorySize when MemorySize > ?MAX_MEMORY ->
-                            ?debug_print(
-                                {error,
-                                    prometheus_event_queue_terminating_on_memory_overload,
-                                    {queue, Len},
-                                    {memory_bytes, MemorySize},
-                                    {last_event, Last}
-                                }
-                            ),
                             exit(memory_overload);
                         _ -> no_action
                     end;

--- a/src/hb_event.erl
+++ b/src/hb_event.erl
@@ -7,6 +7,7 @@
 -export([log_event/6]).
 -export([setup_logger/0]).
 -export([increment/3, increment/4, increment_callers/1]).
+-include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 -define(OVERLOAD_QUEUE_LENGTH, 10_000).
@@ -366,6 +367,14 @@ check_overload(Last, N) ->
                     % we can be restarted by the next caller.
                     case MemorySize of
                         MemorySize when MemorySize > ?MAX_MEMORY ->
+                            ?debug_print(
+                                {error,
+                                    prometheus_event_queue_terminating_on_memory_overload,
+                                    {queue, Len},
+                                    {memory_bytes, MemorySize},
+                                    {last_event, Last}
+                                }
+                            ),
                             exit(memory_overload);
                         _ -> no_action
                     end;

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -20,6 +20,7 @@
 -include("include/hb.hrl").
 -include("include/hb_opts.hrl").
 -include("include/hb_arweave_nodes.hrl").
+-include("include/hb_store_arweave.hrl").
 
 %%% Environment variables that can be used to override the default message.
 -ifdef(TEST).
@@ -303,7 +304,7 @@ raw_default_message() ->
         <<"copycat-memory-budget">> => 6 * 1024 * 1024 * 1024,
         <<"copycat-depth-recursion-cap">> => 6, % 2x the deepest we've seen to date
         <<"arweave-block-workers">> => 3,
-        <<"copycat-scope">> => ["offset", "parent"],
+        <<"copycat-scope">> => [?SCOPE_OFFSET, ?SCOPE_PARENT],
         %% Dev options
         <<"mode">> => debug,
         <<"profiling">> => true,

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -299,6 +299,9 @@ raw_default_message() ->
         <<"relay-http-client">> => httpc,
         %% The default codec to use for commitment signatures.
         <<"commitment-device">> => <<"httpsig@1.0">>,
+        %% Copycat-specific options.
+        copycat_memory_cap => 6 * 1024 * 1024 * 1024,
+        copycat_depth_recursion_cap => 4,
         %% Dev options
         <<"mode">> => debug,
         <<"profiling">> => true,

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -301,7 +301,9 @@ raw_default_message() ->
         <<"commitment-device">> => <<"httpsig@1.0">>,
         %% Copycat-specific options.
         copycat_memory_cap => 6 * 1024 * 1024 * 1024,
+        copycat_memory_budget => 6 * 1024 * 1024 * 1024,
         copycat_depth_recursion_cap => 6, % 2x the deepest we've seen to date
+        arweave_block_workers => 3,
         %% Dev options
         <<"mode">> => debug,
         <<"profiling">> => true,

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -300,7 +300,6 @@ raw_default_message() ->
         %% The default codec to use for commitment signatures.
         <<"commitment-device">> => <<"httpsig@1.0">>,
         %% Copycat-specific options.
-        copycat_memory_cap => 6 * 1024 * 1024 * 1024,
         copycat_memory_budget => 6 * 1024 * 1024 * 1024,
         copycat_depth_recursion_cap => 6, % 2x the deepest we've seen to date
         arweave_block_workers => 3,

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -301,7 +301,7 @@ raw_default_message() ->
         <<"commitment-device">> => <<"httpsig@1.0">>,
         %% Copycat-specific options.
         copycat_memory_cap => 6 * 1024 * 1024 * 1024,
-        copycat_depth_recursion_cap => 4,
+        copycat_depth_recursion_cap => 6, % 2x the deepest we've seen to date
         %% Dev options
         <<"mode">> => debug,
         <<"profiling">> => true,

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -300,9 +300,10 @@ raw_default_message() ->
         %% The default codec to use for commitment signatures.
         <<"commitment-device">> => <<"httpsig@1.0">>,
         %% Copycat-specific options.
-        <<"copycat_memory_budget">> => 6 * 1024 * 1024 * 1024,
-        <<"copycat_depth_recursion_cap">> => 6, % 2x the deepest we've seen to date
-        <<"arweave_block_workers">> => 3,
+        <<"copycat-memory-budget">> => 6 * 1024 * 1024 * 1024,
+        <<"copycat-depth-recursion-cap">> => 6, % 2x the deepest we've seen to date
+        <<"arweave-block-workers">> => 3,
+        <<"copycat-scope">> => ["offset", "parent"],
         %% Dev options
         <<"mode">> => debug,
         <<"profiling">> => true,

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -300,9 +300,9 @@ raw_default_message() ->
         %% The default codec to use for commitment signatures.
         <<"commitment-device">> => <<"httpsig@1.0">>,
         %% Copycat-specific options.
-        copycat_memory_budget => 6 * 1024 * 1024 * 1024,
-        copycat_depth_recursion_cap => 6, % 2x the deepest we've seen to date
-        arweave_block_workers => 3,
+        <<"copycat_memory_budget">> => 6 * 1024 * 1024 * 1024,
+        <<"copycat_depth_recursion_cap">> => 6, % 2x the deepest we've seen to date
+        <<"arweave_block_workers">> => 3,
         %% Dev options
         <<"mode">> => debug,
         <<"profiling">> => true,

--- a/src/hb_prometheus.erl
+++ b/src/hb_prometheus.erl
@@ -1,7 +1,7 @@
 %%% @doc HyperBEAM wrapper for Prometheus metrics.
 -module(hb_prometheus).
 -export([ensure_started/0, declare/2, measure_and_report/2, measure_and_report/3]).
--export([observe/2, observe/3, inc/2, inc/3, inc/4, dec/2, dec/3, dec/4]).
+-export([observe/2, observe/3, inc/2, inc/3, inc/4, dec/2, dec/3, dec/4, set/4]).
 -define(STARTED_CACHE_KEY, {?MODULE, started}).
 
 %% @doc Ensure the Prometheus application has been started. Caches startup
@@ -119,3 +119,12 @@ dec(Type, Metrics, Labels, Value) ->
 
 do_dec(gauge, Name, Labels, Value) ->
     prometheus_gauge:dec(Name, Labels, Value).
+
+set(gauge, Name, Labels, Value) ->
+    case ensure_started() of
+        ok ->
+            try prometheus_gauge:set(Name, Labels, Value)
+            catch error:mfa_already_exists -> ok
+            end;
+        _ -> ok
+    end.

--- a/src/hb_store.erl
+++ b/src/hb_store.erl
@@ -91,8 +91,8 @@ behavior_info(callbacks) ->
 
 %% @doc Store access policies to function names.
 -define(STORE_ACCESS_POLICIES, #{
-    <<"read">> => [read, resolve, list, type, match, scope],
-    <<"write">> => [write, link, group, reset, scope],
+    <<"read">> => [read, resolve, list, type, match, scope, start, stop],
+    <<"write">> => [write, link, group, reset, scope, start, stop],
     <<"admin">> => [start, stop, reset, scope]
 }).
 
@@ -560,6 +560,7 @@ start_one(Store = #{ <<"store-module">> := Mod }, Req, Opts) ->
     end.
 
 call_store_start(Mod, Store, Req, Opts) ->
+    code:ensure_loaded(Mod),
     case erlang:function_exported(Mod, start, 3) of
         true -> Mod:start(Store, Req, Opts);
         false -> Mod:start(Store)

--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -343,7 +343,7 @@ write_parent(ItemID, ParentData, Type, Store, Opts) ->
     case 
         lists:member(
             ?SCOPE_PARENT, 
-            hb_maps:get(<<"copycat-scope">>, Opts, [?SCOPE_PARENT])
+            hb_opts:get(<<"copycat-scope">>, [], Opts)
         ) of
         true ->
             Entry = encode_parent_entry(ParentData, Type),
@@ -364,7 +364,7 @@ write_offset(
     case 
         lists:member(
             ?SCOPE_OFFSET, 
-            hb_maps:get(<<"copycat-scope">>, Opts, [?SCOPE_OFFSET])
+            hb_opts:get(<<"copycat-scope">>, [], Opts)
         ) of
         true ->
             Value = hb_store_arweave_offset:encode(CodecName, StartOffset, Length),

--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -6,11 +6,19 @@
 %%% Unused Store API:
 -export([resolve/3, write/3, link/3, group/3]).
 %%% Indexing API:
--export([store_from_opts/1, write_offset/5, read_offset/2, read_parent/3, decode_parent_entries/1, read_chunks/3]).
+-export([store_from_opts/1, write_offset/6, write_parent/5, read_offset/2, read_parent/3, decode_parent_entries/1, read_chunks/3]).
+-export([block_indexed_path/1, block_items_path/2]).
+-export([read_block_item_counts/2, read_block_item_ids/2]).
+-export([ensure_cutover_height/2, read_cutover_height/1, is_tx_indexed/2 ]).
+-export([write_block_item_ids/4, read_block_marker_depth/2]).
+-export([decode_item_ids/1, is_block_indexed/3, is_post_cutover/2, mark_block_indexed/3 ]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 -define(PARTITION_SIZE, 3_600_000_000_000).
+-define(SCOPE_PARENT, <<"parent">>).
+-define(SCOPE_OFFSET, <<"offset">>).
+-define(CUTOVER_KEY, <<"block/marker-cutover-height">>).
 
 %% @doc Find the first Arweave store from the given node message. Searches first
 %% for the `arweave_index_store' option, and if not found, searches the main
@@ -122,6 +130,28 @@ decode_parent_entries(<<1, ParentID:32/binary, Rest/binary>>) ->
     end;
 decode_parent_entries(_Corrupt) ->
     {error, corrupt_parent_data}.
+
+
+%% @doc Return the store path for a parent index entry.
+parent_path(ItemID) when byte_size(ItemID) =:= 32 ->
+    <<"parent/", ItemID/binary>>.
+
+%% @doc Encode a parent entry for storage.
+encode_parent_entry(Height, block) when is_integer(Height) ->
+    <<0, Height:64/big-unsigned>>;
+encode_parent_entry(ParentID, bundle) when byte_size(ParentID) =:= 32 ->
+    <<1, ParentID:32/binary>>.
+
+%% Block Information Index
+
+%% @doc Return the store path for a block completion marker.
+block_indexed_path(Height) ->
+    <<"block/", (hb_util:bin(Height))/binary, "/depth">>.
+
+%% @doc Return the store path for a per-block item index at a given depth.
+block_items_path(Height, Depth) ->
+    <<"block/", (hb_util:bin(Height))/binary,
+        "/items/", (hb_util:bin(Depth))/binary>>.
 
 %% @doc Read the data at the given key, reading the `local-store' first if
 %% available.
@@ -309,30 +339,209 @@ read_chunks(StartOffset, Length, Opts) ->
         Opts
     ).
 
+%% @doc Write a parent entry for an item to the index store.
+write_parent(ItemID, ParentData, Type, Store, Opts) ->
+    case 
+        lists:member(
+            ?SCOPE_PARENT, 
+            hb_maps:get(<<"copycat-scope">>, Opts, [?SCOPE_PARENT])
+        ) of
+        true ->
+            Entry = encode_parent_entry(ParentData, Type),
+            hb_store:write(Store, #{parent_path(ItemID) => Entry}, Opts);
+        false ->
+            ok 
+    end.
+
 %% @doc Write offset information to the index store.
 write_offset(
-        StoreOpts = #{ <<"index-store">> := IndexStore },
+        #{ <<"index-store">> := IndexStore },
         ID,
         CodecName,
         StartOffset,
-        Length
+        Length,
+        Opts
     ) ->
-    Value = hb_store_arweave_offset:encode(CodecName, StartOffset, Length),
-    ?event(
-        debug_store_arweave,
-        {writing_offset, 
-            {id, {explicit, ID}},
-            {type, CodecName},
-            {start_offset, StartOffset},
-            {length, Length},
-            {value, {explicit, Value}}
-        }
+    case 
+        lists:member(
+            ?SCOPE_OFFSET, 
+            hb_maps:get(<<"copycat-scope">>, Opts, [?SCOPE_OFFSET])
+        ) of
+        true ->
+            Value = hb_store_arweave_offset:encode(CodecName, StartOffset, Length),
+            ?event(
+                debug_store_arweave,
+                {writing_offset, 
+                    {id, {explicit, ID}},
+                    {type, CodecName},
+                    {start_offset, StartOffset},
+                    {length, Length},
+                    {value, {explicit, Value}}
+                }
+            ),
+            hb_store:write(
+                IndexStore,
+                #{ hb_store_arweave_offset:path(ID) => Value },
+                Opts
+             );
+        false ->
+            ok
+    end.
+
+%% @doc Probe item entries upward from depth 1, applying TransformFun to each.
+probe_block_items(Height, Opts, TransformFun) ->
+    case store_from_opts(Opts) of
+        no_store -> 
+            erlang:display({no_store, Opts}),
+            #{};
+        #{ <<"index-store">> := Store } ->
+            probe_block_items(Height, Store, 1, #{}, TransformFun, Opts)
+    end.
+
+probe_block_items(Height, Store, Depth, Acc, TransformFun, Opts) ->
+    case hb_store:read(Store, block_items_path(Height, Depth), Opts) of
+        {ok, Bin} ->
+            Key = hb_util:bin(Depth),
+            probe_block_items(
+                Height, Store, Depth + 1,
+                Acc#{Key => TransformFun(Bin)}, TransformFun, Opts);
+        {error, not_found} ->
+            Acc
+    end.
+
+count_ids(Bin) when byte_size(Bin) rem 32 =:= 0 ->
+    byte_size(Bin) div 32;
+count_ids(_) -> <<"corrupt">>.
+
+decode_and_encode_ids(Bin) ->
+    case decode_item_ids(Bin) of
+        {error, _} -> <<"corrupt">>;
+        List -> [hb_util:encode(ID) || ID <- List]
+    end.
+
+read_block_item_counts(Height, Opts) ->
+    probe_block_items(Height, Opts, fun count_ids/1).
+
+read_block_item_ids(Height, Opts) ->
+    probe_block_items(Height, Opts, fun decode_and_encode_ids/1).
+
+%% @doc Write per-depth item ID lists for a block.
+%% Writes an entry for every depth from 1 through AchievedDepth (empty if
+%% no items at that level), plus any partial depths beyond AchievedDepth
+%% that were collected during indexing.
+write_block_item_ids(Height, AchievedDepth, ItemIDs, Opts) ->
+    Store = get_index_store(Opts),
+    MaxStoredDepth = case maps:keys(ItemIDs) of
+        [] -> AchievedDepth;
+        Keys -> max(AchievedDepth, lists:max(Keys))
+    end,
+    Results = lists:map(
+        fun(D) ->
+            IDs = maps:get(D, ItemIDs, []),
+            Bin = encode_item_ids(IDs),
+            hb_store:write(
+                Store,
+                #{block_items_path(Height, D) => Bin},
+                Opts
+            )
+        end,
+        lists:seq(1, MaxStoredDepth)
     ),
+    case lists:all(fun(R) -> R =:= ok end, Results) of
+        true -> ok;
+        false ->
+            ?event(copycat_short,
+                {block_item_ids_write_failed,
+                    {height, Height}}),
+            {error, item_ids_write_failed}
+    end.
+
+%% @doc Encode a list of 32-byte raw IDs into a single binary.
+encode_item_ids(IDs) ->
+    << <<ID:32/binary>> || ID <- IDs >>.
+
+%% @doc Decode a binary of concatenated 32-byte IDs into a list.
+%% Rejects binaries whose size is not a multiple of 32.
+decode_item_ids(<<>>) -> [];
+decode_item_ids(Bin) when byte_size(Bin) rem 32 =/= 0 ->
+    {error, invalid_item_ids_binary};
+decode_item_ids(Bin) ->
+    decode_item_ids_acc(Bin, []).
+
+decode_item_ids_acc(<<>>, Acc) -> lists:reverse(Acc);
+decode_item_ids_acc(<<ID:32/binary, Rest/binary>>, Acc) ->
+    decode_item_ids_acc(Rest, [ID | Acc]).
+
+%% @doc Read the stored marker depth for a block, or undefined if none.
+read_block_marker_depth(Height, Opts) ->
+    case store_from_opts(Opts) of
+        no_store -> undefined;
+        #{ <<"index-store">> := Store } ->
+            case hb_store:read(Store, block_indexed_path(Height), Opts) of
+                {ok, Bin} ->
+                    try binary_to_integer(Bin)
+                    catch _:_ -> undefined
+                    end;
+                {error, not_found} -> undefined
+            end
+    end.
+
+%% @doc Check if a block has been indexed at the given depth or deeper.
+is_block_indexed(undefined, _TargetDepth, _Opts) ->
+    false;
+is_block_indexed(Height, TargetDepth, Opts) ->
+    case read_block_marker_depth(Height, Opts) of
+        undefined -> false;
+        StoredDepth -> StoredDepth >= TargetDepth
+    end.
+
+%% @doc Write a block completion marker with the achieved depth.
+mark_block_indexed(Height, Depth, Opts) ->
+    Store = get_index_store(Opts),
     hb_store:write(
-        IndexStore,
-        #{ hb_store_arweave_offset:path(ID) => Value },
-        StoreOpts
+        Store,
+        #{block_indexed_path(Height) => integer_to_binary(Depth)},
+        Opts
     ).
+
+%% @doc Read the persisted cutover height from the index store.
+read_cutover_height(Opts) ->
+    Store = get_index_store(Opts),
+    case hb_store:read(Store, ?CUTOVER_KEY, Opts) of
+        {ok, Bin} -> hb_util:int(Bin);
+        {error, not_found} -> undefined
+    end.
+
+%% @doc Write the cutover height if not already set.
+ensure_cutover_height(Height, Opts) ->
+    case read_cutover_height(Opts) of
+        undefined ->
+            Store = get_index_store(Opts),
+            hb_store:write(Store, #{?CUTOVER_KEY => hb_util:bin(Height)}, Opts),
+            ?event(copycat_short, {marker_cutover_initialized, {height, Height}});
+        _ -> ok
+    end.
+
+%% @doc Check if a transaction ID is indexed in the arweave index store.
+is_tx_indexed(TXID, Opts) ->
+    Store = get_index_store(Opts),
+    case hb_store:read(Store, hb_store_arweave_offset:path(TXID), Opts) of
+        {ok, _} -> true;
+        {error, not_found} -> false
+    end.
+
+is_post_cutover(undefined, _Opts) -> false;
+is_post_cutover(Height, Opts) ->
+    case read_cutover_height(Opts) of
+        undefined -> false;
+        Cutover -> Height >= Cutover
+    end.
+
+get_index_store(Opts) ->
+    case store_from_opts(Opts) of
+        #{ <<"index-store">> := Store } -> Store;
+        _ -> throw(no_index_store_available)
+    end.
 
 %% @doc Record the partition that data is found in when it is requested.
 record_partition_metric(Offset, Result, StoreOpts) when is_integer(Offset) ->
@@ -384,17 +593,24 @@ init_prometheus() ->
 
 %%% Tests
 
+setup_test_store() ->
+    IndexStore = [hb_test_utils:test_store()],
+    ArweaveStore = 
+        #{
+            <<"store-module">> => hb_store_arweave,
+            <<"index-store">> => IndexStore
+         },
+    Opts = #{<<"store">> => [ArweaveStore]},
+    {IndexStore, ArweaveStore, Opts}.
+
 write_read_tx_test() ->
-    Store = [hb_test_utils:test_store()],
-    Opts = #{ 
-        <<"index-store">> => Store 
-    },
+    {_, ArweaveStoreOpts, Opts} = setup_test_store(),
     ID = <<"bndIwac23-s0K11TLC1N7z472sLGAkiOdhds87ZywoE">>,
     EndOffset = 363524457284025,
     Size = 8387,
     StartOffset = EndOffset - Size,
-    ok = write_offset(Opts, ID, <<"tx@1.0">>, StartOffset, Size),
-    {ok, Bundle} = read(Opts, #{ <<"read">> => ID }, Opts),
+    ok = write_offset(ArweaveStoreOpts, ID, <<"tx@1.0">>, StartOffset, Size, Opts),
+    {ok, Bundle} = read(ArweaveStoreOpts, #{ <<"read">> => ID }, Opts),
     ?assert(hb_message:verify(Bundle, all, #{})),
     {ok, Child} =
         hb_ao:resolve(
@@ -428,27 +644,23 @@ write_read_tx_test() ->
 %% @doc Stale ANS-104 offset: fake ID pointing to a known bundle TX's
 %% data range. The deserialized item's ID won't match the fake ID.
 stale_ans104_offset_returns_error_test() ->
-    Store = [hb_test_utils:test_store()],
-    Opts = #{<<"index-store">> => Store},
+    {_, ArweaveStoreOpts, Opts} = setup_test_store(),
     FakeID = <<"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA">>,
     RealEndOffset = 363524457284025,
     RealSize = 8387,
     RealStartOffset = RealEndOffset - RealSize,
-    ok = write_offset(Opts, FakeID, <<"ans104@1.0">>, RealStartOffset, RealSize),
-    Result = read(Opts, #{ <<"read">> => FakeID }, Opts),
+    ok = write_offset(ArweaveStoreOpts, FakeID, <<"ans104@1.0">>, RealStartOffset, RealSize, Opts),
+    Result = read(ArweaveStoreOpts, #{ <<"read">> => FakeID }, Opts),
     ?assertMatch({error, {id_mismatch, _, _}}, Result).
 
 %% @doc The L1 TX has bundle tags, but data is not a valid bundle.
 write_read_fake_bundle_tx_test() ->
-    Store = [hb_test_utils:test_store()],
-    Opts = #{ 
-        <<"index-store">> => Store 
-    },
+    {_, ArweaveStoreOpts, Opts} = setup_test_store(),
     ID = <<"cGNURX2IUt98VKVIeXSfYe6eulNwPEqijaQfvatzd_o">>,
     Size = 2,
     StartOffset = 155309918167286,
-    ok = write_offset(Opts, ID, <<"tx@1.0">>, StartOffset, Size),
-    {ok, TX} = read(Opts, #{ <<"read">> => ID }, Opts),
+    ok = write_offset(ArweaveStoreOpts, ID, <<"tx@1.0">>, StartOffset, Size, Opts),
+    {ok, TX} = read(ArweaveStoreOpts, #{ <<"read">> => ID }, Opts),
     ?assert(hb_message:verify(TX, all, #{})),
     ok.
 
@@ -456,12 +668,56 @@ write_read_fake_bundle_tx_test() ->
 %% so ar_bundles:deserialize/1 throws. The catch in load_item/4 must convert
 %% that throw into {error, _} rather than crashing.
 load_item_deserialize_throws_test() ->
-    Store = [hb_test_utils:test_store()],
-    Opts = #{<<"index-store">> => Store},
+    {_, ArweaveStoreOpts, Opts} = setup_test_store(),
     FakeID = <<"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB">>,
     %% Same interior offset used in dev_arweave bundle_header_garbage_guard test:
     %% the bytes at ProbeOffset are mid-TX application data, not an ANS-104 header.
     ProbeOffset = 376836336327208,
     Size = 4096,
-    ok = write_offset(Opts, FakeID, <<"ans104@1.0">>, ProbeOffset - 1, Size),
-    ?assertMatch({error, _}, read(Opts, FakeID, #{})).
+    ok = write_offset(ArweaveStoreOpts, FakeID, <<"ans104@1.0">>, ProbeOffset - 1, Size, Opts),
+    ?assertMatch({error, _}, read(ArweaveStoreOpts, #{<<"read">> => FakeID}, #{})).
+
+corrupt_item_ids_read_test() ->
+    {IndexStore, _StoreOpts, Opts} = setup_test_store(),
+    Height = 99999999,
+    ok = hb_store:write(IndexStore, #{block_indexed_path(Height) => <<"2">>}, Opts),
+    ok = hb_store:write(IndexStore, #{block_items_path(Height, 1) => <<0:256>>}, Opts),
+    ok = hb_store:write(IndexStore, #{block_items_path(Height, 2) => <<0:240>>}, Opts),
+    Counts = read_block_item_counts(Height, Opts),
+    erlang:display({counts, Counts}),
+    ?assertEqual(1, maps:get(<<"1">>, Counts)),
+    ?assertEqual(<<"corrupt">>, maps:get(<<"2">>, Counts)),
+    IDs = read_block_item_ids(Height, Opts),
+    ?assertEqual(1, length(maps:get(<<"1">>, IDs))),
+    ?assertEqual(<<"corrupt">>, maps:get(<<"2">>, IDs)),
+    ok.
+
+parent_encode_decode_test() ->
+    BlockEntry = encode_parent_entry(12345, block),
+    ?assertEqual(<<0, 12345:64/big-unsigned>>, BlockEntry),
+    BundleID = crypto:strong_rand_bytes(32),
+    BundleEntry = encode_parent_entry(BundleID, bundle),
+    ?assertEqual(<<1, BundleID:32/binary>>, BundleEntry),
+    Combined = <<BlockEntry/binary, BundleEntry/binary>>,
+    Decoded = decode_parent_entries(Combined),
+    ?assertEqual([{12345, block}, {BundleID, bundle}], Decoded),
+    ok.
+
+parent_not_found_test() ->
+    {_IndexStore, ArweaveStoreOpts, Opts} = setup_test_store(),
+    UnknownID = crypto:strong_rand_bytes(32),
+    ?assertEqual(
+       not_found, 
+       hb_store_arweave:read_parent(ArweaveStoreOpts, UnknownID, Opts),
+       Opts
+    ),
+    ok.
+
+decode_item_ids_validation_test() ->
+    ?assertEqual([], decode_item_ids(<<>>)),
+    GoodBin = <<0:256, 1:256>>,
+    ?assertEqual(2, length(decode_item_ids(GoodBin))),
+    BadBin = <<0:240>>,
+    ?assertEqual({error, invalid_item_ids_binary}, decode_item_ids(BadBin)),
+    ok.
+

--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -13,11 +13,10 @@
 -export([write_block_item_ids/4, read_block_marker_depth/2]).
 -export([decode_item_ids/1, is_block_indexed/3, is_post_cutover/2, mark_block_indexed/3 ]).
 -include("include/hb.hrl").
+-include("include/hb_store_arweave.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 -define(PARTITION_SIZE, 3_600_000_000_000).
--define(SCOPE_PARENT, <<"parent">>).
--define(SCOPE_OFFSET, <<"offset">>).
 -define(CUTOVER_KEY, <<"block/marker-cutover-height">>).
 
 %% @doc Find the first Arweave store from the given node message. Searches first

--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -31,9 +31,9 @@ first_arweave_store(
 first_arweave_store([_ | Rest]) -> first_arweave_store(Rest).
 
 %% @doc Start the Arweave store, and the downstream associated index store.
-start(#{<<"index-store">> := IndexStore}, _Req, _Opts) ->
+start(#{<<"index-store">> := IndexStore}, Req, Opts) ->
     init_prometheus(),
-    hb_store:start(IndexStore).
+    hb_store:start(IndexStore, Req, Opts).
 
 %% @doc Although the index is local, loading an item via the index will make
 %% requests to a remote node, so we define the scope as remote.
@@ -464,4 +464,4 @@ load_item_deserialize_throws_test() ->
     ProbeOffset = 376836336327208,
     Size = 4096,
     ok = write_offset(Opts, FakeID, <<"ans104@1.0">>, ProbeOffset - 1, Size),
-    ?assertMatch({error, _}, read(Opts, FakeID)).
+    ?assertMatch({error, _}, read(Opts, FakeID, #{})).

--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -183,22 +183,36 @@ load_item(ExpectedID, StartOffset, Length, Opts) ->
         fun() ->
             case read_chunks(StartOffset, Length, Opts) of
                 {ok, SerializedItem} ->
-                    Item =
-                        ar_bundles:deserialize(SerializedItem),
-                    case hb_util:encode(Item#tx.id) of
-                        ExpectedID ->
-                            {ok, hb_message:convert(
-                                Item,
-                                <<"structured@1.0">>,
-                                <<"ans104@1.0">>,
-                                Opts
-                            )};
-                        ActualID ->
-                            {error,
-                                {id_mismatch,
-                                    ExpectedID, ActualID}}
+                    try
+                        Item =
+                            ar_bundles:deserialize(SerializedItem),
+                        case hb_util:encode(Item#tx.id) of
+                            ExpectedID ->
+                                {ok, hb_message:convert(
+                                    Item,
+                                    <<"structured@1.0">>,
+                                    <<"ans104@1.0">>,
+                                    Opts
+                                )};
+                            ActualID ->
+                                ?event(error, {load_item, {id_mismatch}}),
+                                {error,
+                                    {id_mismatch,
+                                        ExpectedID, ActualID}}
+                        end
+                    catch _:Reason:Stacktrace ->
+                        %% Due to malformed encoding, attempt to deserialize
+                        %% can throw.
+                        ?event(error, 
+                            {load_item, 
+                                {expected_id, ExpectedID}, 
+                                {reason, Reason},
+                                {stacktrace, Stacktrace}
+                            }),
+                        {error, Reason}
                     end;
                 {error, Reason} ->
+                    ?event(error, {load_item, Reason}),
                     {error, Reason}
             end
         end,
@@ -408,3 +422,17 @@ write_read_fake_bundle_tx_test() ->
     {ok, TX} = read(Opts, #{ <<"read">> => ID }, Opts),
     ?assert(hb_message:verify(TX, all, #{})),
     ok.
+
+%% @doc Interior Arweave offset returns bytes that are not a valid ANS-104 item,
+%% so ar_bundles:deserialize/1 throws. The catch in load_item/4 must convert
+%% that throw into {error, _} rather than crashing.
+load_item_deserialize_throws_test() ->
+    Store = [hb_test_utils:test_store()],
+    Opts = #{<<"index-store">> => Store},
+    FakeID = <<"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB">>,
+    %% Same interior offset used in dev_arweave bundle_header_garbage_guard test:
+    %% the bytes at ProbeOffset are mid-TX application data, not an ANS-104 header.
+    ProbeOffset = 376836336327208,
+    Size = 4096,
+    ok = write_offset(Opts, FakeID, <<"ans104@1.0">>, ProbeOffset - 1, Size),
+    ?assertMatch({error, _}, read(Opts, FakeID)).

--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -6,7 +6,7 @@
 %%% Unused Store API:
 -export([resolve/3, write/3, link/3, group/3]).
 %%% Indexing API:
--export([store_from_opts/1, write_offset/5, read_offset/2, read_parent/2, decode_parent_entries/1, read_chunks/3]).
+-export([store_from_opts/1, write_offset/5, read_offset/2, read_parent/3, decode_parent_entries/1, read_chunks/3]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -16,7 +16,7 @@
 %% for the `arweave_index_store' option, and if not found, searches the main
 %% `store' list for the first Arweave store with an index.
 store_from_opts(Opts) ->
-    case hb_opts:get(arweave_index_store, no_store, Opts) of
+    case hb_opts:get(<<"arweave-index-store">>, no_store, Opts) of
         no_store -> first_arweave_store(hb_opts:get(store, [], Opts));
         IndexStoreOpts -> IndexStoreOpts
     end.
@@ -95,10 +95,10 @@ read_offset(StoreOpts = #{ <<"index-store">> := IndexStore }, ID) ->
 read_offset(_, _) -> not_found.
 
 %% @doc Read the parent entries for an item from the index store.
-read_parent(#{ <<"index-store">> := IndexStore }, ID) ->
+read_parent(#{ <<"index-store">> := IndexStore }, ID, Opts) ->
     NormalizedID = hb_util:native_id(ID),
     ParentPath = <<"parent/", NormalizedID/binary>>,
-    case hb_store:read(IndexStore, ParentPath) of
+    case hb_store:read(IndexStore, ParentPath, Opts) of
         {ok, Bin} ->
             case decode_parent_entries(Bin) of
                 {error, _} = Err -> Err;
@@ -107,7 +107,7 @@ read_parent(#{ <<"index-store">> := IndexStore }, ID) ->
         _ ->
             not_found
     end;
-read_parent(_, _) -> not_found.
+read_parent(_, _, _) -> not_found.
 
 decode_parent_entries(<<>>) -> [];
 decode_parent_entries(<<0, Height:64/big-unsigned, Rest/binary>>) ->

--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -6,7 +6,7 @@
 %%% Unused Store API:
 -export([resolve/3, write/3, link/3, group/3]).
 %%% Indexing API:
--export([store_from_opts/1, write_offset/5, read_offset/2, read_chunks/3]).
+-export([store_from_opts/1, write_offset/5, read_offset/2, read_parent/2, decode_parent_entries/1, read_chunks/3]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -93,6 +93,35 @@ read_offset(StoreOpts = #{ <<"index-store">> := IndexStore }, ID) ->
             not_found
     end;
 read_offset(_, _) -> not_found.
+
+%% @doc Read the parent entries for an item from the index store.
+read_parent(#{ <<"index-store">> := IndexStore }, ID) ->
+    NormalizedID = hb_util:native_id(ID),
+    ParentPath = <<"parent/", NormalizedID/binary>>,
+    case hb_store:read(IndexStore, ParentPath) of
+        {ok, Bin} ->
+            case decode_parent_entries(Bin) of
+                {error, _} = Err -> Err;
+                Entries -> {ok, Entries}
+            end;
+        _ ->
+            not_found
+    end;
+read_parent(_, _) -> not_found.
+
+decode_parent_entries(<<>>) -> [];
+decode_parent_entries(<<0, Height:64/big-unsigned, Rest/binary>>) ->
+    case decode_parent_entries(Rest) of
+        {error, _} = Err -> Err;
+        Tail -> [{Height, block} | Tail]
+    end;
+decode_parent_entries(<<1, ParentID:32/binary, Rest/binary>>) ->
+    case decode_parent_entries(Rest) of
+        {error, _} = Err -> Err;
+        Tail -> [{ParentID, bundle} | Tail]
+    end;
+decode_parent_entries(_Corrupt) ->
+    {error, corrupt_parent_data}.
 
 %% @doc Read the data at the given key, reading the `local-store' first if
 %% available.

--- a/src/hb_store_arweave_offset.erl
+++ b/src/hb_store_arweave_offset.erl
@@ -26,7 +26,7 @@
 %%% to contract to only the number of bytes actually necessary to represent it.
 %%% 
 -module(hb_store_arweave_offset).
--export([encode/3, decode/1, path/1]).
+-export([encode/3, decode/1, path/1, mismatch_path/1]).
 -include("include/hb.hrl").
 
 %% @doc Determine if a value is within a given unsigned bit range.
@@ -41,6 +41,10 @@
 %% of `~arweave@2.9/offset/` implied.
 path(ID) when ?IS_ID(ID) -> hb_util:native_id(ID);
 path(ID) -> throw({cannot_encode_path, ID}).
+
+mismatch_path(ID) when ?IS_ID(ID) ->
+    <<"mismatch/", (hb_util:native_id(ID))/binary>>;
+mismatch_path(ID) -> throw({cannot_encode_mismatch_path, ID}).
 
 %% @doc Encode the offset of the data if it is valid. Throws `cannot_encode_offset'
 %% if invalid.

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -23,6 +23,7 @@
 -export([start/3, stop/3, scope/0, scope/1, reset/3]).
 -export([read/3, write/3, list/3, match/3]).
 -export([group/3, link/3, type/3, resolve/3]).
+-export([overlay_count/1]).
 
 %% Test framework and project includes
 -include_lib("eunit/include/eunit.hrl").
@@ -62,9 +63,12 @@ start(Opts = #{ <<"name">> := DataDir }, _Req, _NodeOpts) ->
                 batch_size,
                 hb_util:int(maps:get(<<"batch-size">>, Opts, ?DEFAULT_BATCH_SIZE))
             },
-            no_mem_init,
-            no_sync
+            no_mem_init
         ] ++
+        case maps:get(<<"sync">>, Opts, false) of
+            true -> [];
+            false -> [no_sync]
+        end ++
         case maps:get(<<"read-ahead">>, Opts, true) of
             true -> [];
             false -> [no_readahead]
@@ -84,7 +88,11 @@ start(Opts = #{ <<"name">> := DataDir }, _Req, _NodeOpts) ->
     % Create the LMDB environment with specified size limit
     {ok, Env} = elmdb:env_open(DataDirPath, EnvOpts),
     {ok, DBInstance} = elmdb:db_open(Env, [create]),
-    {ok, #{ <<"env">> => Env, <<"db">> => DBInstance }};
+    SyncInterval = hb_util:int(maps:get(<<"sync-interval">>, Opts, 0)),
+    MonitorPid = spawn(fun() ->
+        overlay_monitor_loop(Env, DBInstance, DataDir, SyncInterval, 0)
+    end),
+    {ok, #{ <<"env">> => Env, <<"db">> => DBInstance, <<"monitor">> => MonitorPid }};
 start(_Store, _Req, _NodeOpts) ->
     {error, {badarg, <<"StoreOpts must be a map">>}}.
 
@@ -547,8 +555,19 @@ resolve(Opts, #{ <<"resolve">> := Path }, _NodeOpts) ->
 %% @doc Retrieve or create the LMDB environment handle for a database.
 find_env(Opts) -> hb_store:find(Opts).
 
+%% @doc Return the number of writes currently pending in the elmdb overlay.
+%% Safe to call on any live database — does not trigger any I/O.
+-spec overlay_count(map()) -> non_neg_integer().
+overlay_count(Opts) ->
+    #{ <<"db">> := DB } = find_env(Opts),
+    elmdb:overlay_count(DB).
+
 %% Shutdown LMDB environment and cleanup resources
-stop(#{ <<"store-module">> := ?MODULE, <<"name">> := DataDir }, _Req, _Opts) ->
+stop(#{ <<"store-module">> := ?MODULE, <<"name">> := DataDir } = StoreOpts, _Req, _Opts) ->
+    case maps:get(<<"monitor">>, StoreOpts, undefined) of
+        undefined -> ok;
+        Pid -> exit(Pid, shutdown)
+    end,
     % Soft-close by name; refs stay valid and reopen lazily on next access.
     catch elmdb:env_close_by_name(hb_util:list(DataDir)),
     ok;
@@ -593,6 +612,26 @@ sample_metrics(Name, StartTime, Type) ->
         miss -> ok
     end.
 
+%% @doc Periodically samples overlay_count and reports it to Prometheus.
+%% When sync-interval > 0, also calls env_sync every that many seconds,
+%% decoupling durability from the per-commit flush worker path.
+overlay_monitor_loop(Env, DBInstance, StoreName, SyncInterval, SecondsSinceSync) ->
+    receive
+        stop -> ok
+    after 1000 ->
+        Count = elmdb:overlay_count(DBInstance),
+        hb_prometheus:set(gauge, hb_store_lmdb_overlay_count, [StoreName], Count),
+        NextSecondsSinceSync =
+            case SyncInterval > 0 andalso SecondsSinceSync + 1 >= SyncInterval of
+                true ->
+                    elmdb:env_sync(Env),
+                    0;
+                false ->
+                    SecondsSinceSync + 1
+            end,
+        overlay_monitor_loop(Env, DBInstance, StoreName, SyncInterval, NextSecondsSinceSync)
+    end.
+
 init_prometheus() ->
     hb_prometheus:declare(histogram, [
         {name, hb_store_lmdb_duration_seconds},
@@ -604,6 +643,11 @@ init_prometheus() ->
         {name, hb_store_lmdb_hit},
         {labels, [name]},
         {help, "LMDB name requested"}
+    ]),
+    hb_prometheus:declare(gauge, [
+        {name, hb_store_lmdb_overlay_count},
+        {labels, [store_name]},
+        {help, "Number of writes pending in the elmdb overlay for each store"}
     ]),
     ok.
 

--- a/src/hb_store_lmdb.erl
+++ b/src/hb_store_lmdb.erl
@@ -566,7 +566,15 @@ overlay_count(Opts) ->
 stop(#{ <<"store-module">> := ?MODULE, <<"name">> := DataDir } = StoreOpts, _Req, _Opts) ->
     case maps:get(<<"monitor">>, StoreOpts, undefined) of
         undefined -> ok;
-        Pid -> exit(Pid, shutdown)
+        Pid -> 
+            Ref = erlang:monitor(process, Pid),
+            exit(Pid, shutdown),
+            receive
+                {'DOWN', Ref, process, Pid, _Reason} -> ok
+            after 5000 ->
+                erlang:demonitor(Ref, [flush]),
+                ok
+            end
     end,
     % Soft-close by name; refs stay valid and reopen lazily on next access.
     catch elmdb:env_close_by_name(hb_util:list(DataDir)),

--- a/src/include/hb_store_arweave.hrl
+++ b/src/include/hb_store_arweave.hrl
@@ -1,0 +1,3 @@
+-define(SCOPE_PARENT, <<"parent">>).
+-define(SCOPE_OFFSET, <<"offset">>).
+

--- a/test/arbundles.js/upload-items.js
+++ b/test/arbundles.js/upload-items.js
@@ -7,15 +7,15 @@ const BUNDLER_URL = "http://localhost:8734";
 const DEFAULT_WALLET = "../../hyperbeam-key.json";
 const CONCURRENT_UPLOADS = 100; // Number of parallel uploads
 
-async function performanceTest(walletPath, itemCount, bytesPerItem = 0) {
+async function performanceTest(walletPath, itemCount, bytesPerItem = 0, bundlerUrl = BUNDLER_URL) {
   const wallet = require(path.resolve(walletPath));
   const signer = new ArweaveSigner(wallet);
-  const endpoint = `${BUNDLER_URL}/~bundler@1.0/item?codec-device=ans104@1.0`;
+  const endpoint = `${bundlerUrl}/~bundler@1.0/item?codec-device=ans104@1.0`;
 
   console.log("\n" + "=".repeat(70));
   console.log("ANS-104 Bundle Upload Performance Test");
   console.log("=".repeat(70));
-  console.log(`Target:     ${BUNDLER_URL}`);
+  console.log(`Target:     ${bundlerUrl}`);
   console.log(`Items:      ${itemCount}`);
   console.log(`Item Size:  ${bytesPerItem > 0 ? `~${bytesPerItem} bytes` : 'default'}`);
   console.log(`Concurrent: ${CONCURRENT_UPLOADS}`);
@@ -138,23 +138,26 @@ if (require.main === module) {
   const walletPath = firstIsNumber ? DEFAULT_WALLET : (process.argv[2] || DEFAULT_WALLET);
   const itemCount   = parseInt(firstIsNumber ? process.argv[2] : process.argv[3], 10);
   const bytesPerItem = parseInt(firstIsNumber ? process.argv[3] : process.argv[4], 10) || 0;
+  const bundlerUrl = (firstIsNumber ? process.argv[4] : process.argv[5]) || BUNDLER_URL;
 
   if (!itemCount || itemCount < 1 || isNaN(itemCount)) {
-    console.error("Usage: node upload-items.js [wallet_path] <number_of_items> [bytes_per_item]");
+    console.error("Usage: node upload-items.js [wallet_path] <number_of_items> [bytes_per_item] [bundler_url]");
     console.error("");
     console.error("Arguments:");
     console.error("  wallet_path      - Path to Arweave wallet JSON (default: ../../hyperbeam-key.json)");
     console.error("  number_of_items  - Number of data items to create and upload");
     console.error("  bytes_per_item   - Minimum size of each item in bytes (optional)");
+    console.error("  bundler_url      - Bundler base URL (default: " + BUNDLER_URL + ")");
     console.error("");
     console.error("Examples:");
     console.error("  node upload-items.js 100");
     console.error("  node upload-items.js 100 1024");
     console.error("  node upload-items.js /path/to/wallet.json 100 1024");
+    console.error("  node upload-items.js 100 0 http://other-bundler:8734");
     process.exit(1);
   }
 
-  performanceTest(walletPath, itemCount, bytesPerItem)
+  performanceTest(walletPath, itemCount, bytesPerItem, bundlerUrl)
     .then(() => {
       process.exit(0);
     })


### PR DESCRIPTION
## Summary

- Add L1 TX filtering with owner/tag support, offset loading, and block depth indexing (Rani)
- Add tests, refactor internals, improve logging, and fix operational issues (James)
- Add per-block item index with depth tracking and inventory mode
- Add parallel block processing with shared memory budget (configurable workers + byte-level throttling)
- Add parent containment index: track which block or bundle contains each item
- Add `~arweave@2.9/parent=<id>` endpoint for parent lookups

## How to use

### Index blocks

Index a range of blocks at depth 3 (L1 TXs → L2 bundle items → L3 nested items):

```bash
curl "http://localhost:8005/~copycat@1.0/arweave?from=1890000&to=1889000&depth=3"
```

For long-running indexing, use the cron wrapper to avoid HTTP timeout killing the job:

```bash
curl "http://localhost:8005/~cron@1.0/once?cron-path=~copycat@1.0/arweave&from=-1&to=1862995&depth=3"
```

### Query the inventory

See what was indexed per block, grouped by depth level:

```bash
curl "http://localhost:8005/~copycat@1.0/arweave?from=1890000&to=1889990&mode=inventory"
```

Example response:
```json
{
  "1890000": {
    "depth": 3,
    "items": {
      "1": ["txid1", "txid2"],
      "2": ["bundleitem1", "bundleitem2"],
      "3": ["nesteditem1"]
    }
  }
}
```

### Look up an item's parent

Find which block or bundle contains a given item:

```bash
curl "http://localhost:8005/~arweave@2.9/parent=CwxY--7bsqjtw2lneMUjkmYT9CWAYZvsmsO06dY232g"
```

Response:
```json
{"parents": [{"type": "bundle", "id": "Rve4-grgOw8jXLVw3f6nUhQvlVn6AYm7wA4I5HeKW74"}]}
```

## What gets indexed

The copycat indexer writes these entries to the index store:

- **Offset index** (`<item-id>` → codec + offset + length): maps each item to its location in the Arweave weave
- **Block marker** (`block/<height>/depth` → integer): records that a block was indexed and to what depth
- **Block item index** (`block/<height>/items/<depth>` → item IDs): lists items found at each depth level
- **Parent index** (`parent/<item-id>` → type + parent ref): maps each item to its containing block (height) or bundle (ID)

## Configuration

| Key | Default | Description |
|-----|---------|-------------|
| `arweave_block_workers` | 3 | Max concurrent blocks being processed |
| `arweave_index_workers` | 1 | Max concurrent TXs within a block |
| `copycat_memory_budget` | 6 GB | Global memory pool for concurrent downloads |
| `copycat_memory_cap` | 6 GB | Per-TX hard ceiling (skip if larger) |