### PR TITLE
test: document Luerl reference semantics for ao.unset 

### DIFF
--- a/src/dev_lua.erl
+++ b/src/dev_lua.erl
@@ -517,6 +517,20 @@ simple_invocation_test() ->
     },
     ?assertEqual(2, hb_ao:get(<<"assoctable/b">>, Base, #{})).
 
+ao_unset_reference_bug_test() ->
+    {ok, Script} = file:read_file("test/test.lua"),
+    Base = #{
+        <<"device">> => <<"lua@5.3a">>,
+        <<"module">> => #{
+            <<"content-type">> => <<"application/lua">>,
+            <<"body">> => Script
+        },
+        <<"parameters">> => []
+    },
+    {ok, Res} = hb_ao:resolve(Base, <<"ao_unset_reference_bug">>, #{}),
+    ?assertEqual(not_found, hb_ao:get(<<"shared/wallet1">>, Res, #{})),
+    ?assertEqual(<<"__ao-unset__">>, hb_ao:get(<<"targeted/wallet1">>, Res, #{})).
+
 post_invocation_message_validation_test() ->
     {ok, Script} = file:read_file("test/test.lua"),
     Opts = #{ priv_wallet => hb:wallet() },

--- a/test/test.lua
+++ b/test/test.lua
@@ -161,3 +161,18 @@ function inc(base, req, opts)
     base.count = base.count + 1
     return base
 end
+
+function ao_unset_reference_bug(base, req, opts)
+    local Routes = { ["wallet1"] = "__ao-unset__" }
+    local shared = { routes = Routes }
+    Routes["wallet1"] = nil
+
+    local targeted = { routes = {["wallet1"] = "__ao-unset__"} }
+
+    local outbox = {
+        shared = shared.routes,
+        targeted = targeted.routes
+    }
+
+    return outbox
+end


### PR DESCRIPTION
#829 introduced the `ao.unset` sentinel for removing fields from `patch@1.0` cached state. It added `convert_unset_values/1` at the HB boundary so `"__ao-unset__"` strings get converted to the `unset` atom that `dev_message:set/3` treats as a key removal (which in itself was a bug). But the fix only works, till the `"__ao-unset__"` reaches to HB. Found out, it doesn't always.

## The remaining foot-gun

`ao.send or Send()` shallow-clones top-level keys of the message. When a handler does:
                                                                                                                             
```lua                                                                                                                   
  Routes[owner] = ao.unset
  Send({ device = "patch@1.0", routes = Routes })
  Routes[owner] = nil  
```     
...the outbox entry's routes field is a `#tref` pointing to the same Luerl heap table as the global Routes. The post-Send, Routes[owner] = nil calls `ttdict:erase` on the shared table. By the time the Lua func returns and `luerl:call_function_dec` walks the heap to decode the outbox, the sentinel key is gone. `convert_unset_values` never sees it. patch@1.0 device never learns the key should be removed. 
    
## The pattern that works                                                                                                     
   
Use a fresh small table and do not mutate the source between Send & the decode boundary.                                                                                                     

-- Bad: reference leak, nil erases sentinel before patch@1.0 sees it                                                       
```lua
Routes[owner] = ao.unset
Send({ device = "patch@1.0", routes = Routes })                                                                            
Routes[owner] = nil                                                                                                      
```
-- Good: targeted small table, no shared ref to mutate                                                                     
```lua
Routes[owner] = nil
Send({ device = "patch@1.0", routes = {[owner] = ao.unset} })                                                              
```                                                                                                                           
The good pattern is O(1), explicit about intent, and cheaper computation than shallow-cloning the full table inside ao.send (which can be used when there is a multiple update in a single call).                                                                        
  
### This PR                                                                                                                    

Adds `ao_unset_reference_bug_test` in `dev_lua.erl` with a companion Lua func in `test/test.lua`. Two assertions document both semantics:                                                       

- shared/wallet1 -> not_found (reference leak erased the sentinel)
- targeted/wallet1 -> "__ao-unset__" (since, it's kinda new table, it survives)                                                                                                               

Locks in the Luerl reference behavior as a contract and gives future lua process authors an executable reference for the right pattern. 