### PR TITLE
feat: auto-parallelize all `*_test_parallel[_]`tests

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,7 @@
 {erl_opts, [debug_info, {d, 'COWBOY_QUICER', 1}, {d, 'GUN_QUICER', 1}]}.
+% `hb_test_parallel' is used as a parse_transform by every module that
+% includes `hb.hrl' under `-ifdef(TEST)', so it must be compiled first.
+{erl_first_files, ["src/hb_test_parallel.erl"]}.
 {plugins, [pc, rebar3_rustler, rebar_edown_plugin, {rebar3_eunit_start, {git, "https://github.com/permaweb/rebar3_eunit_start.git", {ref, "04ec53fea187039770db0d4459b7aeb01a9021af"}}}]}.
 
 % Increase `scale_timeouts` when running on a slower machine.

--- a/src/hb_test_parallel.erl
+++ b/src/hb_test_parallel.erl
@@ -1,0 +1,175 @@
+%%% @doc A tiny parse_transform plus runtime helper that lets EUnit modules
+%%% opt in to parallel test execution by name.
+%%%
+%%% Any 0-arity function whose name ends in `_test_parallel' or
+%%% `_test_parallel_' is treated as a parallel test: the transform
+%%% auto-exports it and -- when the module does not already define one --
+%%% injects an `all_parallel_test_/0' generator that runs all such
+%%% functions in a single `{inparallel, ...}' EUnit batch.
+%%%
+%%% Because the `_test_parallel' suffix does not match EUnit's own
+%%% `_test'/`_test_' auto-discovery, the original function names are not
+%%% renamed. The name you write is the name that gets compiled, and every
+%%% test runs exactly once.
+%%%
+%%% Activation is by including `hb.hrl', which wires the transform in
+%%% under `-ifdef(TEST)'. Example:
+%%%
+%%% ```
+%%% -include("include/hb.hrl").
+%%%
+%%% foo_test_parallel() -> ?assertEqual(1, 1).
+%%% bar_test_parallel_() -> {timeout, 30, fun() -> ?assert(true) end}.
+%%% '''
+%%%
+%%% That is the whole contract. No manual exports, no hand-written
+%%% generator, and nothing renamed.
+-module(hb_test_parallel).
+-export([parse_transform/2, all/1]).
+
+-define(SIMPLE_SUFFIX, "_test_parallel").
+-define(GENERATOR_SUFFIX, "_test_parallel_").
+-define(GENERATOR_NAME, all_parallel_test_).
+
+%% @doc Runtime helper invoked by the injected `all_parallel_test_/0'
+%% generator. Returns an `{inparallel, [...]}' EUnit test spec covering
+%% every `_test_parallel[_]/0' function exported by `Module'.
+%%
+%% Safe to call from a REPL (`hb_test_parallel:all(dev_name).') to inspect
+%% what the generator will run, which is the primary debugging hook if a
+%% test unexpectedly does or does not appear in the parallel batch.
+all(Module) ->
+    Funs =
+        lists:sort(
+            [
+                F
+            ||
+                {F, 0} <- Module:module_info(exports),
+                    is_parallel_test_name(F)
+            ]
+        ),
+    {inparallel,
+        [
+            {atom_to_list(F), fun Module:F/0}
+        ||
+            F <- Funs
+        ]
+    }.
+
+%%% Compiler entry point.
+
+%% @doc Invoked by the Erlang compiler when a module is compiled with
+%% `-compile({parse_transform, hb_test_parallel}).'. Scans the module's
+%% abstract forms, adds any missing exports for `_test_parallel[_]/0'
+%% functions, and injects `all_parallel_test_/0' when the module does
+%% not supply its own.
+parse_transform(Forms, _Options) ->
+    {Matching, HasGenerator} = scan(Forms),
+    case Matching of
+        [] ->
+            %% No parallel tests in this module; leave the forms alone.
+            Forms;
+        _ ->
+            Exports = exports_to_inject(Matching, HasGenerator),
+            Forms1 = inject_exports(Forms, Exports),
+            case HasGenerator of
+                true -> Forms1;
+                false -> inject_generator(Forms1)
+            end
+    end.
+
+%%% Internal helpers.
+
+%% @doc Scan the forms once, returning the names of matching functions
+%% and whether the user has already defined `all_parallel_test_/0'.
+scan(Forms) ->
+    lists:foldl(
+        fun
+            (
+                {function, _Line, Name, 0, _Clauses},
+                {Matching, HasGenerator}
+            ) ->
+                NowHasGenerator = HasGenerator orelse Name == ?GENERATOR_NAME,
+                case is_parallel_test_name(Name) of
+                    true -> {[Name | Matching], NowHasGenerator};
+                    false -> {Matching, NowHasGenerator}
+                end;
+            (_Other, State) ->
+                State
+        end,
+        {[], false},
+        Forms
+    ).
+
+%% @doc True when `Name' ends in `_test_parallel' or `_test_parallel_'.
+is_parallel_test_name(Name) ->
+    Str = atom_to_list(Name),
+    lists:suffix(?SIMPLE_SUFFIX, Str)
+        orelse lists:suffix(?GENERATOR_SUFFIX, Str).
+
+%% @doc Build the list of `{Name, 0}' entries the transform needs to add
+%% to the module's export table: every matching test, plus the generator
+%% when the transform is going to inject one.
+exports_to_inject(Matching, HasGenerator) ->
+    BaseExports = [{F, 0} || F <- Matching],
+    case HasGenerator of
+        true -> BaseExports;
+        false -> [{?GENERATOR_NAME, 0} | BaseExports]
+    end.
+
+%% @doc Insert a single `-export([...])' attribute just before the first
+%% function definition in `Forms'. The position does not matter for
+%% correctness, but sitting next to the function body makes the injected
+%% attribute easy to find in compiler error messages.
+inject_exports(Forms, Exports) ->
+    inject_exports(Forms, Exports, []).
+
+inject_exports(
+    [Form = {function, Line, _, _, _} | Rest],
+    Exports,
+    Seen
+) ->
+    Attribute = {attribute, Line, export, Exports},
+    lists:reverse(Seen) ++ [Attribute, Form | Rest];
+inject_exports([Form | Rest], Exports, Seen) ->
+    inject_exports(Rest, Exports, [Form | Seen]);
+inject_exports([], _Exports, Seen) ->
+    %% No function definitions in the module; nothing useful to inject
+    %% against. Return the forms unchanged.
+    lists:reverse(Seen).
+
+%% @doc Inject the stub
+%%
+%% ```
+%% all_parallel_test_() -> hb_test_parallel:all(?MODULE).
+%% '''
+%%
+%% just before the module's `eof' marker. The body is a single remote
+%% call; all of the discovery logic lives in `all/1' so that it stays
+%% debuggable at runtime.
+inject_generator(Forms) ->
+    {Before, [Eof]} = lists:split(length(Forms) - 1, Forms),
+    Line =
+        case Eof of
+            {eof, L} -> L;
+            _ -> 1
+        end,
+    Before ++ [generator_form(Line, module_of(Forms)), Eof].
+
+%% @doc Extract the module name from a list of abstract forms.
+module_of(Forms) ->
+    hd([M || {attribute, _, module, M} <- Forms]).
+
+%% @doc Build the abstract form for
+%% `all_parallel_test_() -> hb_test_parallel:all(Module).'.
+generator_form(Line, Module) ->
+    Call =
+        {call, Line,
+            {remote, Line,
+                {atom, Line, ?MODULE},
+                {atom, Line, all}
+            },
+            [{atom, Line, Module}]
+        },
+    Clause = {clause, Line, [], [], [Call]},
+    {function, Line, ?GENERATOR_NAME, 0, [Clause]}.

--- a/src/include/hb.hrl
+++ b/src/include/hb.hrl
@@ -49,3 +49,12 @@
 %% @doc Draw a horizontal line in the logs.
 -define(hr(), io:format(standard_error, "--------------------------------------------------------------------------------~n", [])).
 -define(hr(Str), io:format(standard_error, iolist_to_binary(["---------------------------------------- ", Str, " ----------------------------------------~n"]), [])).
+
+%%% Parallel-test auto-wiring. In a test build, every module that includes
+%%% `hb.hrl' has `hb_test_parallel' activated: 0-arity functions whose
+%%% names end in `_test_parallel' or `_test_parallel_' are exported and
+%%% collected into an injected `all_parallel_test_/0' EUnit generator.
+%%% See `hb_test_parallel' for the contract.
+-ifdef(TEST).
+-compile({parse_transform, hb_test_parallel}).
+-endif.


### PR DESCRIPTION
`hb_test_parallel.erl' is a minimal parse_transform and runtime helper
that lets a test module opt into parallel EUnit execution of specific tests (leaving the others serial) purely by naming convention:

```
    foo_test_parallel()    -> ?assert(...).
    bar_test_parallel_()   -> {timeout, 30, fun() -> ... end}.
```

The transform does two things at compile time:

  * auto-exports every 0-arity function whose name ends in  `_test_parallel' or `_test_parallel_', and
  * (when the module does not already define one) injects
```
        all_parallel_test_() -> hb_test_parallel:all(?MODULE).
```
There is no rename: the names the author writes are the names that
get compiled. EUnit's own auto-discovery only matches `_test' and
`_test_' suffixes, so our `_parallel'-ending names are ignored by it
and only run once, via the injected generator.

Activation is by including `hb.hrl', which wires the transform in under `-ifdef(TEST)'. `rebar.config' sets `erl_first_files' so the transform module compiles before anything that uses it.

No existing modules are converted in this PR -- the infrastructure
lands on its own so that subsequent PRs can migrate individual test
suites module-by-module.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
