### PR TITLE
fix: non-numeric RawSlot and now/3 scheduler path error handling

### DIFF
--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -224,32 +224,36 @@ compute(Base, Req, Opts) ->
                     {error, not_found}
             end;
         RawSlot ->
-            Slot = hb_util:int(RawSlot),
-            case dev_process_cache:read(ProcID, Slot, Opts) of
-                {ok, Result} ->
-                    % The result is already cached, so we can return it.
-                    ?event(
-                        {compute_result_cached,
-                            {proc_id, ProcID},
-                            {slot, Slot},
-                            {result, Result}
-                        }
-                    ),
-                    {ok, without_snapshot(Result, Opts)};
-                not_found ->
-                    {ok, Loaded} = ensure_loaded(ProcBase, Req, Opts),
-                    ?event(compute,
-                        {computing, {process_id, ProcID},
-                        {to_slot, Slot}},
-                        Opts
-                    ),
-                    compute_to_slot(
-                        ProcID,
-                        Loaded,
-                        Req,
-                        Slot,
-                        Opts
-                    )
+            case hb_util:safe_int(RawSlot) of
+                {ok, Slot} ->
+                    case dev_process_cache:read(ProcID, Slot, Opts) of
+                        {ok, Result} ->
+                            % The result is already cached, so we can return it.
+                            ?event(
+                                {compute_result_cached,
+                                    {proc_id, ProcID},
+                                    {slot, Slot},
+                                    {result, Result}
+                                }
+                            ),
+                            {ok, without_snapshot(Result, Opts)};
+                        not_found ->
+                            {ok, Loaded} = ensure_loaded(ProcBase, Req, Opts),
+                            ?event(compute,
+                                {computing, {process_id, ProcID},
+                                {to_slot, Slot}},
+                                Opts
+                            ),
+                            compute_to_slot(
+                                ProcID,
+                                Loaded,
+                                Req,
+                                Slot,
+                                Opts
+                            )
+                    end;
+                {error, _} ->
+                    {error, invalid_slot}
             end
     end.
 

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -578,18 +578,21 @@ now(RawBase, Req, Opts) ->
     ProcessID = dev_process_lib:process_id(Base, #{}, Opts),
     case hb_opts:get(process_now_from_cache, false, Opts) of
         false ->
-            {ok, CurrentSlot} =
-                hb_ao:resolve(
-                    Base,
-                    #{ <<"path">> => <<"slot/current">> },
-                    Opts
-                ),
-            ?event({now_called, {process, ProcessID}, {slot, CurrentSlot}}),
-            hb_ao:resolve(
+            case hb_ao:resolve(
                 Base,
-                #{ <<"path">> => <<"compute">>, <<"slot">> => CurrentSlot },
+                #{ <<"path">> => <<"slot/current">> },
                 Opts
-            );
+            ) of
+                {ok, CurrentSlot} ->
+                    ?event({now_called, {process, ProcessID}, {slot, CurrentSlot}}),
+                    hb_ao:resolve(
+                        Base,
+                        #{ <<"path">> => <<"compute">>, <<"slot">> => CurrentSlot },
+                        Opts
+                    );
+                {error, _} = Error ->
+                    Error
+            end;
         CacheParam ->
             % We are serving the latest known state from the cache, rather
             % than computing it.

--- a/src/dev_process_test_vectors.erl
+++ b/src/dev_process_test_vectors.erl
@@ -549,6 +549,20 @@ prior_results_accessible_test_() ->
 		)
 	end}.
 
+invalid_compute_slot_test_() ->
+    {timeout, 30, fun() ->
+        Opts = test_opts(),
+        Base = aos_process(Opts),
+        ?assertEqual(
+            {error, invalid_slot},
+            hb_ao:resolve(
+                Base,
+                #{ <<"path">> => <<"compute">>, <<"slot">> => <<"abc">> },
+                Opts
+            )
+        )
+    end}.
+
 persistent_process_test() ->
     {timeout, 30, fun() ->
         Opts = test_opts(),


### PR DESCRIPTION
* `RawSlot` was passed blindly to `hb_util:int/1` where it would crash on non-numeric slots (`<<"abc">>`) - fixed it by switching to case matching `hb_util:safe_int/1`

* `now/3` was hard-matching the resp shape returned by the scheduler slot/current path, dismissing potential {error, Reason} resp shapes. fixed it by doing a safer resp shape case match. N.B : the scheduler slot/current path also have throw path internally, if we want to handle that too instead of 500, we gotta try/catch or address it on shxeduler lvl

* added `invalid_compute_slot_test_` all tests pass

```
  [done in 22.554 s]
=======================================================
  All 18 tests passed.
  ```