### PR TITLE
impr: dev_arweave tests to use inparallel

### DIFF
--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -1047,9 +1047,48 @@ event_request(Path, Method, Status, Extra) ->
 
 %%% Tests
 
+dev_arweave_test_() ->
+    {inparallel, [
+        {timeout, 60, fun test_bundle_header_garbage_guard/0},
+        {timeout, 60, fun test_post_ans104_message/0},
+        {timeout, 60, fun test_post_tx_message/0},
+        {timeout, 60, fun test_post_tx_json_failure/0},
+        {timeout, 60, fun test_post_tx_json_success/0},
+        {timeout, 60, fun test_post_tx_json_mixed_status_prefers_success/0},
+        {timeout, 30, fun test_best_response_handles_failed_connect_entries/0},
+        {timeout, 30, fun test_best_response_non_map_error_round_trips/0},
+        {timeout, 60, fun test_get_tx_basic_data/0},
+        {timeout, 60, fun test_get_tx_split_chunk/0},
+        {timeout, 60, fun test_get_tx_basic_data_exclude_data/0},
+        {timeout, 60, fun test_get_tx_data_tag_exclude_data/0},
+        {timeout, 60, fun test_head_raw_tx/0},
+        {timeout, 60, fun test_head_raw_ans104/0},
+        {timeout, 60, fun test_get_raw_range_tx/0},
+        {timeout, 60, fun test_get_raw_range_ans104/0},
+        {timeout, 60, fun test_get_tx_rsa_nested_bundle/0},
+        {timeout, 60, fun test_get_bad_tx/0},
+        {timeout, 60, fun test_get_partial_chunk_post_split/0},
+        {timeout, 60, fun test_get_full_chunk_post_split/0},
+        {timeout, 60, fun test_get_multi_chunk_post_split/0},
+        {timeout, 60, fun test_get_mid_chunk_post_split/0},
+        {timeout, 60, fun test_get_partial_chunk_pre_split/0},
+        {timeout, 60, fun test_get_full_chunk_pre_split/0},
+        {timeout, 60, fun test_get_multi_chunk_pre_split/0},
+        {timeout, 60, fun test_get_mid_chunk_pre_split/0},
+        {timeout, 60, fun test_get_pre_split_small_chunks/0},
+        {timeout, 60, fun test_get_post_split_small_chunks/0},
+        {timeout, 60, fun test_get_pre_split_gap/0},
+        {timeout, 60, fun test_get_pre_split_small_tx/0},
+        {timeout, 60, fun test_get_ed25519_item/0},
+        {timeout, 60, fun test_bucket_based_offset_fail/0},
+        {timeout, 60, fun test_bucket_based_offset_pass/0},
+        {timeout, 60, fun test_reassemble_bundle1/0},
+        {timeout, 60, fun test_reassemble_bundle2/0}
+    ]}.
+
 %% @doc A fixed bad interior offset from a live TX is rejected by
 %% bundle_header/3 as invalid_bundle_header.
-bundle_header_garbage_guard_test() ->
+test_bundle_header_garbage_guard() ->
     ServerOpts = #{ store => [hb_test_utils:test_store()] },
     _Server = hb_http_server:start_node(ServerOpts),
     ProbeOffset = 376836336327208,
@@ -1060,7 +1099,7 @@ bundle_header_garbage_guard_test() ->
     ).
 
 
-post_ans104_message_test() ->
+test_post_ans104_message() ->
     Port = rand:uniform(10000) + 10000,
     ServerOpts = #{
         store => [hb_test_utils:test_store()],
@@ -1116,7 +1155,7 @@ post_ans104_message_test() ->
         dev_bundler:stop_server()
     end.
 
-post_tx_message_test() ->
+test_post_tx_message() ->
     ServerOpts = #{ store => [hb_test_utils:test_store()] },
     Server = hb_http_server:start_node(ServerOpts),
     ClientOpts =
@@ -1152,7 +1191,7 @@ post_tx_message_test() ->
     ?assertEqual(<<"Transaction verification failed.">>, Body),
     ok.
 
-post_tx_json_failure_test() ->
+test_post_tx_json_failure() ->
     ServerOpts = #{ store => [hb_test_utils:test_store()] },
     Server = hb_http_server:start_node(ServerOpts),
     ClientOpts = post_tx_json_client_opts(),
@@ -1165,7 +1204,7 @@ post_tx_json_failure_test() ->
     ?assertEqual(<<"Transaction verification failed.">>, Body),
     ok.
 
-post_tx_json_success_test() ->
+test_post_tx_json_success() ->
     {Response, Node1Posts, Node2Posts} =
         post_tx_json_two_node_test({200, <<"OK-1">>}, {200, <<"OK-2">>}),
     ?assertMatch({ok, #{ <<"status">> := 200 }}, Response),
@@ -1173,7 +1212,7 @@ post_tx_json_success_test() ->
     ?assertEqual(1, length(Node2Posts)),
     ok.
 
-post_tx_json_mixed_status_prefers_success_test() ->
+test_post_tx_json_mixed_status_prefers_success() ->
     {Response, Node1Posts, Node2Posts} =
         post_tx_json_two_node_test(
             {400, <<"Transaction verification failed.">>},
@@ -1184,7 +1223,7 @@ post_tx_json_mixed_status_prefers_success_test() ->
     ?assertEqual(1, length(Node2Posts)),
     ok.
 
-best_response_handles_failed_connect_entries_test() ->
+test_best_response_handles_failed_connect_entries() ->
     FailedConnect =
         {failed_connect,
             [
@@ -1201,7 +1240,7 @@ best_response_handles_failed_connect_entries_test() ->
         best_response(Responses)
     ).
 
-best_response_non_map_error_round_trips_test() ->
+test_best_response_non_map_error_round_trips() ->
     FailedConnect =
         {failed_connect,
             [
@@ -1301,7 +1340,9 @@ post_tx_json_request(Server, ClientOpts) ->
 
 %% @doc Build isolated test opts and pre-index the blocks for the given TXIDs.
 setup_arweave_index_opts(TXIDs) ->
-    TestStore = hb_test_utils:test_store(hb_store_volatile, <<"arweave-index">>),
+    setup_arweave_index_opts(TXIDs, <<"arweave-index">>).
+setup_arweave_index_opts(TXIDs, Tag) ->
+    TestStore = hb_test_utils:test_store(hb_store_volatile, <<"arweave-index-", Tag/binary>>),
     IndexStore = #{ <<"module">> => hb_store_arweave, <<"index-store">> => [TestStore] },
     Opts = #{
         store => [TestStore],
@@ -1364,7 +1405,7 @@ tx_index_block(<<"jI0A4BASHaUdCCsdv249BxDX6IlE0Ko391TuI6REATw">>) -> 1289677;
 tx_index_block(<<"4FnBmvgWmqXWEEprjVqBsV5aRpAgF6_yJX_GTGsSZjY">>) -> 753012;
 tx_index_block(<<"YR9m4c3CrlljCRYEWBLeoKekbAyYZRMo2Kpz61IeNp8">>) -> 1233918.
 
-get_tx_basic_data_test() ->
+test_get_tx_basic_data() ->
     {ok, Structured} = hb_ao:resolve(
         #{ <<"device">> => <<"arweave@2.9">> },
         #{
@@ -1392,7 +1433,7 @@ get_tx_basic_data_test() ->
     ok.
 
 %% @doc The data for this transaction ends with two smaller chunks.
-get_tx_split_chunk_test() ->
+test_get_tx_split_chunk() ->
     {ok, Structured} = hb_ao:resolve(
         #{ <<"device">> => <<"arweave@2.9">> },
         #{
@@ -1421,7 +1462,7 @@ get_tx_split_chunk_test() ->
         hb_message:id(Child, signed)),
     ok.
 
-get_tx_basic_data_exclude_data_test() ->
+test_get_tx_basic_data_exclude_data() ->
     TXID = <<"ptBC0UwDmrUTBQX3MqZ1lB57ex20ygwzkjjCrQjIx3o">>,
     Opts = setup_arweave_index_opts([TXID]),
     {ok, Structured} = hb_ao:resolve(
@@ -1458,7 +1499,7 @@ get_tx_basic_data_exclude_data_test() ->
     ?assertEqual(<<"PEShWA1ER2jq7CatAPpOZ30TeLrjOSpaf_Po7_hKPo4">>, DataHash),
     ok.
 
-get_tx_data_tag_exclude_data_test() ->
+test_get_tx_data_tag_exclude_data() ->
     TXID = <<"jI0A4BASHaUdCCsdv249BxDX6IlE0Ko391TuI6REATw">>,
     Opts = setup_arweave_index_opts([TXID]),
     {ok, Structured} = hb_ao:resolve(
@@ -1494,7 +1535,7 @@ get_tx_data_tag_exclude_data_test() ->
     ?assertEqual(<<"IHyJ9BlQaHLWVwwklMwV1XEYXGjwx2B6HXNJZ4yJXeQ">>, DataHash),
     ok.
 
-head_raw_tx_test() ->
+test_head_raw_tx() ->
     TXID = <<"ptBC0UwDmrUTBQX3MqZ1lB57ex20ygwzkjjCrQjIx3o">>,
     Opts = setup_arweave_index_opts([TXID]),
     {ok, Result} =
@@ -1521,8 +1562,9 @@ head_raw_tx_test() ->
         hb_maps:find(<<"header-length">>, Result, Opts)
     ).
 
-head_raw_ans104_test() ->
-    Opts = setup_arweave_index_opts([]),
+test_head_raw_ans104() ->
+    %% Need to define a new tag to avoid clash with other parallel tests
+    Opts = setup_arweave_index_opts([], <<"test_head_raw_ans104">>),
     DataItemID = <<"0vy2Ey8bWkSDcRIvWQJjxDeVGYOrTSmYIIhBILJntY8">>,
     BlockBin = hb_util:bin(1_827_942),
     hb_ao:resolve(
@@ -1548,7 +1590,7 @@ head_raw_ans104_test() ->
         hb_maps:find(<<"content-length">>, Result, Opts)
     ).
 
-get_raw_range_tx_test() ->
+test_get_raw_range_tx() ->
     DataItemID = <<"ptBC0UwDmrUTBQX3MqZ1lB57ex20ygwzkjjCrQjIx3o">>,
     Opts = setup_arweave_index_opts([DataItemID]),
     {ok, Result} =
@@ -1588,7 +1630,7 @@ get_raw_range_tx_test() ->
         hb_maps:find(<<"body">>, Result2, Opts)
     ).
 
-get_raw_range_ans104_test() ->
+test_get_raw_range_ans104() ->
     Opts = setup_arweave_index_opts([]),
     DataItemID = <<"0vy2Ey8bWkSDcRIvWQJjxDeVGYOrTSmYIIhBILJntY8">>,
     BlockBin = hb_util:bin(1_827_942),
@@ -1633,7 +1675,7 @@ get_raw_range_ans104_test() ->
         hb_maps:find(<<"body">>, Result2, Opts)
     ).
 
-get_tx_rsa_nested_bundle_test() ->
+test_get_tx_rsa_nested_bundle() ->
     Node = hb_http_server:start_node(),
     Path = <<"/~arweave@2.9/tx=bndIwac23-s0K11TLC1N7z472sLGAkiOdhds87ZywoE">>,
     {ok, Root} = hb_http:get(Node, Path, #{}),
@@ -1676,7 +1718,7 @@ get_tx_rsa_large_bundle_test_disabled() ->
         ok
     end}.
 
-get_bad_tx_test() ->
+test_get_bad_tx() ->
     Node = hb_http_server:start_node(),
     Path = <<"/~arweave@2.9/tx=INVALID-ID">>,
     Res = hb_http:get(Node, Path, #{}),
@@ -1715,7 +1757,7 @@ serialize_data_item_test_disabled() ->
     ?assert(ar_bundles:verify_item(VerifiedItem)),
     ok.
 
-get_partial_chunk_post_split_test() ->
+test_get_partial_chunk_post_split() ->
     %% https://arweave.net/tx/QL7_EnmrFtx-0wVgPr2IwaGWQT8vmPcF3R20CKMO3D4/offset
     %% 
     Offset = 378092137521399,
@@ -1736,7 +1778,7 @@ get_partial_chunk_post_split_test() ->
     ),
     ok.
 
-get_full_chunk_post_split_test() ->
+test_get_full_chunk_post_split() ->
     %% https://arweave.net/tx/QL7_EnmrFtx-0wVgPr2IwaGWQT8vmPcF3R20CKMO3D4/offset
     %% 
     Offset = 378092137521399,
@@ -1757,7 +1799,7 @@ get_full_chunk_post_split_test() ->
     ),
     ok.
 
-get_multi_chunk_post_split_test() ->
+test_get_multi_chunk_post_split() ->
     %% https://arweave.net/tx/QL7_EnmrFtx-0wVgPr2IwaGWQT8vmPcF3R20CKMO3D4/offset
     %% 
     Offset = 378092137521399,
@@ -1780,7 +1822,7 @@ get_multi_chunk_post_split_test() ->
 
 
 %% @doc Query a chunk range that starts and ends in the middle of a chunk.
-get_mid_chunk_post_split_test() ->
+test_get_mid_chunk_post_split() ->
     %% https://arweave.net/tx/QL7_EnmrFtx-0wVgPr2IwaGWQT8vmPcF3R20CKMO3D4/offset
     %% 
     Offset = 378092137521399 + 200_000,
@@ -1801,7 +1843,7 @@ get_mid_chunk_post_split_test() ->
     ),
     ok.
 
-get_partial_chunk_pre_split_test() ->
+test_get_partial_chunk_pre_split() ->
     %% https://arweave.net/tx/v4ophPvV-cNp5gkpkjMuUZ-lf-fBfm1Wk-pB4vJb00E/offset
     %% 
     Offset = 30575701172109,
@@ -1822,7 +1864,7 @@ get_partial_chunk_pre_split_test() ->
     ),
     ok.
 
-get_full_chunk_pre_split_test() ->
+test_get_full_chunk_pre_split() ->
     %% https://arweave.net/tx/v4ophPvV-cNp5gkpkjMuUZ-lf-fBfm1Wk-pB4vJb00E/offset
     %% 
     Offset = 30575701172109,
@@ -1843,7 +1885,7 @@ get_full_chunk_pre_split_test() ->
     ),
     ok.
 
-get_multi_chunk_pre_split_test() ->
+test_get_multi_chunk_pre_split() ->
     %% https://arweave.net/tx/v4ophPvV-cNp5gkpkjMuUZ-lf-fBfm1Wk-pB4vJb00E/offset
     %% 
     Offset = 30575701172109,
@@ -1864,7 +1906,7 @@ get_multi_chunk_pre_split_test() ->
     ),
     ok.
 
-get_mid_chunk_pre_split_test() ->
+test_get_mid_chunk_pre_split() ->
     %% https://arweave.net/tx/v4ophPvV-cNp5gkpkjMuUZ-lf-fBfm1Wk-pB4vJb00E/offset
     %% 
     Offset = 30575701172109 + 200_000,
@@ -1885,7 +1927,7 @@ get_mid_chunk_pre_split_test() ->
     ),
     ok.
 
-get_pre_split_small_chunks_test() ->
+test_get_pre_split_small_chunks() ->
     TXID = <<"4FnBmvgWmqXWEEprjVqBsV5aRpAgF6_yJX_GTGsSZjY">>,
     Opts = setup_arweave_index_opts([TXID]),
     assert_chunk_range(
@@ -1897,7 +1939,7 @@ get_pre_split_small_chunks_test() ->
         Opts
     ).
 
-get_post_split_small_chunks_test() ->
+test_get_post_split_small_chunks() ->
     TXID = <<"YR9m4c3CrlljCRYEWBLeoKekbAyYZRMo2Kpz61IeNp8">>,
     Opts = setup_arweave_index_opts([TXID]),
     assert_chunk_range(
@@ -1909,7 +1951,7 @@ get_post_split_small_chunks_test() ->
         Opts
     ).
 
-get_pre_split_gap_test() ->
+test_get_pre_split_gap() ->
     TXID = <<"VexuG68KCNpw21fGZw1ycRCYBtQMHhl274zGDBh3kQE">>,
     Opts = setup_arweave_index_opts([TXID]),
     assert_chunk_range(
@@ -1921,7 +1963,7 @@ get_pre_split_gap_test() ->
         Opts
     ).
 
-get_pre_split_small_tx_test() ->
+test_get_pre_split_small_tx() ->
     TXID = <<"K4C4dLZ7V4ffYJcR9JtVQwIXCTLD1mMCUaPbHuUdFgw">>,
     Opts = setup_arweave_index_opts([TXID]),
     assert_chunk_range(
@@ -1935,7 +1977,7 @@ get_pre_split_small_tx_test() ->
 
 %% @doc Checks an item that begins in the middle of a chunk - without
 %% special handling get_chunk_range() used to leave off the last few bytes
-get_ed25519_item_test() ->
+test_get_ed25519_item() ->
     TXID = <<"jTFA8XDI_rqmUB6-hhoJF4Yi7p6ZpS_0AByFLU1OPrU">>,
     DataItemID = <<"1rTy7gQuK9lJydlKqCEhtGLp2WWG-GOrVo5JdiCmaxs">>,
     Opts = setup_arweave_index_opts([TXID]),
@@ -1950,7 +1992,7 @@ get_ed25519_item_test() ->
 
 %% @doc this test fails if the chunks are queried with
 %% the `x-bucket-based-offset' header set.
-bucket_based_offset_fail_test() ->
+test_bucket_based_offset_fail() ->
     TXID = <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>,
     DataItemID = <<"z-oKJfhMq5qoVFrljEfiBKgumaJmCWVxNJaavR5aPE8">>,
     Opts = setup_arweave_index_opts([TXID]),
@@ -1965,7 +2007,7 @@ bucket_based_offset_fail_test() ->
 
 %% @doc this dataitem needs the 'x-bucket-based-offset' header set OR
 %% special handling.
-bucket_based_offset_pass_test() ->
+test_bucket_based_offset_pass() ->
     DataItemID = <<"cTI07T1OrF0KZEqPmZji1VTdbeKJG7kMAVlLu7KQvyw">>,
     Opts = setup_arweave_index_opts([]),
     assert_chunk_range(
@@ -1977,10 +2019,10 @@ bucket_based_offset_pass_test() ->
         Opts
     ).
 
-reassemble_bundle1_test() ->
+test_reassemble_bundle1() ->
     assert_bundle_tx(<<"c1-FkhQd-Ul-VpIMR5Vs77lK__BlzHzena2zgNh_hME">>).
 
-reassemble_bundle2_test() ->
+test_reassemble_bundle2() ->
     assert_bundle_tx(<<"OVjj52NvyIys7u84Rv1uqRG2vswlF95QDVPSmsmlwLk">>).
 
 %% @doc This asserts that a bundle is correctly represented in the weave.

--- a/src/dev_manifest.erl
+++ b/src/dev_manifest.erl
@@ -203,7 +203,17 @@ linkify(Manifest, _Opts) ->
 
 %%% Tests
 
-resolve_test() ->
+dev_manifest_test_() ->
+    {inparallel, [
+        {timeout, 60, fun test_resolve/0},
+        {timeout, 60, fun test_manifest_default_fallback/0},
+        {timeout, 60, fun test_manifest_404_error/0},
+        {timeout, 60, fun test_manifest_inner_redirect/0},
+        {timeout, 60, fun test_access_key_path_in_manifest/0},
+        {timeout, 60, fun test_manifest_should_fallback_on_not_found_path/0}
+    ]}.
+
+test_resolve() ->
     Opts = #{
         store => hb_opts:get(store, no_viable_store, #{}),
         on => #{
@@ -263,7 +273,7 @@ resolve_test() ->
         hb_http:get(Node, << LegacyManifestID/binary, "/nested/page2" >>, Opts)),
     ok.
 
-manifest_default_fallback_test() ->
+test_manifest_default_fallback() ->
     Opts = #{ store => hb_opts:get(store, no_viable_store, #{}) },
     {ok, ManifestID} = create_generic_manifest(Opts),
     ?event({manifest_id, ManifestID}),
@@ -274,7 +284,7 @@ manifest_default_fallback_test() ->
     ),
     ok.
 
-manifest_404_error_test() ->
+test_manifest_404_error() ->
     Opts = #{
         store => hb_opts:get(store, no_viable_store, #{}),
         manifest_404 => error
@@ -346,7 +356,7 @@ manifest_download_via_raw_endpoint_test_ignore() ->
     ).
 
 %% @doc Accessing `/TXID` of a manifest transaction should access the index key.
-manifest_inner_redirect_test() ->
+test_manifest_inner_redirect() ->
     Opts = test_env_opts(),
     Node = hb_http_server:start_node(Opts),
     %% Request manifest to node.
@@ -360,7 +370,7 @@ manifest_inner_redirect_test() ->
     ).
 
 %% @doc Accessing `/TXID/assets/ArticleBlock-Dtwjc54T.js` should return valid message.
-access_key_path_in_manifest_test() ->
+test_access_key_path_in_manifest() ->
     Opts = test_env_opts(),
     Node = hb_http_server:start_node(Opts),
     ?assertMatch(
@@ -374,7 +384,7 @@ access_key_path_in_manifest_test() ->
 
 %% This works with `not_found.js` but doesn't follow the logic if under a 
 %% folder structure, like `assets/not_found.js .
-manifest_should_fallback_on_not_found_path_test() ->
+test_manifest_should_fallback_on_not_found_path() ->
     Opts = test_env_opts(),
     Node = hb_http_server:start_node(Opts),
     ?assertMatch(


### PR DESCRIPTION
Improve `dev_arweave` tests from 34s to 14s.
`dev_arweave: test_reassemble_bundle2...[13.671 s] ok` is the one taking longer.

Improve `dev_manifest` tests from 14s to 6s


`dev_copycat_arweave` and `dev_query_test_vectors` fail tests when trying to convert to parallel.

Flaky tests
```
dev_node_process: lookup_spawn_test...*failed*
dev_node_process: lookup_execute_test...*failed*
```