### PR TITLE
fix: catch throw instead of error

### DIFF
--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -811,7 +811,6 @@ get_schedule(Base, Req, Opts) ->
     From =
         case hb_ao:get(<<"from">>, Req, not_found, Opts) of
             not_found -> 0;
-            X when X < 0 -> 0;
             FromRes -> 
                 case hb_util:safe_int(FromRes) of
                     {ok, FromInt} when FromInt < 0 -> 0;

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -381,7 +381,7 @@ post_schedule(Base, Req, Opts) ->
         ToSched ->
             do_post_schedule(Base, Req, ToSched, Opts)
     catch
-        error:{necessary_message_not_found, _, _} ->
+        throw:{necessary_message_not_found, _, _} ->
             {error,
                 #{
                     <<"status">> => 404,

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -812,49 +812,65 @@ get_schedule(Base, Req, Opts) ->
         case hb_ao:get(<<"from">>, Req, not_found, Opts) of
             not_found -> 0;
             X when X < 0 -> 0;
-            FromRes -> hb_util:int(FromRes)
+            FromRes -> 
+                case hb_util:safe_int(FromRes) of
+                    {ok, FromInt} when FromInt < 0 -> 0;
+                    {ok, FromInt} -> FromInt;
+                    {error, _} -> {error, invalid_from}
+                end
         end,
     To =
         case hb_ao:get(<<"to">>, Req, not_found, Opts) of
             not_found -> undefined;
-            ToRes -> hb_util:int(ToRes)
+            ToRes -> 
+                case hb_util:safe_int(ToRes) of
+                    {ok, ToInt} -> ToInt;
+                    {error, _} -> {error, invalid_to}
+                end
         end,
-    Format = hb_ao:get(<<"accept">>, Req, <<"application/http">>, Opts),
-    ?event(
-        {parsed_get_schedule,
-            {process, ProcID},
-            {from, From},
-            {to, To},
-            {format, Format}
-        }
-    ),
-    case find_server(ProcID, Base, Opts) of
-        {local, _PID} ->
-            generate_local_schedule(Format, ProcID, From, To, Opts);
-        {redirect, Redirect} ->
-            ?event({redirect_received, {redirect, Redirect}}),
-            case hb_opts:get(scheduler_follow_redirects, true, Opts) of
-                true ->
-                    case get_remote_schedule(ProcID, From, To, Redirect, Opts) of
-                        {ok, Res} ->
-                            case uri_string:percent_decode(Format) of
-                                <<"application/aos-2">> ->
-                                    dev_scheduler_formats:assignments_to_aos2(
-                                        ProcID,
-                                        hb_ao:get(
-                                            <<"assignments">>, Res, [], Opts),
-                                        hb_util:atom(hb_ao:get(
-                                            <<"continues">>, Res, false, Opts)),
-                                        Opts
-                                    );
-                                _ ->
-                                    {ok, Res}
+    case {From, To} of
+        {{error, invalid_from}, _} ->
+            {error, #{ <<"status">> => 400, <<"body">> => <<"invalid_from">> }};
+        {_, {error, invalid_to}} ->
+            {error, #{ <<"status">> => 400, <<"body">> => <<"invalid_to">> }};
+        _ ->
+            Format = hb_ao:get(<<"accept">>, Req, <<"application/http">>, Opts),
+            ?event(
+                {parsed_get_schedule,
+                    {process, ProcID},
+                    {from, From},
+                    {to, To},
+                    {format, Format}
+                }
+            ),
+            case find_server(ProcID, Base, Opts) of
+                {local, _PID} ->
+                    generate_local_schedule(Format, ProcID, From, To, Opts);
+                {redirect, Redirect} ->
+                    ?event({redirect_received, {redirect, Redirect}}),
+                    case hb_opts:get(scheduler_follow_redirects, true, Opts) of
+                        true ->
+                            case get_remote_schedule(ProcID, From, To, Redirect, Opts) of
+                                {ok, Res} ->
+                                    case uri_string:percent_decode(Format) of
+                                        <<"application/aos-2">> ->
+                                            dev_scheduler_formats:assignments_to_aos2(
+                                                ProcID,
+                                                hb_ao:get(
+                                                    <<"assignments">>, Res, [], Opts),
+                                                hb_util:atom(hb_ao:get(
+                                                    <<"continues">>, Res, false, Opts)),
+                                                Opts
+                                            );
+                                        _ ->
+                                            {ok, Res}
+                                    end;
+                                {error, Res} ->
+                                    {error, Res}
                             end;
-                        {error, Res} ->
-                            {error, Res}
-                    end;
-                false ->
-                    {ok, Redirect}
+                        false ->
+                            {ok, Redirect}
+                    end
             end
     end.
 


### PR DESCRIPTION
* `post_schedule/3` was catching `error:{...}` but `hb_cache:ensure_all_loaded/2` raises that as a throw
* hardened from/to slot in `get_schedule/3` where it was not validating if the passed From/To is non-numeric, and pass it blindly to `hb_util:int/1` -> crash (throw 500)

also the `X when X < 0 -> 0;` branch was 'flaky'/bypassed given X was binary. switched hb_util:int/1 to hb_util:safe_int/1 and handled invalid non-numeric slot ranges

<img width="1736" height="205" alt="image" src="https://github.com/user-attachments/assets/6e8a0faf-eb07-4eff-8cc6-c7ec19c0c60c" />
<img width="2405" height="1633" alt="image" src="https://github.com/user-attachments/assets/c9bc5fc7-68c0-4daf-819c-0ffd20b8ae8d" />
