### PR TITLE
chore: bump b64rs

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -145,7 +145,7 @@
 
 {deps, [
     {elmdb, {git, "https://github.com/permaweb/elmdb-rs.git", {ref, "de36a64870e671dc325b33d7aa9a368fd6a06db8"}}},
-    {b64rs, {git, "https://github.com/permaweb/b64rs.git", {ref, "c6da6b61634b14e423e8f95ad51a7694bffb2438"}}},
+    {b64rs, {git, "https://github.com/permaweb/b64rs.git", {ref, "94b7d8e51d9a44f3bd12b7d138dd0d2cb74c169f"}}},
     {base32, "1.0.0"},
     {cowlib, "2.16.0"},
 	{cowboy, "2.14.0"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -2,7 +2,7 @@
 [{<<"accept">>,{pkg,<<"accept">>,<<"0.3.7">>},1},
  {<<"b64rs">>,
   {git,"https://github.com/permaweb/b64rs.git",
-       {ref,"c6da6b61634b14e423e8f95ad51a7694bffb2438"}},
+       {ref,"94b7d8e51d9a44f3bd12b7d138dd0d2cb74c169f"}},
   0},
  {<<"base32">>,{pkg,<<"base32">>,<<"1.0.0">>},0},
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.15.0">>},1},


### PR DESCRIPTION
New version handles more "forgiving" base64 cases and adds more proptests to ensure all else is covered.

https://github.com/permaweb/b64rs/commit/94b7d8e51d9a44f3bd12b7d138dd0d2cb74c169f