### PR TITLE
feat: add http_request paranoid mode for outbound message verification

### DIFF
--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -357,6 +357,8 @@ route_to_request(M, {error, Reason}, _Opts) ->
 %% already present in the message, and sets it to `true' if it is not.
 prepare_request(Format, Method, Peer, Path, RawMessage, Opts) ->
     Message = hb_ao:normalize_keys(RawMessage, Opts),
+    % Verify the outbound message if paranoid mode is enabled for http_request
+    hb_message:paranoid_verify(http_request, Message, Opts),
     % Generate a `cookie' key for the message, if an unencoded cookie is
     % present.
     {MaybeCookie, WithoutCookie} =

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -75,6 +75,13 @@
         mode => {"HB_MODE", fun list_to_existing_atom/1},
         paranoid_verify =>
             {"HB_PARANOID", fun topic_list_to_atoms/1, "false"},
+        % Acceptable values for paranoid_verify:
+        %   false - No paranoid verification
+        %   true - Verify all messages in all contexts
+        %   [http_request] - Verify messages in outbound HTTP requests only
+        %   [cache_write] - Verify messages only when writing to cache
+        %   [cache_read] - Verify messages only when reading from cache
+        %   [http_request, cache_write] - Verify in both contexts
         debug_print =>
             {
                 "HB_PRINT",


### PR DESCRIPTION
Adds paranoid verification in `hb_http:prepare_request` for outbound http requests if `HB_PARANOID=http_request` is set