### PR TITLE
impr: Update to use latest elmdb-rs code

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -144,7 +144,7 @@
 ]}.
 
 {deps, [
-    {elmdb, {git, "https://github.com/permaweb/elmdb-rs.git", {ref, "de36a64870e671dc325b33d7aa9a368fd6a06db8"}}},
+    {elmdb, {git, "https://github.com/permaweb/elmdb-rs.git", {ref, "06ccf937abc250cb22c782d568efcaa39f5452ff"}}},
     {b64rs, {git, "https://github.com/permaweb/b64rs.git", {ref, "94b7d8e51d9a44f3bd12b7d138dd0d2cb74c169f"}}},
     {base32, "1.0.0"},
     {cowlib, "2.16.0"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -11,7 +11,7 @@
  {<<"ddskerl">>,{pkg,<<"ddskerl">>,<<"0.4.2">>},1},
  {<<"elmdb">>,
   {git,"https://github.com/permaweb/elmdb-rs.git",
-       {ref,"de36a64870e671dc325b33d7aa9a368fd6a06db8"}},
+       {ref,"06ccf937abc250cb22c782d568efcaa39f5452ff"}},
   0},
  {<<"eqwalizer_support">>,
   {git_subdir,"https://github.com/whatsapp/eqwalizer.git",


### PR DESCRIPTION
This will use:
- https://github.com/permaweb/elmdb-rs/pull/10
- https://github.com/permaweb/elmdb-rs/pull/12

These were already tested in production.