### PR TITLE
perf: memoize node message, leading to ~81% single-step AO-Core exec speedup

### DIFF
--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -141,8 +141,24 @@ default_message_with_env() ->
         ?ENV_KEYS
     ).
 
-%% @doc The default configuration options of the hyperbeam node.
+%% @doc The default configuration options of the hyperbeam node. The result is
+%% memoised in the process dictionary on first call — every subsequent
+%% invocation in the same process returns the cached map without rebuilding
+%% it. The immutable portion of the node config is genuinely constant for the
+%% lifetime of a process, so this is safe; the `cached_os_env/2' helper
+%% applies the same pattern to environment-variable lookups below.
 default_message() ->
+    case erlang:get(default_message) of
+        undefined ->
+            Cached = raw_default_message(),
+            erlang:put(default_message, Cached),
+            Cached;
+        Cached -> Cached
+    end.
+
+%% @doc The raw (uncached) default message. Internal — callers should use
+%% `default_message/0' which memoises this value per-process.
+raw_default_message() ->
     #{
         %%%%%%%% Functional options %%%%%%%%
         hb_config_location => <<"config.flat">>,


### PR DESCRIPTION
Caches the raw default message in the process dictionary on first call; subsequent calls in the same Erlang process return the cached message directly. The default node message only changes at node boot, takes no arguments to generate, and so is maximally cacheable. We were cacheing individual keys from the node opts before, but now we cache the full message, too.

Claude explains the findings in-depth as follows:

Measured impact on hb_ao:resolve/3 (simple, single-step), warm-runtime
escript harness, Opts={store, priv_wallet}:

  before: 17,693/s  (56.5 us/resolve)
  after:  95,382/s  (10.5 us/resolve)
  speedup: 5.4x, or 81% time reduction

The immutable portion of the node config is constant for the lifetime
of an Erlang process, so the cache is always safe; mutating code paths
that need a fresh base (none found in the current tree) can call
raw_default_message/0 directly.

All 2148 targeted tests pass (hb_opts, hb_ao_test_vectors,
hb_message_test_vectors).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
