### PR TITLE
wip: copycat arweave pending bundles and unconfirmed -> confirmed reads

### DIFF
--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -510,26 +510,32 @@ get_chunk_range_relative(Offset, Length, RelativeTXID, Opts) ->
         ),
     GETFun =
         fun(XOffset) ->
-            pending(
-                #{},
-                #{ <<"offset">> => XOffset, <<"pending">> => RelativeTXID },
-                Opts
+            decode_relative_chunk(
+                pending(
+                    #{},
+                    #{ <<"offset">> => XOffset, <<"pending">> => RelativeTXID },
+                    Opts
+                )
             )
         end,
     case fetch_and_collect(Offsets, GETFun, Opts) of
         {ok, ChunkInfos} ->
-            Concatenated =
-                hb_util:bin(
-                    lists:map(
-                        fun(JSONStruct) ->
-                            hb_util:decode(maps:get(<<"chunk">>, JSONStruct))
-                        end,
-                        ChunkInfos
-                    )
-                ),
-            {ok, Concatenated};
+            assemble_relative_chunks(ChunkInfos, Offset);
         Error -> Error
     end.
+
+assemble_relative_chunks(ChunkInfos, Offset) ->
+    assemble_chunks(ChunkInfos, Offset + 1).
+
+decode_relative_chunk({ok, JSON}) ->
+    Chunk = hb_util:decode(maps:get(<<"chunk">>, JSON)),
+    ChunkEnd = ar_merkle:extract_note(
+        hb_util:decode(maps:get(<<"data_path">>, JSON))
+    ),
+    ChunkStart = ChunkEnd - byte_size(Chunk) + 1,
+    {ok, {ChunkStart, ChunkEnd, Chunk}};
+decode_relative_chunk({error, _} = Err) ->
+    Err.
 
 %% @doc Iteratively detect gaps in coverage and fetch the chunk at the start
 %% of each gap until the entire range [Offset, EndOffset] is covered.
@@ -2020,6 +2026,16 @@ extract_chunk_params_default_length_test() ->
         {ok, 123, 1, undefined},
         extract_chunk_params(#{ <<"offset">> => 123 }, #{})
     ).
+
+assemble_relative_chunks_zero_offset_test() ->
+    {ok, [Chunk]} =
+        assemble_relative_chunks([{1, 5, <<"abcde">>}], 0),
+    ?assertEqual(<<"abcde">>, hb_util:bin(Chunk)).
+
+assemble_relative_chunks_nonzero_offset_test() ->
+    {ok, [Chunk]} =
+        assemble_relative_chunks([{1, 5, <<"abcde">>}], 2),
+    ?assertEqual(<<"cde">>, hb_util:bin(Chunk)).
 
 get_pre_split_small_chunks_test() ->
     TXID = <<"4FnBmvgWmqXWEEprjVqBsV5aRpAgF6_yJX_GTGsSZjY">>,

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -506,33 +506,32 @@ get_chunk_range_variable_size(Offset, EndOffset, Opts) ->
     end.
 
 %% @doc Return a chunk or range of bytes relative to a specific, unconfirmed,
-%% transaction's data root.
+%% transaction's data root. Pending chunk lookups query the only chunk by
+%% `data_size` for single-chunk TXs, otherwise start at 256KiB and advance in
+%% 256KiB steps with a final cap at `data_size`.
 get_chunk_range_relative(Offset, Length, RelativeTXID, Opts) ->
-    hb_prometheus:observe(
-        Length,
-        arweave_chunk_load_requested_bytes,
-        []
-    ),
-    Offsets =
-        generate_offsets(
-            max(1, Offset + 1),
-            (Offset + Length),
-            ?DATA_CHUNK_SIZE
-        ),
-    GETFun =
-        fun(XOffset) ->
-            decode_relative_chunk(
-                pending(
-                    #{},
-                    #{ <<"offset">> => XOffset, <<"pending">> => RelativeTXID },
-                    Opts
-                )
-            )
-        end,
-    case fetch_and_collect(Offsets, GETFun, Opts) of
-        {ok, ChunkInfos} ->
-            assemble_relative_chunks(ChunkInfos, Offset);
-        Error -> Error
+    case pending_tx_data_size(RelativeTXID, Opts) of
+        {ok, DataSize} ->
+            hb_prometheus:observe(
+                Length,
+                arweave_chunk_load_requested_bytes,
+                []
+            ),
+            Offsets = pending_relative_chunk_offsets(Offset, Length, DataSize),
+            GETFun =
+                fun(XOffset) ->
+                    QueryRes = pending_chunk_query(RelativeTXID, XOffset, Opts),
+                    decode_relative_chunk(
+                        QueryRes
+                    )
+                end,
+            case fetch_and_collect(Offsets, GETFun, Opts) of
+                {ok, ChunkInfos} ->
+                    assemble_relative_chunks(ChunkInfos, Offset);
+                Error -> Error
+            end;
+        Error ->
+            Error
     end.
 
 assemble_relative_chunks(ChunkInfos, Offset) ->
@@ -610,6 +609,179 @@ generate_offsets(Current, End, _Step, Acc) when Current > End ->
     Offsets;
 generate_offsets(Current, End, Step, Acc) ->
     generate_offsets(Current + Step, End, Step, [Current | Acc]).
+
+pending_chunk_query(TXID, XOffset, Opts) ->
+    {RetryCount, RetryDelay} = pending_chunk_poll_config(Opts),
+    pending_chunk_query(
+        TXID,
+        XOffset,
+        Opts,
+        RetryCount,
+        RetryDelay,
+        RetryCount,
+        erlang:monotonic_time(millisecond)
+    ).
+
+pending_chunk_query(
+    TXID,
+    XOffset,
+    Opts,
+    RetryCount,
+    RetryDelay,
+    TotalRetries,
+    StartTimeMs
+) ->
+    Attempt = TotalRetries - RetryCount + 1,
+    case pending_chunk_request(TXID, XOffset, Opts) of
+        {error, not_found} when RetryCount > 0 ->
+            maybe_log_pending_chunk_retry(
+                Attempt,
+                TXID,
+                XOffset,
+                RetryDelay,
+                Opts
+            ),
+            timer:sleep(RetryDelay),
+            pending_chunk_query(
+                TXID,
+                XOffset,
+                Opts,
+                RetryCount - 1,
+                RetryDelay,
+                TotalRetries,
+                StartTimeMs
+            );
+        {ok, _} = Result when Attempt > 1 ->
+            pending_chunk_progress(
+                Opts,
+                {pending_chunk_recovered,
+                    {tx_id, {explicit, TXID}},
+                    {offset, XOffset},
+                    {attempt, Attempt},
+                    {
+                        elapsed_ms,
+                        erlang:monotonic_time(millisecond) - StartTimeMs
+                    }}
+            ),
+            Result;
+        {error, not_found} = Result when Attempt > 1 ->
+            pending_chunk_progress(
+                Opts,
+                {pending_chunk_gave_up,
+                    {tx_id, {explicit, TXID}},
+                    {offset, XOffset},
+                    {attempts, Attempt},
+                    {
+                        elapsed_ms,
+                        erlang:monotonic_time(millisecond) - StartTimeMs
+                    }}
+            ),
+            Result;
+        Result ->
+            Result
+    end.
+
+maybe_log_pending_chunk_retry(Attempt, TXID, XOffset, RetryDelay, Opts) ->
+    case Attempt =:= 1 orelse Attempt rem 10 =:= 0 of
+        true ->
+            pending_chunk_progress(
+                Opts,
+                {pending_chunk_retrying,
+                    {tx_id, {explicit, TXID}},
+                    {offset, XOffset},
+                    {attempt, Attempt},
+                    {retry_in_ms, RetryDelay}}
+            );
+        false ->
+            ok
+    end.
+
+pending_chunk_progress(Opts, Event) ->
+    case hb_opts:get(arweave_mempool_progress, false, Opts) of
+        true -> ?event(copycat_short, Event);
+        false -> ok
+    end.
+
+pending_chunk_request(TXID, XOffset, Opts) ->
+    request(
+        <<"GET">>,
+        <<
+            "/unconfirmed_chunk/",
+            TXID/binary,
+            "/",
+            (hb_util:bin(XOffset))/binary
+        >>,
+        Opts
+    ).
+
+pending_chunk_poll_config(Opts) ->
+    RawRetryCount = max(0, hb_opts:get(arweave_pending_chunk_poll_attempts, 0, Opts)),
+    RetryDelay = max(1, hb_opts:get(arweave_pending_chunk_poll_ms, 500, Opts)),
+    MinRetryWindowMs = max(
+        0,
+        hb_opts:get(arweave_pending_chunk_poll_min_ms, 20000, Opts)
+    ),
+    RetryCount =
+        case RawRetryCount of
+            0 -> 0;
+            _ -> max(RawRetryCount, ceil_div(MinRetryWindowMs, RetryDelay))
+        end,
+    {RetryCount, RetryDelay}.
+
+ceil_div(0, _Denominator) -> 0;
+ceil_div(Numerator, Denominator) ->
+    (Numerator + Denominator - 1) div Denominator.
+
+%% @doc Fetch the advertised data size for an unconfirmed transaction.
+pending_tx_data_size(TXID, Opts) ->
+    case pending(#{}, #{ <<"pending">> => TXID }, Opts#{ exclude_data => true }) of
+        {ok, JSON} ->
+            {ok, hb_util:int(maps:get(<<"data_size">>, JSON))};
+        Error ->
+            Error
+    end.
+
+%% @doc Return the pending chunk end offsets using 256KiB stepping with a final
+%% cap at `data_size`.
+pending_relative_chunk_offsets(_Offset, Length, _DataSize) when Length =< 0 ->
+    [];
+pending_relative_chunk_offsets(Offset, _Length, DataSize) when Offset >= DataSize ->
+    [];
+pending_relative_chunk_offsets(Offset, Length, DataSize) ->
+    RangeStart = max(1, Offset + 1),
+    RangeEnd = min(Offset + Length, DataSize),
+    ChunkEnds = pending_chunk_end_offsets(DataSize),
+    pending_relative_chunk_offsets(ChunkEnds, RangeStart, RangeEnd, 0, []).
+
+pending_relative_chunk_offsets(
+    [ChunkEnd | Rest], RangeStart, RangeEnd, PrevEnd, Acc
+) ->
+    ChunkStart = PrevEnd + 1,
+    NewAcc =
+        case chunk_overlaps_range(ChunkStart, ChunkEnd, RangeStart, RangeEnd) of
+            true -> [ChunkEnd | Acc];
+            false -> Acc
+        end,
+    pending_relative_chunk_offsets(Rest, RangeStart, RangeEnd, ChunkEnd, NewAcc);
+pending_relative_chunk_offsets([], _RangeStart, _RangeEnd, _PrevEnd, Acc) ->
+    lists:reverse(Acc).
+
+pending_chunk_end_offsets(DataSize) when DataSize =< ?DATA_CHUNK_SIZE ->
+    [DataSize];
+pending_chunk_end_offsets(DataSize) ->
+    pending_chunk_end_offsets(?DATA_CHUNK_SIZE, DataSize, []).
+
+pending_chunk_end_offsets(Current, DataSize, Acc) when Current < DataSize ->
+    pending_chunk_end_offsets(
+        Current + ?DATA_CHUNK_SIZE,
+        DataSize,
+        [Current | Acc]
+    );
+pending_chunk_end_offsets(_Current, DataSize, Acc) ->
+    lists:reverse([DataSize | Acc]).
+
+chunk_overlaps_range(ChunkStart, ChunkEnd, RangeStart, RangeEnd) ->
+    ChunkEnd >= RangeStart andalso ChunkStart =< RangeEnd.
 
 %% @doc Decode a chunk response into a {Start, End, Binary} tuple.
 %% Runs inside the pmap worker so raw JSON is GC'd per-worker.
@@ -880,48 +1052,27 @@ pending(Base, Request, Opts) ->
                     request(<<"GET">>, <<"/tx/pending">>, Opts)
             end;
         TXID ->
+            ExcludeData =
+                case find_key(<<"exclude-data">>, Base, Request, Opts) of
+                    not_found -> hb_opts:get(exclude_data, false, Opts);
+                    Value -> hb_util:bool(Value)
+                end,
             case hb_maps:find(<<"offset">>, Request, Opts) of
                 error ->
                     % Retreive a bare TX header by its TXID
-                    request(<<"GET">>, <<"/unconfirmed_tx/", TXID/binary>>, Opts);
-                {ok, RawOffset} ->
-                    try hb_util:int(RawOffset) of
-                        Offset when Offset < 0 ->
-                            {error, #{
-                                <<"status">> => 400,
-                                <<"content-type">> => <<"application/json">>,
-                                <<"body">> => <<"{\"error\":\"invalid_offset\"}">>
-                            }};
-                        Offset ->
-                            % Download an unconfirmed chunk by its offset
-                            request(
-                                <<"GET">>,
-                                <<
-                                    "/unconfirmed_chunk/",
-                                    TXID/binary,
-                                    "/",
-                                    (hb_util:bin(Offset))/binary
-                                >>,
-                                Opts#{
-                                    exclude_data =>
-                                        hb_util:bool(
-                                            find_key(
-                                                <<"exclude-data">>,
-                                                Base,
-                                                Request,
-                                                Opts
-                                            )
-                                        )
-                                }
-                            )
-                    catch
-                        _:_ ->
-                            {error, #{
-                                <<"status">> => 400,
-                                <<"content-type">> => <<"application/json">>,
-                                <<"body">> => <<"{\"error\":\"invalid_offset\"}">>
-                            }}
-                    end
+                    request(
+                        <<"GET">>,
+                        <<"/unconfirmed_tx/", TXID/binary>>,
+                        Opts#{
+                            exclude_data => ExcludeData
+                        }
+                    );
+                {ok, _RawOffset} ->
+                    {error, #{
+                        <<"status">> => 400,
+                        <<"content-type">> => <<"application/json">>,
+                        <<"body">> => <<"{\"error\":\"invalid_offset\"}">>
+                    }}
             end
     end.
 
@@ -2052,6 +2203,25 @@ extract_chunk_params_default_length_test() ->
     ?assertEqual(
         {ok, 123, 1, undefined},
         extract_chunk_params(#{ <<"offset">> => 123 }, #{})
+    ).
+
+pending_relative_chunk_offsets_single_chunk_test() ->
+    ?assertEqual([1234], pending_relative_chunk_offsets(0, 1, 1234)),
+    ?assertEqual([1234], pending_relative_chunk_offsets(0, 1234, 1234)).
+
+pending_relative_chunk_offsets_standard_multi_chunk_test() ->
+    DataSize = 315127,
+    ?assertEqual(
+        [?DATA_CHUNK_SIZE],
+        pending_relative_chunk_offsets(0, 1, DataSize)
+    ),
+    ?assertEqual(
+        [DataSize],
+        pending_relative_chunk_offsets(?DATA_CHUNK_SIZE, 1, DataSize)
+    ),
+    ?assertEqual(
+        [?DATA_CHUNK_SIZE, DataSize],
+        pending_relative_chunk_offsets(0, DataSize, DataSize)
     ).
 
 get_pre_split_small_chunks_test() ->

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -215,16 +215,19 @@ head_raw_tx(TXID, Offset, Length, Opts) ->
 %% @doc ANS-104 headers are stored as part of the global Arweave data tree, so
 %% so to read the data associated with their IDs, we must first read the header
 %% chunk, deserialize it, and offset our data read from its starting offset.
-head_raw_ans104(TXID, Offset, Length, _Opts) when not is_integer(Offset) ->
-    {ok, #{
-        <<"raw-id">> => TXID,
-        <<"offset">> => Offset,
-        <<"data-offset">> => Offset,
-        <<"content-type">> => <<"application/octet-stream">>,
-        <<"header-length">> => 0,
-        <<"content-length">> => Length,
-        <<"accept-ranges">> => <<"bytes">>
-    }};
+head_raw_ans104(TXID, Offset, Length, Opts) when not is_integer(Offset) ->
+    HeaderReq =
+        #{
+            <<"path">> => <<"chunk">>,
+            <<"offset">> => Offset,
+            <<"length">> => min(Length, ?DATA_CHUNK_SIZE)
+        },
+    case hb_ao:resolve(#{ <<"device">> => <<"arweave@2.9">> }, HeaderReq, Opts) of
+        {ok, HeaderChunk} ->
+            do_head_raw_ans104(TXID, Offset, Length, HeaderChunk, Opts);
+        {error, Error} ->
+            {error, Error}
+    end;
 head_raw_ans104(TXID, ArweaveOffset, Length, Opts) ->
     ?event(debug_raw, {head_raw_ans104, {txid, TXID}, {arweave_offset, ArweaveOffset}, {length, Length}}),
     HeaderReq =
@@ -250,12 +253,20 @@ do_head_raw_ans104(TXID, ArweaveOffset, Length, Data, _Opts) ->
         #{
             <<"raw-id">> => TXID,
             <<"offset">> => ArweaveOffset,
-            <<"data-offset">> => ArweaveOffset + HeaderSize,
+            <<"data-offset">> => add_ans104_offset(ArweaveOffset, HeaderSize),
             <<"content-type">> => ContentType,
             <<"header-length">> => HeaderSize,
             <<"content-length">> => Length - HeaderSize,
             <<"accept-ranges">> => <<"bytes">>
         }
+    }.
+
+add_ans104_offset(Offset, HeaderSize) when is_integer(Offset) ->
+    Offset + HeaderSize;
+add_ans104_offset(#{ <<"relative">> := ParentID, <<"offset">> := Offset }, HeaderSize) ->
+    #{
+        <<"relative">> => ParentID,
+        <<"offset">> => Offset + HeaderSize
     }.
 
 %% @doc Get raw transaction *data* and `content-type` of an Arweave message.
@@ -2036,6 +2047,12 @@ assemble_relative_chunks_nonzero_offset_test() ->
     {ok, [Chunk]} =
         assemble_relative_chunks([{1, 5, <<"abcde">>}], 2),
     ?assertEqual(<<"cde">>, hb_util:bin(Chunk)).
+
+extract_chunk_params_default_length_test() ->
+    ?assertEqual(
+        {ok, 123, 1, undefined},
+        extract_chunk_params(#{ <<"offset">> => 123 }, #{})
+    ).
 
 get_pre_split_small_chunks_test() ->
     TXID = <<"4FnBmvgWmqXWEEprjVqBsV5aRpAgF6_yJX_GTGsSZjY">>,

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -2199,12 +2199,6 @@ assemble_relative_chunks_nonzero_offset_test() ->
         assemble_relative_chunks([{1, 5, <<"abcde">>}], 2),
     ?assertEqual(<<"cde">>, hb_util:bin(Chunk)).
 
-extract_chunk_params_default_length_test() ->
-    ?assertEqual(
-        {ok, 123, 1, undefined},
-        extract_chunk_params(#{ <<"offset">> => 123 }, #{})
-    ).
-
 pending_relative_chunk_offsets_single_chunk_test() ->
     ?assertEqual([1234], pending_relative_chunk_offsets(0, 1, 1234)),
     ?assertEqual([1234], pending_relative_chunk_offsets(0, 1234, 1234)).

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -862,28 +862,43 @@ pending(Base, Request, Opts) ->
                     % Retreive a bare TX header by its TXID
                     request(<<"GET">>, <<"/unconfirmed_tx/", TXID/binary>>, Opts);
                 {ok, RawOffset} ->
-                    Offset = hb_util:int(RawOffset),
-                    % Download an unconfirmed chunk by its offset
-                    request(
-                        <<"GET">>,
-                        <<
-                            "/unconfirmed_chunk/",
-                            TXID/binary,
-                            "/",
-                            (hb_util:bin(Offset))/binary
-                        >>,
-                        Opts#{
-                            exclude_data =>
-                                hb_util:bool(
-                                    find_key(
-                                        <<"exclude-data">>,
-                                        Base,
-                                        Request,
-                                        Opts
-                                    )
-                                )
-                        }
-                    )
+                    try hb_util:int(RawOffset) of
+                        Offset when Offset < 0 ->
+                            {error, #{
+                                <<"status">> => 400,
+                                <<"content-type">> => <<"application/json">>,
+                                <<"body">> => <<"{\"error\":\"invalid_offset\"}">>
+                            }};
+                        Offset ->
+                            % Download an unconfirmed chunk by its offset
+                            request(
+                                <<"GET">>,
+                                <<
+                                    "/unconfirmed_chunk/",
+                                    TXID/binary,
+                                    "/",
+                                    (hb_util:bin(Offset))/binary
+                                >>,
+                                Opts#{
+                                    exclude_data =>
+                                        hb_util:bool(
+                                            find_key(
+                                                <<"exclude-data">>,
+                                                Base,
+                                                Request,
+                                                Opts
+                                            )
+                                        )
+                                }
+                            )
+                    catch
+                        _:_ ->
+                            {error, #{
+                                <<"status">> => 400,
+                                <<"content-type">> => <<"application/json">>,
+                                <<"body">> => <<"{\"error\":\"invalid_offset\"}">>
+                            }}
+                    end
             end
     end.
 
@@ -1043,7 +1058,7 @@ to_tx_message(Type, ID, Path, {ok, #{ <<"body">> := Body }}, LogExtra, Opts) ->
             {tx, TXHeader}
         }
     ),
-    {ok, Data} =
+    DataRes =
         case (TXHeader#tx.data_size == 0) orelse hb_opts:get(exclude_data, false, Opts) of
             true -> {ok, <<>>};
             false ->
@@ -1058,15 +1073,30 @@ to_tx_message(Type, ID, Path, {ok, #{ <<"body">> := Body }}, LogExtra, Opts) ->
                         )
                 end
         end,
-    {
-        ok,
-        hb_message:convert(
-            TXHeader#tx{ data = Data },
-            <<"structured@1.0">>,
-            <<"tx@1.0">>,
-            Opts
-        )
-    }.
+    case DataRes of
+        {ok, Data} ->
+            {
+                ok,
+                hb_message:convert(
+                    TXHeader#tx{ data = Data },
+                    <<"structured@1.0">>,
+                    <<"tx@1.0">>,
+                    Opts
+                )
+            };
+        {error, not_found} ->
+            {
+                ok,
+                hb_message:convert(
+                    TXHeader#tx{ data = ?DEFAULT_DATA },
+                    <<"structured@1.0">>,
+                    <<"tx@1.0">>,
+                    Opts
+                )
+            };
+        Error ->
+            Error
+    end.
 
 event_request(Path, Method, Status, Extra) ->
     BaseList = [{request, {explicit, Path}}, {method, Method}, {status, Status}],
@@ -1241,6 +1271,52 @@ best_response_non_map_error_round_trips_test() ->
         {error, FailedConnect},
         to_message(<<"/tx">>, <<"GET">>, {error, FailedConnect}, [], #{})
     ).
+
+tx_raw_fetch_error_round_trips_test() ->
+    {ok, MockNode, MockHandle} = hb_mock_server:start([
+        {"/raw/:id", tx_raw, {500, <<"boom">>}}
+    ]),
+    ClientOpts = post_tx_json_client_opts(),
+    HeaderBody = post_tx_json_payload(ClientOpts),
+    TXID = maps:get(<<"id">>, hb_json:decode(HeaderBody)),
+    Opts =
+        ClientOpts#{
+            routes => [
+                #{
+                    <<"template">> =>
+                        #{
+                            <<"path">> => <<"^/arweave/raw">>,
+                            <<"method">> => <<"GET">>
+                        },
+                    <<"nodes">> =>
+                        [
+                            #{
+                                <<"match">> => <<"^/arweave">>,
+                                <<"with">> => MockNode,
+                                <<"opts">> => #{ http_client => httpc }
+                            }
+                        ],
+                    <<"parallel">> => 1,
+                    <<"responses">> => 1,
+                    <<"stop-after">> => true,
+                    <<"admissible-status">> => 200
+                }
+            ]
+        },
+    try
+        ?assertMatch(
+            {error, _},
+            to_message(
+                <<"/tx/", TXID/binary>>,
+                <<"GET">>,
+                {ok, #{ <<"body">> => HeaderBody }},
+                [],
+                Opts
+            )
+        )
+    after
+        hb_mock_server:stop(MockHandle)
+    end.
 
 post_tx_json_two_node_test(Node1TxResponse, Node2TxResponse) ->
     {ok, MockNode1, MockHandle1} = hb_mock_server:start([
@@ -1709,6 +1785,26 @@ get_bad_tx_test() ->
     Path = <<"/~arweave@2.9/tx=INVALID-ID">>,
     Res = hb_http:get(Node, Path, #{}),
     ?assertEqual({error, not_found}, Res).
+
+pending_invalid_offset_returns_invalid_offset_test() ->
+    {error, Error} =
+        hb_ao:resolve(
+            #{ <<"device">> => <<"arweave@2.9">> },
+            #{
+                <<"path">> => <<"pending">>,
+                <<"pending">> => <<"cat">>,
+                <<"offset">> => <<"dog">>
+            },
+            #{}
+        ),
+    ?assertMatch(
+        #{
+            <<"status">> := 400,
+            <<"content-type">> := <<"application/json">>,
+            <<"body">> := <<"{\"error\":\"invalid_offset\"}">>
+        },
+        Error
+    ).
 
 %% @doc: helper test to generate and write a dataitem to disk so that we
 %% can validate it using 3rd-party js libraries and gateways.

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -855,7 +855,13 @@ tx_anchor(_Base, _Request, Opts) ->
 %% nodes, or a specific unconfirmed transaction header by its TXID.
 pending(Base, Request, Opts) ->
     case find_key(<<"pending">>, Base, Request, Opts) of
-        not_found -> request(<<"GET">>, <<"/tx/pending">>, Opts);
+        not_found ->
+            case hb_opts:get(arweave_static_pending_txids, not_found, Opts) of
+                TXIDs when is_list(TXIDs) ->
+                    {ok, TXIDs};
+                _ ->
+                    request(<<"GET">>, <<"/tx/pending">>, Opts)
+            end;
         TXID ->
             case hb_maps:find(<<"offset">>, Request, Opts) of
                 error ->

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -469,7 +469,8 @@ observe_event(MetricName, Fun) ->
     Result.
 
 %% @doc Scan the mempool and index any accessible unconfirmed TXs.
-index_mempool(_Request, Opts) ->
+index_mempool(Request, Opts) ->
+    SenderFilter = mempool_sender_filter(Request, Opts),
     case dev_arweave:pending(#{}, #{}, Opts) of
         {ok, TXIDs} when is_list(TXIDs) ->
             mempool_progress(
@@ -477,7 +478,7 @@ index_mempool(_Request, Opts) ->
                 {mempool_scan_started, {pending_count, length(TXIDs)}}
             ),
             Results = parallel_map(TXIDs,
-                fun(TXID) -> index_mempool_tx(TXID, Opts) end, Opts),
+                fun(TXID) -> index_mempool_tx(TXID, SenderFilter, Opts) end, Opts),
             Summary = lists:foldl(
                 fun mempool_accumulate_result/2,
                 mempool_empty_summary(),
@@ -492,6 +493,23 @@ mempool_progress(Opts, Event) ->
     case hb_opts:get(arweave_mempool_progress, false, Opts) of
         true -> ?event(copycat_short, Event);
         false -> ok
+    end.
+
+mempool_sender_filter(Request, Opts) ->
+    case hb_maps:find(<<"sender">>, Request, Opts) of
+        {ok, Sender} when is_binary(Sender) ->
+            normalize_sender_filter(Sender);
+        _ ->
+            not_found
+    end.
+
+normalize_sender_filter(Sender) when is_binary(Sender) ->
+    case byte_size(Sender) of
+        32 -> hb_util:human_id(Sender);
+        42 -> Sender;
+        43 -> Sender;
+        44 -> Sender;
+        _ -> Sender
     end.
 
 mempool_empty_summary() ->
@@ -516,6 +534,8 @@ mempool_accumulate_result(Result, Acc) ->
 
 mempool_result_summary(existing) ->
     (mempool_empty_summary())#{ existing => 1 };
+mempool_result_summary(filtered) ->
+    mempool_empty_summary();
 mempool_result_summary(indexed) ->
     (mempool_empty_summary())#{ indexed => 1 };
 mempool_result_summary(missing_data) ->
@@ -538,44 +558,14 @@ mempool_result_summary(#{ status := Status } = Result) ->
 mempool_result_summary(_) ->
     (mempool_empty_summary())#{ failed => 1 }.
 
-index_mempool_tx(TXID, Opts) ->
+index_mempool_tx(TXID, SenderFilter, Opts) ->
     mempool_progress(Opts, {mempool_tx_started, {tx_id, {explicit, TXID}}}),
     Result =
-        case is_tx_indexed(TXID, Opts) of
-            true -> existing;
-            false ->
-                mempool_progress(
-                    Opts,
-                    {mempool_tx_header_fetch_started, {tx_id, {explicit, TXID}}}
-                ),
-                case dev_arweave:pending(
-                    #{},
-                    #{ <<"pending">> => TXID },
-                    Opts#{ exclude_data => true }
-                ) of
-                    {ok, StructuredTX} ->
-                        mempool_progress(
-                            Opts,
-                            {mempool_tx_header_fetch_finished,
-                                {tx_id, {explicit, TXID}}}
-                        ),
-                        TX = hb_message:convert(
-                            StructuredTX,
-                            <<"tx@1.0">>,
-                            <<"structured@1.0">>,
-                            Opts
-                        ),
-                        mempool_progress(
-                            Opts,
-                            {mempool_tx_convert_finished,
-                                {tx_id, {explicit, TXID}},
-                                {data_size, TX#tx.data_size},
-                                {bundle, is_bundle_tx(TX, Opts)}}
-                        ),
-                        write_mempool_offsets(TXID, TX, Opts);
-                    _ ->
-                        failed
-                end
+        case SenderFilter of
+            not_found ->
+                index_mempool_tx_unfiltered(TXID, Opts);
+            _ ->
+                index_mempool_tx_filtered(TXID, SenderFilter, Opts)
         end,
     mempool_progress(
         Opts,
@@ -585,8 +575,69 @@ index_mempool_tx(TXID, Opts) ->
     ),
     Result.
 
+index_mempool_tx_unfiltered(TXID, Opts) ->
+    case is_tx_indexed(TXID, Opts) of
+        true -> existing;
+        false ->
+            case load_mempool_tx_header(TXID, Opts) of
+                {ok, TX} -> write_mempool_offsets(TXID, TX, Opts);
+                error -> failed
+            end
+    end.
+
+index_mempool_tx_filtered(TXID, SenderFilter, Opts) ->
+    case load_mempool_tx_header(TXID, Opts) of
+        {ok, TX} ->
+            case mempool_tx_sender_matches(TX, SenderFilter) of
+                false -> filtered;
+                true ->
+                    case is_tx_indexed(TXID, Opts) of
+                        true -> existing;
+                        false -> write_mempool_offsets(TXID, TX, Opts)
+                    end
+            end;
+        error ->
+            failed
+    end.
+
+load_mempool_tx_header(TXID, Opts) ->
+    mempool_progress(
+        Opts,
+        {mempool_tx_header_fetch_started, {tx_id, {explicit, TXID}}}
+    ),
+    case dev_arweave:pending(
+        #{},
+        #{ <<"pending">> => TXID },
+        Opts#{ exclude_data => true }
+    ) of
+        {ok, StructuredTX} ->
+            mempool_progress(
+                Opts,
+                {mempool_tx_header_fetch_finished,
+                    {tx_id, {explicit, TXID}}}
+            ),
+            TX = hb_message:convert(
+                StructuredTX,
+                <<"tx@1.0">>,
+                <<"structured@1.0">>,
+                Opts
+            ),
+            mempool_progress(
+                Opts,
+                {mempool_tx_convert_finished,
+                    {tx_id, {explicit, TXID}},
+                    {data_size, TX#tx.data_size},
+                    {bundle, is_bundle_tx(TX, Opts)}}
+            ),
+            {ok, TX};
+        _ ->
+            error
+    end.
+
 mempool_progress_result(existing) ->
     {status, existing};
+mempool_progress_result(filtered) ->
+    {status, filtered};
 mempool_progress_result(indexed) ->
     {status, indexed};
 mempool_progress_result(missing_data) ->
@@ -599,6 +650,12 @@ mempool_progress_result(#{ status := Status }) ->
     {status, Status};
 mempool_progress_result(_) ->
     {status, failed}.
+
+mempool_tx_sender_matches(TX, SenderFilter) ->
+    case ar_tx:get_owner_address(TX) of
+        not_set -> false;
+        OwnerAddress -> normalize_sender_filter(OwnerAddress) =:= SenderFilter
+    end.
 
 write_mempool_offsets(TXID, TX, Opts) ->
     Store = hb_store_arweave:store_from_opts(Opts),

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -471,7 +471,7 @@ observe_event(MetricName, Fun) ->
 %% @doc Scan the mempool and index any accessible unconfirmed TXs.
 index_mempool(Request, Opts) ->
     SenderFilter = mempool_sender_filter(Request, Opts),
-    case dev_arweave:pending(#{}, #{}, Opts) of
+    case mempool_pending(#{}, #{}, Opts) of
         {ok, TXIDs} when is_list(TXIDs) ->
             mempool_progress(
                 Opts,
@@ -493,6 +493,14 @@ mempool_progress(Opts, Event) ->
     case hb_opts:get(arweave_mempool_progress, false, Opts) of
         true -> ?event(copycat_short, Event);
         false -> ok
+    end.
+
+mempool_pending(Base, Request, Opts) ->
+    case hb_opts:get(arweave_pending_fun, undefined, Opts) of
+        Fun when is_function(Fun, 3) ->
+            Fun(Base, Request, Opts);
+        _ ->
+            dev_arweave:pending(Base, Request, Opts)
     end.
 
 mempool_sender_filter(Request, Opts) ->
@@ -605,11 +613,25 @@ load_mempool_tx_header(TXID, Opts) ->
         Opts,
         {mempool_tx_header_fetch_started, {tx_id, {explicit, TXID}}}
     ),
-    case dev_arweave:pending(
+    case mempool_pending(
         #{},
         #{ <<"pending">> => TXID },
         Opts#{ exclude_data => true }
     ) of
+        {ok, TX} when is_record(TX, tx) ->
+            mempool_progress(
+                Opts,
+                {mempool_tx_header_fetch_finished,
+                    {tx_id, {explicit, TXID}}}
+            ),
+            mempool_progress(
+                Opts,
+                {mempool_tx_convert_finished,
+                    {tx_id, {explicit, TXID}},
+                    {data_size, TX#tx.data_size},
+                    {bundle, is_bundle_tx(TX, Opts)}}
+            ),
+            {ok, TX};
         {ok, StructuredTX} ->
             mempool_progress(
                 Opts,
@@ -827,6 +849,53 @@ mempool_tx_sender_matches_owner_address_test() ->
     TX = #tx{ owner = <<1>>, owner_address = Address },
     ?assert(mempool_tx_sender_matches(TX, hb_util:human_id(Address))),
     ?assertNot(mempool_tx_sender_matches(TX, hb_util:human_id(crypto:strong_rand_bytes(32)))).
+
+mempool_sender_filter_indexes_matching_tx_test() ->
+    TestStore = hb_test_utils:test_store(),
+    IndexStore = #{ <<"index-store">> => [TestStore] },
+    BaseOpts = #{
+        store => [TestStore],
+        arweave_index_ids => true,
+        arweave_index_store => IndexStore
+    },
+    ok = hb_store:reset([TestStore]),
+    ok = hb_store:start([TestStore]),
+    MatchTXID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    OtherTXID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    Sender = <<"FPjbN_btYKzcf8QASjs30v5C0FPv7XpwKXENBW8dqVw">>,
+    MatchTX = mempool_test_pending_tx(Sender),
+    OtherTX = mempool_test_pending_tx(
+        hb_util:human_id(crypto:strong_rand_bytes(32))
+    ),
+    Opts = BaseOpts#{
+        arweave_pending_fun =>
+            fun(_, #{ <<"pending">> := PendingTXID }, _)
+                    when PendingTXID =:= MatchTXID ->
+                    {ok, MatchTX};
+               (_, #{ <<"pending">> := PendingTXID }, _)
+                    when PendingTXID =:= OtherTXID ->
+                    {ok, OtherTX};
+               (_, Request, _) when map_size(Request) =:= 0 ->
+                    {ok, [MatchTXID, OtherTXID]}
+            end
+    },
+    ?assertEqual(
+        {ok, (mempool_empty_summary())#{ indexed => 1, tx_offsets_written => 1 }},
+        arweave(
+            #{},
+            #{ <<"mode">> => <<"mempool">>, <<"sender">> => Sender },
+            Opts
+        )
+    ),
+    ?assert(is_tx_indexed(MatchTXID, Opts)),
+    ?assertNot(is_tx_indexed(OtherTXID, Opts)).
+
+mempool_test_pending_tx(Sender) ->
+    #tx{
+        format = 2,
+        owner = <<1>>,
+        owner_address = Sender
+    }.
 
 index_ids_test() ->
     %% Test block: https://viewblock.io/arweave/block/1827942

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -815,6 +815,19 @@ standalone_item_id(_) -> not_found.
 
 %%% Tests
 
+mempool_result_summary_filtered_test() ->
+    ?assertEqual(mempool_empty_summary(), mempool_result_summary(filtered)).
+
+normalize_sender_filter_binary_address_test() ->
+    Address = crypto:strong_rand_bytes(32),
+    ?assertEqual(hb_util:human_id(Address), normalize_sender_filter(Address)).
+
+mempool_tx_sender_matches_owner_address_test() ->
+    Address = crypto:strong_rand_bytes(32),
+    TX = #tx{ owner = <<1>>, owner_address = Address },
+    ?assert(mempool_tx_sender_matches(TX, hb_util:human_id(Address))),
+    ?assertNot(mempool_tx_sender_matches(TX, hb_util:human_id(crypto:strong_rand_bytes(32)))).
+
 index_ids_test() ->
     %% Test block: https://viewblock.io/arweave/block/1827942
     %% Note: this block includes a data item with an Ethereum signature. This

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -512,21 +512,26 @@ write_mempool_offsets(TXID, TX, Opts) ->
     Store = hb_store_arweave:store_from_opts(Opts),
     ok = hb_store_arweave:write_offset(
         Store, TXID, <<"tx@1.0">>, relative, TX#tx.data_size),
-    write_mempool_children(Store, TXID, TX, Opts),
+    case load_mempool_data(TXID, TX, Opts) of
+        {ok, Data} ->
+            write_mempool_children(Store, TXID, TX, Data, Opts);
+        _ ->
+            ok
+    end,
     ok.
 
-write_mempool_children(Store, TXID, TX, Opts) ->
+write_mempool_children(Store, TXID, TX, Data, Opts) ->
     case is_bundle_tx(TX, Opts) of
         true ->
-            try ar_bundles:decode_bundle_header(TX#tx.data) of
+            try ar_bundles:decode_bundle_header(Data) of
                 {ItemsBin, BundleIndex} ->
-                    HeaderSize = byte_size(TX#tx.data) - byte_size(ItemsBin),
+                    HeaderSize = byte_size(Data) - byte_size(ItemsBin),
                     write_mempool_items(Store, TXID, BundleIndex, HeaderSize);
                 _ -> ok
             catch _:_ -> ok
             end;
         false ->
-            case standalone_item_id(TX) of
+            case standalone_item_id(Data) of
                 {ok, ItemID} ->
                     Ref = #{ <<"relative">> => TXID, <<"offset">> => 0 },
                     hb_store_arweave:write_offset(
@@ -543,7 +548,23 @@ write_mempool_items(Store, TXID, [{ItemID, Size} | Rest], Offset) ->
         Store, hb_util:encode(ItemID), <<"ans104@1.0">>, Ref, Size),
     write_mempool_items(Store, TXID, Rest, Offset + Size).
 
-standalone_item_id(#tx{ data = Data }) when is_binary(Data), Data =/= <<>> ->
+load_mempool_data(_TXID, #tx{ data_size = 0 }, _Opts) ->
+    {ok, <<>>};
+load_mempool_data(TXID, #tx{ data_size = Size }, Opts) when Size > 0 ->
+    hb_ao:resolve(
+        #{ <<"device">> => <<"arweave@2.9">> },
+        #{
+            <<"path">> => <<"chunk">>,
+            <<"offset">> => #{
+                <<"relative">> => TXID,
+                <<"offset">> => 0
+            },
+            <<"length">> => Size
+        },
+        Opts
+    ).
+
+standalone_item_id(Data) when is_binary(Data), Data =/= <<>> ->
     try
         Item = ar_bundles:deserialize(Data),
         case ar_bundles:verify_item(Item) of

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -472,61 +472,174 @@ observe_event(MetricName, Fun) ->
 index_mempool(_Request, Opts) ->
     case dev_arweave:pending(#{}, #{}, Opts) of
         {ok, TXIDs} when is_list(TXIDs) ->
+            mempool_progress(
+                Opts,
+                {mempool_scan_started, {pending_count, length(TXIDs)}}
+            ),
             Results = parallel_map(TXIDs,
                 fun(TXID) -> index_mempool_tx(TXID, Opts) end, Opts),
-            Summary = lists:foldl(fun(R, Acc) ->
-                K = case R of
-                    ok -> indexed; existing -> existing;
-                    missing_data -> missing_data; _ -> failed
-                end,
-                Acc#{ K => maps:get(K, Acc) + 1 }
-            end, #{ indexed => 0, existing => 0,
-                    missing_data => 0, failed => 0 }, Results),
-            ?event(copycat_short, {mempool_scan_completed, Summary}),
+            Summary = lists:foldl(
+                fun mempool_accumulate_result/2,
+                mempool_empty_summary(),
+                Results
+            ),
+            mempool_progress(Opts, {mempool_scan_completed, Summary}),
             {ok, Summary};
         Error -> Error
     end.
 
-index_mempool_tx(TXID, Opts) ->
-    case is_tx_indexed(TXID, Opts) of
-        true -> existing;
-        false ->
-            case dev_arweave:pending(#{}, #{ <<"pending">> => TXID }, Opts) of
-                {ok, StructuredTX} ->
-                    TX = hb_message:convert(StructuredTX,
-                        <<"tx@1.0">>, <<"structured@1.0">>, Opts),
-                    case has_mempool_data(TX) of
-                        true -> write_mempool_offsets(TXID, TX, Opts);
-                        false -> missing_data
-                    end;
-                _ -> failed
-            end
+mempool_progress(Opts, Event) ->
+    case hb_opts:get(arweave_mempool_progress, false, Opts) of
+        true -> ?event(copycat_short, Event);
+        false -> ok
     end.
 
-has_mempool_data(#tx{ data_size = 0 }) -> true;
-has_mempool_data(#tx{ data = D, data_size = S })
-        when is_binary(D) -> byte_size(D) =:= S;
-has_mempool_data(_) -> false.
+mempool_empty_summary() ->
+    #{
+        indexed => 0,
+        existing => 0,
+        missing_data => 0,
+        failed => 0,
+        tx_offsets_written => 0,
+        bundle_txs => 0,
+        items_indexed => 0
+    }.
+
+mempool_accumulate_result(Result, Acc) ->
+    maps:fold(
+        fun(Key, Value, SummaryAcc) ->
+            SummaryAcc#{ Key => maps:get(Key, SummaryAcc) + Value }
+        end,
+        Acc,
+        mempool_result_summary(Result)
+    ).
+
+mempool_result_summary(existing) ->
+    (mempool_empty_summary())#{ existing => 1 };
+mempool_result_summary(indexed) ->
+    (mempool_empty_summary())#{ indexed => 1 };
+mempool_result_summary(missing_data) ->
+    (mempool_empty_summary())#{ missing_data => 1 };
+mempool_result_summary(ok) ->
+    (mempool_empty_summary())#{ indexed => 1 };
+mempool_result_summary(failed) ->
+    (mempool_empty_summary())#{ failed => 1 };
+mempool_result_summary(#{ status := Status } = Result) ->
+    Base = mempool_result_summary(Status),
+    lists:foldl(
+        fun(Key, SummaryAcc) ->
+            SummaryAcc#{
+                Key => maps:get(Key, SummaryAcc) + maps:get(Key, Result, 0)
+            }
+        end,
+        Base,
+        [tx_offsets_written, bundle_txs, items_indexed]
+    );
+mempool_result_summary(_) ->
+    (mempool_empty_summary())#{ failed => 1 }.
+
+index_mempool_tx(TXID, Opts) ->
+    mempool_progress(Opts, {mempool_tx_started, {tx_id, {explicit, TXID}}}),
+    Result =
+        case is_tx_indexed(TXID, Opts) of
+            true -> existing;
+            false ->
+                mempool_progress(
+                    Opts,
+                    {mempool_tx_header_fetch_started, {tx_id, {explicit, TXID}}}
+                ),
+                case dev_arweave:pending(
+                    #{},
+                    #{ <<"pending">> => TXID },
+                    Opts#{ exclude_data => true }
+                ) of
+                    {ok, StructuredTX} ->
+                        mempool_progress(
+                            Opts,
+                            {mempool_tx_header_fetch_finished,
+                                {tx_id, {explicit, TXID}}}
+                        ),
+                        TX = hb_message:convert(
+                            StructuredTX,
+                            <<"tx@1.0">>,
+                            <<"structured@1.0">>,
+                            Opts
+                        ),
+                        mempool_progress(
+                            Opts,
+                            {mempool_tx_convert_finished,
+                                {tx_id, {explicit, TXID}},
+                                {data_size, TX#tx.data_size},
+                                {bundle, is_bundle_tx(TX, Opts)}}
+                        ),
+                        write_mempool_offsets(TXID, TX, Opts);
+                    _ ->
+                        failed
+                end
+        end,
+    mempool_progress(
+        Opts,
+        {mempool_tx_finished,
+            {tx_id, {explicit, TXID}},
+            mempool_progress_result(Result)}
+    ),
+    Result.
+
+mempool_progress_result(existing) ->
+    {status, existing};
+mempool_progress_result(indexed) ->
+    {status, indexed};
+mempool_progress_result(missing_data) ->
+    {status, missing_data};
+mempool_progress_result(ok) ->
+    {status, indexed};
+mempool_progress_result(failed) ->
+    {status, failed};
+mempool_progress_result(#{ status := Status }) ->
+    {status, Status};
+mempool_progress_result(_) ->
+    {status, failed}.
 
 write_mempool_offsets(TXID, TX, Opts) ->
     Store = hb_store_arweave:store_from_opts(Opts),
-    ok = hb_store_arweave:write_offset(
-        Store, TXID, <<"tx@1.0">>, relative, TX#tx.data_size),
+    mempool_progress(
+        Opts,
+        {mempool_data_load_started,
+            {tx_id, {explicit, TXID}},
+            {length, TX#tx.data_size}}
+    ),
     case load_mempool_data(TXID, TX, Opts) of
         {ok, Data} ->
+            mempool_progress(
+                Opts,
+                {mempool_data_loaded,
+                    {tx_id, {explicit, TXID}},
+                    {loaded_bytes, byte_size(Data)}}
+            ),
+            ok = hb_store_arweave:write_offset(
+                Store, TXID, <<"tx@1.0">>, relative, TX#tx.data_size),
             write_mempool_children(Store, TXID, TX, Data, Opts);
-        _ ->
-            ok
-    end,
-    ok.
+        _Error ->
+            #{ status => missing_data }
+    end.
 
 write_mempool_children(Store, TXID, TX, Data, Opts) ->
     case is_bundle_tx(TX, Opts) of
         true ->
             case load_mempool_bundle_index(TXID, Data, Opts) of
                 {ok, HeaderSize, BundleIndex} ->
-                    write_mempool_items(Store, TXID, BundleIndex, HeaderSize);
-                _ -> ok
+                    write_mempool_items(Store, TXID, BundleIndex, HeaderSize),
+                    #{
+                        status => indexed,
+                        tx_offsets_written => 1,
+                        bundle_txs => 1,
+                        items_indexed => length(BundleIndex)
+                    };
+                _Error ->
+                    #{
+                        status => failed,
+                        tx_offsets_written => 1
+                    }
             end;
         false ->
             case standalone_item_id(Data) of
@@ -534,8 +647,17 @@ write_mempool_children(Store, TXID, TX, Data, Opts) ->
                     Ref = #{ <<"relative">> => TXID, <<"offset">> => 0 },
                     hb_store_arweave:write_offset(
                         Store, ItemID, <<"ans104@1.0">>,
-                        Ref, TX#tx.data_size);
-                not_found -> ok
+                        Ref, TX#tx.data_size),
+                    #{
+                        status => indexed,
+                        tx_offsets_written => 1,
+                        items_indexed => 1
+                    };
+                not_found ->
+                    #{
+                        status => indexed,
+                        tx_offsets_written => 1
+                    }
             end
     end.
 
@@ -618,7 +740,11 @@ load_mempool_bundle_index(TXID, <<>>, Opts) ->
         {error, invalid_bundle_header}
     end.
 
-standalone_item_id(Data) when is_binary(Data), Data =/= <<>> ->
+standalone_item_id(<<SigType:2/binary, _/binary>> = Data)
+        when is_binary(Data), Data =/= <<>> ->
+    case lists:member(SigType, [<<1, 0>>, <<2, 0>>, <<3, 0>>, <<4, 0>>, <<7, 0>>]) of
+        false -> not_found;
+        true ->
     try
         Item = ar_bundles:deserialize(Data),
         case ar_bundles:verify_item(Item) of
@@ -626,6 +752,7 @@ standalone_item_id(Data) when is_binary(Data), Data =/= <<>> ->
             false -> not_found
         end
     catch _:_ -> not_found
+    end
     end;
 standalone_item_id(_) -> not_found.
 

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -523,12 +523,10 @@ write_mempool_offsets(TXID, TX, Opts) ->
 write_mempool_children(Store, TXID, TX, Data, Opts) ->
     case is_bundle_tx(TX, Opts) of
         true ->
-            try ar_bundles:decode_bundle_header(Data) of
-                {ItemsBin, BundleIndex} ->
-                    HeaderSize = byte_size(Data) - byte_size(ItemsBin),
+            case load_mempool_bundle_index(TXID, Data, Opts) of
+                {ok, HeaderSize, BundleIndex} ->
                     write_mempool_items(Store, TXID, BundleIndex, HeaderSize);
                 _ -> ok
-            catch _:_ -> ok
             end;
         false ->
             case standalone_item_id(Data) of
@@ -563,6 +561,62 @@ load_mempool_data(TXID, #tx{ data_size = Size }, Opts) when Size > 0 ->
         },
         Opts
     ).
+
+load_mempool_bundle_index(_TXID, Data, _Opts) when is_binary(Data), Data =/= <<>> ->
+    try ar_bundles:decode_bundle_header(Data) of
+        {ItemsBin, BundleIndex} ->
+            {ok, byte_size(Data) - byte_size(ItemsBin), BundleIndex};
+        invalid_bundle_header ->
+            {error, invalid_bundle_header}
+    catch _:_ ->
+        {error, invalid_bundle_header}
+    end;
+load_mempool_bundle_index(TXID, <<>>, Opts) ->
+    try
+        {ok, FirstChunk} =
+            hb_ao:resolve(
+                #{ <<"device">> => <<"arweave@2.9">> },
+                #{
+                    <<"path">> => <<"chunk">>,
+                    <<"offset">> => #{
+                        <<"relative">> => TXID,
+                        <<"offset">> => 0
+                    }
+                },
+                Opts
+            ),
+        case ar_bundles:bundle_header_size(FirstChunk) of
+            invalid_bundle_header ->
+                {error, invalid_bundle_header};
+            HeaderSize when HeaderSize =< byte_size(FirstChunk) ->
+                {_ItemsBin, BundleIndex} =
+                    ar_bundles:decode_bundle_header(
+                        binary:part(FirstChunk, 0, HeaderSize)
+                    ),
+                {ok, HeaderSize, BundleIndex};
+            HeaderSize ->
+                RemainingSize = HeaderSize - byte_size(FirstChunk),
+                {ok, RemainingChunk} =
+                    hb_ao:resolve(
+                        #{ <<"device">> => <<"arweave@2.9">> },
+                        #{
+                            <<"path">> => <<"chunk">>,
+                            <<"offset">> => #{
+                                <<"relative">> => TXID,
+                                <<"offset">> => byte_size(FirstChunk)
+                            },
+                            <<"length">> => RemainingSize
+                        },
+                        Opts
+                    ),
+                HeaderBin = <<FirstChunk/binary, RemainingChunk/binary>>,
+                {_ItemsBin, BundleIndex} =
+                    ar_bundles:decode_bundle_header(HeaderBin),
+                {ok, HeaderSize, BundleIndex}
+        end
+    catch _:_ ->
+        {error, invalid_bundle_header}
+    end.
 
 standalone_item_id(Data) when is_binary(Data), Data =/= <<>> ->
     try

--- a/src/hb_store_arweave.erl
+++ b/src/hb_store_arweave.erl
@@ -159,14 +159,14 @@ root_offset(GlobalOffset, _Store) when is_integer(GlobalOffset) -> GlobalOffset;
 root_offset(Offset, Store) -> root_offset(Offset, 0, Store).
 root_offset(#{ <<"relative">> := P, <<"offset">> := Off }, Acc, Store) ->
     case read_offset(Store, P) of
-        {ok, Next = #{ <<"relative">> := _, <<"offset">> := _ }} ->
+        {ok, #{ <<"offset">> := Next = #{ <<"relative">> := _, <<"offset">> := _ } }} ->
             % We have another relative offset. Continue.
             root_offset(Next, Acc + Off, Store);
-        {ok, relative} ->
+        {ok, #{ <<"offset">> := relative }} ->
             % We have reached an unconfirmed TX as the root of the relative offset
             % chain, so we return an offset against that.
             #{ <<"relative">> => P, <<"offset">> => Acc + Off };
-        {ok, GlobalOffset} when is_integer(GlobalOffset) ->
+        {ok, #{ <<"offset">> := GlobalOffset }} when is_integer(GlobalOffset) ->
             % We have reached a confirmed TX as the root of the relative offset
             % chain, so we return a global offset.
             GlobalOffset + Acc + Off;
@@ -394,3 +394,16 @@ write_read_fake_bundle_tx_test() ->
     {ok, TX} = read(Opts, ID),
     ?assert(hb_message:verify(TX, all, #{})),
     ok.
+
+root_offset_confirmed_parent_test() ->
+    Store = [hb_test_utils:test_store()],
+    Opts = #{ <<"index-store">> => Store },
+    ParentID = <<"bndIwac23-s0K11TLC1N7z472sLGAkiOdhds87ZywoE">>,
+    ok = write_offset(Opts, ParentID, <<"tx@1.0">>, 12345, 99),
+    ?assertEqual(
+        12352,
+        root_offset(
+            #{ <<"relative">> => ParentID, <<"offset">> => 7 },
+            Opts
+        )
+    ).


### PR DESCRIPTION

  ## findings

  - `dev_copycat_arweave:index_mempool_tx/2` & `write_mempool_children/5` were decoding pending bundle members from `TX#tx.data` after `dev_arweave:pending()` -> `hb_message:convert()` - so for pending bundles this is not a reliableand it was producing the wrong child IDs and weird 'insupported ans104 signature threshold'. the source of truth has to be the raw pending bundle bytes

  - `dev_arweave:get_chunk_range_relative/4` was treating arweave's `unconfirmed_chunk/` res like settled chunk res, e.g. pending chunks dont have `absolute_end_offset` field, instead we have to derive chunk boundaries from `data_path`

  - `dev_arweave:head_raw_ans104/4` in the relative-offset branch returned the full serialized ans104 item for pending child `raw=` requests instead of just the data bytes part (similar to how canonical raw/ path work)

  - `dev_arweave:get_chunk/3` and `extract_chunk_params/2` regressed implicit no-`length` chunk and `dev_arweave:bundle_header/2` depends on that path (resulted in correct copycat indexing flow)

  - `hb_store_arweave:root_offset/2` was matching `read_offset/2` results as if they were raw offsets rather than wrapped maps. this meantcchildren first indexed as relative (unconfirmed) did not always normalize correctly once the parent bundle was later indexed as confirmed

  ## patches

  - `dev_arweave:pending/3`
  given arweave's unstable `/unconfirmed_tx` `/unconfirmed_chunk` paths, i added on this branch a temporary `arweave_static_pending_txids` that let us pin a list of recent CONFIRMED txs as return it from pending/3 - given that  /unconfirmed paths works (not very stable tho) for recent confirmed IDs.

  - `dev_copycat_arweave:index_mempool_tx/2` / `write_mempool_children/5`
    - fetch the raw pending bundle body via `~arweave@2.9/chunk` using a relative offset ref:
      - `#{<<"relative">> => TXID, <<"offset">> => 0}`
    - this resolve via `dev_arweave:get_chunk_range_relative/4` into arweave `/unconfirmed_chunk` path
    - decode bundle items/children from those raw pending bytes
    - stop deriving pending child IDs from re-encoded structured tx data

  - `dev_arweave:get_chunk_range_relative/4`
    - decode pending chunk bounds from `data_path`
    - assemble relative reads from the requested byte offset correctly

  - `dev_arweave:head_raw_ans104/4`
    - parse the relative ans104 item header
    - advance `data-offset` by the header size
    - make `raw=<pending_child_item_id>` return payload bytes, matching the settled path

  - `dev_arweave:get_chunk/3` / `extract_chunk_params/2`
    - restore implicit `length = 1` chunk probing when `length` is omitted

  - `hb_store_arweave:root_offset/2`
    - handle `read_offset/2` resp shape correctly
    - collapse relative child refs into global offsets once the parent bundle is confirmed
    
    
 ## NB:
 
 * `arweave_static_pending_txids` is a temporary solution until arweave's `unconfirmed_chunk/` & `unconfirmed_tx/` are stable
 * work on copycat in this PR is based off `feat/mempool-offsets` branch, therefore only L1 TXs and L2 items support (no L-n depth support)

  