### PR TITLE
fix: arweave mempool and raw request errors handling

### DIFF
--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -158,7 +158,7 @@ head_raw(Base, Request, Opts) ->
     ?event(debug_raw, {raw, {base, Base}, {request, Request}}),
     case find_key(<<"raw">>, Base, Request, Opts) of
         not_found -> {error, not_found};
-        TXID ->
+        TXID when ?IS_ID(TXID) ->
             % Read the data from the local cache.
             IndexStore = hb_store_arweave:store_from_opts(Opts),
             case hb_store_arweave:read_offset(IndexStore, TXID) of
@@ -182,7 +182,9 @@ head_raw(Base, Request, Opts) ->
                         Opts
                     ),
                     {error, not_found}
-            end
+            end;
+        _ ->
+            {error, not_found}
     end.
 
 %% @doc Arweave transaction headers are not part of the Arweave data tree, and
@@ -1567,6 +1569,20 @@ head_raw_tx_test() ->
     ?assertEqual(
         {ok, 0},
         hb_maps:find(<<"header-length">>, Result, Opts)
+    ).
+
+head_raw_invalid_id_returns_not_found_test() ->
+    ?assertEqual(
+        {error, not_found},
+        hb_ao:resolve(
+            #{ <<"device">> => <<"arweave@2.9">> },
+            #{
+                <<"path">> => <<"raw">>,
+                <<"raw">> => <<"lol">>,
+                <<"method">> => <<"HEAD">>
+            },
+            #{}
+        )
     ).
 
 head_raw_ans104_test() ->

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -1008,37 +1008,39 @@ to_tx_message(Type, ID, Path, {ok, #{ <<"body">> := Body }}, LogExtra, Opts) ->
             {tx, TXHeader}
         }
     ),
-    {ok, Data} =
+    DataRes =
         case hb_opts:get(exclude_data, false, Opts) of
-            true -> {ok, ?DEFAULT_DATA};
+            true ->
+                {ok, ?DEFAULT_DATA};
             false ->
-                DataRes =
-                    case Type of
-                        tx ->
-                            request(<<"GET">>, <<"/raw/", ID/binary>>, Opts);
-                        pending ->
-                            get_chunk_range_relative(
-                                0,
-                                TXHeader#tx.data_size,
-                                ID,
-                                Opts
-                            )
-                    end,
-                case DataRes of
-                    {ok, RawData} -> {ok, RawData};
-                    {error, not_found} -> {ok, ?DEFAULT_DATA};
-                    Error -> Error    
+                case Type of
+                    tx ->
+                        request(<<"GET">>, <<"/raw/", ID/binary>>, Opts);
+                    pending ->
+                        get_chunk_range_relative(
+                            0,
+                            TXHeader#tx.data_size,
+                            ID,
+                            Opts
+                        )
                 end
         end,
-    {
-        ok,
-        hb_message:convert(
-            TXHeader#tx{ data = Data },
-            <<"structured@1.0">>,
-            <<"tx@1.0">>,
-            Opts
-        )
-    }.
+    case DataRes of
+        {ok, RawData} ->
+            {
+                ok,
+                hb_message:convert(
+                    TXHeader#tx{ data = RawData },
+                    <<"structured@1.0">>,
+                    <<"tx@1.0">>,
+                    Opts
+                )
+            };
+        {error, not_found} ->
+            {ok, hb_message:convert(TXHeader, <<"structured@1.0">>, <<"tx@1.0">>, Opts)};
+        Error ->
+            Error
+    end.
 
 event_request(Path, Method, Status, Extra) ->
     BaseList = [{request, {explicit, Path}}, {method, Method}, {status, Status}],
@@ -1213,6 +1215,52 @@ best_response_non_map_error_round_trips_test() ->
         {error, FailedConnect},
         to_message(<<"/tx">>, <<"GET">>, {error, FailedConnect}, [], #{})
     ).
+
+tx_raw_fetch_error_round_trips_test() ->
+    {ok, MockNode, MockHandle} = hb_mock_server:start([
+        {"/raw/:id", tx_raw, {500, <<"boom">>}}
+    ]),
+    ClientOpts = post_tx_json_client_opts(),
+    HeaderBody = post_tx_json_payload(ClientOpts),
+    TXID = maps:get(<<"id">>, hb_json:decode(HeaderBody)),
+    Opts =
+        ClientOpts#{
+            routes => [
+                #{
+                    <<"template">> =>
+                        #{
+                            <<"path">> => <<"^/arweave/raw">>,
+                            <<"method">> => <<"GET">>
+                        },
+                    <<"nodes">> =>
+                        [
+                            #{
+                                <<"match">> => <<"^/arweave">>,
+                                <<"with">> => MockNode,
+                                <<"opts">> => #{ http_client => httpc }
+                            }
+                        ],
+                    <<"parallel">> => 1,
+                    <<"responses">> => 1,
+                    <<"stop-after">> => true,
+                    <<"admissible-status">> => 200
+                }
+            ]
+        },
+    try
+        ?assertMatch(
+            {error, _},
+            to_message(
+                <<"/tx/", TXID/binary>>,
+                <<"GET">>,
+                {ok, #{ <<"body">> => HeaderBody }},
+                [],
+                Opts
+            )
+        )
+    after
+        hb_mock_server:stop(MockHandle)
+    end.
 
 post_tx_json_two_node_test(Node1TxResponse, Node2TxResponse) ->
     {ok, MockNode1, MockHandle1} = hb_mock_server:start([

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -830,6 +830,12 @@ pending(Base, Request, Opts) ->
                     request(<<"GET">>, <<"/unconfirmed_tx/", TXID/binary>>, Opts);
                 {ok, RawOffset} ->
                     try hb_util:int(RawOffset) of
+                        Offset when Offset < 0 ->
+                            {error, #{
+                                <<"status">> => 400,
+                                <<"content-type">> => <<"application/json">>,
+                                <<"body">> => <<"{\"error\":\"invalid_offset\"}">>
+                            }};
                         Offset ->
                             % Download an unconfirmed chunk by its offset
                             request(
@@ -854,7 +860,11 @@ pending(Base, Request, Opts) ->
                             )
                     catch
                         _:_ ->
-                            {error, not_found}
+                            {error, #{
+                                <<"status">> => 400,
+                                <<"content-type">> => <<"application/json">>,
+                                <<"body">> => <<"{\"error\":\"invalid_offset\"}">>
+                            }}
                     end
             end
     end.
@@ -1590,18 +1600,24 @@ head_raw_invalid_id_returns_not_found_test() ->
         )
     ).
 
-pending_invalid_offset_returns_not_found_test() ->
-    ?assertEqual(
-        {error, not_found},
+pending_invalid_offset_returns_invalid_offset_test() ->
+    {error, Error} =
         hb_ao:resolve(
             #{ <<"device">> => <<"arweave@2.9">> },
             #{
                 <<"path">> => <<"pending">>,
-                <<"pending">> => <<"lol">>,
-                <<"offset">> => <<"abc">>
+                <<"pending">> => <<"cat">>,
+                <<"offset">> => <<"dog">>
             },
             #{}
-        )
+        ),
+    ?assertMatch(
+        #{
+            <<"status">> := 400,
+            <<"content-type">> := <<"application/json">>,
+            <<"body">> := <<"{\"error\":\"invalid_offset\"}">>
+        },
+        Error
     ).
 
 head_raw_ans104_test() ->

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -829,28 +829,33 @@ pending(Base, Request, Opts) ->
                     % Retreive a bare TX header by its TXID
                     request(<<"GET">>, <<"/unconfirmed_tx/", TXID/binary>>, Opts);
                 {ok, RawOffset} ->
-                    Offset = hb_util:int(RawOffset),
-                    % Download an unconfirmed chunk by its offset
-                    request(
-                        <<"GET">>,
-                        <<
-                            "/unconfirmed_chunk/",
-                            TXID/binary,
-                            "/",
-                            (hb_util:bin(Offset))/binary
-                        >>,
-                        Opts#{
-                            exclude_data =>
-                                hb_util:bool(
-                                    find_key(
-                                        <<"exclude-data">>,
-                                        Base,
-                                        Request,
-                                        Opts
-                                    )
-                                )
-                        }
-                    )
+                    try hb_util:int(RawOffset) of
+                        Offset ->
+                            % Download an unconfirmed chunk by its offset
+                            request(
+                                <<"GET">>,
+                                <<
+                                    "/unconfirmed_chunk/",
+                                    TXID/binary,
+                                    "/",
+                                    (hb_util:bin(Offset))/binary
+                                >>,
+                                Opts#{
+                                    exclude_data =>
+                                        hb_util:bool(
+                                            find_key(
+                                                <<"exclude-data">>,
+                                                Base,
+                                                Request,
+                                                Opts
+                                            )
+                                        )
+                                }
+                            )
+                    catch
+                        _:_ ->
+                            {error, not_found}
+                    end
             end
     end.
 
@@ -1580,6 +1585,20 @@ head_raw_invalid_id_returns_not_found_test() ->
                 <<"path">> => <<"raw">>,
                 <<"raw">> => <<"lol">>,
                 <<"method">> => <<"HEAD">>
+            },
+            #{}
+        )
+    ).
+
+pending_invalid_offset_returns_not_found_test() ->
+    ?assertEqual(
+        {error, not_found},
+        hb_ao:resolve(
+            #{ <<"device">> => <<"arweave@2.9">> },
+            #{
+                <<"path">> => <<"pending">>,
+                <<"pending">> => <<"lol">>,
+                <<"offset">> => <<"abc">>
             },
             #{}
         )


### PR DESCRIPTION

  ## findings

  - `to_tx_message/6` could crash with `badmatch` on non-`not_found` data fetch errors due to `{ok, Data} = ...`
  - invalid `/raw` ids could throw `cannot_encode_path` (err 500)
  - non-numeric pending chunk offsets could crash with `badarg` in `hb_util:int/1` (err 500)

  ## patches

  -  `to_tx_message/6` now do (as it was doing before #842  ):
    - `{ok, RawData}` -> tx with data
    - `{error, not_found}` -> header only tx
    - other errors -> returned as `Error`
  
- high level guard `head_raw/3` with `?IS_ID`, so invalid `/raw` ids return `not_found` instead of throwing `cannot_encode_path` (vs https://arweave.net/raw/hello)
 - wrap pending offset parsing in `pending/3`, so non-numeric offsets return `not_found` instead of crashing with `badarg`

  ## tests

  - `tx_raw_fetch_error_round_trips_test`
  - `head_raw_invalid_id_returns_not_found_test
  - `pending_invalid_offset_returns_not_found_test`
  
  and all tests pass
  
  ```bash
   [done in 85.576 s]
=======================================================
  All 38 tests passed.
  ```

  ## note

  i noticed that pending offsets still have one edge case:
  - non-numeric offsets like `offset=abc` now resolve locally as `404` (as described in the patch)
  - BUT, negative offsets like `offset=-1` still parse and round-trip upstream arweave nodes, which currently returns `{"error":"invalid_offset"}`

^ 
<img width="1086" height="160" alt="image" src="https://github.com/user-attachments/assets/0d5fc60d-486b-4e5d-84f1-d4b52092c9d5" />

should both be canonalized? hyperbeam mimicking arweave ideally in both cases? 

also should i target feat/mempool-offsets instead of neo/edge @samcamwilliams ?



## followup


* pending/3 offset validation now return error shape equal to arweave node and 400 status code



http://tip-1.arweave.xyz:1984/unconfirmed_chunk/aa/-1 
<img width="1200" height="219" alt="image" src="https://github.com/user-attachments/assets/43c2723a-3708-4d04-a6be-707d36a933a5" />


