### PR TITLE
feat: pass original assignment id on deduped messages

### DIFF
--- a/src/dev_genesis_wasm.erl
+++ b/src/dev_genesis_wasm.erl
@@ -135,6 +135,8 @@ do_compute(State, Req, Opts) ->
                         <<"slot">> =>
                             hb_maps:get(<<"slot">>, Req, -1, Opts),
                         <<"skip">> => true,
+                        <<"original-assignment-id">> => 
+                            hb_message:id(Req, signed, Opts),
                         <<"body">> => 
                             hb_message:commit(
                                 #{

--- a/src/dev_scheduler_formats.erl
+++ b/src/dev_scheduler_formats.erl
@@ -151,7 +151,7 @@ aos2_to_assignment(A, RawOpts) ->
             aos2_normalize_data(AssignmentData),
             Opts
         ),
-        ?event({result_assignment, Assignment}),
+    ?event({result_assignment, Assignment}),
     NormalizedAssignment = aos2_normalize_types(Assignment),
     {ok, Message} =
         case hb_maps:get(<<"message">>, Node, undefined, Opts) of


### PR DESCRIPTION
On dedup messages, which are skipped, now along with "Skip" flag pass the original assignment ID, such that the CU can use it to calculate the hashchain