### PR TITLE
impr: parallelization and isolation of test suites, cutting full exec time to ~3m.

### DIFF
--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -13,49 +13,6 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--ifdef(TEST).
-%% Test cases exported so `all_tests_test_/0' can run them in parallel via
-%% `fun ?MODULE:name/0'. Each case starts an isolated node so they are safe
-%% to run concurrently.
--export([
-    bundle_header_garbage_guard_tc/0,
-    post_ans104_message_tc/0,
-    post_tx_message_tc/0,
-    post_tx_json_failure_tc/0,
-    post_tx_json_success_tc/0,
-    post_tx_json_mixed_status_prefers_success_tc/0,
-    best_response_handles_failed_connect_entries_tc/0,
-    best_response_non_map_error_round_trips_tc/0,
-    get_tx_basic_data_tc/0,
-    get_tx_split_chunk_tc/0,
-    get_tx_basic_data_exclude_data_tc/0,
-    get_tx_data_tag_exclude_data_tc/0,
-    head_raw_tx_tc/0,
-    head_raw_ans104_tc/0,
-    get_raw_range_tx_tc/0,
-    get_raw_range_ans104_tc/0,
-    get_tx_rsa_nested_bundle_tc/0,
-    get_bad_tx_tc/0,
-    get_partial_chunk_post_split_tc/0,
-    get_full_chunk_post_split_tc/0,
-    get_multi_chunk_post_split_tc/0,
-    get_mid_chunk_post_split_tc/0,
-    get_partial_chunk_pre_split_tc/0,
-    get_full_chunk_pre_split_tc/0,
-    get_multi_chunk_pre_split_tc/0,
-    get_mid_chunk_pre_split_tc/0,
-    get_pre_split_small_chunks_tc/0,
-    get_post_split_small_chunks_tc/0,
-    get_pre_split_gap_tc/0,
-    get_pre_split_small_tx_tc/0,
-    get_ed25519_item_tc/0,
-    bucket_based_offset_fail_tc/0,
-    bucket_based_offset_pass_tc/0,
-    reassemble_bundle1_tc/0,
-    reassemble_bundle2_tc/0
-]).
--endif.
-
 -define(IS_BLOCK_ID(X), (is_binary(X) andalso byte_size(X) == 64)).
 
 %% @doc Route unknown keys through offset resolution first, then fall back to
@@ -1091,57 +1048,9 @@ event_request(Path, Method, Status, Extra) ->
 
 %%% Tests
 
-%% @doc Run every test in this module in parallel. Each case starts its own
-%% node with a fresh store, so there is no shared state to race on. This cuts
-%% the module's wall time from ~19s serial to roughly the slowest test.
-all_tests_test_() ->
-    {inparallel,
-        [
-            {atom_to_list(F), fun ?MODULE:F/0}
-        ||
-            F <- [
-                bundle_header_garbage_guard_tc,
-                post_ans104_message_tc,
-                post_tx_message_tc,
-                post_tx_json_failure_tc,
-                post_tx_json_success_tc,
-                post_tx_json_mixed_status_prefers_success_tc,
-                best_response_handles_failed_connect_entries_tc,
-                best_response_non_map_error_round_trips_tc,
-                get_tx_basic_data_tc,
-                get_tx_split_chunk_tc,
-                get_tx_basic_data_exclude_data_tc,
-                get_tx_data_tag_exclude_data_tc,
-                head_raw_tx_tc,
-                head_raw_ans104_tc,
-                get_raw_range_tx_tc,
-                get_raw_range_ans104_tc,
-                get_tx_rsa_nested_bundle_tc,
-                get_bad_tx_tc,
-                get_partial_chunk_post_split_tc,
-                get_full_chunk_post_split_tc,
-                get_multi_chunk_post_split_tc,
-                get_mid_chunk_post_split_tc,
-                get_partial_chunk_pre_split_tc,
-                get_full_chunk_pre_split_tc,
-                get_multi_chunk_pre_split_tc,
-                get_mid_chunk_pre_split_tc,
-                get_pre_split_small_chunks_tc,
-                get_post_split_small_chunks_tc,
-                get_pre_split_gap_tc,
-                get_pre_split_small_tx_tc,
-                get_ed25519_item_tc,
-                bucket_based_offset_fail_tc,
-                bucket_based_offset_pass_tc,
-                reassemble_bundle1_tc,
-                reassemble_bundle2_tc
-            ]
-        ]
-    }.
-
 %% @doc A fixed bad interior offset from a live TX is rejected by
 %% bundle_header/3 as invalid_bundle_header.
-bundle_header_garbage_guard_tc() ->
+bundle_header_garbage_guard_test_parallel() ->
     ServerOpts = #{ store => [hb_test_utils:test_store()] },
     _Server = hb_http_server:start_node(ServerOpts),
     ProbeOffset = 376836336327208,
@@ -1152,7 +1061,7 @@ bundle_header_garbage_guard_tc() ->
     ).
 
 
-post_ans104_message_tc() ->
+post_ans104_message_test_parallel() ->
     Port = rand:uniform(10000) + 10000,
     ServerOpts = #{
         store => [hb_test_utils:test_store()],
@@ -1208,7 +1117,7 @@ post_ans104_message_tc() ->
         dev_bundler:stop_server()
     end.
 
-post_tx_message_tc() ->
+post_tx_message_test_parallel() ->
     ServerOpts = #{ store => [hb_test_utils:test_store()] },
     Server = hb_http_server:start_node(ServerOpts),
     ClientOpts =
@@ -1244,7 +1153,7 @@ post_tx_message_tc() ->
     ?assertEqual(<<"Transaction verification failed.">>, Body),
     ok.
 
-post_tx_json_failure_tc() ->
+post_tx_json_failure_test_parallel() ->
     ServerOpts = #{ store => [hb_test_utils:test_store()] },
     Server = hb_http_server:start_node(ServerOpts),
     ClientOpts = post_tx_json_client_opts(),
@@ -1257,7 +1166,7 @@ post_tx_json_failure_tc() ->
     ?assertEqual(<<"Transaction verification failed.">>, Body),
     ok.
 
-post_tx_json_success_tc() ->
+post_tx_json_success_test_parallel() ->
     {Response, Node1Posts, Node2Posts} =
         post_tx_json_two_node_test({200, <<"OK-1">>}, {200, <<"OK-2">>}),
     ?assertMatch({ok, #{ <<"status">> := 200 }}, Response),
@@ -1265,7 +1174,7 @@ post_tx_json_success_tc() ->
     ?assertEqual(1, length(Node2Posts)),
     ok.
 
-post_tx_json_mixed_status_prefers_success_tc() ->
+post_tx_json_mixed_status_prefers_success_test_parallel() ->
     {Response, Node1Posts, Node2Posts} =
         post_tx_json_two_node_test(
             {400, <<"Transaction verification failed.">>},
@@ -1276,7 +1185,7 @@ post_tx_json_mixed_status_prefers_success_tc() ->
     ?assertEqual(1, length(Node2Posts)),
     ok.
 
-best_response_handles_failed_connect_entries_tc() ->
+best_response_handles_failed_connect_entries_test_parallel() ->
     FailedConnect =
         {failed_connect,
             [
@@ -1293,7 +1202,7 @@ best_response_handles_failed_connect_entries_tc() ->
         best_response(Responses)
     ).
 
-best_response_non_map_error_round_trips_tc() ->
+best_response_non_map_error_round_trips_test_parallel() ->
     FailedConnect =
         {failed_connect,
             [
@@ -1456,7 +1365,7 @@ tx_index_block(<<"jI0A4BASHaUdCCsdv249BxDX6IlE0Ko391TuI6REATw">>) -> 1289677;
 tx_index_block(<<"4FnBmvgWmqXWEEprjVqBsV5aRpAgF6_yJX_GTGsSZjY">>) -> 753012;
 tx_index_block(<<"YR9m4c3CrlljCRYEWBLeoKekbAyYZRMo2Kpz61IeNp8">>) -> 1233918.
 
-get_tx_basic_data_tc() ->
+get_tx_basic_data_test_parallel() ->
     {ok, Structured} = hb_ao:resolve(
         #{ <<"device">> => <<"arweave@2.9">> },
         #{
@@ -1484,7 +1393,7 @@ get_tx_basic_data_tc() ->
     ok.
 
 %% @doc The data for this transaction ends with two smaller chunks.
-get_tx_split_chunk_tc() ->
+get_tx_split_chunk_test_parallel() ->
     {ok, Structured} = hb_ao:resolve(
         #{ <<"device">> => <<"arweave@2.9">> },
         #{
@@ -1513,7 +1422,7 @@ get_tx_split_chunk_tc() ->
         hb_message:id(Child, signed)),
     ok.
 
-get_tx_basic_data_exclude_data_tc() ->
+get_tx_basic_data_exclude_data_test_parallel() ->
     TXID = <<"ptBC0UwDmrUTBQX3MqZ1lB57ex20ygwzkjjCrQjIx3o">>,
     Opts = setup_arweave_index_opts([TXID]),
     {ok, Structured} = hb_ao:resolve(
@@ -1550,7 +1459,7 @@ get_tx_basic_data_exclude_data_tc() ->
     ?assertEqual(<<"PEShWA1ER2jq7CatAPpOZ30TeLrjOSpaf_Po7_hKPo4">>, DataHash),
     ok.
 
-get_tx_data_tag_exclude_data_tc() ->
+get_tx_data_tag_exclude_data_test_parallel() ->
     TXID = <<"jI0A4BASHaUdCCsdv249BxDX6IlE0Ko391TuI6REATw">>,
     Opts = setup_arweave_index_opts([TXID]),
     {ok, Structured} = hb_ao:resolve(
@@ -1586,7 +1495,7 @@ get_tx_data_tag_exclude_data_tc() ->
     ?assertEqual(<<"IHyJ9BlQaHLWVwwklMwV1XEYXGjwx2B6HXNJZ4yJXeQ">>, DataHash),
     ok.
 
-head_raw_tx_tc() ->
+head_raw_tx_test_parallel() ->
     TXID = <<"ptBC0UwDmrUTBQX3MqZ1lB57ex20ygwzkjjCrQjIx3o">>,
     Opts = setup_arweave_index_opts([TXID]),
     {ok, Result} =
@@ -1613,7 +1522,7 @@ head_raw_tx_tc() ->
         hb_maps:find(<<"header-length">>, Result, Opts)
     ).
 
-head_raw_ans104_tc() ->
+head_raw_ans104_test_parallel() ->
     Opts = setup_arweave_index_opts([]),
     DataItemID = <<"0vy2Ey8bWkSDcRIvWQJjxDeVGYOrTSmYIIhBILJntY8">>,
     BlockBin = hb_util:bin(1_827_942),
@@ -1640,7 +1549,7 @@ head_raw_ans104_tc() ->
         hb_maps:find(<<"content-length">>, Result, Opts)
     ).
 
-get_raw_range_tx_tc() ->
+get_raw_range_tx_test_parallel() ->
     DataItemID = <<"ptBC0UwDmrUTBQX3MqZ1lB57ex20ygwzkjjCrQjIx3o">>,
     Opts = setup_arweave_index_opts([DataItemID]),
     {ok, Result} =
@@ -1680,7 +1589,7 @@ get_raw_range_tx_tc() ->
         hb_maps:find(<<"body">>, Result2, Opts)
     ).
 
-get_raw_range_ans104_tc() ->
+get_raw_range_ans104_test_parallel() ->
     Opts = setup_arweave_index_opts([]),
     DataItemID = <<"0vy2Ey8bWkSDcRIvWQJjxDeVGYOrTSmYIIhBILJntY8">>,
     BlockBin = hb_util:bin(1_827_942),
@@ -1725,7 +1634,7 @@ get_raw_range_ans104_tc() ->
         hb_maps:find(<<"body">>, Result2, Opts)
     ).
 
-get_tx_rsa_nested_bundle_tc() ->
+get_tx_rsa_nested_bundle_test_parallel() ->
     Node = hb_http_server:start_node(),
     Path = <<"/~arweave@2.9/tx=bndIwac23-s0K11TLC1N7z472sLGAkiOdhds87ZywoE">>,
     {ok, Root} = hb_http:get(Node, Path, #{}),
@@ -1768,7 +1677,7 @@ get_tx_rsa_large_bundle_test_disabled() ->
         ok
     end}.
 
-get_bad_tx_tc() ->
+get_bad_tx_test_parallel() ->
     Node = hb_http_server:start_node(),
     Path = <<"/~arweave@2.9/tx=INVALID-ID">>,
     Res = hb_http:get(Node, Path, #{}),
@@ -1807,7 +1716,7 @@ serialize_data_item_test_disabled() ->
     ?assert(ar_bundles:verify_item(VerifiedItem)),
     ok.
 
-get_partial_chunk_post_split_tc() ->
+get_partial_chunk_post_split_test_parallel() ->
     %% https://arweave.net/tx/QL7_EnmrFtx-0wVgPr2IwaGWQT8vmPcF3R20CKMO3D4/offset
     %% 
     Offset = 378092137521399,
@@ -1828,7 +1737,7 @@ get_partial_chunk_post_split_tc() ->
     ),
     ok.
 
-get_full_chunk_post_split_tc() ->
+get_full_chunk_post_split_test_parallel() ->
     %% https://arweave.net/tx/QL7_EnmrFtx-0wVgPr2IwaGWQT8vmPcF3R20CKMO3D4/offset
     %% 
     Offset = 378092137521399,
@@ -1849,7 +1758,7 @@ get_full_chunk_post_split_tc() ->
     ),
     ok.
 
-get_multi_chunk_post_split_tc() ->
+get_multi_chunk_post_split_test_parallel() ->
     %% https://arweave.net/tx/QL7_EnmrFtx-0wVgPr2IwaGWQT8vmPcF3R20CKMO3D4/offset
     %% 
     Offset = 378092137521399,
@@ -1872,7 +1781,7 @@ get_multi_chunk_post_split_tc() ->
 
 
 %% @doc Query a chunk range that starts and ends in the middle of a chunk.
-get_mid_chunk_post_split_tc() ->
+get_mid_chunk_post_split_test_parallel() ->
     %% https://arweave.net/tx/QL7_EnmrFtx-0wVgPr2IwaGWQT8vmPcF3R20CKMO3D4/offset
     %% 
     Offset = 378092137521399 + 200_000,
@@ -1893,7 +1802,7 @@ get_mid_chunk_post_split_tc() ->
     ),
     ok.
 
-get_partial_chunk_pre_split_tc() ->
+get_partial_chunk_pre_split_test_parallel() ->
     %% https://arweave.net/tx/v4ophPvV-cNp5gkpkjMuUZ-lf-fBfm1Wk-pB4vJb00E/offset
     %% 
     Offset = 30575701172109,
@@ -1914,7 +1823,7 @@ get_partial_chunk_pre_split_tc() ->
     ),
     ok.
 
-get_full_chunk_pre_split_tc() ->
+get_full_chunk_pre_split_test_parallel() ->
     %% https://arweave.net/tx/v4ophPvV-cNp5gkpkjMuUZ-lf-fBfm1Wk-pB4vJb00E/offset
     %% 
     Offset = 30575701172109,
@@ -1935,7 +1844,7 @@ get_full_chunk_pre_split_tc() ->
     ),
     ok.
 
-get_multi_chunk_pre_split_tc() ->
+get_multi_chunk_pre_split_test_parallel() ->
     %% https://arweave.net/tx/v4ophPvV-cNp5gkpkjMuUZ-lf-fBfm1Wk-pB4vJb00E/offset
     %% 
     Offset = 30575701172109,
@@ -1956,7 +1865,7 @@ get_multi_chunk_pre_split_tc() ->
     ),
     ok.
 
-get_mid_chunk_pre_split_tc() ->
+get_mid_chunk_pre_split_test_parallel() ->
     %% https://arweave.net/tx/v4ophPvV-cNp5gkpkjMuUZ-lf-fBfm1Wk-pB4vJb00E/offset
     %% 
     Offset = 30575701172109 + 200_000,
@@ -1977,7 +1886,7 @@ get_mid_chunk_pre_split_tc() ->
     ),
     ok.
 
-get_pre_split_small_chunks_tc() ->
+get_pre_split_small_chunks_test_parallel() ->
     TXID = <<"4FnBmvgWmqXWEEprjVqBsV5aRpAgF6_yJX_GTGsSZjY">>,
     Opts = setup_arweave_index_opts([TXID]),
     assert_chunk_range(
@@ -1989,7 +1898,7 @@ get_pre_split_small_chunks_tc() ->
         Opts
     ).
 
-get_post_split_small_chunks_tc() ->
+get_post_split_small_chunks_test_parallel() ->
     TXID = <<"YR9m4c3CrlljCRYEWBLeoKekbAyYZRMo2Kpz61IeNp8">>,
     Opts = setup_arweave_index_opts([TXID]),
     assert_chunk_range(
@@ -2001,7 +1910,7 @@ get_post_split_small_chunks_tc() ->
         Opts
     ).
 
-get_pre_split_gap_tc() ->
+get_pre_split_gap_test_parallel() ->
     TXID = <<"VexuG68KCNpw21fGZw1ycRCYBtQMHhl274zGDBh3kQE">>,
     Opts = setup_arweave_index_opts([TXID]),
     assert_chunk_range(
@@ -2013,7 +1922,7 @@ get_pre_split_gap_tc() ->
         Opts
     ).
 
-get_pre_split_small_tx_tc() ->
+get_pre_split_small_tx_test_parallel() ->
     TXID = <<"K4C4dLZ7V4ffYJcR9JtVQwIXCTLD1mMCUaPbHuUdFgw">>,
     Opts = setup_arweave_index_opts([TXID]),
     assert_chunk_range(
@@ -2027,7 +1936,7 @@ get_pre_split_small_tx_tc() ->
 
 %% @doc Checks an item that begins in the middle of a chunk - without
 %% special handling get_chunk_range() used to leave off the last few bytes
-get_ed25519_item_tc() ->
+get_ed25519_item_test_parallel() ->
     TXID = <<"jTFA8XDI_rqmUB6-hhoJF4Yi7p6ZpS_0AByFLU1OPrU">>,
     DataItemID = <<"1rTy7gQuK9lJydlKqCEhtGLp2WWG-GOrVo5JdiCmaxs">>,
     Opts = setup_arweave_index_opts([TXID]),
@@ -2042,7 +1951,7 @@ get_ed25519_item_tc() ->
 
 %% @doc this test fails if the chunks are queried with
 %% the `x-bucket-based-offset' header set.
-bucket_based_offset_fail_tc() ->
+bucket_based_offset_fail_test_parallel() ->
     TXID = <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>,
     DataItemID = <<"z-oKJfhMq5qoVFrljEfiBKgumaJmCWVxNJaavR5aPE8">>,
     Opts = setup_arweave_index_opts([TXID]),
@@ -2057,7 +1966,7 @@ bucket_based_offset_fail_tc() ->
 
 %% @doc this dataitem needs the 'x-bucket-based-offset' header set OR
 %% special handling.
-bucket_based_offset_pass_tc() ->
+bucket_based_offset_pass_test_parallel() ->
     DataItemID = <<"cTI07T1OrF0KZEqPmZji1VTdbeKJG7kMAVlLu7KQvyw">>,
     Opts = setup_arweave_index_opts([]),
     assert_chunk_range(
@@ -2069,10 +1978,10 @@ bucket_based_offset_pass_tc() ->
         Opts
     ).
 
-reassemble_bundle1_tc() ->
+reassemble_bundle1_test_parallel() ->
     assert_bundle_tx(<<"c1-FkhQd-Ul-VpIMR5Vs77lK__BlzHzena2zgNh_hME">>).
 
-reassemble_bundle2_tc() ->
+reassemble_bundle2_test_parallel() ->
     assert_bundle_tx(<<"OVjj52NvyIys7u84Rv1uqRG2vswlF95QDVPSmsmlwLk">>).
 
 %% @doc This asserts that a bundle is correctly represented in the weave.

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -13,6 +13,49 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-ifdef(TEST).
+%% Test cases exported so `all_tests_test_/0' can run them in parallel via
+%% `fun ?MODULE:name/0'. Each case starts an isolated node so they are safe
+%% to run concurrently.
+-export([
+    bundle_header_garbage_guard_tc/0,
+    post_ans104_message_tc/0,
+    post_tx_message_tc/0,
+    post_tx_json_failure_tc/0,
+    post_tx_json_success_tc/0,
+    post_tx_json_mixed_status_prefers_success_tc/0,
+    best_response_handles_failed_connect_entries_tc/0,
+    best_response_non_map_error_round_trips_tc/0,
+    get_tx_basic_data_tc/0,
+    get_tx_split_chunk_tc/0,
+    get_tx_basic_data_exclude_data_tc/0,
+    get_tx_data_tag_exclude_data_tc/0,
+    head_raw_tx_tc/0,
+    head_raw_ans104_tc/0,
+    get_raw_range_tx_tc/0,
+    get_raw_range_ans104_tc/0,
+    get_tx_rsa_nested_bundle_tc/0,
+    get_bad_tx_tc/0,
+    get_partial_chunk_post_split_tc/0,
+    get_full_chunk_post_split_tc/0,
+    get_multi_chunk_post_split_tc/0,
+    get_mid_chunk_post_split_tc/0,
+    get_partial_chunk_pre_split_tc/0,
+    get_full_chunk_pre_split_tc/0,
+    get_multi_chunk_pre_split_tc/0,
+    get_mid_chunk_pre_split_tc/0,
+    get_pre_split_small_chunks_tc/0,
+    get_post_split_small_chunks_tc/0,
+    get_pre_split_gap_tc/0,
+    get_pre_split_small_tx_tc/0,
+    get_ed25519_item_tc/0,
+    bucket_based_offset_fail_tc/0,
+    bucket_based_offset_pass_tc/0,
+    reassemble_bundle1_tc/0,
+    reassemble_bundle2_tc/0
+]).
+-endif.
+
 -define(IS_BLOCK_ID(X), (is_binary(X) andalso byte_size(X) == 64)).
 
 %% @doc Route unknown keys through offset resolution first, then fall back to
@@ -1048,9 +1091,57 @@ event_request(Path, Method, Status, Extra) ->
 
 %%% Tests
 
+%% @doc Run every test in this module in parallel. Each case starts its own
+%% node with a fresh store, so there is no shared state to race on. This cuts
+%% the module's wall time from ~19s serial to roughly the slowest test.
+all_tests_test_() ->
+    {inparallel,
+        [
+            {atom_to_list(F), fun ?MODULE:F/0}
+        ||
+            F <- [
+                bundle_header_garbage_guard_tc,
+                post_ans104_message_tc,
+                post_tx_message_tc,
+                post_tx_json_failure_tc,
+                post_tx_json_success_tc,
+                post_tx_json_mixed_status_prefers_success_tc,
+                best_response_handles_failed_connect_entries_tc,
+                best_response_non_map_error_round_trips_tc,
+                get_tx_basic_data_tc,
+                get_tx_split_chunk_tc,
+                get_tx_basic_data_exclude_data_tc,
+                get_tx_data_tag_exclude_data_tc,
+                head_raw_tx_tc,
+                head_raw_ans104_tc,
+                get_raw_range_tx_tc,
+                get_raw_range_ans104_tc,
+                get_tx_rsa_nested_bundle_tc,
+                get_bad_tx_tc,
+                get_partial_chunk_post_split_tc,
+                get_full_chunk_post_split_tc,
+                get_multi_chunk_post_split_tc,
+                get_mid_chunk_post_split_tc,
+                get_partial_chunk_pre_split_tc,
+                get_full_chunk_pre_split_tc,
+                get_multi_chunk_pre_split_tc,
+                get_mid_chunk_pre_split_tc,
+                get_pre_split_small_chunks_tc,
+                get_post_split_small_chunks_tc,
+                get_pre_split_gap_tc,
+                get_pre_split_small_tx_tc,
+                get_ed25519_item_tc,
+                bucket_based_offset_fail_tc,
+                bucket_based_offset_pass_tc,
+                reassemble_bundle1_tc,
+                reassemble_bundle2_tc
+            ]
+        ]
+    }.
+
 %% @doc A fixed bad interior offset from a live TX is rejected by
 %% bundle_header/3 as invalid_bundle_header.
-bundle_header_garbage_guard_test() ->
+bundle_header_garbage_guard_tc() ->
     ServerOpts = #{ store => [hb_test_utils:test_store()] },
     _Server = hb_http_server:start_node(ServerOpts),
     ProbeOffset = 376836336327208,
@@ -1061,7 +1152,7 @@ bundle_header_garbage_guard_test() ->
     ).
 
 
-post_ans104_message_test() ->
+post_ans104_message_tc() ->
     Port = rand:uniform(10000) + 10000,
     ServerOpts = #{
         store => [hb_test_utils:test_store()],
@@ -1117,7 +1208,7 @@ post_ans104_message_test() ->
         dev_bundler:stop_server()
     end.
 
-post_tx_message_test() ->
+post_tx_message_tc() ->
     ServerOpts = #{ store => [hb_test_utils:test_store()] },
     Server = hb_http_server:start_node(ServerOpts),
     ClientOpts =
@@ -1153,7 +1244,7 @@ post_tx_message_test() ->
     ?assertEqual(<<"Transaction verification failed.">>, Body),
     ok.
 
-post_tx_json_failure_test() ->
+post_tx_json_failure_tc() ->
     ServerOpts = #{ store => [hb_test_utils:test_store()] },
     Server = hb_http_server:start_node(ServerOpts),
     ClientOpts = post_tx_json_client_opts(),
@@ -1166,7 +1257,7 @@ post_tx_json_failure_test() ->
     ?assertEqual(<<"Transaction verification failed.">>, Body),
     ok.
 
-post_tx_json_success_test() ->
+post_tx_json_success_tc() ->
     {Response, Node1Posts, Node2Posts} =
         post_tx_json_two_node_test({200, <<"OK-1">>}, {200, <<"OK-2">>}),
     ?assertMatch({ok, #{ <<"status">> := 200 }}, Response),
@@ -1174,7 +1265,7 @@ post_tx_json_success_test() ->
     ?assertEqual(1, length(Node2Posts)),
     ok.
 
-post_tx_json_mixed_status_prefers_success_test() ->
+post_tx_json_mixed_status_prefers_success_tc() ->
     {Response, Node1Posts, Node2Posts} =
         post_tx_json_two_node_test(
             {400, <<"Transaction verification failed.">>},
@@ -1185,7 +1276,7 @@ post_tx_json_mixed_status_prefers_success_test() ->
     ?assertEqual(1, length(Node2Posts)),
     ok.
 
-best_response_handles_failed_connect_entries_test() ->
+best_response_handles_failed_connect_entries_tc() ->
     FailedConnect =
         {failed_connect,
             [
@@ -1202,7 +1293,7 @@ best_response_handles_failed_connect_entries_test() ->
         best_response(Responses)
     ).
 
-best_response_non_map_error_round_trips_test() ->
+best_response_non_map_error_round_trips_tc() ->
     FailedConnect =
         {failed_connect,
             [
@@ -1365,7 +1456,7 @@ tx_index_block(<<"jI0A4BASHaUdCCsdv249BxDX6IlE0Ko391TuI6REATw">>) -> 1289677;
 tx_index_block(<<"4FnBmvgWmqXWEEprjVqBsV5aRpAgF6_yJX_GTGsSZjY">>) -> 753012;
 tx_index_block(<<"YR9m4c3CrlljCRYEWBLeoKekbAyYZRMo2Kpz61IeNp8">>) -> 1233918.
 
-get_tx_basic_data_test() ->
+get_tx_basic_data_tc() ->
     {ok, Structured} = hb_ao:resolve(
         #{ <<"device">> => <<"arweave@2.9">> },
         #{
@@ -1393,7 +1484,7 @@ get_tx_basic_data_test() ->
     ok.
 
 %% @doc The data for this transaction ends with two smaller chunks.
-get_tx_split_chunk_test() ->
+get_tx_split_chunk_tc() ->
     {ok, Structured} = hb_ao:resolve(
         #{ <<"device">> => <<"arweave@2.9">> },
         #{
@@ -1422,7 +1513,7 @@ get_tx_split_chunk_test() ->
         hb_message:id(Child, signed)),
     ok.
 
-get_tx_basic_data_exclude_data_test() ->
+get_tx_basic_data_exclude_data_tc() ->
     TXID = <<"ptBC0UwDmrUTBQX3MqZ1lB57ex20ygwzkjjCrQjIx3o">>,
     Opts = setup_arweave_index_opts([TXID]),
     {ok, Structured} = hb_ao:resolve(
@@ -1459,7 +1550,7 @@ get_tx_basic_data_exclude_data_test() ->
     ?assertEqual(<<"PEShWA1ER2jq7CatAPpOZ30TeLrjOSpaf_Po7_hKPo4">>, DataHash),
     ok.
 
-get_tx_data_tag_exclude_data_test() ->
+get_tx_data_tag_exclude_data_tc() ->
     TXID = <<"jI0A4BASHaUdCCsdv249BxDX6IlE0Ko391TuI6REATw">>,
     Opts = setup_arweave_index_opts([TXID]),
     {ok, Structured} = hb_ao:resolve(
@@ -1495,7 +1586,7 @@ get_tx_data_tag_exclude_data_test() ->
     ?assertEqual(<<"IHyJ9BlQaHLWVwwklMwV1XEYXGjwx2B6HXNJZ4yJXeQ">>, DataHash),
     ok.
 
-head_raw_tx_test() ->
+head_raw_tx_tc() ->
     TXID = <<"ptBC0UwDmrUTBQX3MqZ1lB57ex20ygwzkjjCrQjIx3o">>,
     Opts = setup_arweave_index_opts([TXID]),
     {ok, Result} =
@@ -1522,7 +1613,7 @@ head_raw_tx_test() ->
         hb_maps:find(<<"header-length">>, Result, Opts)
     ).
 
-head_raw_ans104_test() ->
+head_raw_ans104_tc() ->
     Opts = setup_arweave_index_opts([]),
     DataItemID = <<"0vy2Ey8bWkSDcRIvWQJjxDeVGYOrTSmYIIhBILJntY8">>,
     BlockBin = hb_util:bin(1_827_942),
@@ -1549,7 +1640,7 @@ head_raw_ans104_test() ->
         hb_maps:find(<<"content-length">>, Result, Opts)
     ).
 
-get_raw_range_tx_test() ->
+get_raw_range_tx_tc() ->
     DataItemID = <<"ptBC0UwDmrUTBQX3MqZ1lB57ex20ygwzkjjCrQjIx3o">>,
     Opts = setup_arweave_index_opts([DataItemID]),
     {ok, Result} =
@@ -1589,7 +1680,7 @@ get_raw_range_tx_test() ->
         hb_maps:find(<<"body">>, Result2, Opts)
     ).
 
-get_raw_range_ans104_test() ->
+get_raw_range_ans104_tc() ->
     Opts = setup_arweave_index_opts([]),
     DataItemID = <<"0vy2Ey8bWkSDcRIvWQJjxDeVGYOrTSmYIIhBILJntY8">>,
     BlockBin = hb_util:bin(1_827_942),
@@ -1634,7 +1725,7 @@ get_raw_range_ans104_test() ->
         hb_maps:find(<<"body">>, Result2, Opts)
     ).
 
-get_tx_rsa_nested_bundle_test() ->
+get_tx_rsa_nested_bundle_tc() ->
     Node = hb_http_server:start_node(),
     Path = <<"/~arweave@2.9/tx=bndIwac23-s0K11TLC1N7z472sLGAkiOdhds87ZywoE">>,
     {ok, Root} = hb_http:get(Node, Path, #{}),
@@ -1677,7 +1768,7 @@ get_tx_rsa_large_bundle_test_disabled() ->
         ok
     end}.
 
-get_bad_tx_test() ->
+get_bad_tx_tc() ->
     Node = hb_http_server:start_node(),
     Path = <<"/~arweave@2.9/tx=INVALID-ID">>,
     Res = hb_http:get(Node, Path, #{}),
@@ -1716,7 +1807,7 @@ serialize_data_item_test_disabled() ->
     ?assert(ar_bundles:verify_item(VerifiedItem)),
     ok.
 
-get_partial_chunk_post_split_test() ->
+get_partial_chunk_post_split_tc() ->
     %% https://arweave.net/tx/QL7_EnmrFtx-0wVgPr2IwaGWQT8vmPcF3R20CKMO3D4/offset
     %% 
     Offset = 378092137521399,
@@ -1737,7 +1828,7 @@ get_partial_chunk_post_split_test() ->
     ),
     ok.
 
-get_full_chunk_post_split_test() ->
+get_full_chunk_post_split_tc() ->
     %% https://arweave.net/tx/QL7_EnmrFtx-0wVgPr2IwaGWQT8vmPcF3R20CKMO3D4/offset
     %% 
     Offset = 378092137521399,
@@ -1758,7 +1849,7 @@ get_full_chunk_post_split_test() ->
     ),
     ok.
 
-get_multi_chunk_post_split_test() ->
+get_multi_chunk_post_split_tc() ->
     %% https://arweave.net/tx/QL7_EnmrFtx-0wVgPr2IwaGWQT8vmPcF3R20CKMO3D4/offset
     %% 
     Offset = 378092137521399,
@@ -1781,7 +1872,7 @@ get_multi_chunk_post_split_test() ->
 
 
 %% @doc Query a chunk range that starts and ends in the middle of a chunk.
-get_mid_chunk_post_split_test() ->
+get_mid_chunk_post_split_tc() ->
     %% https://arweave.net/tx/QL7_EnmrFtx-0wVgPr2IwaGWQT8vmPcF3R20CKMO3D4/offset
     %% 
     Offset = 378092137521399 + 200_000,
@@ -1802,7 +1893,7 @@ get_mid_chunk_post_split_test() ->
     ),
     ok.
 
-get_partial_chunk_pre_split_test() ->
+get_partial_chunk_pre_split_tc() ->
     %% https://arweave.net/tx/v4ophPvV-cNp5gkpkjMuUZ-lf-fBfm1Wk-pB4vJb00E/offset
     %% 
     Offset = 30575701172109,
@@ -1823,7 +1914,7 @@ get_partial_chunk_pre_split_test() ->
     ),
     ok.
 
-get_full_chunk_pre_split_test() ->
+get_full_chunk_pre_split_tc() ->
     %% https://arweave.net/tx/v4ophPvV-cNp5gkpkjMuUZ-lf-fBfm1Wk-pB4vJb00E/offset
     %% 
     Offset = 30575701172109,
@@ -1844,7 +1935,7 @@ get_full_chunk_pre_split_test() ->
     ),
     ok.
 
-get_multi_chunk_pre_split_test() ->
+get_multi_chunk_pre_split_tc() ->
     %% https://arweave.net/tx/v4ophPvV-cNp5gkpkjMuUZ-lf-fBfm1Wk-pB4vJb00E/offset
     %% 
     Offset = 30575701172109,
@@ -1865,7 +1956,7 @@ get_multi_chunk_pre_split_test() ->
     ),
     ok.
 
-get_mid_chunk_pre_split_test() ->
+get_mid_chunk_pre_split_tc() ->
     %% https://arweave.net/tx/v4ophPvV-cNp5gkpkjMuUZ-lf-fBfm1Wk-pB4vJb00E/offset
     %% 
     Offset = 30575701172109 + 200_000,
@@ -1886,7 +1977,7 @@ get_mid_chunk_pre_split_test() ->
     ),
     ok.
 
-get_pre_split_small_chunks_test() ->
+get_pre_split_small_chunks_tc() ->
     TXID = <<"4FnBmvgWmqXWEEprjVqBsV5aRpAgF6_yJX_GTGsSZjY">>,
     Opts = setup_arweave_index_opts([TXID]),
     assert_chunk_range(
@@ -1898,7 +1989,7 @@ get_pre_split_small_chunks_test() ->
         Opts
     ).
 
-get_post_split_small_chunks_test() ->
+get_post_split_small_chunks_tc() ->
     TXID = <<"YR9m4c3CrlljCRYEWBLeoKekbAyYZRMo2Kpz61IeNp8">>,
     Opts = setup_arweave_index_opts([TXID]),
     assert_chunk_range(
@@ -1910,7 +2001,7 @@ get_post_split_small_chunks_test() ->
         Opts
     ).
 
-get_pre_split_gap_test() ->
+get_pre_split_gap_tc() ->
     TXID = <<"VexuG68KCNpw21fGZw1ycRCYBtQMHhl274zGDBh3kQE">>,
     Opts = setup_arweave_index_opts([TXID]),
     assert_chunk_range(
@@ -1922,7 +2013,7 @@ get_pre_split_gap_test() ->
         Opts
     ).
 
-get_pre_split_small_tx_test() ->
+get_pre_split_small_tx_tc() ->
     TXID = <<"K4C4dLZ7V4ffYJcR9JtVQwIXCTLD1mMCUaPbHuUdFgw">>,
     Opts = setup_arweave_index_opts([TXID]),
     assert_chunk_range(
@@ -1936,7 +2027,7 @@ get_pre_split_small_tx_test() ->
 
 %% @doc Checks an item that begins in the middle of a chunk - without
 %% special handling get_chunk_range() used to leave off the last few bytes
-get_ed25519_item_test() ->
+get_ed25519_item_tc() ->
     TXID = <<"jTFA8XDI_rqmUB6-hhoJF4Yi7p6ZpS_0AByFLU1OPrU">>,
     DataItemID = <<"1rTy7gQuK9lJydlKqCEhtGLp2WWG-GOrVo5JdiCmaxs">>,
     Opts = setup_arweave_index_opts([TXID]),
@@ -1951,7 +2042,7 @@ get_ed25519_item_test() ->
 
 %% @doc this test fails if the chunks are queried with
 %% the `x-bucket-based-offset' header set.
-bucket_based_offset_fail_test() ->
+bucket_based_offset_fail_tc() ->
     TXID = <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>,
     DataItemID = <<"z-oKJfhMq5qoVFrljEfiBKgumaJmCWVxNJaavR5aPE8">>,
     Opts = setup_arweave_index_opts([TXID]),
@@ -1966,7 +2057,7 @@ bucket_based_offset_fail_test() ->
 
 %% @doc this dataitem needs the 'x-bucket-based-offset' header set OR
 %% special handling.
-bucket_based_offset_pass_test() ->
+bucket_based_offset_pass_tc() ->
     DataItemID = <<"cTI07T1OrF0KZEqPmZji1VTdbeKJG7kMAVlLu7KQvyw">>,
     Opts = setup_arweave_index_opts([]),
     assert_chunk_range(
@@ -1978,10 +2069,10 @@ bucket_based_offset_pass_test() ->
         Opts
     ).
 
-reassemble_bundle1_test() ->
+reassemble_bundle1_tc() ->
     assert_bundle_tx(<<"c1-FkhQd-Ul-VpIMR5Vs77lK__BlzHzena2zgNh_hME">>).
 
-reassemble_bundle2_test() ->
+reassemble_bundle2_tc() ->
     assert_bundle_tx(<<"OVjj52NvyIys7u84Rv1uqRG2vswlF95QDVPSmsmlwLk">>).
 
 %% @doc This asserts that a bundle is correctly represented in the weave.

--- a/src/dev_arweave_offset.erl
+++ b/src/dev_arweave_offset.erl
@@ -353,39 +353,28 @@ parse_offset_test() ->
 
 offset_item_cases_test() ->
     Opts = #{},
-    % A simple message.
-    assert_offset_item(
-        <<"160399272861859">>,
-        498852,
-        #{ <<"content-type">> => <<"image/png">> },
-        Opts
-    ),
-    % A reference with a given length.
-    assert_offset_item(
-        <<"160399272861859-498852">>,
-        498852,
-        #{ <<"content-type">> => <<"image/png">> },
-        Opts
-    ),
-    % A reference to a byte in the middle of the test message.
-    assert_offset_item(
-        <<"160399273000000">>,
-        498852,
-        #{ <<"content-type">> => <<"image/png">> },
-        Opts
-    ),
-    % A megabyte reference to the item, occurring in the middle of the item.
-    assert_offset_item(
-        <<"160399273m">>,
-        498852,
-        #{ <<"content-type">> => <<"image/png">> },
-        Opts
-    ),
-    assert_offset_item(
-        <<"384600234780716">>,
-        856691,
-        #{ <<"content-type">> => <<"image/jpeg">> },
-        Opts
+    Png = #{ <<"content-type">> => <<"image/png">> },
+    Jpeg = #{ <<"content-type">> => <<"image/jpeg">> },
+    %% Each case fetches a live item from arweave.net; running the five
+    %% cases in parallel cuts the wall time to roughly the slowest fetch.
+    Cases =
+        [
+            %% A simple message.
+            {<<"160399272861859">>, 498852, Png},
+            %% A reference with a given length.
+            {<<"160399272861859-498852">>, 498852, Png},
+            %% A reference to a byte in the middle of the test message.
+            {<<"160399273000000">>, 498852, Png},
+            %% A megabyte reference to the item, occurring in the middle.
+            {<<"160399273m">>, 498852, Png},
+            {<<"384600234780716">>, 856691, Jpeg}
+        ],
+    hb_pmap:parallel_map(
+        Cases,
+        fun({Path, DataSize, Tags}) ->
+            assert_offset_item(Path, DataSize, Tags, Opts)
+        end,
+        length(Cases)
     ),
     ok.
 

--- a/src/dev_bundler.erl
+++ b/src/dev_bundler.erl
@@ -15,9 +15,43 @@
 %%% available for reading instantly (`optimistically'), even before the
 %%% transaction is dispatched.
 -module(dev_bundler).
--export([tx/3, item/3, ensure_server/1, stop_server/0, get_state/0]).
+-export([tx/3, item/3, ensure_server/1, stop_server/0, stop_server/1]).
+-export([get_state/0, get_state/1]).
 %%% Test-only exports.
 -export([start_mock_gateway/1]).
+
+-ifdef(TEST).
+%% Test cases exported so `all_tests_test_/0' can run them in parallel via
+%% `fun ?MODULE:name/0'. Each case receives a unique `bundler_server_name'
+%% in the `NodeOpts' returned from `start_mock_gateway/1', so concurrent
+%% tests no longer race on the legacy global `?SERVER_NAME' atom.
+-export([
+    bundle_count_tc/0,
+    bundle_size_tc/0,
+    bundle_dispatch_delay_tc/0,
+    nested_bundle_tc/0,
+    price_error_tc/0,
+    anchor_error_tc/0,
+    tx_error_tc/0,
+    unsigned_dataitem_tc/0,
+    idle_tc/0,
+    dispatch_blocking_tc/0,
+    recover_respects_max_items_tc/0,
+    complete_task_sequence_tc/0,
+    recover_bundles_tc/0,
+    post_tx_price_failure_retry_tc/0,
+    post_tx_anchor_failure_retry_tc/0,
+    post_tx_post_failure_retry_tc/0,
+    post_proof_failure_retry_tc/0,
+    rapid_dispatch_tc/0,
+    one_bundle_fails_others_continue_tc/0,
+    parallel_task_execution_tc/0,
+    exponential_backoff_timing_tc/0,
+    independent_task_retry_counts_tc/0,
+    invalid_item_tc/0,
+    cache_write_failure_tc/0
+]).
+-endif.
 -include("include/hb.hrl").
 -include("include/dev_bundler.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -129,25 +163,41 @@ cache_item(Item, Opts) ->
 
 %%% Bundling server.
 
+%% @doc Look up the registration name for the bundler server. Defaults to
+%% the legacy global atom `?SERVER_NAME' so production code is unchanged;
+%% tests pass a unique `bundler_server_name' in `Opts' so each test gets
+%% its own server and concurrent tests do not race on the singleton.
+server_name(Opts) ->
+    hb_opts:get(bundler_server_name, ?SERVER_NAME, Opts).
+
 %% @doc Return the PID of the bundler server. If the server is not running,
-%% it is started and registered with the name `?SERVER_NAME'.
+%% it is started and registered with the name returned by `server_name/1'.
 ensure_server(Opts) ->
+    Name = server_name(Opts),
     hb_name:singleton(
-        ?SERVER_NAME,
+        Name,
         fun() -> init(Opts) end
     ).
 
+%% @doc Stop the default bundler server. Used by production-oriented
+%% tests that rely on the global `?SERVER_NAME'.
 stop_server() ->
-    case hb_name:lookup(?SERVER_NAME) of
+    stop_server(#{}).
+stop_server(Opts) ->
+    Name = server_name(Opts),
+    case hb_name:lookup(Name) of
         undefined -> ok;
         PID ->
             PID ! stop,
-            hb_name:unregister(?SERVER_NAME)
+            hb_name:unregister(Name)
     end.
 
 %% @doc Return the current bundler server state for tests.
 get_state() ->
-    case hb_name:lookup(?SERVER_NAME) of
+    get_state(#{}).
+get_state(Opts) ->
+    Name = server_name(Opts),
+    case hb_name:lookup(Name) of
         undefined -> undefined;
         PID ->
             PID ! {get_state, self(), Ref = make_ref()},
@@ -519,16 +569,80 @@ recover_bundle(CommittedTX, Items, State = #state{opts = Opts}) ->
 %%% Tests
 %%%===================================================================
 
-bundle_count_test() ->
+%% @doc Run most tests in this module in parallel: `start_mock_gateway/1'
+%% stamps a unique `bundler_server_name' into `NodeOpts', so each bundler
+%% server is isolated per test. A few tests assert tight wall-clock
+%% timing bounds (retry backoff, non-blocking dispatch timings), and
+%% those false-fail under the CPU contention of a parallel run. Those
+%% run after the parallel batch in an `inorder' group.
+all_tests_test_() ->
+    ParallelSafe = [
+        bundle_count_tc,
+        bundle_size_tc,
+        nested_bundle_tc,
+        price_error_tc,
+        anchor_error_tc,
+        tx_error_tc,
+        unsigned_dataitem_tc,
+        recover_respects_max_items_tc,
+        complete_task_sequence_tc,
+        recover_bundles_tc,
+        post_tx_price_failure_retry_tc,
+        post_tx_anchor_failure_retry_tc,
+        post_tx_post_failure_retry_tc,
+        post_proof_failure_retry_tc,
+        rapid_dispatch_tc,
+        one_bundle_fails_others_continue_tc,
+        parallel_task_execution_tc,
+        independent_task_retry_counts_tc,
+        invalid_item_tc,
+        cache_write_failure_tc
+    ],
+    %% These tests assert tight wall-clock timing windows that only hold
+    %% when the VM has spare schedulers; run after the parallel batch so
+    %% they see an un-contended system.
+    %% - bundle_dispatch_delay_tc / dispatch_blocking_tc: mock server
+    %%   sleeps and the test asserts on timing differences.
+    %% - exponential_backoff_timing_tc: asserts exact retry delay
+    %%   windows (`?assert(Delay1 >= 70 andalso Delay1 =< 200)').
+    %% - idle_tc: the bundler flushes on a ~400 ms idle timer and
+    %%   `?assertEqual(0, length(...))' depends on nothing having
+    %%   flushed yet 150 ms after the post, which fails under contention.
+    TimingSensitive = [
+        idle_tc,
+        bundle_dispatch_delay_tc,
+        dispatch_blocking_tc,
+        exponential_backoff_timing_tc
+    ],
+    {inorder,
+        [
+            {inparallel,
+                [
+                    {atom_to_list(F), fun ?MODULE:F/0}
+                ||
+                    F <- ParallelSafe
+                ]
+            },
+            {inorder,
+                [
+                    {atom_to_list(F), fun ?MODULE:F/0}
+                ||
+                    F <- TimingSensitive
+                ]
+            }
+        ]
+    }.
+
+bundle_count_tc() ->
     test_bundle(#{ bundler_max_items => 3 }).
 
-bundle_size_test() ->
+bundle_size_tc() ->
     test_bundle(#{ bundler_max_size => floor(3.6 * ?DATA_CHUNK_SIZE) }).
 
-bundle_dispatch_delay_test() -> 
+bundle_dispatch_delay_tc() -> 
     test_bundle(#{ bundler_max_bundle_dispatch_delay => 3000  }).
 
-nested_bundle_test() ->
+nested_bundle_tc() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     % NodeOpts redirects arweave gateway requests to the mock server.
@@ -563,22 +677,22 @@ nested_bundle_test() ->
         ok
     after
         %% Always cleanup, even if test fails
-        stop_test_servers(ServerHandle)
+        stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-price_error_test() ->
+price_error_tc() ->
     test_api_error(#{
         price => {500, <<"error">>},
         tx_anchor => {200, hb_util:encode(rand:bytes(32))}
     }).
 
-anchor_error_test() ->
+anchor_error_tc() ->
     test_api_error(#{
         price => {200, <<"12345">>},
         tx_anchor => {500, <<"error">>}
     }).
 
-tx_error_test() ->
+tx_error_tc() ->
     {ServerHandle, NodeOpts} = start_mock_gateway(
         #{
             tx => {400, <<"Transaction verification failed.">>},
@@ -604,10 +718,10 @@ tx_error_test() ->
         ok
     after
         %% Always cleanup, even if test fails
-        stop_test_servers(ServerHandle)
+        stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-unsigned_dataitem_test() ->
+unsigned_dataitem_tc() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     % NodeOpts redirects arweave gateway requests to the mock server.
@@ -638,10 +752,10 @@ unsigned_dataitem_test() ->
             Response)
     after
         %% Always cleanup, even if test fails
-        stop_test_servers(ServerHandle)
+        stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-idle_test() ->
+idle_tc() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     {ServerHandle, NodeOpts} = start_mock_gateway(
@@ -691,10 +805,10 @@ idle_test() ->
             Node, Items, Anchor, Price, hd(TXs), Proofs, ClientOpts),
         ok
     after
-        stop_test_servers(ServerHandle)
+        stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-dispatch_blocking_test() ->
+dispatch_blocking_tc() ->
     BlockTime = 500,
     Anchor = rand:bytes(32),
     Price = 12345,
@@ -750,12 +864,12 @@ dispatch_blocking_test() ->
         ok
     after
         %% Always cleanup, even if test fails
-        stop_test_servers(ServerHandle)
+        stop_test_servers(ServerHandle, NodeOpts)
     end.
 
 %% @doc Test that items are recovered and posted while respecting the
 %% max_items limit.
-recover_respects_max_items_test() ->
+recover_respects_max_items_tc() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     {ServerHandle, NodeOpts} = start_mock_gateway(#{
@@ -792,10 +906,10 @@ recover_respects_max_items_test() ->
         ?assertEqual(3, length(TXs)),
         ok
     after
-        stop_test_servers(ServerHandle)
+        stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-complete_task_sequence_test() ->
+complete_task_sequence_tc() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     {ServerHandle, NodeOpts} = start_mock_gateway(#{
@@ -821,7 +935,7 @@ complete_task_sequence_test() ->
         ?assertEqual(1, length(TXs)),
         Proofs = hb_mock_server:get_requests(chunk, 1, ServerHandle),
         ?assertEqual(1, length(Proofs)),
-        State = get_state(),
+        State = get_state(Opts),
         ?assertNotEqual(undefined, State),
         ?assertNotEqual(timeout, State),
         Workers = State#state.workers,
@@ -836,10 +950,10 @@ complete_task_sequence_test() ->
         ?assertEqual(0, maps:size(Bundles)),
         ok
     after
-        stop_test_servers(ServerHandle)
+        stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-recover_bundles_test() ->
+recover_bundles_tc() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     {ServerHandle, NodeOpts} = start_mock_gateway(#{
@@ -876,7 +990,7 @@ recover_bundles_test() ->
         ok = dev_bundler_cache:write_tx(CommittedTX2, [Item4], Opts),
         ok = dev_bundler_cache:complete_tx(CommittedTX2, Opts),
         ensure_server(Opts),
-        State = get_state(),
+        State = get_state(Opts),
         ?assertNotEqual(undefined, State),
         ?assertNotEqual(timeout, State),
         TXs = hb_mock_server:get_requests(tx, 1, ServerHandle, 200),
@@ -889,14 +1003,14 @@ recover_bundles_test() ->
                 2000
             )
         ),
-        FinalState = get_state(),
+        FinalState = get_state(Opts),
         ?assertEqual(0, maps:size(FinalState#state.bundles)),
         ok
     after
-        stop_test_servers(ServerHandle)
+        stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-post_tx_price_failure_retry_test() ->
+post_tx_price_failure_retry_tc() ->
     Anchor = rand:bytes(32),
     FailCount = 3,
     setup_test_counter(price_attempts_counter),
@@ -929,10 +1043,10 @@ post_tx_price_failure_retry_test() ->
         ok
     after
         cleanup_test_counter(price_attempts_counter),
-        stop_test_servers(ServerHandle)
+        stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-post_tx_anchor_failure_retry_test() ->
+post_tx_anchor_failure_retry_tc() ->
     Price = 12345,
     FailCount = 3,
     setup_test_counter(anchor_attempts_counter),
@@ -965,10 +1079,10 @@ post_tx_anchor_failure_retry_test() ->
         ok
     after
         cleanup_test_counter(anchor_attempts_counter),
-        stop_test_servers(ServerHandle)
+        stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-post_tx_post_failure_retry_test() ->
+post_tx_post_failure_retry_tc() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     FailCount = 4,
@@ -1003,10 +1117,10 @@ post_tx_post_failure_retry_test() ->
         ok
     after
         cleanup_test_counter(tx_attempts_counter),
-        stop_test_servers(ServerHandle)
+        stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-post_proof_failure_retry_test() ->
+post_proof_failure_retry_tc() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     FailCount = 2,
@@ -1043,10 +1157,10 @@ post_proof_failure_retry_test() ->
         ok
     after
         cleanup_test_counter(chunk_attempts_counter),
-        stop_test_servers(ServerHandle)
+        stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-rapid_dispatch_test() ->
+rapid_dispatch_tc() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     {ServerHandle, NodeOpts} = start_mock_gateway(#{
@@ -1077,10 +1191,10 @@ rapid_dispatch_test() ->
         ?assertEqual(10, length(TXs)),
         ok
     after
-        stop_test_servers(ServerHandle)
+        stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-one_bundle_fails_others_continue_test() ->
+one_bundle_fails_others_continue_tc() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     setup_test_counter(mixed_attempts_counter),
@@ -1114,10 +1228,10 @@ one_bundle_fails_others_continue_test() ->
         ok
     after
         cleanup_test_counter(mixed_attempts_counter),
-        stop_test_servers(ServerHandle)
+        stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-parallel_task_execution_test() ->
+parallel_task_execution_tc() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     SleepTime = 120,
@@ -1152,10 +1266,10 @@ parallel_task_execution_test() ->
         ?assert(ElapsedTime < 2000, "ElapsedTime: " ++ integer_to_list(ElapsedTime)),
         ok
     after
-        stop_test_servers(ServerHandle)
+        stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-exponential_backoff_timing_test() ->
+exponential_backoff_timing_tc() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     FailCount = 5,
@@ -1205,10 +1319,10 @@ exponential_backoff_timing_test() ->
         ok
     after
         cleanup_test_counter(backoff_cap_counter),
-        stop_test_servers(ServerHandle)
+        stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-independent_task_retry_counts_test() ->
+independent_task_retry_counts_tc() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     setup_test_counter(independent_retry_counter),
@@ -1244,10 +1358,10 @@ independent_task_retry_counts_test() ->
         ok
     after
         cleanup_test_counter(independent_retry_counter),
-        stop_test_servers(ServerHandle)
+        stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-invalid_item_test() ->
+invalid_item_tc() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     {ServerHandle, NodeOpts} = start_mock_gateway(#{
@@ -1287,10 +1401,10 @@ invalid_item_test() ->
             <<"details">> := <<"signature-verification-failed">>}}, DirectResult),
         ok
     after
-        stop_test_servers(ServerHandle)
+        stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-cache_write_failure_test() ->
+cache_write_failure_tc() ->
     GoodOpts = #{store => hb_test_utils:test_store()},
     BadOpts = #{
         store => undefined,
@@ -1320,8 +1434,10 @@ cache_write_failure_test() ->
     end.
 
 stop_test_servers(ServerHandle) ->
+    stop_test_servers(ServerHandle, #{}).
+stop_test_servers(ServerHandle, Opts) ->
     hb_mock_server:stop(ServerHandle),
-    stop_server().
+    stop_server(Opts).
 
 test_bundle(Opts) ->
     Anchor = rand:bytes(32),
@@ -1358,7 +1474,7 @@ test_bundle(Opts) ->
         ok
     after
         %% Always cleanup, even if test fails
-        stop_test_servers(ServerHandle)
+        stop_test_servers(ServerHandle, NodeOpts)
     end.
 
 test_api_error(Responses) ->
@@ -1384,7 +1500,7 @@ test_api_error(Responses) ->
         ok
     after
         %% Always cleanup, even if test fails
-        stop_test_servers(ServerHandle)
+        stop_test_servers(ServerHandle, NodeOpts)
     end.
 
 new_data_item(Index, Size) ->
@@ -1521,6 +1637,10 @@ start_mock_gateway(Responses) ->
     {ok, MockServer, ServerHandle} = hb_mock_server:start(Endpoints),
     NodeOpts = #{
         gateway => MockServer,
+        %% Unique server name per test: each test gets its own bundler
+        %% server process and `hb_name:singleton/2' registration, so
+        %% parallel tests do not race on the default `?SERVER_NAME' atom.
+        bundler_server_name => {bundler_server, make_ref()},
         routes => [
             #{
                 <<"template">> => <<"/arweave">>,

--- a/src/dev_bundler.erl
+++ b/src/dev_bundler.erl
@@ -20,38 +20,6 @@
 %%% Test-only exports.
 -export([start_mock_gateway/1]).
 
--ifdef(TEST).
-%% Test cases exported so `all_tests_test_/0' can run them in parallel via
-%% `fun ?MODULE:name/0'. Each case builds its own wallet, and `server_name/1'
-%% derives the bundler server's registration name from the wallet address,
-%% so concurrent tests own independent bundler servers by construction.
--export([
-    bundle_count_tc/0,
-    bundle_size_tc/0,
-    bundle_dispatch_delay_tc/0,
-    nested_bundle_tc/0,
-    price_error_tc/0,
-    anchor_error_tc/0,
-    tx_error_tc/0,
-    unsigned_dataitem_tc/0,
-    idle_tc/0,
-    dispatch_blocking_tc/0,
-    recover_respects_max_items_tc/0,
-    complete_task_sequence_tc/0,
-    recover_bundles_tc/0,
-    post_tx_price_failure_retry_tc/0,
-    post_tx_anchor_failure_retry_tc/0,
-    post_tx_post_failure_retry_tc/0,
-    post_proof_failure_retry_tc/0,
-    rapid_dispatch_tc/0,
-    one_bundle_fails_others_continue_tc/0,
-    parallel_task_execution_tc/0,
-    exponential_backoff_timing_tc/0,
-    independent_task_retry_counts_tc/0,
-    invalid_item_tc/0,
-    cache_write_failure_tc/0
-]).
--endif.
 -include("include/hb.hrl").
 -include("include/dev_bundler.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -576,80 +544,25 @@ recover_bundle(CommittedTX, Items, State = #state{opts = Opts}) ->
 %%% Tests
 %%%===================================================================
 
-%% @doc Run most tests in this module in parallel: each test's wallet is
-%% fresh, so `server_name/1' hands each test an independent bundler
-%% registration without any shared-name contention. A few tests assert
-%% tight wall-clock timing bounds (retry backoff, non-blocking dispatch
-%% timings), and those false-fail under the CPU contention of a parallel
-%% run. Those run after the parallel batch in an `inorder' group.
-all_tests_test_() ->
-    ParallelSafe = [
-        bundle_count_tc,
-        bundle_size_tc,
-        nested_bundle_tc,
-        price_error_tc,
-        anchor_error_tc,
-        tx_error_tc,
-        unsigned_dataitem_tc,
-        recover_respects_max_items_tc,
-        complete_task_sequence_tc,
-        recover_bundles_tc,
-        post_tx_price_failure_retry_tc,
-        post_tx_anchor_failure_retry_tc,
-        post_tx_post_failure_retry_tc,
-        post_proof_failure_retry_tc,
-        rapid_dispatch_tc,
-        one_bundle_fails_others_continue_tc,
-        parallel_task_execution_tc,
-        independent_task_retry_counts_tc,
-        invalid_item_tc,
-        cache_write_failure_tc
-    ],
-    %% These tests assert tight wall-clock timing windows that only hold
-    %% when the VM has spare schedulers; run after the parallel batch so
-    %% they see an un-contended system.
-    %% - bundle_dispatch_delay_tc / dispatch_blocking_tc: mock server
-    %%   sleeps and the test asserts on timing differences.
-    %% - exponential_backoff_timing_tc: asserts exact retry delay
-    %%   windows (`?assert(Delay1 >= 70 andalso Delay1 =< 200)').
-    %% - idle_tc: the bundler flushes on a ~400 ms idle timer and
-    %%   `?assertEqual(0, length(...))' depends on nothing having
-    %%   flushed yet 150 ms after the post, which fails under contention.
-    TimingSensitive = [
-        idle_tc,
-        bundle_dispatch_delay_tc,
-        dispatch_blocking_tc,
-        exponential_backoff_timing_tc
-    ],
-    {inorder,
-        [
-            {inparallel,
-                [
-                    {atom_to_list(F), fun ?MODULE:F/0}
-                ||
-                    F <- ParallelSafe
-                ]
-            },
-            {inorder,
-                [
-                    {atom_to_list(F), fun ?MODULE:F/0}
-                ||
-                    F <- TimingSensitive
-                ]
-            }
-        ]
-    }.
+%%% Four test cases below (`idle_test', `bundle_dispatch_delay_test',
+%%% `dispatch_blocking_test', `exponential_backoff_timing_test') assert
+%%% wall-clock timing against the bundler's internal timers. They use
+%%% EUnit's plain `_test/0' convention rather than `_test_parallel/0'
+%%% so they run sequentially, before the parse_transform-injected
+%%% `all_parallel_test_/0' inparallel batch runs the other 20 cases.
+%%% Keeping them out of the batch avoids a ~20% flake seen when
+%%% `timer:sleep/1' returns late under same-module scheduler pressure.
 
-bundle_count_tc() ->
+bundle_count_test_parallel() ->
     test_bundle(#{ bundler_max_items => 3 }).
 
-bundle_size_tc() ->
+bundle_size_test_parallel() ->
     test_bundle(#{ bundler_max_size => floor(3.6 * ?DATA_CHUNK_SIZE) }).
 
-bundle_dispatch_delay_tc() -> 
+bundle_dispatch_delay_test() ->
     test_bundle(#{ bundler_max_bundle_dispatch_delay => 3000  }).
 
-nested_bundle_tc() ->
+nested_bundle_test_parallel() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     % NodeOpts redirects arweave gateway requests to the mock server.
@@ -687,19 +600,19 @@ nested_bundle_tc() ->
         stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-price_error_tc() ->
+price_error_test_parallel() ->
     test_api_error(#{
         price => {500, <<"error">>},
         tx_anchor => {200, hb_util:encode(rand:bytes(32))}
     }).
 
-anchor_error_tc() ->
+anchor_error_test_parallel() ->
     test_api_error(#{
         price => {200, <<"12345">>},
         tx_anchor => {500, <<"error">>}
     }).
 
-tx_error_tc() ->
+tx_error_test_parallel() ->
     {ServerHandle, NodeOpts} = start_mock_gateway(
         #{
             tx => {400, <<"Transaction verification failed.">>},
@@ -728,7 +641,7 @@ tx_error_tc() ->
         stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-unsigned_dataitem_tc() ->
+unsigned_dataitem_test_parallel() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     % NodeOpts redirects arweave gateway requests to the mock server.
@@ -762,7 +675,7 @@ unsigned_dataitem_tc() ->
         stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-idle_tc() ->
+idle_test() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     {ServerHandle, NodeOpts} = start_mock_gateway(
@@ -815,7 +728,7 @@ idle_tc() ->
         stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-dispatch_blocking_tc() ->
+dispatch_blocking_test() ->
     BlockTime = 500,
     Anchor = rand:bytes(32),
     Price = 12345,
@@ -876,7 +789,7 @@ dispatch_blocking_tc() ->
 
 %% @doc Test that items are recovered and posted while respecting the
 %% max_items limit.
-recover_respects_max_items_tc() ->
+recover_respects_max_items_test_parallel() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     {ServerHandle, NodeOpts} = start_mock_gateway(#{
@@ -916,7 +829,7 @@ recover_respects_max_items_tc() ->
         stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-complete_task_sequence_tc() ->
+complete_task_sequence_test_parallel() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     {ServerHandle, NodeOpts} = start_mock_gateway(#{
@@ -960,7 +873,7 @@ complete_task_sequence_tc() ->
         stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-recover_bundles_tc() ->
+recover_bundles_test_parallel() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     {ServerHandle, NodeOpts} = start_mock_gateway(#{
@@ -1017,7 +930,7 @@ recover_bundles_tc() ->
         stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-post_tx_price_failure_retry_tc() ->
+post_tx_price_failure_retry_test_parallel() ->
     Anchor = rand:bytes(32),
     FailCount = 3,
     setup_test_counter(price_attempts_counter),
@@ -1053,7 +966,7 @@ post_tx_price_failure_retry_tc() ->
         stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-post_tx_anchor_failure_retry_tc() ->
+post_tx_anchor_failure_retry_test_parallel() ->
     Price = 12345,
     FailCount = 3,
     setup_test_counter(anchor_attempts_counter),
@@ -1089,7 +1002,7 @@ post_tx_anchor_failure_retry_tc() ->
         stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-post_tx_post_failure_retry_tc() ->
+post_tx_post_failure_retry_test_parallel() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     FailCount = 4,
@@ -1127,7 +1040,7 @@ post_tx_post_failure_retry_tc() ->
         stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-post_proof_failure_retry_tc() ->
+post_proof_failure_retry_test_parallel() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     FailCount = 2,
@@ -1167,7 +1080,7 @@ post_proof_failure_retry_tc() ->
         stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-rapid_dispatch_tc() ->
+rapid_dispatch_test_parallel() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     {ServerHandle, NodeOpts} = start_mock_gateway(#{
@@ -1201,7 +1114,7 @@ rapid_dispatch_tc() ->
         stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-one_bundle_fails_others_continue_tc() ->
+one_bundle_fails_others_continue_test_parallel() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     setup_test_counter(mixed_attempts_counter),
@@ -1238,7 +1151,7 @@ one_bundle_fails_others_continue_tc() ->
         stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-parallel_task_execution_tc() ->
+parallel_task_execution_test_parallel() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     SleepTime = 120,
@@ -1276,7 +1189,7 @@ parallel_task_execution_tc() ->
         stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-exponential_backoff_timing_tc() ->
+exponential_backoff_timing_test() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     FailCount = 5,
@@ -1329,7 +1242,7 @@ exponential_backoff_timing_tc() ->
         stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-independent_task_retry_counts_tc() ->
+independent_task_retry_counts_test_parallel() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     setup_test_counter(independent_retry_counter),
@@ -1368,7 +1281,7 @@ independent_task_retry_counts_tc() ->
         stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-invalid_item_tc() ->
+invalid_item_test_parallel() ->
     Anchor = rand:bytes(32),
     Price = 12345,
     {ServerHandle, NodeOpts} = start_mock_gateway(#{
@@ -1411,7 +1324,7 @@ invalid_item_tc() ->
         stop_test_servers(ServerHandle, NodeOpts)
     end.
 
-cache_write_failure_tc() ->
+cache_write_failure_test_parallel() ->
     GoodOpts = #{store => hb_test_utils:test_store()},
     BadOpts = #{
         store => undefined,

--- a/src/dev_bundler.erl
+++ b/src/dev_bundler.erl
@@ -22,9 +22,9 @@
 
 -ifdef(TEST).
 %% Test cases exported so `all_tests_test_/0' can run them in parallel via
-%% `fun ?MODULE:name/0'. Each case receives a unique `bundler_server_name'
-%% in the `NodeOpts' returned from `start_mock_gateway/1', so concurrent
-%% tests no longer race on the legacy global `?SERVER_NAME' atom.
+%% `fun ?MODULE:name/0'. Each case builds its own wallet, and `server_name/1'
+%% derives the bundler server's registration name from the wallet address,
+%% so concurrent tests own independent bundler servers by construction.
 -export([
     bundle_count_tc/0,
     bundle_size_tc/0,
@@ -163,12 +163,19 @@ cache_item(Item, Opts) ->
 
 %%% Bundling server.
 
-%% @doc Look up the registration name for the bundler server. Defaults to
-%% the legacy global atom `?SERVER_NAME' so production code is unchanged;
-%% tests pass a unique `bundler_server_name' in `Opts' so each test gets
-%% its own server and concurrent tests do not race on the singleton.
+%% @doc Look up the registration name for the bundler server. Derived from
+%% the HTTP server's identity (which `hb_http_server:new_server/1' itself
+%% computes from `priv_wallet') so there is exactly one bundler per HTTP
+%% server on a BEAM node. Falls back to the legacy global `?SERVER_NAME'
+%% atom when no wallet is available (kept for production callers that
+%% stopped the server without a configured wallet).
 server_name(Opts) ->
-    hb_opts:get(bundler_server_name, ?SERVER_NAME, Opts).
+    case hb_opts:get(priv_wallet, undefined, Opts) of
+        undefined -> ?SERVER_NAME;
+        Wallet ->
+            {bundler_server,
+                hb_util:human_id(ar_wallet:to_address(Wallet))}
+    end.
 
 %% @doc Return the PID of the bundler server. If the server is not running,
 %% it is started and registered with the name returned by `server_name/1'.
@@ -569,12 +576,12 @@ recover_bundle(CommittedTX, Items, State = #state{opts = Opts}) ->
 %%% Tests
 %%%===================================================================
 
-%% @doc Run most tests in this module in parallel: `start_mock_gateway/1'
-%% stamps a unique `bundler_server_name' into `NodeOpts', so each bundler
-%% server is isolated per test. A few tests assert tight wall-clock
-%% timing bounds (retry backoff, non-blocking dispatch timings), and
-%% those false-fail under the CPU contention of a parallel run. Those
-%% run after the parallel batch in an `inorder' group.
+%% @doc Run most tests in this module in parallel: each test's wallet is
+%% fresh, so `server_name/1' hands each test an independent bundler
+%% registration without any shared-name contention. A few tests assert
+%% tight wall-clock timing bounds (retry backoff, non-blocking dispatch
+%% timings), and those false-fail under the CPU contention of a parallel
+%% run. Those run after the parallel batch in an `inorder' group.
 all_tests_test_() ->
     ParallelSafe = [
         bundle_count_tc,
@@ -1637,10 +1644,6 @@ start_mock_gateway(Responses) ->
     {ok, MockServer, ServerHandle} = hb_mock_server:start(Endpoints),
     NodeOpts = #{
         gateway => MockServer,
-        %% Unique server name per test: each test gets its own bundler
-        %% server process and `hb_name:singleton/2' registration, so
-        %% parallel tests do not race on the default `?SERVER_NAME' atom.
-        bundler_server_name => {bundler_server, make_ref()},
         routes => [
             #{
                 <<"template">> => <<"/arweave">>,

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -8,6 +8,31 @@
 -include_lib("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-ifdef(TEST).
+%% Test cases exported so they can be referenced by the parallel test
+%% generator `all_tests_test_/0' via `fun ?MODULE:name/0'. Each case is
+%% isolated via `setup_index_opts/0', so they are safe to run in parallel.
+-export([
+    index_ids_tc/0,
+    small_bundle_header_tc/0,
+    large_bundle_header_tc/0,
+    invalid_bundle_header_tc/0,
+    invalid_bundle_tc/0,
+    block_with_large_integer_tc/0,
+    empty_block_tc/0,
+    tx_with_no_data_tc/0,
+    non_string_tags_tc/0,
+    list_index_tc/0,
+    auto_stop_on_indexed_block_tc/0,
+    explicit_to_reindexes_all_tc/0,
+    auto_stop_partial_index_tc/0,
+    negative_parse_range_tc/0,
+    latest_height_failure_tc/0,
+    negative_resolved_height_tc/0,
+    negative_from_index_tc/0
+]).
+-endif.
+
 -define(ARWEAVE_DEVICE, <<"~arweave@2.9">>).
 
 % GET /~cron@1.0/once&cron-path=~copycat@1.0/arweave
@@ -486,7 +511,38 @@ observe_event(MetricName, Fun) ->
 
 %%% Tests
 
-index_ids_test() ->
+%% @doc All tests in this module run in parallel. Each test creates its own
+%% isolated test store via `setup_index_opts/0', so there is no shared state
+%% that could race. Running them in parallel cuts the module's wall time from
+%% ~33s serial to the length of the single slowest test.
+all_tests_test_() ->
+    {inparallel,
+        [
+            {atom_to_list(F), fun ?MODULE:F/0}
+        ||
+            F <- [
+                index_ids_tc,
+                small_bundle_header_tc,
+                large_bundle_header_tc,
+                invalid_bundle_header_tc,
+                invalid_bundle_tc,
+                block_with_large_integer_tc,
+                empty_block_tc,
+                tx_with_no_data_tc,
+                non_string_tags_tc,
+                list_index_tc,
+                auto_stop_on_indexed_block_tc,
+                explicit_to_reindexes_all_tc,
+                auto_stop_partial_index_tc,
+                negative_parse_range_tc,
+                latest_height_failure_tc,
+                negative_resolved_height_tc,
+                negative_from_index_tc
+            ]
+        ]
+    }.
+
+index_ids_tc() ->
     %% Test block: https://viewblock.io/arweave/block/1827942
     %% Note: this block includes a data item with an Ethereum signature. This
     %% signature type is not yet (as of Jan 2026) supported by ar_bundles.erl,
@@ -555,7 +611,7 @@ index_ids_test() ->
    ok.
 
 %% @doc Test a bundle header that fits in a single chunk.
-small_bundle_header_test() ->
+small_bundle_header_tc() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     TXID = <<"29TsnbqPQ_7rQ_r4KF5qRr995W1wBw_mTy6WEMy40aw">>,
     {ok, #{ <<"body">> := OffsetBody }} =
@@ -576,7 +632,7 @@ small_bundle_header_test() ->
     ok.
 
 %% @doc Test a bundle header that doesn't fit in a single chunk.
-large_bundle_header_test() ->
+large_bundle_header_tc() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     TXID = <<"bnMTI7LglBGSaK5EdV_juh6GNtXLm0cd5lkd2q4nlT0">>,
     {ok, #{ <<"body">> := OffsetBody }} =
@@ -596,7 +652,7 @@ large_bundle_header_test() ->
     ?assertEqual(960032, HeaderSize),
     ok.
 
-invalid_bundle_header_test() ->
+invalid_bundle_header_tc() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     TXID = <<"cGNURX2IUt98VKVIeXSfYe6eulNwPEqijaQfvatzd_o">>,
     {ok, #{ <<"body">> := OffsetBody }} =
@@ -614,7 +670,7 @@ invalid_bundle_header_test() ->
         download_bundle_header(EndOffset, Size, Opts)),
     ok.
 
-invalid_bundle_test() ->
+invalid_bundle_tc() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     Block = 1307606,
     {ok, Block} =
@@ -634,7 +690,7 @@ invalid_bundle_test() ->
     assert_item_read(<<"cGNURX2IUt98VKVIeXSfYe6eulNwPEqijaQfvatzd_o">>, Opts),
     ok.
 
-block_with_large_integer_test() ->
+block_with_large_integer_tc() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     Block = 633719,
     {ok, Block} =
@@ -647,7 +703,7 @@ block_with_large_integer_test() ->
     assert_item_read(<<"UXpcKTl6Mh34eTFSgny4NcIqoUjBcgYIcMqromcS6_Q">>, Opts),
     ok.
 
-empty_block_test() ->
+empty_block_tc() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     Block = 1865858,
     {ok, Block} =
@@ -720,7 +776,7 @@ tx_with_data_tag_test_disabled() ->
     assert_item_read(<<"jI0A4BASHaUdCCsdv249BxDX6IlE0Ko391TuI6REATw">>, Opts),
     ok.
 
-tx_with_no_data_test() ->
+tx_with_no_data_tc() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     Block = 1826700,
     BlockBin = hb_util:bin(Block),
@@ -781,13 +837,13 @@ tx_with_no_data_test() ->
     ?assertEqual([ ], maps:get(<<"not-indexed">>, BlockInfo)),
     ok.
 
-non_string_tags_test() ->
+non_string_tags_tc() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     Res = resolve_tx_header(<<"752P6t4cOjMabYHqzC6hyLhxyo4YKZLblg7va_J21YE">>, Opts),
     ?assertEqual(error, Res),
     ok.
 
-list_index_test() ->
+list_index_tc() ->
     %% Test block: https://viewblock.io/arweave/block/1827942
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     %% First index the block using write mode
@@ -836,7 +892,7 @@ list_index_test() ->
     ?assertEqual([ ], maps:get(<<"not-indexed">>, BlockInfo)),
     ok.
 
-auto_stop_on_indexed_block_test() ->
+auto_stop_on_indexed_block_tc() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     IndexedBlock = 1827941,
     Higher1 = IndexedBlock + 1,
@@ -866,7 +922,7 @@ auto_stop_on_indexed_block_test() ->
     ?assertNot(has_any_indexed_tx(IndexedBlock-1, Opts)),
     ok.
 
-explicit_to_reindexes_all_test() ->
+explicit_to_reindexes_all_tc() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     IndexedBlock = 1827942,
     LowerBlock = IndexedBlock - 1,
@@ -896,7 +952,7 @@ explicit_to_reindexes_all_test() ->
 
 %% @doc Manually write to the index to simulate a partially indexed block.
 %% This should also trigger a stop when the `to` option is omitted.
-auto_stop_partial_index_test() ->
+auto_stop_partial_index_tc() ->
     {_TestStore, StoreOpts, Opts} = setup_index_opts(),
     Block = 1826700,
     HigherBlock = Block + 1,
@@ -933,7 +989,7 @@ auto_stop_partial_index_test() ->
     ?assertNot(has_any_indexed_tx(Block-1, Opts)),
     ok.
 
-negative_parse_range_test() ->
+negative_parse_range_tc() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     {ok, Tip} =
         hb_ao:resolve(
@@ -950,7 +1006,7 @@ negative_parse_range_test() ->
     ?assertEqual(hb_util:int(Tip) - 3, NegativeTo),
     ok.
 
-latest_height_failure_test() ->
+latest_height_failure_tc() ->
     {ok, MockURL, MockHandle} = hb_mock_server:start([
         {"/block/current", block_current, {500, <<"Internal Server Error">>}}
     ]),
@@ -987,7 +1043,7 @@ latest_height_failure_test() ->
         hb_mock_server:stop(MockHandle)
     end.
 
-negative_resolved_height_test() ->
+negative_resolved_height_tc() ->
     {ok, MockURL, MockHandle} = hb_mock_server:start([
         {"/block/current", block_current,
             {200, <<"{\"height\": 5}">>}}
@@ -1021,7 +1077,7 @@ negative_resolved_height_test() ->
         hb_mock_server:stop(MockHandle)
     end.
 
-negative_from_index_test() ->
+negative_from_index_tc() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     {ok, Tip} = latest_height(Opts),
     StopBlock = 1827942,

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -8,31 +8,6 @@
 -include_lib("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--ifdef(TEST).
-%% Test cases exported so they can be referenced by the parallel test
-%% generator `all_tests_test_/0' via `fun ?MODULE:name/0'. Each case is
-%% isolated via `setup_index_opts/0', so they are safe to run in parallel.
--export([
-    index_ids_tc/0,
-    small_bundle_header_tc/0,
-    large_bundle_header_tc/0,
-    invalid_bundle_header_tc/0,
-    invalid_bundle_tc/0,
-    block_with_large_integer_tc/0,
-    empty_block_tc/0,
-    tx_with_no_data_tc/0,
-    non_string_tags_tc/0,
-    list_index_tc/0,
-    auto_stop_on_indexed_block_tc/0,
-    explicit_to_reindexes_all_tc/0,
-    auto_stop_partial_index_tc/0,
-    negative_parse_range_tc/0,
-    latest_height_failure_tc/0,
-    negative_resolved_height_tc/0,
-    negative_from_index_tc/0
-]).
--endif.
-
 -define(ARWEAVE_DEVICE, <<"~arweave@2.9">>).
 
 % GET /~cron@1.0/once&cron-path=~copycat@1.0/arweave
@@ -511,38 +486,7 @@ observe_event(MetricName, Fun) ->
 
 %%% Tests
 
-%% @doc All tests in this module run in parallel. Each test creates its own
-%% isolated test store via `setup_index_opts/0', so there is no shared state
-%% that could race. Running them in parallel cuts the module's wall time from
-%% ~33s serial to the length of the single slowest test.
-all_tests_test_() ->
-    {inparallel,
-        [
-            {atom_to_list(F), fun ?MODULE:F/0}
-        ||
-            F <- [
-                index_ids_tc,
-                small_bundle_header_tc,
-                large_bundle_header_tc,
-                invalid_bundle_header_tc,
-                invalid_bundle_tc,
-                block_with_large_integer_tc,
-                empty_block_tc,
-                tx_with_no_data_tc,
-                non_string_tags_tc,
-                list_index_tc,
-                auto_stop_on_indexed_block_tc,
-                explicit_to_reindexes_all_tc,
-                auto_stop_partial_index_tc,
-                negative_parse_range_tc,
-                latest_height_failure_tc,
-                negative_resolved_height_tc,
-                negative_from_index_tc
-            ]
-        ]
-    }.
-
-index_ids_tc() ->
+index_ids_test_parallel() ->
     %% Test block: https://viewblock.io/arweave/block/1827942
     %% Note: this block includes a data item with an Ethereum signature. This
     %% signature type is not yet (as of Jan 2026) supported by ar_bundles.erl,
@@ -611,7 +555,7 @@ index_ids_tc() ->
    ok.
 
 %% @doc Test a bundle header that fits in a single chunk.
-small_bundle_header_tc() ->
+small_bundle_header_test_parallel() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     TXID = <<"29TsnbqPQ_7rQ_r4KF5qRr995W1wBw_mTy6WEMy40aw">>,
     {ok, #{ <<"body">> := OffsetBody }} =
@@ -632,7 +576,7 @@ small_bundle_header_tc() ->
     ok.
 
 %% @doc Test a bundle header that doesn't fit in a single chunk.
-large_bundle_header_tc() ->
+large_bundle_header_test_parallel() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     TXID = <<"bnMTI7LglBGSaK5EdV_juh6GNtXLm0cd5lkd2q4nlT0">>,
     {ok, #{ <<"body">> := OffsetBody }} =
@@ -652,7 +596,7 @@ large_bundle_header_tc() ->
     ?assertEqual(960032, HeaderSize),
     ok.
 
-invalid_bundle_header_tc() ->
+invalid_bundle_header_test_parallel() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     TXID = <<"cGNURX2IUt98VKVIeXSfYe6eulNwPEqijaQfvatzd_o">>,
     {ok, #{ <<"body">> := OffsetBody }} =
@@ -670,7 +614,7 @@ invalid_bundle_header_tc() ->
         download_bundle_header(EndOffset, Size, Opts)),
     ok.
 
-invalid_bundle_tc() ->
+invalid_bundle_test_parallel() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     Block = 1307606,
     {ok, Block} =
@@ -690,7 +634,7 @@ invalid_bundle_tc() ->
     assert_item_read(<<"cGNURX2IUt98VKVIeXSfYe6eulNwPEqijaQfvatzd_o">>, Opts),
     ok.
 
-block_with_large_integer_tc() ->
+block_with_large_integer_test_parallel() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     Block = 633719,
     {ok, Block} =
@@ -703,7 +647,7 @@ block_with_large_integer_tc() ->
     assert_item_read(<<"UXpcKTl6Mh34eTFSgny4NcIqoUjBcgYIcMqromcS6_Q">>, Opts),
     ok.
 
-empty_block_tc() ->
+empty_block_test_parallel() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     Block = 1865858,
     {ok, Block} =
@@ -776,7 +720,7 @@ tx_with_data_tag_test_disabled() ->
     assert_item_read(<<"jI0A4BASHaUdCCsdv249BxDX6IlE0Ko391TuI6REATw">>, Opts),
     ok.
 
-tx_with_no_data_tc() ->
+tx_with_no_data_test_parallel() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     Block = 1826700,
     BlockBin = hb_util:bin(Block),
@@ -837,13 +781,13 @@ tx_with_no_data_tc() ->
     ?assertEqual([ ], maps:get(<<"not-indexed">>, BlockInfo)),
     ok.
 
-non_string_tags_tc() ->
+non_string_tags_test_parallel() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     Res = resolve_tx_header(<<"752P6t4cOjMabYHqzC6hyLhxyo4YKZLblg7va_J21YE">>, Opts),
     ?assertEqual(error, Res),
     ok.
 
-list_index_tc() ->
+list_index_test_parallel() ->
     %% Test block: https://viewblock.io/arweave/block/1827942
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     %% First index the block using write mode
@@ -892,7 +836,7 @@ list_index_tc() ->
     ?assertEqual([ ], maps:get(<<"not-indexed">>, BlockInfo)),
     ok.
 
-auto_stop_on_indexed_block_tc() ->
+auto_stop_on_indexed_block_test_parallel() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     IndexedBlock = 1827941,
     Higher1 = IndexedBlock + 1,
@@ -922,7 +866,7 @@ auto_stop_on_indexed_block_tc() ->
     ?assertNot(has_any_indexed_tx(IndexedBlock-1, Opts)),
     ok.
 
-explicit_to_reindexes_all_tc() ->
+explicit_to_reindexes_all_test_parallel() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     IndexedBlock = 1827942,
     LowerBlock = IndexedBlock - 1,
@@ -952,7 +896,7 @@ explicit_to_reindexes_all_tc() ->
 
 %% @doc Manually write to the index to simulate a partially indexed block.
 %% This should also trigger a stop when the `to` option is omitted.
-auto_stop_partial_index_tc() ->
+auto_stop_partial_index_test_parallel() ->
     {_TestStore, StoreOpts, Opts} = setup_index_opts(),
     Block = 1826700,
     HigherBlock = Block + 1,
@@ -989,7 +933,7 @@ auto_stop_partial_index_tc() ->
     ?assertNot(has_any_indexed_tx(Block-1, Opts)),
     ok.
 
-negative_parse_range_tc() ->
+negative_parse_range_test_parallel() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     {ok, Tip} =
         hb_ao:resolve(
@@ -1006,7 +950,7 @@ negative_parse_range_tc() ->
     ?assertEqual(hb_util:int(Tip) - 3, NegativeTo),
     ok.
 
-latest_height_failure_tc() ->
+latest_height_failure_test_parallel() ->
     {ok, MockURL, MockHandle} = hb_mock_server:start([
         {"/block/current", block_current, {500, <<"Internal Server Error">>}}
     ]),
@@ -1043,7 +987,7 @@ latest_height_failure_tc() ->
         hb_mock_server:stop(MockHandle)
     end.
 
-negative_resolved_height_tc() ->
+negative_resolved_height_test_parallel() ->
     {ok, MockURL, MockHandle} = hb_mock_server:start([
         {"/block/current", block_current,
             {200, <<"{\"height\": 5}">>}}
@@ -1077,7 +1021,7 @@ negative_resolved_height_tc() ->
         hb_mock_server:stop(MockHandle)
     end.
 
-negative_from_index_tc() ->
+negative_from_index_test_parallel() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     {ok, Tip} = latest_height(Opts),
     StopBlock = 1827942,

--- a/src/dev_copycat_graphql.erl
+++ b/src/dev_copycat_graphql.erl
@@ -5,6 +5,20 @@
 -include_lib("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-ifdef(TEST).
+-export([
+    basic_tc/0,
+    query_tc/0,
+    tag_value_tc/0,
+    owners_filter_tc/0,
+    recipients_filter_tc/0,
+    ids_filter_tc/0,
+    all_filter_tc/0,
+    combined_filters_tc/0,
+    fetch_scheduler_location_tc/0
+]).
+-endif.
+
 -define(SUPPORTED_FILTERS,
     [
         <<"query">>, 
@@ -267,6 +281,28 @@ default_query(Parts) ->
         " } pageInfo { hasNextPage } } }">>}.
 
 %%% Tests
+
+%% @doc All tests run in parallel. Each `run_test_node/0' call creates an
+%% isolated store and HTTP server, so there is no shared state to race on.
+all_tests_test_() ->
+    {inparallel,
+        [
+            {atom_to_list(F), fun ?MODULE:F/0}
+        ||
+            F <- [
+                basic_tc,
+                query_tc,
+                tag_value_tc,
+                owners_filter_tc,
+                recipients_filter_tc,
+                ids_filter_tc,
+                all_filter_tc,
+                combined_filters_tc,
+                fetch_scheduler_location_tc
+            ]
+        ]
+    }.
+
 %% @doc Run node for testing
 run_test_node() ->
     Store = hb_test_utils:test_store(),
@@ -274,7 +310,7 @@ run_test_node() ->
     Node = hb_http_server:start_node(Opts),
     {Node ,Opts}. 
 %% @doc Basic test to test copycat device
-basic_test() ->
+basic_tc() ->
     {Node, _Opts} = run_test_node(),
     {ok, Res} =
         hb_http:get(
@@ -287,7 +323,7 @@ basic_test() ->
     ?event({basic_test_result, Res}),
     ok.
 
-query_test() ->
+query_tc() ->
     Base = #{
         <<"query">> => #{
             <<"tags">> => #{
@@ -318,7 +354,7 @@ query_test() ->
     ok.
 
 %% @doc Test tag/value pair format
-tag_value_test() ->
+tag_value_tc() ->
     Base = #{<<"tag">> => <<"type">>, <<"value">> => <<"process">>},
     {ok, Query} = parse_query(Base, #{}, #{}),
     ?event({tag_value_test, {query, Query}}),
@@ -331,7 +367,7 @@ tag_value_test() ->
     ok.
 
 %% @doc Test owners filter with single value
-owners_filter_test() ->
+owners_filter_tc() ->
     Base = #{<<"owners">> => <<"addr123">>},
     {ok, Query} = parse_query(Base, #{}, #{}),
     ?event({owners_filter_test, {query, Query}}),
@@ -344,7 +380,7 @@ owners_filter_test() ->
     ok.
 
 %% @doc Test recipients filter with array values
-recipients_filter_test() ->
+recipients_filter_tc() ->
     Base = #{<<"recipients">> => [<<"rec1">>, <<"rec2">>]},
     {ok, Query} = parse_query(Base, #{}, #{}),
     ?event({recipients_filter_test, {query, Query}}),
@@ -357,7 +393,7 @@ recipients_filter_test() ->
     ok.
 
 %% @doc Test ids filter
-ids_filter_test() ->
+ids_filter_tc() ->
     Base = #{<<"ids">> => [<<"id1">>, <<"id2">>, <<"id3">>]},
     {ok, Query} = parse_query(Base, #{}, #{}),
     ?event({ids_filter_test, {query, Query}}),
@@ -370,7 +406,7 @@ ids_filter_test() ->
     ok.
 
 %% @doc Test all filter type
-all_filter_test() ->
+all_filter_tc() ->
     Base = #{<<"all">> => <<"true">>},
     {ok, Query} = parse_query(Base, #{}, #{}),
     ?event({all_filter_test, {query, Query}}),
@@ -383,7 +419,7 @@ all_filter_test() ->
     ok.
 
 %% @doc Test combined multiple filters in one query
-combined_filters_test() ->
+combined_filters_tc() ->
     Base = #{
         <<"query">> => #{
             <<"tags">> => #{
@@ -428,7 +464,7 @@ combined_filters_test() ->
     ok.
 
 %% @doc Real world test with actual indexing
-fetch_scheduler_location_test() ->
+fetch_scheduler_location_tc() ->
     {Node, _Opts} = run_test_node(),
     Res =
         hb_http:get(

--- a/src/dev_copycat_graphql.erl
+++ b/src/dev_copycat_graphql.erl
@@ -5,20 +5,6 @@
 -include_lib("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--ifdef(TEST).
--export([
-    basic_tc/0,
-    query_tc/0,
-    tag_value_tc/0,
-    owners_filter_tc/0,
-    recipients_filter_tc/0,
-    ids_filter_tc/0,
-    all_filter_tc/0,
-    combined_filters_tc/0,
-    fetch_scheduler_location_tc/0
-]).
--endif.
-
 -define(SUPPORTED_FILTERS,
     [
         <<"query">>, 
@@ -282,27 +268,6 @@ default_query(Parts) ->
 
 %%% Tests
 
-%% @doc All tests run in parallel. Each `run_test_node/0' call creates an
-%% isolated store and HTTP server, so there is no shared state to race on.
-all_tests_test_() ->
-    {inparallel,
-        [
-            {atom_to_list(F), fun ?MODULE:F/0}
-        ||
-            F <- [
-                basic_tc,
-                query_tc,
-                tag_value_tc,
-                owners_filter_tc,
-                recipients_filter_tc,
-                ids_filter_tc,
-                all_filter_tc,
-                combined_filters_tc,
-                fetch_scheduler_location_tc
-            ]
-        ]
-    }.
-
 %% @doc Run node for testing
 run_test_node() ->
     Store = hb_test_utils:test_store(),
@@ -310,7 +275,7 @@ run_test_node() ->
     Node = hb_http_server:start_node(Opts),
     {Node ,Opts}. 
 %% @doc Basic test to test copycat device
-basic_tc() ->
+basic_test_parallel() ->
     {Node, _Opts} = run_test_node(),
     {ok, Res} =
         hb_http:get(
@@ -323,7 +288,7 @@ basic_tc() ->
     ?event({basic_test_result, Res}),
     ok.
 
-query_tc() ->
+query_test_parallel() ->
     Base = #{
         <<"query">> => #{
             <<"tags">> => #{
@@ -354,7 +319,7 @@ query_tc() ->
     ok.
 
 %% @doc Test tag/value pair format
-tag_value_tc() ->
+tag_value_test_parallel() ->
     Base = #{<<"tag">> => <<"type">>, <<"value">> => <<"process">>},
     {ok, Query} = parse_query(Base, #{}, #{}),
     ?event({tag_value_test, {query, Query}}),
@@ -367,7 +332,7 @@ tag_value_tc() ->
     ok.
 
 %% @doc Test owners filter with single value
-owners_filter_tc() ->
+owners_filter_test_parallel() ->
     Base = #{<<"owners">> => <<"addr123">>},
     {ok, Query} = parse_query(Base, #{}, #{}),
     ?event({owners_filter_test, {query, Query}}),
@@ -380,7 +345,7 @@ owners_filter_tc() ->
     ok.
 
 %% @doc Test recipients filter with array values
-recipients_filter_tc() ->
+recipients_filter_test_parallel() ->
     Base = #{<<"recipients">> => [<<"rec1">>, <<"rec2">>]},
     {ok, Query} = parse_query(Base, #{}, #{}),
     ?event({recipients_filter_test, {query, Query}}),
@@ -393,7 +358,7 @@ recipients_filter_tc() ->
     ok.
 
 %% @doc Test ids filter
-ids_filter_tc() ->
+ids_filter_test_parallel() ->
     Base = #{<<"ids">> => [<<"id1">>, <<"id2">>, <<"id3">>]},
     {ok, Query} = parse_query(Base, #{}, #{}),
     ?event({ids_filter_test, {query, Query}}),
@@ -406,7 +371,7 @@ ids_filter_tc() ->
     ok.
 
 %% @doc Test all filter type
-all_filter_tc() ->
+all_filter_test_parallel() ->
     Base = #{<<"all">> => <<"true">>},
     {ok, Query} = parse_query(Base, #{}, #{}),
     ?event({all_filter_test, {query, Query}}),
@@ -419,7 +384,7 @@ all_filter_tc() ->
     ok.
 
 %% @doc Test combined multiple filters in one query
-combined_filters_tc() ->
+combined_filters_test_parallel() ->
     Base = #{
         <<"query">> => #{
             <<"tags">> => #{
@@ -464,7 +429,7 @@ combined_filters_tc() ->
     ok.
 
 %% @doc Real world test with actual indexing
-fetch_scheduler_location_tc() ->
+fetch_scheduler_location_test_parallel() ->
     {Node, _Opts} = run_test_node(),
     Res =
         hb_http:get(

--- a/src/dev_manifest.erl
+++ b/src/dev_manifest.erl
@@ -7,20 +7,7 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--ifdef(TEST).
-%% Test cases exported so `all_tests_test_/0' can reference them as
-%% `fun ?MODULE:name/0' in the parallel generator below.
--export([
-    resolve_tc/0,
-    manifest_default_fallback_tc/0,
-    manifest_404_error_tc/0,
-    manifest_inner_redirect_tc/0,
-    access_key_path_in_manifest_tc/0,
-    manifest_should_fallback_on_not_found_path_tc/0
-]).
--endif.
-
-%% @doc Use the `route/4' function as the handler for all requests, aside 
+%% @doc Use the `route/4' function as the handler for all requests, aside
 %% from `keys' and `set', which are handled by the default resolver.
 info() ->
     #{
@@ -216,27 +203,7 @@ linkify(Manifest, _Opts) ->
 
 %%% Tests
 
-%% @doc All tests run in parallel. Each test sets up its own store (and, when
-%% needed, its own node via `hb_http_server:start_node/1'), so they are safe
-%% to run concurrently. Parallelising cuts the module's wall time from ~29s
-%% serial to roughly the length of the slowest test.
-all_tests_test_() ->
-    {inparallel,
-        [
-            {atom_to_list(F), fun ?MODULE:F/0}
-        ||
-            F <- [
-                resolve_tc,
-                manifest_default_fallback_tc,
-                manifest_404_error_tc,
-                manifest_inner_redirect_tc,
-                access_key_path_in_manifest_tc,
-                manifest_should_fallback_on_not_found_path_tc
-            ]
-        ]
-    }.
-
-resolve_tc() ->
+resolve_test_parallel() ->
     Opts = #{
         store => hb_opts:get(store, no_viable_store, #{}),
         on => #{
@@ -296,7 +263,7 @@ resolve_tc() ->
         hb_http:get(Node, << LegacyManifestID/binary, "/nested/page2" >>, Opts)),
     ok.
 
-manifest_default_fallback_tc() ->
+manifest_default_fallback_test_parallel() ->
     Opts = #{ store => hb_opts:get(store, no_viable_store, #{}) },
     {ok, ManifestID} = create_generic_manifest(Opts),
     ?event({manifest_id, ManifestID}),
@@ -307,7 +274,7 @@ manifest_default_fallback_tc() ->
     ),
     ok.
 
-manifest_404_error_tc() ->
+manifest_404_error_test_parallel() ->
     Opts = #{
         store => hb_opts:get(store, no_viable_store, #{}),
         manifest_404 => error
@@ -379,7 +346,7 @@ manifest_download_via_raw_endpoint_test_ignore() ->
     ).
 
 %% @doc Accessing `/TXID` of a manifest transaction should access the index key.
-manifest_inner_redirect_tc() ->
+manifest_inner_redirect_test_parallel() ->
     Opts = test_env_opts(),
     Node = hb_http_server:start_node(Opts),
     %% Request manifest to node.
@@ -393,7 +360,7 @@ manifest_inner_redirect_tc() ->
     ).
 
 %% @doc Accessing `/TXID/assets/ArticleBlock-Dtwjc54T.js` should return valid message.
-access_key_path_in_manifest_tc() ->
+access_key_path_in_manifest_test_parallel() ->
     Opts = test_env_opts(),
     Node = hb_http_server:start_node(Opts),
     ?assertMatch(
@@ -407,7 +374,7 @@ access_key_path_in_manifest_tc() ->
 
 %% This works with `not_found.js` but doesn't follow the logic if under a 
 %% folder structure, like `assets/not_found.js .
-manifest_should_fallback_on_not_found_path_tc() ->
+manifest_should_fallback_on_not_found_path_test_parallel() ->
     Opts = test_env_opts(),
     Node = hb_http_server:start_node(Opts),
     ?assertMatch(

--- a/src/dev_manifest.erl
+++ b/src/dev_manifest.erl
@@ -7,6 +7,19 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-ifdef(TEST).
+%% Test cases exported so `all_tests_test_/0' can reference them as
+%% `fun ?MODULE:name/0' in the parallel generator below.
+-export([
+    resolve_tc/0,
+    manifest_default_fallback_tc/0,
+    manifest_404_error_tc/0,
+    manifest_inner_redirect_tc/0,
+    access_key_path_in_manifest_tc/0,
+    manifest_should_fallback_on_not_found_path_tc/0
+]).
+-endif.
+
 %% @doc Use the `route/4' function as the handler for all requests, aside 
 %% from `keys' and `set', which are handled by the default resolver.
 info() ->
@@ -203,7 +216,27 @@ linkify(Manifest, _Opts) ->
 
 %%% Tests
 
-resolve_test() ->
+%% @doc All tests run in parallel. Each test sets up its own store (and, when
+%% needed, its own node via `hb_http_server:start_node/1'), so they are safe
+%% to run concurrently. Parallelising cuts the module's wall time from ~29s
+%% serial to roughly the length of the slowest test.
+all_tests_test_() ->
+    {inparallel,
+        [
+            {atom_to_list(F), fun ?MODULE:F/0}
+        ||
+            F <- [
+                resolve_tc,
+                manifest_default_fallback_tc,
+                manifest_404_error_tc,
+                manifest_inner_redirect_tc,
+                access_key_path_in_manifest_tc,
+                manifest_should_fallback_on_not_found_path_tc
+            ]
+        ]
+    }.
+
+resolve_tc() ->
     Opts = #{
         store => hb_opts:get(store, no_viable_store, #{}),
         on => #{
@@ -263,7 +296,7 @@ resolve_test() ->
         hb_http:get(Node, << LegacyManifestID/binary, "/nested/page2" >>, Opts)),
     ok.
 
-manifest_default_fallback_test() ->
+manifest_default_fallback_tc() ->
     Opts = #{ store => hb_opts:get(store, no_viable_store, #{}) },
     {ok, ManifestID} = create_generic_manifest(Opts),
     ?event({manifest_id, ManifestID}),
@@ -274,7 +307,7 @@ manifest_default_fallback_test() ->
     ),
     ok.
 
-manifest_404_error_test() ->
+manifest_404_error_tc() ->
     Opts = #{
         store => hb_opts:get(store, no_viable_store, #{}),
         manifest_404 => error
@@ -346,7 +379,7 @@ manifest_download_via_raw_endpoint_test_ignore() ->
     ).
 
 %% @doc Accessing `/TXID` of a manifest transaction should access the index key.
-manifest_inner_redirect_test() ->
+manifest_inner_redirect_tc() ->
     Opts = test_env_opts(),
     Node = hb_http_server:start_node(Opts),
     %% Request manifest to node.
@@ -360,7 +393,7 @@ manifest_inner_redirect_test() ->
     ).
 
 %% @doc Accessing `/TXID/assets/ArticleBlock-Dtwjc54T.js` should return valid message.
-access_key_path_in_manifest_test() ->
+access_key_path_in_manifest_tc() ->
     Opts = test_env_opts(),
     Node = hb_http_server:start_node(Opts),
     ?assertMatch(
@@ -374,7 +407,7 @@ access_key_path_in_manifest_test() ->
 
 %% This works with `not_found.js` but doesn't follow the logic if under a 
 %% folder structure, like `assets/not_found.js .
-manifest_should_fallback_on_not_found_path_test() ->
+manifest_should_fallback_on_not_found_path_tc() ->
     Opts = test_env_opts(),
     Node = hb_http_server:start_node(Opts),
     ?assertMatch(

--- a/src/dev_name.erl
+++ b/src/dev_name.erl
@@ -10,21 +10,6 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--ifdef(TEST).
-%% Test cases exported so `all_tests_test_/0' can run them in parallel.
--export([
-    no_resolvers_tc/0,
-    single_resolver_tc/0,
-    message_lookup_tc/0,
-    multiple_resolvers_tc/0,
-    load_and_execute_tc/0,
-    arns_json_snapshot_tc/0,
-    arns_host_resolution_tc/0,
-    arns_host_resolution_with_node_host_tc/0,
-    localhost_root_request_skips_name_resolution_tc/0
-]).
--endif.
-
 %%% Core functionality.
 
 %% @doc Configure the `default' key to proxy to the `resolver/4' function.
@@ -197,28 +182,7 @@ name_from_host(ReqHost, RawNodeHost) ->
 
 %%% Tests.
 
-%% @doc Run every test in this module in parallel. Each case uses its own
-%% opts/store, so no shared state exists to race on.
-all_tests_test_() ->
-    {inparallel,
-        [
-            {atom_to_list(F), fun ?MODULE:F/0}
-        ||
-            F <- [
-                no_resolvers_tc,
-                single_resolver_tc,
-                message_lookup_tc,
-                multiple_resolvers_tc,
-                load_and_execute_tc,
-                arns_json_snapshot_tc,
-                arns_host_resolution_tc,
-                arns_host_resolution_with_node_host_tc,
-                localhost_root_request_skips_name_resolution_tc
-            ]
-        ]
-    }.
-
-no_resolvers_tc() ->
+no_resolvers_test_parallel() ->
     ?assertEqual(
         not_found,
         resolve(<<"hello">>, #{}, #{}, #{ only => local })
@@ -242,7 +206,7 @@ device_resolver(Msg) ->
         }
     }.
 
-single_resolver_tc() ->
+single_resolver_test_parallel() ->
     ?assertEqual(
         {ok, <<"world">>},
         resolve(
@@ -258,7 +222,7 @@ single_resolver_tc() ->
     ).
 
 %% @doc Lookup a name in a message and return it.
-message_lookup_tc() ->
+message_lookup_test_parallel() ->
     ?assertEqual(
         {ok, <<"world">>},
         resolve(
@@ -275,7 +239,7 @@ message_lookup_tc() ->
         )
     ).
 
-multiple_resolvers_tc() ->
+multiple_resolvers_test_parallel() ->
     ?assertEqual(
         {ok, <<"bigger-world">>},
         resolve(
@@ -296,7 +260,7 @@ multiple_resolvers_tc() ->
     ).
 
 %% @doc Test that we can resolve messages from a name loaded with the device.
-load_and_execute_tc() ->
+load_and_execute_test_parallel() ->
     TestKey = <<"test-key", (hb_util:bin(erlang:system_time(millisecond)))/binary>>,
     {ok, ID} = hb_cache:write(
         #{
@@ -345,7 +309,7 @@ test_arns_opts() ->
     }.
 
 %% @doc Names from JSON test.
-arns_json_snapshot_tc() ->
+arns_json_snapshot_test_parallel() ->
     Opts = test_arns_opts(),
     ?assertMatch(
         {ok, <<"text/html">>},
@@ -359,7 +323,7 @@ arns_json_snapshot_tc() ->
         )
     ).
 
-arns_host_resolution_tc() ->
+arns_host_resolution_test_parallel() ->
     Opts = test_arns_opts(),
     Node = hb_http_server:start_node(Opts),
     ?assertMatch(
@@ -374,7 +338,7 @@ arns_host_resolution_tc() ->
         )
     ).
 
-arns_host_resolution_with_node_host_tc() ->
+arns_host_resolution_with_node_host_test_parallel() ->
     Opts = (test_arns_opts())#{ node_host => <<"http://localhost">>, port => 0 },
     Node = hb_http_server:start_node(Opts),
     ?assertMatch(
@@ -389,7 +353,7 @@ arns_host_resolution_with_node_host_tc() ->
         )
     ).
 
-localhost_root_request_skips_name_resolution_tc() ->
+localhost_root_request_skips_name_resolution_test_parallel() ->
     Opts = (test_arns_opts())#{ port => 0 },
     Node = hb_http_server:start_node(Opts),
     ?assertMatch(

--- a/src/dev_name.erl
+++ b/src/dev_name.erl
@@ -10,6 +10,21 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-ifdef(TEST).
+%% Test cases exported so `all_tests_test_/0' can run them in parallel.
+-export([
+    no_resolvers_tc/0,
+    single_resolver_tc/0,
+    message_lookup_tc/0,
+    multiple_resolvers_tc/0,
+    load_and_execute_tc/0,
+    arns_json_snapshot_tc/0,
+    arns_host_resolution_tc/0,
+    arns_host_resolution_with_node_host_tc/0,
+    localhost_root_request_skips_name_resolution_tc/0
+]).
+-endif.
+
 %%% Core functionality.
 
 %% @doc Configure the `default' key to proxy to the `resolver/4' function.
@@ -182,7 +197,28 @@ name_from_host(ReqHost, RawNodeHost) ->
 
 %%% Tests.
 
-no_resolvers_test() ->
+%% @doc Run every test in this module in parallel. Each case uses its own
+%% opts/store, so no shared state exists to race on.
+all_tests_test_() ->
+    {inparallel,
+        [
+            {atom_to_list(F), fun ?MODULE:F/0}
+        ||
+            F <- [
+                no_resolvers_tc,
+                single_resolver_tc,
+                message_lookup_tc,
+                multiple_resolvers_tc,
+                load_and_execute_tc,
+                arns_json_snapshot_tc,
+                arns_host_resolution_tc,
+                arns_host_resolution_with_node_host_tc,
+                localhost_root_request_skips_name_resolution_tc
+            ]
+        ]
+    }.
+
+no_resolvers_tc() ->
     ?assertEqual(
         not_found,
         resolve(<<"hello">>, #{}, #{}, #{ only => local })
@@ -206,7 +242,7 @@ device_resolver(Msg) ->
         }
     }.
 
-single_resolver_test() ->
+single_resolver_tc() ->
     ?assertEqual(
         {ok, <<"world">>},
         resolve(
@@ -222,7 +258,7 @@ single_resolver_test() ->
     ).
 
 %% @doc Lookup a name in a message and return it.
-message_lookup_test() ->
+message_lookup_tc() ->
     ?assertEqual(
         {ok, <<"world">>},
         resolve(
@@ -239,7 +275,7 @@ message_lookup_test() ->
         )
     ).
 
-multiple_resolvers_test() ->
+multiple_resolvers_tc() ->
     ?assertEqual(
         {ok, <<"bigger-world">>},
         resolve(
@@ -260,7 +296,7 @@ multiple_resolvers_test() ->
     ).
 
 %% @doc Test that we can resolve messages from a name loaded with the device.
-load_and_execute_test() ->
+load_and_execute_tc() ->
     TestKey = <<"test-key", (hb_util:bin(erlang:system_time(millisecond)))/binary>>,
     {ok, ID} = hb_cache:write(
         #{
@@ -309,7 +345,7 @@ test_arns_opts() ->
     }.
 
 %% @doc Names from JSON test.
-arns_json_snapshot_test() ->
+arns_json_snapshot_tc() ->
     Opts = test_arns_opts(),
     ?assertMatch(
         {ok, <<"text/html">>},
@@ -323,7 +359,7 @@ arns_json_snapshot_test() ->
         )
     ).
 
-arns_host_resolution_test() ->
+arns_host_resolution_tc() ->
     Opts = test_arns_opts(),
     Node = hb_http_server:start_node(Opts),
     ?assertMatch(
@@ -338,7 +374,7 @@ arns_host_resolution_test() ->
         )
     ).
 
-arns_host_resolution_with_node_host_test() ->
+arns_host_resolution_with_node_host_tc() ->
     Opts = (test_arns_opts())#{ node_host => <<"http://localhost">>, port => 0 },
     Node = hb_http_server:start_node(Opts),
     ?assertMatch(
@@ -353,7 +389,7 @@ arns_host_resolution_with_node_host_test() ->
         )
     ).
 
-localhost_root_request_skips_name_resolution_test() ->
+localhost_root_request_skips_name_resolution_tc() ->
     Opts = (test_arns_opts())#{ port => 0 },
     Node = hb_http_server:start_node(Opts),
     ?assertMatch(

--- a/src/dev_process_test_vectors.erl
+++ b/src/dev_process_test_vectors.erl
@@ -6,6 +6,31 @@
 -export([init/0, aos_process/0, aos_process/1, test_process/0, wasm_process/1]).
 -export([schedule_aos_call/2, schedule_aos_call/3]).
 
+-ifdef(TEST).
+%% Test cases exported so `all_tests_test_/0' can run them in parallel via
+%% `fun ?MODULE:name/0'. Each case sets up its own store and, where
+%% applicable, its own HTTP server, so there is no shared state to race on.
+-export([
+    schedule_on_process_tc_/0,
+    get_scheduler_slot_tc/0,
+    recursive_path_resolution_tc/0,
+    test_device_compute_tc/0,
+    wasm_compute_tc/0,
+    wasm_compute_from_id_tc/0,
+    http_wasm_process_by_id_tc/0,
+    aos_compute_tc_/0,
+    aos_browsable_state_tc_/0,
+    aos_state_access_via_http_tc_/0,
+    aos_state_patch_tc_/0,
+    restore_tc_/0,
+    now_results_tc_/0,
+    prior_results_accessible_tc_/0,
+    persistent_process_tc/0,
+    simple_wasm_persistent_worker_benchmark_tc/0,
+    aos_persistent_worker_benchmark_tc_/0
+]).
+-endif.
+
 init() -> application:ensure_all_started(hb).
 
 test_opts() ->
@@ -170,7 +195,40 @@ schedule_wasm_call(Base, FuncName, Params, Opts) ->
         ),
     ?assertMatch({ok, _}, hb_ao:resolve(Base, Req, Opts)).
 
-schedule_on_process_test_() ->
+%% @doc Run every test in this module in parallel. Each case creates its own
+%% store (and its own node where applicable), so there is no shared state
+%% that could race. Parallelising cuts the module's wall time from ~27 s
+%% serial (dominated by several 2-5 s AOS tests) to roughly the slowest
+%% test. `_tc_/0' generators return test specs (e.g. `{timeout, N, Fun}')
+%% and eunit expands them transparently when referenced as `fun M:F/0'.
+all_tests_test_() ->
+    {inparallel,
+        [
+            {atom_to_list(F), fun ?MODULE:F/0}
+        ||
+            F <- [
+                schedule_on_process_tc_,
+                get_scheduler_slot_tc,
+                recursive_path_resolution_tc,
+                test_device_compute_tc,
+                wasm_compute_tc,
+                wasm_compute_from_id_tc,
+                http_wasm_process_by_id_tc,
+                aos_compute_tc_,
+                aos_browsable_state_tc_,
+                aos_state_access_via_http_tc_,
+                aos_state_patch_tc_,
+                restore_tc_,
+                now_results_tc_,
+                prior_results_accessible_tc_,
+                persistent_process_tc,
+                simple_wasm_persistent_worker_benchmark_tc,
+                aos_persistent_worker_benchmark_tc_
+            ]
+        ]
+    }.
+
+schedule_on_process_tc_() ->
 	{timeout, 30, fun()->
 		Opts = test_opts(),
 		Base = aos_process(Opts),
@@ -192,7 +250,7 @@ schedule_on_process_test_() ->
 		)
 	end}.
 
-get_scheduler_slot_test() ->
+get_scheduler_slot_tc() ->
     Opts = test_opts(),
     Base = base_process(Opts),
     schedule_test_message(Base, <<"TEST TEXT 1">>, Opts),
@@ -206,7 +264,7 @@ get_scheduler_slot_test() ->
         hb_ao:resolve(Base, Req, Opts)
     ).
 
-recursive_path_resolution_test() ->
+recursive_path_resolution_tc() ->
     Opts = test_opts(),
     Base = base_process(Opts),
     schedule_test_message(Base, <<"TEST TEXT 1">>, Opts),
@@ -223,7 +281,7 @@ recursive_path_resolution_test() ->
     ),
     ok.
 
-test_device_compute_test() ->
+test_device_compute_tc() ->
     Opts = test_opts(),
     Base = test_process(Opts),
     schedule_test_message(Base, <<"TEST TEXT 1">>, Opts),
@@ -242,7 +300,7 @@ test_device_compute_test() ->
     ?assertEqual(1, hb_ao:get(<<"results/assignment-slot">>, Res, Opts)),
     ?assertEqual([1,1,0,0], hb_ao:get(<<"already-seen">>, Res, Opts)).
 
-wasm_compute_test() ->
+wasm_compute_tc() ->
     Opts = test_opts(),
     Base = wasm_process(<<"test/test-64.wasm">>, Opts),
     schedule_wasm_call(Base, <<"fac">>, [2.0], Opts),
@@ -285,7 +343,7 @@ wasm_compute_test() ->
     % ?assertEqual([2.0], hb_ao:get(<<"results/output">>, Slot0Res, Opts)),
     % ?assertEqual([6.0], hb_ao:get(<<"results/output">>, Slot1Res, Opts)).
 
-wasm_compute_from_id_test() ->
+wasm_compute_from_id_tc() ->
     Opts = test_opts(#{ cache_control => <<"always">> }),
     Base = wasm_process(<<"test/test-64.wasm">>, Opts),
     schedule_wasm_call(Base, <<"fac">>, [5.0], Opts),
@@ -295,7 +353,7 @@ wasm_compute_from_id_test() ->
     ?event(process_compute, {computed_message, {res, Res}}),
     ?assertEqual([120.0], hb_ao:get(<<"results/output">>, Res, Opts)).
 
-http_wasm_process_by_id_test() ->
+http_wasm_process_by_id_tc() ->
     rand:seed(default),
     SchedWallet = ar_wallet:new(),
     Node = hb_http_server:start_node(Opts = #{
@@ -344,7 +402,7 @@ http_wasm_process_by_id_test() ->
     ?event({compute_msg_res, {msg4, Msg4}}),
     ?assertEqual([120.0], hb_ao:get(<<"results/output">>, Msg4, Opts)).
 
-aos_compute_test_() ->
+aos_compute_tc_() ->
     {timeout, 30, fun() ->
         Opts = test_opts(),
         Base = aos_process(Opts),
@@ -363,7 +421,7 @@ aos_compute_test_() ->
         {ok, Res3}
     end}.
 
-aos_browsable_state_test_() ->
+aos_browsable_state_tc_() ->
     {timeout, 30, fun() ->
         Opts = test_opts(#{ cache_control => <<"always">> }),
         Base = aos_process(Opts),
@@ -385,7 +443,7 @@ aos_browsable_state_test_() ->
         ?assertEqual(4, Res)
     end}.
 
-aos_state_access_via_http_test_() ->
+aos_state_access_via_http_tc_() ->
     {timeout, 60, fun() ->
         rand:seed(default),
         Wallet = ar_wallet:new(),
@@ -444,7 +502,7 @@ aos_state_access_via_http_test_() ->
         ok
     end}.
 
-aos_state_patch_test_() ->
+aos_state_patch_tc_() ->
     {timeout, 30, fun() ->
         Wallet = hb:wallet(),
         Opts = test_opts(),
@@ -487,7 +545,7 @@ aos_state_patch_test_() ->
     end}.
 
 %% @doc Manually test state restoration without using the cache.
-restore_test_() -> {timeout, 30, fun do_test_restore/0}.
+restore_tc_() -> {timeout, 30, fun do_test_restore/0}.
 
 do_test_restore() ->
     % Init the process and schedule 3 messages:
@@ -518,7 +576,7 @@ do_test_restore() ->
     ?event({result_b, ResultB}),
     ?assertEqual(<<"1337">>, hb_ao:get(<<"results/data">>, ResultB, Opts)).
 
-now_results_test_() ->
+now_results_tc_() ->
     {timeout, 30, fun() ->
         Opts = test_opts(),
         Base = aos_process(Opts),
@@ -527,7 +585,7 @@ now_results_test_() ->
         ?assertEqual({ok, <<"4">>}, hb_ao:resolve(Base, <<"now/results/data">>, Opts))
     end}.
 
-prior_results_accessible_test_() ->
+prior_results_accessible_tc_() ->
 	{timeout, 30, fun() ->
 		Opts = test_opts(#{ process_async_cache => false }),
 		Base = aos_process(Opts),
@@ -549,7 +607,7 @@ prior_results_accessible_test_() ->
 		)
 	end}.
 
-persistent_process_test() ->
+persistent_process_tc() ->
     {timeout, 30, fun() ->
         Opts = test_opts(),
         Base = aos_process(Opts),
@@ -583,7 +641,7 @@ persistent_process_test() ->
         ?assert(T2 - T1 < ((T1 - T0)/2))
     end}.
 
-simple_wasm_persistent_worker_benchmark_test() ->
+simple_wasm_persistent_worker_benchmark_tc() ->
     Opts = test_opts(),
     BenchTime = 0.05,
     Base = wasm_process(<<"test/test-64.wasm">>, Opts),
@@ -622,7 +680,7 @@ simple_wasm_persistent_worker_benchmark_test() ->
     ?assert(Iterations >= 1),
     ok.
 
-aos_persistent_worker_benchmark_test_() ->
+aos_persistent_worker_benchmark_tc_() ->
     {timeout, 30, fun() ->
         BenchTime = 0.25,
         init(),

--- a/src/dev_process_test_vectors.erl
+++ b/src/dev_process_test_vectors.erl
@@ -6,31 +6,6 @@
 -export([init/0, aos_process/0, aos_process/1, test_process/0, wasm_process/1]).
 -export([schedule_aos_call/2, schedule_aos_call/3]).
 
--ifdef(TEST).
-%% Test cases exported so `all_tests_test_/0' can run them in parallel via
-%% `fun ?MODULE:name/0'. Each case sets up its own store and, where
-%% applicable, its own HTTP server, so there is no shared state to race on.
--export([
-    schedule_on_process_tc_/0,
-    get_scheduler_slot_tc/0,
-    recursive_path_resolution_tc/0,
-    test_device_compute_tc/0,
-    wasm_compute_tc/0,
-    wasm_compute_from_id_tc/0,
-    http_wasm_process_by_id_tc/0,
-    aos_compute_tc_/0,
-    aos_browsable_state_tc_/0,
-    aos_state_access_via_http_tc_/0,
-    aos_state_patch_tc_/0,
-    restore_tc_/0,
-    now_results_tc_/0,
-    prior_results_accessible_tc_/0,
-    persistent_process_tc/0,
-    simple_wasm_persistent_worker_benchmark_tc/0,
-    aos_persistent_worker_benchmark_tc_/0
-]).
--endif.
-
 init() -> application:ensure_all_started(hb).
 
 test_opts() ->
@@ -195,40 +170,7 @@ schedule_wasm_call(Base, FuncName, Params, Opts) ->
         ),
     ?assertMatch({ok, _}, hb_ao:resolve(Base, Req, Opts)).
 
-%% @doc Run every test in this module in parallel. Each case creates its own
-%% store (and its own node where applicable), so there is no shared state
-%% that could race. Parallelising cuts the module's wall time from ~27 s
-%% serial (dominated by several 2-5 s AOS tests) to roughly the slowest
-%% test. `_tc_/0' generators return test specs (e.g. `{timeout, N, Fun}')
-%% and eunit expands them transparently when referenced as `fun M:F/0'.
-all_tests_test_() ->
-    {inparallel,
-        [
-            {atom_to_list(F), fun ?MODULE:F/0}
-        ||
-            F <- [
-                schedule_on_process_tc_,
-                get_scheduler_slot_tc,
-                recursive_path_resolution_tc,
-                test_device_compute_tc,
-                wasm_compute_tc,
-                wasm_compute_from_id_tc,
-                http_wasm_process_by_id_tc,
-                aos_compute_tc_,
-                aos_browsable_state_tc_,
-                aos_state_access_via_http_tc_,
-                aos_state_patch_tc_,
-                restore_tc_,
-                now_results_tc_,
-                prior_results_accessible_tc_,
-                persistent_process_tc,
-                simple_wasm_persistent_worker_benchmark_tc,
-                aos_persistent_worker_benchmark_tc_
-            ]
-        ]
-    }.
-
-schedule_on_process_tc_() ->
+schedule_on_process_test_parallel_() ->
 	{timeout, 30, fun()->
 		Opts = test_opts(),
 		Base = aos_process(Opts),
@@ -250,7 +192,7 @@ schedule_on_process_tc_() ->
 		)
 	end}.
 
-get_scheduler_slot_tc() ->
+get_scheduler_slot_test_parallel() ->
     Opts = test_opts(),
     Base = base_process(Opts),
     schedule_test_message(Base, <<"TEST TEXT 1">>, Opts),
@@ -264,7 +206,7 @@ get_scheduler_slot_tc() ->
         hb_ao:resolve(Base, Req, Opts)
     ).
 
-recursive_path_resolution_tc() ->
+recursive_path_resolution_test_parallel() ->
     Opts = test_opts(),
     Base = base_process(Opts),
     schedule_test_message(Base, <<"TEST TEXT 1">>, Opts),
@@ -281,7 +223,7 @@ recursive_path_resolution_tc() ->
     ),
     ok.
 
-test_device_compute_tc() ->
+test_device_compute_test_parallel() ->
     Opts = test_opts(),
     Base = test_process(Opts),
     schedule_test_message(Base, <<"TEST TEXT 1">>, Opts),
@@ -300,7 +242,7 @@ test_device_compute_tc() ->
     ?assertEqual(1, hb_ao:get(<<"results/assignment-slot">>, Res, Opts)),
     ?assertEqual([1,1,0,0], hb_ao:get(<<"already-seen">>, Res, Opts)).
 
-wasm_compute_tc() ->
+wasm_compute_test_parallel() ->
     Opts = test_opts(),
     Base = wasm_process(<<"test/test-64.wasm">>, Opts),
     schedule_wasm_call(Base, <<"fac">>, [2.0], Opts),
@@ -343,7 +285,7 @@ wasm_compute_tc() ->
     % ?assertEqual([2.0], hb_ao:get(<<"results/output">>, Slot0Res, Opts)),
     % ?assertEqual([6.0], hb_ao:get(<<"results/output">>, Slot1Res, Opts)).
 
-wasm_compute_from_id_tc() ->
+wasm_compute_from_id_test_parallel() ->
     Opts = test_opts(#{ cache_control => <<"always">> }),
     Base = wasm_process(<<"test/test-64.wasm">>, Opts),
     schedule_wasm_call(Base, <<"fac">>, [5.0], Opts),
@@ -353,7 +295,7 @@ wasm_compute_from_id_tc() ->
     ?event(process_compute, {computed_message, {res, Res}}),
     ?assertEqual([120.0], hb_ao:get(<<"results/output">>, Res, Opts)).
 
-http_wasm_process_by_id_tc() ->
+http_wasm_process_by_id_test_parallel() ->
     rand:seed(default),
     SchedWallet = ar_wallet:new(),
     Node = hb_http_server:start_node(Opts = #{
@@ -402,7 +344,7 @@ http_wasm_process_by_id_tc() ->
     ?event({compute_msg_res, {msg4, Msg4}}),
     ?assertEqual([120.0], hb_ao:get(<<"results/output">>, Msg4, Opts)).
 
-aos_compute_tc_() ->
+aos_compute_test_parallel_() ->
     {timeout, 30, fun() ->
         Opts = test_opts(),
         Base = aos_process(Opts),
@@ -421,7 +363,7 @@ aos_compute_tc_() ->
         {ok, Res3}
     end}.
 
-aos_browsable_state_tc_() ->
+aos_browsable_state_test_parallel_() ->
     {timeout, 30, fun() ->
         Opts = test_opts(#{ cache_control => <<"always">> }),
         Base = aos_process(Opts),
@@ -443,7 +385,7 @@ aos_browsable_state_tc_() ->
         ?assertEqual(4, Res)
     end}.
 
-aos_state_access_via_http_tc_() ->
+aos_state_access_via_http_test_parallel_() ->
     {timeout, 60, fun() ->
         rand:seed(default),
         Wallet = ar_wallet:new(),
@@ -502,7 +444,7 @@ aos_state_access_via_http_tc_() ->
         ok
     end}.
 
-aos_state_patch_tc_() ->
+aos_state_patch_test_parallel_() ->
     {timeout, 30, fun() ->
         Wallet = hb:wallet(),
         Opts = test_opts(),
@@ -545,7 +487,7 @@ aos_state_patch_tc_() ->
     end}.
 
 %% @doc Manually test state restoration without using the cache.
-restore_tc_() -> {timeout, 30, fun do_test_restore/0}.
+restore_test_parallel_() -> {timeout, 30, fun do_test_restore/0}.
 
 do_test_restore() ->
     % Init the process and schedule 3 messages:
@@ -576,7 +518,7 @@ do_test_restore() ->
     ?event({result_b, ResultB}),
     ?assertEqual(<<"1337">>, hb_ao:get(<<"results/data">>, ResultB, Opts)).
 
-now_results_tc_() ->
+now_results_test_parallel_() ->
     {timeout, 30, fun() ->
         Opts = test_opts(),
         Base = aos_process(Opts),
@@ -585,7 +527,7 @@ now_results_tc_() ->
         ?assertEqual({ok, <<"4">>}, hb_ao:resolve(Base, <<"now/results/data">>, Opts))
     end}.
 
-prior_results_accessible_tc_() ->
+prior_results_accessible_test_parallel_() ->
 	{timeout, 30, fun() ->
 		Opts = test_opts(#{ process_async_cache => false }),
 		Base = aos_process(Opts),
@@ -607,7 +549,7 @@ prior_results_accessible_tc_() ->
 		)
 	end}.
 
-persistent_process_tc() ->
+persistent_process_test_parallel() ->
     {timeout, 30, fun() ->
         Opts = test_opts(),
         Base = aos_process(Opts),
@@ -641,7 +583,7 @@ persistent_process_tc() ->
         ?assert(T2 - T1 < ((T1 - T0)/2))
     end}.
 
-simple_wasm_persistent_worker_benchmark_tc() ->
+simple_wasm_persistent_worker_benchmark_test_parallel() ->
     Opts = test_opts(),
     BenchTime = 0.05,
     Base = wasm_process(<<"test/test-64.wasm">>, Opts),
@@ -680,7 +622,7 @@ simple_wasm_persistent_worker_benchmark_tc() ->
     ?assert(Iterations >= 1),
     ok.
 
-aos_persistent_worker_benchmark_tc_() ->
+aos_persistent_worker_benchmark_test_parallel_() ->
     {timeout, 30, fun() ->
         BenchTime = 0.25,
         init(),

--- a/src/dev_query_graphql.erl
+++ b/src/dev_query_graphql.erl
@@ -3,6 +3,7 @@
 -module(dev_query_graphql).
 %%% AO-Core API:
 -export([handle/3]).
+-export([register_controller/1]).
 %%% GraphQL Callbacks:
 -export([execute/4, input/2]).
 %%% Submodule helpers:
@@ -31,26 +32,54 @@
 schema() ->
     hb_util:ok(file:read_file("scripts/schema.gql")).
 
-%% @doc Ensure that the GraphQL schema and context are initialized. Can be 
-%% called many times.
+%% @doc Ensure that the GraphQL schema and context are initialized. Can be
+%% called many times, including concurrently: only one caller runs `init/1'
+%% (the underlying `graphql' library rejects a second `load_schema' with
+%% `entry_already_exists_in_schema'). Losers of the registration race wait
+%% for the winner to finish `init/1', using `persistent_term' as the signal.
 ensure_started() -> ensure_started(#{}).
 ensure_started(Opts) ->
-    case hb_name:lookup(graphql_controller) of
-        PID when is_pid(PID) -> ok;
-        undefined ->
-            Parent = self(),
-            PID =
-                spawn_link(
-                    fun() ->
-                        init(Opts),
-                        Parent ! {started, self()},
-                        receive stop -> ok end
-                    end
-                ),
-            receive {started, PID} -> ok
-            after ?START_TIMEOUT -> exit(graphql_start_timeout)
-            end
+    case persistent_term:get({?MODULE, ready}, false) of
+        true -> ok;
+        false -> start_or_await(Opts)
     end.
+
+start_or_await(Opts) ->
+    Parent = self(),
+    Ref = make_ref(),
+    spawn(
+        fun() ->
+            Self = self(),
+            case ?MODULE:register_controller(Self) of
+                ok ->
+                    init(Opts),
+                    persistent_term:put({?MODULE, ready}, true),
+                    Parent ! {Ref, started},
+                    receive stop -> ok end;
+                error ->
+                    Parent ! {Ref, lost_race}
+            end
+        end
+    ),
+    receive
+        {Ref, started} -> ok;
+        {Ref, lost_race} -> await_ready()
+    after ?START_TIMEOUT -> exit(graphql_start_timeout)
+    end.
+
+await_ready() ->
+    case hb_util:wait_until(
+            fun() -> persistent_term:get({?MODULE, ready}, false) end,
+            ?START_TIMEOUT
+        ) of
+        true -> ok;
+        false -> exit(graphql_start_timeout)
+    end.
+
+%% @doc Atomically register the current process as the GraphQL controller.
+%% Exposed so `ensure_started/1' can invoke it in a spawned process.
+register_controller(Pid) ->
+    hb_name:register(graphql_controller, Pid).
 
 %% @doc Initialize the GraphQL schema and context. Should only be called once.
 init(_Opts) ->
@@ -78,8 +107,6 @@ init(_Opts) ->
     ?event(graphql_schema_definition_inserted),
     ok = graphql:validate_schema(),
     ?event(graphql_schema_validated),
-    hb_name:register(graphql_controller, self()),
-    ?event(graphql_controller_registered),
     ok.
 
 handle(_Base, RawReq, Opts) ->

--- a/src/dev_query_graphql.erl
+++ b/src/dev_query_graphql.erl
@@ -3,7 +3,6 @@
 -module(dev_query_graphql).
 %%% AO-Core API:
 -export([handle/3]).
--export([register_controller/1]).
 %%% GraphQL Callbacks:
 -export([execute/4, input/2]).
 %%% Submodule helpers:
@@ -32,54 +31,35 @@
 schema() ->
     hb_util:ok(file:read_file("scripts/schema.gql")).
 
-%% @doc Ensure that the GraphQL schema and context are initialized. Can be
-%% called many times, including concurrently: only one caller runs `init/1'
-%% (the underlying `graphql' library rejects a second `load_schema' with
-%% `entry_already_exists_in_schema'). Losers of the registration race wait
-%% for the winner to finish `init/1', using `persistent_term' as the signal.
+%% @doc Ensure that the GraphQL schema and context are initialized. Safe to
+%% call many times, including concurrently. `hb_name:singleton/2' guarantees
+%% only one process runs `init/1' -- the `graphql' library rejects a second
+%% `load_schema' with `entry_already_exists_in_schema'. A `persistent_term'
+%% flag lets callers wait for init to finish: `singleton/2' returns as soon
+%% as the spawned process is registered, which is before `init/1' completes.
 ensure_started() -> ensure_started(#{}).
 ensure_started(Opts) ->
     case persistent_term:get({?MODULE, ready}, false) of
         true -> ok;
-        false -> start_or_await(Opts)
-    end.
-
-start_or_await(Opts) ->
-    Parent = self(),
-    Ref = make_ref(),
-    spawn(
-        fun() ->
-            Self = self(),
-            case ?MODULE:register_controller(Self) of
-                ok ->
+        false ->
+            hb_name:singleton(
+                graphql_controller,
+                fun() ->
                     init(Opts),
                     persistent_term:put({?MODULE, ready}, true),
-                    Parent ! {Ref, started},
-                    receive stop -> ok end;
-                error ->
-                    Parent ! {Ref, lost_race}
+                    receive stop -> ok end
+                end
+            ),
+            case hb_util:wait_until(
+                    fun() ->
+                        persistent_term:get({?MODULE, ready}, false)
+                    end,
+                    ?START_TIMEOUT
+                ) of
+                true -> ok;
+                false -> exit(graphql_start_timeout)
             end
-        end
-    ),
-    receive
-        {Ref, started} -> ok;
-        {Ref, lost_race} -> await_ready()
-    after ?START_TIMEOUT -> exit(graphql_start_timeout)
     end.
-
-await_ready() ->
-    case hb_util:wait_until(
-            fun() -> persistent_term:get({?MODULE, ready}, false) end,
-            ?START_TIMEOUT
-        ) of
-        true -> ok;
-        false -> exit(graphql_start_timeout)
-    end.
-
-%% @doc Atomically register the current process as the GraphQL controller.
-%% Exposed so `ensure_started/1' can invoke it in a spawned process.
-register_controller(Pid) ->
-    hb_name:register(graphql_controller, Pid).
 
 %% @doc Initialize the GraphQL schema and context. Should only be called once.
 init(_Opts) ->

--- a/src/dev_query_test_vectors.erl
+++ b/src/dev_query_test_vectors.erl
@@ -4,6 +4,61 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-ifdef(TEST).
+%% Test cases exported so `all_tests_test_/0' can run them in parallel via
+%% `fun ?MODULE:name/0'. Each case calls `test_env_with_blocks/2' or
+%% `hb_http_server:start_node/1' with a fresh `hb_test_utils:test_store/0'
+%% so tests are isolated.
+-export([
+    simple_blocks_query_tc/0,
+    block_by_height_query_tc/0,
+    simple_ans104_query_tc/0,
+    transactions_query_tags_tc/0,
+    transactions_query_owners_tc/0,
+    transactions_query_recipients_tc/0,
+    transactions_query_ids_tc/0,
+    transactions_query_combined_tc/0,
+    transactions_query_sort_by_block_tc/0,
+    transactions_query_filter_by_block_tc/0,
+    transactions_query_filter_by_block_excludes_unknown_offsets_tc/0,
+    transactions_query_filter_by_block_can_ignore_ranges_tc/0,
+    transactions_query_ids_preserve_arweave_tx_id_tc/0,
+    transactions_query_cursor_by_offset_tc/0,
+    transaction_query_by_id_tc/0,
+    transaction_query_full_tc/0,
+    transaction_query_not_found_tc/0,
+    transaction_query_with_anchor_tc/0
+]).
+-endif.
+
+all_tests_test_() ->
+    {inparallel,
+        [
+            {atom_to_list(F), fun ?MODULE:F/0}
+        ||
+            F <- [
+                simple_blocks_query_tc,
+                block_by_height_query_tc,
+                simple_ans104_query_tc,
+                transactions_query_tags_tc,
+                transactions_query_owners_tc,
+                transactions_query_recipients_tc,
+                transactions_query_ids_tc,
+                transactions_query_combined_tc,
+                transactions_query_sort_by_block_tc,
+                transactions_query_filter_by_block_tc,
+                transactions_query_filter_by_block_excludes_unknown_offsets_tc,
+                transactions_query_filter_by_block_can_ignore_ranges_tc,
+                transactions_query_ids_preserve_arweave_tx_id_tc,
+                transactions_query_cursor_by_offset_tc,
+                transaction_query_by_id_tc,
+                transaction_query_full_tc,
+                transaction_query_not_found_tc,
+                transaction_query_with_anchor_tc
+            ]
+        ]
+    }.
+
 %%% Test helpers.
 
 write_test_message(Opts) ->
@@ -95,7 +150,7 @@ write_test_message_with_recipient(Recipient, Opts) ->
 
 %%% Tests
 
-simple_blocks_query_test() ->
+simple_blocks_query_tc() ->
     Opts =
         #{
             priv_wallet => ar_wallet:new(),
@@ -141,7 +196,7 @@ simple_blocks_query_test() ->
         dev_query_graphql:test_query(Node, Query, #{}, Opts)
     ).
 
-block_by_height_query_test() ->
+block_by_height_query_tc() ->
     Opts =
         #{
             priv_wallet => ar_wallet:new(),
@@ -193,7 +248,7 @@ block_by_height_query_test() ->
         dev_query_graphql:test_query(Node, Query, #{}, Opts)
     ).
 
-simple_ans104_query_test() ->
+simple_ans104_query_tc() ->
     Opts =
         #{
             priv_wallet => Wallet = ar_wallet:new(),
@@ -260,7 +315,7 @@ simple_ans104_query_test() ->
     ).
 
 %% @doc Test transactions query with tags filter
-transactions_query_tags_test() ->
+transactions_query_tags_tc() ->
     Opts =
         #{
             priv_wallet => ar_wallet:new(),
@@ -323,7 +378,7 @@ transactions_query_tags_test() ->
     ).
 
 %% @doc Test transactions query with owners filter
-transactions_query_owners_test() ->
+transactions_query_owners_tc() ->
     Opts =
         #{
             priv_wallet => Wallet = ar_wallet:new(),
@@ -385,7 +440,7 @@ transactions_query_owners_test() ->
     ).
 
 %% @doc Test transactions query with recipients filter
-transactions_query_recipients_test() ->
+transactions_query_recipients_tc() ->
     Opts =
         #{
             priv_wallet => ar_wallet:new(),
@@ -450,7 +505,7 @@ transactions_query_recipients_test() ->
     ).
 
 %% @doc Test transactions query with ids filter
-transactions_query_ids_test() ->
+transactions_query_ids_tc() ->
     Opts =
         #{
             priv_wallet => ar_wallet:new(),
@@ -512,7 +567,7 @@ transactions_query_ids_test() ->
     ).
 
 %% @doc Test transactions query with combined filters
-transactions_query_combined_test() ->
+transactions_query_combined_tc() ->
     Opts =
         #{
             priv_wallet => Wallet = ar_wallet:new(),
@@ -578,7 +633,7 @@ transactions_query_combined_test() ->
         Res
     ).
 
-transactions_query_sort_by_block_test() ->
+transactions_query_sort_by_block_tc() ->
     {ok, Node, Opts} = test_env_with_blocks(1892159, 1892158),
     EarlierID = <<"xBpOR2KOjYEgv5HmddMlAgYa-yMvfEVl-0XzRIfm2uY">>,
     LaterID = <<"HVr7EpRhlPkbwdnoXKHf25p7BPa0qJOs6C7XueLthA0">>,
@@ -621,7 +676,7 @@ transactions_query_sort_by_block_test() ->
     VerifyFun(<<"HEIGHT_ASC">>, EarlierID, LaterID),
     VerifyFun(<<"HEIGHT_DESC">>, LaterID, EarlierID).
 
-transactions_query_filter_by_block_test() ->
+transactions_query_filter_by_block_tc() ->
     {ok, Node, Opts} = test_env_with_blocks(1892159, 1892158),
     EarlierID = <<"xBpOR2KOjYEgv5HmddMlAgYa-yMvfEVl-0XzRIfm2uY">>,
     LaterID = <<"HVr7EpRhlPkbwdnoXKHf25p7BPa0qJOs6C7XueLthA0">>,
@@ -668,7 +723,7 @@ transactions_query_filter_by_block_test() ->
     VerifyFun(1892157, 1892158, [EarlierID], [LaterID]),
     VerifyFun(1892159, 1892160, [LaterID], [EarlierID]).
 
-transactions_query_filter_by_block_excludes_unknown_offsets_test() ->
+transactions_query_filter_by_block_excludes_unknown_offsets_tc() ->
     {ok, _Node, Opts} = test_env_with_blocks(1892159, 1892158),
     {ok, ID} =
         hb_cache:write(
@@ -701,7 +756,7 @@ transactions_query_filter_by_block_excludes_unknown_offsets_test() ->
         )
     ).
 
-transactions_query_filter_by_block_can_ignore_ranges_test() ->
+transactions_query_filter_by_block_can_ignore_ranges_tc() ->
     {ok, _Node, BaseOpts} = test_env_with_blocks(1892159, 1892158),
     Opts = BaseOpts#{ query_arweave_ignore_block_ranges => true },
     {ok, ID} =
@@ -736,7 +791,7 @@ transactions_query_filter_by_block_can_ignore_ranges_test() ->
         )
     ).
 
-transactions_query_ids_preserve_arweave_tx_id_test() ->
+transactions_query_ids_preserve_arweave_tx_id_tc() ->
     {ok, _Node, Opts} = test_env_with_blocks(1892487, 1892487),
     ID = <<"mT7pIQx9ORnemXoIzWmKwymiZJxtOSvzxm3P44M9C1A">>,
     ?assertMatch(
@@ -767,7 +822,7 @@ transactions_query_ids_preserve_arweave_tx_id_test() ->
         )
     ).
 
-transactions_query_cursor_by_offset_test() ->
+transactions_query_cursor_by_offset_tc() ->
     {ok, Node, Opts} = test_env_with_blocks(1892159, 1892158),
     EarlierID = <<"xBpOR2KOjYEgv5HmddMlAgYa-yMvfEVl-0XzRIfm2uY">>,
     LaterID = <<"HVr7EpRhlPkbwdnoXKHf25p7BPa0qJOs6C7XueLthA0">>,
@@ -878,7 +933,7 @@ transactions_query_cursor_by_offset_test() ->
     ).
 
 %% @doc Test single transaction query by ID
-transaction_query_by_id_test() ->
+transaction_query_by_id_tc() ->
     Opts =
         #{
             priv_wallet => ar_wallet:new(),
@@ -928,7 +983,7 @@ transaction_query_by_id_test() ->
     ).
 
 %% @doc Test single transaction query with more fields  
-transaction_query_full_test() ->
+transaction_query_full_tc() ->
     Opts =
         #{
             priv_wallet => SenderKey = ar_wallet:new(),
@@ -1005,7 +1060,7 @@ transaction_query_full_test() ->
     ).
 
 %% @doc Test single transaction query with non-existent ID
-transaction_query_not_found_test() ->
+transaction_query_not_found_tc() ->
     Opts =
         #{
             priv_wallet => ar_wallet:new(),
@@ -1041,7 +1096,7 @@ transaction_query_not_found_test() ->
     ).
 
 %% @doc Test parsing, storing, and querying a transaction with an anchor.
-transaction_query_with_anchor_test() ->
+transaction_query_with_anchor_tc() ->
     Opts =
         #{
             priv_wallet => Wallet = ar_wallet:new(),

--- a/src/dev_query_test_vectors.erl
+++ b/src/dev_query_test_vectors.erl
@@ -4,61 +4,6 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--ifdef(TEST).
-%% Test cases exported so `all_tests_test_/0' can run them in parallel via
-%% `fun ?MODULE:name/0'. Each case calls `test_env_with_blocks/2' or
-%% `hb_http_server:start_node/1' with a fresh `hb_test_utils:test_store/0'
-%% so tests are isolated.
--export([
-    simple_blocks_query_tc/0,
-    block_by_height_query_tc/0,
-    simple_ans104_query_tc/0,
-    transactions_query_tags_tc/0,
-    transactions_query_owners_tc/0,
-    transactions_query_recipients_tc/0,
-    transactions_query_ids_tc/0,
-    transactions_query_combined_tc/0,
-    transactions_query_sort_by_block_tc/0,
-    transactions_query_filter_by_block_tc/0,
-    transactions_query_filter_by_block_excludes_unknown_offsets_tc/0,
-    transactions_query_filter_by_block_can_ignore_ranges_tc/0,
-    transactions_query_ids_preserve_arweave_tx_id_tc/0,
-    transactions_query_cursor_by_offset_tc/0,
-    transaction_query_by_id_tc/0,
-    transaction_query_full_tc/0,
-    transaction_query_not_found_tc/0,
-    transaction_query_with_anchor_tc/0
-]).
--endif.
-
-all_tests_test_() ->
-    {inparallel,
-        [
-            {atom_to_list(F), fun ?MODULE:F/0}
-        ||
-            F <- [
-                simple_blocks_query_tc,
-                block_by_height_query_tc,
-                simple_ans104_query_tc,
-                transactions_query_tags_tc,
-                transactions_query_owners_tc,
-                transactions_query_recipients_tc,
-                transactions_query_ids_tc,
-                transactions_query_combined_tc,
-                transactions_query_sort_by_block_tc,
-                transactions_query_filter_by_block_tc,
-                transactions_query_filter_by_block_excludes_unknown_offsets_tc,
-                transactions_query_filter_by_block_can_ignore_ranges_tc,
-                transactions_query_ids_preserve_arweave_tx_id_tc,
-                transactions_query_cursor_by_offset_tc,
-                transaction_query_by_id_tc,
-                transaction_query_full_tc,
-                transaction_query_not_found_tc,
-                transaction_query_with_anchor_tc
-            ]
-        ]
-    }.
-
 %%% Test helpers.
 
 write_test_message(Opts) ->
@@ -150,7 +95,7 @@ write_test_message_with_recipient(Recipient, Opts) ->
 
 %%% Tests
 
-simple_blocks_query_tc() ->
+simple_blocks_query_test_parallel() ->
     Opts =
         #{
             priv_wallet => ar_wallet:new(),
@@ -196,7 +141,7 @@ simple_blocks_query_tc() ->
         dev_query_graphql:test_query(Node, Query, #{}, Opts)
     ).
 
-block_by_height_query_tc() ->
+block_by_height_query_test_parallel() ->
     Opts =
         #{
             priv_wallet => ar_wallet:new(),
@@ -248,7 +193,7 @@ block_by_height_query_tc() ->
         dev_query_graphql:test_query(Node, Query, #{}, Opts)
     ).
 
-simple_ans104_query_tc() ->
+simple_ans104_query_test_parallel() ->
     Opts =
         #{
             priv_wallet => Wallet = ar_wallet:new(),
@@ -315,7 +260,7 @@ simple_ans104_query_tc() ->
     ).
 
 %% @doc Test transactions query with tags filter
-transactions_query_tags_tc() ->
+transactions_query_tags_test_parallel() ->
     Opts =
         #{
             priv_wallet => ar_wallet:new(),
@@ -378,7 +323,7 @@ transactions_query_tags_tc() ->
     ).
 
 %% @doc Test transactions query with owners filter
-transactions_query_owners_tc() ->
+transactions_query_owners_test_parallel() ->
     Opts =
         #{
             priv_wallet => Wallet = ar_wallet:new(),
@@ -440,7 +385,7 @@ transactions_query_owners_tc() ->
     ).
 
 %% @doc Test transactions query with recipients filter
-transactions_query_recipients_tc() ->
+transactions_query_recipients_test_parallel() ->
     Opts =
         #{
             priv_wallet => ar_wallet:new(),
@@ -505,7 +450,7 @@ transactions_query_recipients_tc() ->
     ).
 
 %% @doc Test transactions query with ids filter
-transactions_query_ids_tc() ->
+transactions_query_ids_test_parallel() ->
     Opts =
         #{
             priv_wallet => ar_wallet:new(),
@@ -567,7 +512,7 @@ transactions_query_ids_tc() ->
     ).
 
 %% @doc Test transactions query with combined filters
-transactions_query_combined_tc() ->
+transactions_query_combined_test_parallel() ->
     Opts =
         #{
             priv_wallet => Wallet = ar_wallet:new(),
@@ -633,7 +578,7 @@ transactions_query_combined_tc() ->
         Res
     ).
 
-transactions_query_sort_by_block_tc() ->
+transactions_query_sort_by_block_test_parallel() ->
     {ok, Node, Opts} = test_env_with_blocks(1892159, 1892158),
     EarlierID = <<"xBpOR2KOjYEgv5HmddMlAgYa-yMvfEVl-0XzRIfm2uY">>,
     LaterID = <<"HVr7EpRhlPkbwdnoXKHf25p7BPa0qJOs6C7XueLthA0">>,
@@ -676,7 +621,7 @@ transactions_query_sort_by_block_tc() ->
     VerifyFun(<<"HEIGHT_ASC">>, EarlierID, LaterID),
     VerifyFun(<<"HEIGHT_DESC">>, LaterID, EarlierID).
 
-transactions_query_filter_by_block_tc() ->
+transactions_query_filter_by_block_test_parallel() ->
     {ok, Node, Opts} = test_env_with_blocks(1892159, 1892158),
     EarlierID = <<"xBpOR2KOjYEgv5HmddMlAgYa-yMvfEVl-0XzRIfm2uY">>,
     LaterID = <<"HVr7EpRhlPkbwdnoXKHf25p7BPa0qJOs6C7XueLthA0">>,
@@ -723,7 +668,7 @@ transactions_query_filter_by_block_tc() ->
     VerifyFun(1892157, 1892158, [EarlierID], [LaterID]),
     VerifyFun(1892159, 1892160, [LaterID], [EarlierID]).
 
-transactions_query_filter_by_block_excludes_unknown_offsets_tc() ->
+transactions_query_filter_by_block_excludes_unknown_offsets_test_parallel() ->
     {ok, _Node, Opts} = test_env_with_blocks(1892159, 1892158),
     {ok, ID} =
         hb_cache:write(
@@ -756,7 +701,7 @@ transactions_query_filter_by_block_excludes_unknown_offsets_tc() ->
         )
     ).
 
-transactions_query_filter_by_block_can_ignore_ranges_tc() ->
+transactions_query_filter_by_block_can_ignore_ranges_test_parallel() ->
     {ok, _Node, BaseOpts} = test_env_with_blocks(1892159, 1892158),
     Opts = BaseOpts#{ query_arweave_ignore_block_ranges => true },
     {ok, ID} =
@@ -791,7 +736,7 @@ transactions_query_filter_by_block_can_ignore_ranges_tc() ->
         )
     ).
 
-transactions_query_ids_preserve_arweave_tx_id_tc() ->
+transactions_query_ids_preserve_arweave_tx_id_test_parallel() ->
     {ok, _Node, Opts} = test_env_with_blocks(1892487, 1892487),
     ID = <<"mT7pIQx9ORnemXoIzWmKwymiZJxtOSvzxm3P44M9C1A">>,
     ?assertMatch(
@@ -822,7 +767,7 @@ transactions_query_ids_preserve_arweave_tx_id_tc() ->
         )
     ).
 
-transactions_query_cursor_by_offset_tc() ->
+transactions_query_cursor_by_offset_test_parallel() ->
     {ok, Node, Opts} = test_env_with_blocks(1892159, 1892158),
     EarlierID = <<"xBpOR2KOjYEgv5HmddMlAgYa-yMvfEVl-0XzRIfm2uY">>,
     LaterID = <<"HVr7EpRhlPkbwdnoXKHf25p7BPa0qJOs6C7XueLthA0">>,
@@ -933,7 +878,7 @@ transactions_query_cursor_by_offset_tc() ->
     ).
 
 %% @doc Test single transaction query by ID
-transaction_query_by_id_tc() ->
+transaction_query_by_id_test_parallel() ->
     Opts =
         #{
             priv_wallet => ar_wallet:new(),
@@ -983,7 +928,7 @@ transaction_query_by_id_tc() ->
     ).
 
 %% @doc Test single transaction query with more fields  
-transaction_query_full_tc() ->
+transaction_query_full_test_parallel() ->
     Opts =
         #{
             priv_wallet => SenderKey = ar_wallet:new(),
@@ -1060,7 +1005,7 @@ transaction_query_full_tc() ->
     ).
 
 %% @doc Test single transaction query with non-existent ID
-transaction_query_not_found_tc() ->
+transaction_query_not_found_test_parallel() ->
     Opts =
         #{
             priv_wallet => ar_wallet:new(),
@@ -1096,7 +1041,7 @@ transaction_query_not_found_tc() ->
     ).
 
 %% @doc Test parsing, storing, and querying a transaction with an anchor.
-transaction_query_with_anchor_tc() ->
+transaction_query_with_anchor_test_parallel() ->
     Opts =
         #{
             priv_wallet => Wallet = ar_wallet:new(),

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -30,6 +30,68 @@
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
 
+-ifdef(TEST).
+%% Test cases exported so `all_tests_test_/0' can run them in parallel via
+%% `fun ?MODULE:name/0'. Each case starts its own node(s) and uses a fresh
+%% store, so concurrent execution is safe.
+-export([
+    test_provider_tc/0,
+    dynamic_provider_tc/0,
+    local_process_provider_tc_/0,
+    local_dynamic_router_tc_/0,
+    dynamic_router_pricing_tc_/0,
+    dynamic_router_tc_/0,
+    dynamic_routing_by_performance_tc_/0,
+    weighted_random_strategy_tc/0,
+    shuffled_strategy_tc/0,
+    range_limited_route_filtering_tc/0,
+    strategy_suite_tc_/0,
+    by_base_determinism_tc/0,
+    route_template_message_matches_tc/0,
+    route_regex_matches_tc/0,
+    explicit_route_tc/0,
+    device_call_from_singleton_tc/0,
+    get_routes_tc/0,
+    add_route_tc/0,
+    request_hook_reroute_to_nearest_tc/0,
+    route_nearest_integer_preserves_opts_tc/0,
+    route_multirequest_parallel_limit_tc_/0,
+    full_route_config_tc/0
+]).
+-endif.
+
+all_tests_test_() ->
+    {inparallel,
+        [
+            {atom_to_list(F), fun ?MODULE:F/0}
+        ||
+            F <- [
+                test_provider_tc,
+                dynamic_provider_tc,
+                local_process_provider_tc_,
+                local_dynamic_router_tc_,
+                dynamic_router_pricing_tc_,
+                dynamic_router_tc_,
+                dynamic_routing_by_performance_tc_,
+                weighted_random_strategy_tc,
+                shuffled_strategy_tc,
+                range_limited_route_filtering_tc,
+                strategy_suite_tc_,
+                by_base_determinism_tc,
+                route_template_message_matches_tc,
+                route_regex_matches_tc,
+                explicit_route_tc,
+                device_call_from_singleton_tc,
+                get_routes_tc,
+                add_route_tc,
+                request_hook_reroute_to_nearest_tc,
+                route_nearest_integer_preserves_opts_tc,
+                route_multirequest_parallel_limit_tc_,
+                full_route_config_tc
+            ]
+        ]
+    }.
+
 %% @doc Exported function for getting device info, controls which functions are
 %% exposed via the device API.
 info(_) -> 
@@ -831,7 +893,7 @@ preprocess(Base, RawReq, Opts) ->
 
 %%% Tests
 
-test_provider_test() ->
+test_provider_tc() ->
     Node =
         hb_http_server:start_node(Opts =
             #{
@@ -859,7 +921,7 @@ test_provider_test() ->
         hb_http:get(Node, <<"/~router@1.0/routes/1/node">>, Opts)
     ).
 
-dynamic_provider_test() ->
+dynamic_provider_tc() ->
     {ok, Script} = file:read_file("test/test.lua"),
     Node = hb_http_server:start_node(#{
         router_opts => #{
@@ -880,7 +942,7 @@ dynamic_provider_test() ->
         hb_http:get(Node, <<"/~router@1.0/routes/1/node">>, #{})
     ).
 
-local_process_provider_test_() ->
+local_process_provider_tc_() ->
     {timeout, 30, fun local_process_provider/0}.
 local_process_provider() ->
     {ok, Script} = file:read_file("test/test.lua"),
@@ -930,7 +992,7 @@ local_process_provider() ->
 %% @doc Example of a Lua module being used as the `<<"provider">>' for a
 %% HyperBEAM node. The module utilized in this example dynamically adjusts the
 %% likelihood of routing to a given node, depending upon price and performance.
-local_dynamic_router_test_() ->
+local_dynamic_router_tc_() ->
     {timeout, 60, fun local_dynamic_router/0}.
 local_dynamic_router() ->
     BenchRoutes = 50,
@@ -1054,7 +1116,7 @@ local_dynamic_router() ->
 %%   likelihood based on price and performance factors
 %% - Request preprocessing and routing happens correctly between nodes
 %% - Non-chargeable routes are properly handled via template patterns
-dynamic_router_pricing_test_() ->
+dynamic_router_pricing_tc_() ->
     {timeout, 30, fun dynamic_router_pricing/0}.
 dynamic_router_pricing() ->
     {ok, Module} = file:read_file(<<"scripts/dynamic-router.lua">>),
@@ -1213,7 +1275,7 @@ dynamic_router_pricing() ->
 %% HyperBEAM node. The module utilized in this example dynamically adjusts the
 %% likelihood of routing to a given node, depending upon price and performance.
 %% also include preprocessing support for routing
-dynamic_router_test_() ->
+dynamic_router_tc_() ->
     {timeout, 30, fun dynamic_router/0}.
 dynamic_router() ->
     {ok, Module} = file:read_file(<<"scripts/dynamic-router.lua">>),
@@ -1334,7 +1396,7 @@ dynamic_router() ->
 %% according to the real-time performance of nodes. This test utilizes the
 %% `dynamic-router' script to manage routes and recalculate weights based on the
 %% reported performance.
-dynamic_routing_by_performance_test_() ->
+dynamic_routing_by_performance_tc_() ->
     {timeout, 60, fun dynamic_routing_by_performance/0}.
 dynamic_routing_by_performance() ->
     % Setup test parameters
@@ -1493,7 +1555,7 @@ dynamic_routing_by_performance() ->
     ),
     ok.
 
-weighted_random_strategy_test() ->
+weighted_random_strategy_tc() ->
     Nodes =
         [
             #{ <<"host">> => <<"1">>, <<"weight">> => 1 },
@@ -1506,7 +1568,7 @@ weighted_random_strategy_test() ->
     ?assert(ProportionOfFirstHost < 0.05),
     ?assert(ProportionOfFirstHost >= 0.0001).
 
-shuffled_strategy_test() ->
+shuffled_strategy_tc() ->
     Opts = #{},
     Nodes =
         [
@@ -1545,7 +1607,7 @@ shuffled_strategy_test() ->
         )
     ).
         
-range_limited_route_filtering_test() ->
+range_limited_route_filtering_tc() ->
     Opts = #{},
     Nodes = [
         #{ <<"id">> => 0, <<"max">> => 20 },
@@ -1598,7 +1660,7 @@ range_limited_route_filtering_test() ->
         lists:seq(1, 10)
     ).
 
-strategy_suite_test_() ->
+strategy_suite_tc_() ->
     lists:map(
         fun(Strategy) ->
             {foreach,
@@ -1623,7 +1685,7 @@ strategy_suite_test_() ->
 
 %% @doc Ensure that `By-Base' always chooses the same node for the same
 %% hashpath.
-by_base_determinism_test() ->
+by_base_determinism_tc() ->
     FirstN = 5,
     Nodes = generate_nodes(5),
     HashPaths = generate_hashpaths(100),
@@ -1665,7 +1727,7 @@ unique_nodes(Simulation) ->
         Simulation
     ).
 
-route_template_message_matches_test() ->
+route_template_message_matches_tc() ->
     Routes = [
         #{
             <<"template">> => #{ <<"other-key">> => <<"other-value">> },
@@ -1698,7 +1760,7 @@ route_template_message_matches_test() ->
         )
     ).
 
-route_regex_matches_test() ->
+route_regex_matches_tc() ->
     Routes = [
         #{
             <<"template">> => <<"/.*/compute">>,
@@ -1722,7 +1784,7 @@ route_regex_matches_test() ->
         route(#{ <<"path">> => <<"/a/b/c/bad-key">> }, #{ routes => Routes })
     ).
 
-explicit_route_test() ->
+explicit_route_tc() ->
     Routes = [
         #{
             <<"template">> => <<"*">>,
@@ -1757,7 +1819,7 @@ explicit_route_test() ->
         )
     ).
 
-device_call_from_singleton_test() ->
+device_call_from_singleton_tc() ->
     % Try with a real-world example, taken from a GET request to the router.
     NodeOpts = #{ routes => Routes = [#{
         <<"template">> => <<"/some/path">>,
@@ -1772,7 +1834,7 @@ device_call_from_singleton_test() ->
     ).
     
 
-get_routes_test() ->
+get_routes_tc() ->
     Node = hb_http_server:start_node(
         #{
             force_signed => false,
@@ -1790,7 +1852,7 @@ get_routes_test() ->
     {ok, Recvd} = Res,
     ?assertMatch(<<"our_node">>, Recvd).
 
-add_route_test() ->
+add_route_tc() ->
     Owner = ar_wallet:new(),
     Node = hb_http_server:start_node(
         #{
@@ -1828,7 +1890,7 @@ add_route_test() ->
 
 %% @doc Test that the `preprocess/3' function re-routes a request to remote
 %% peers via `~relay@1.0', according to the node's routing table.
-request_hook_reroute_to_nearest_test() ->
+request_hook_reroute_to_nearest_tc() ->
     Peer1 = hb_http_server:start_node(#{ priv_wallet => W1 = ar_wallet:new() }),
     Peer2 = hb_http_server:start_node(#{ priv_wallet => W2 = ar_wallet:new() }),
     Address1 = hb_util:human_id(ar_wallet:to_address(W1)),
@@ -1886,7 +1948,7 @@ request_hook_reroute_to_nearest_test() ->
     ),
     ?assert(HasValidSigner).
 
-route_nearest_integer_preserves_opts_test() ->
+route_nearest_integer_preserves_opts_tc() ->
     Routes =
         [
             #{
@@ -1953,7 +2015,7 @@ route_nearest_integer_preserves_opts_test() ->
         SelectedURIs
     ).
 
-route_multirequest_parallel_limit_test_() ->
+route_multirequest_parallel_limit_tc_() ->
     {timeout, 30, fun route_multirequest_parallel_limit/0}.
 route_multirequest_parallel_limit() ->
     DelayMs = 300,
@@ -2030,7 +2092,7 @@ route_multirequest_parallel_limit() ->
 %% typical config.json) resolves every request type correctly: single-node
 %% prefix routes, multi-node All-strategy routes, Nearest-Integer chunk
 %% routes, match/with regex routes, and fallback routes.
-full_route_config_test() ->
+full_route_config_tc() ->
     Routes =
         [
             #{

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -30,68 +30,6 @@
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
 
--ifdef(TEST).
-%% Test cases exported so `all_tests_test_/0' can run them in parallel via
-%% `fun ?MODULE:name/0'. Each case starts its own node(s) and uses a fresh
-%% store, so concurrent execution is safe.
--export([
-    test_provider_tc/0,
-    dynamic_provider_tc/0,
-    local_process_provider_tc_/0,
-    local_dynamic_router_tc_/0,
-    dynamic_router_pricing_tc_/0,
-    dynamic_router_tc_/0,
-    dynamic_routing_by_performance_tc_/0,
-    weighted_random_strategy_tc/0,
-    shuffled_strategy_tc/0,
-    range_limited_route_filtering_tc/0,
-    strategy_suite_tc_/0,
-    by_base_determinism_tc/0,
-    route_template_message_matches_tc/0,
-    route_regex_matches_tc/0,
-    explicit_route_tc/0,
-    device_call_from_singleton_tc/0,
-    get_routes_tc/0,
-    add_route_tc/0,
-    request_hook_reroute_to_nearest_tc/0,
-    route_nearest_integer_preserves_opts_tc/0,
-    route_multirequest_parallel_limit_tc_/0,
-    full_route_config_tc/0
-]).
--endif.
-
-all_tests_test_() ->
-    {inparallel,
-        [
-            {atom_to_list(F), fun ?MODULE:F/0}
-        ||
-            F <- [
-                test_provider_tc,
-                dynamic_provider_tc,
-                local_process_provider_tc_,
-                local_dynamic_router_tc_,
-                dynamic_router_pricing_tc_,
-                dynamic_router_tc_,
-                dynamic_routing_by_performance_tc_,
-                weighted_random_strategy_tc,
-                shuffled_strategy_tc,
-                range_limited_route_filtering_tc,
-                strategy_suite_tc_,
-                by_base_determinism_tc,
-                route_template_message_matches_tc,
-                route_regex_matches_tc,
-                explicit_route_tc,
-                device_call_from_singleton_tc,
-                get_routes_tc,
-                add_route_tc,
-                request_hook_reroute_to_nearest_tc,
-                route_nearest_integer_preserves_opts_tc,
-                route_multirequest_parallel_limit_tc_,
-                full_route_config_tc
-            ]
-        ]
-    }.
-
 %% @doc Exported function for getting device info, controls which functions are
 %% exposed via the device API.
 info(_) -> 
@@ -893,7 +831,7 @@ preprocess(Base, RawReq, Opts) ->
 
 %%% Tests
 
-test_provider_tc() ->
+test_provider_test_parallel() ->
     Node =
         hb_http_server:start_node(Opts =
             #{
@@ -921,7 +859,7 @@ test_provider_tc() ->
         hb_http:get(Node, <<"/~router@1.0/routes/1/node">>, Opts)
     ).
 
-dynamic_provider_tc() ->
+dynamic_provider_test_parallel() ->
     {ok, Script} = file:read_file("test/test.lua"),
     Node = hb_http_server:start_node(#{
         router_opts => #{
@@ -942,7 +880,7 @@ dynamic_provider_tc() ->
         hb_http:get(Node, <<"/~router@1.0/routes/1/node">>, #{})
     ).
 
-local_process_provider_tc_() ->
+local_process_provider_test_parallel_() ->
     {timeout, 30, fun local_process_provider/0}.
 local_process_provider() ->
     {ok, Script} = file:read_file("test/test.lua"),
@@ -992,7 +930,7 @@ local_process_provider() ->
 %% @doc Example of a Lua module being used as the `<<"provider">>' for a
 %% HyperBEAM node. The module utilized in this example dynamically adjusts the
 %% likelihood of routing to a given node, depending upon price and performance.
-local_dynamic_router_tc_() ->
+local_dynamic_router_test_parallel_() ->
     {timeout, 60, fun local_dynamic_router/0}.
 local_dynamic_router() ->
     BenchRoutes = 50,
@@ -1116,7 +1054,7 @@ local_dynamic_router() ->
 %%   likelihood based on price and performance factors
 %% - Request preprocessing and routing happens correctly between nodes
 %% - Non-chargeable routes are properly handled via template patterns
-dynamic_router_pricing_tc_() ->
+dynamic_router_pricing_test_parallel_() ->
     {timeout, 30, fun dynamic_router_pricing/0}.
 dynamic_router_pricing() ->
     {ok, Module} = file:read_file(<<"scripts/dynamic-router.lua">>),
@@ -1275,7 +1213,7 @@ dynamic_router_pricing() ->
 %% HyperBEAM node. The module utilized in this example dynamically adjusts the
 %% likelihood of routing to a given node, depending upon price and performance.
 %% also include preprocessing support for routing
-dynamic_router_tc_() ->
+dynamic_router_test_parallel_() ->
     {timeout, 30, fun dynamic_router/0}.
 dynamic_router() ->
     {ok, Module} = file:read_file(<<"scripts/dynamic-router.lua">>),
@@ -1396,7 +1334,7 @@ dynamic_router() ->
 %% according to the real-time performance of nodes. This test utilizes the
 %% `dynamic-router' script to manage routes and recalculate weights based on the
 %% reported performance.
-dynamic_routing_by_performance_tc_() ->
+dynamic_routing_by_performance_test_parallel_() ->
     {timeout, 60, fun dynamic_routing_by_performance/0}.
 dynamic_routing_by_performance() ->
     % Setup test parameters
@@ -1555,7 +1493,7 @@ dynamic_routing_by_performance() ->
     ),
     ok.
 
-weighted_random_strategy_tc() ->
+weighted_random_strategy_test_parallel() ->
     Nodes =
         [
             #{ <<"host">> => <<"1">>, <<"weight">> => 1 },
@@ -1568,7 +1506,7 @@ weighted_random_strategy_tc() ->
     ?assert(ProportionOfFirstHost < 0.05),
     ?assert(ProportionOfFirstHost >= 0.0001).
 
-shuffled_strategy_tc() ->
+shuffled_strategy_test_parallel() ->
     Opts = #{},
     Nodes =
         [
@@ -1607,7 +1545,7 @@ shuffled_strategy_tc() ->
         )
     ).
         
-range_limited_route_filtering_tc() ->
+range_limited_route_filtering_test_parallel() ->
     Opts = #{},
     Nodes = [
         #{ <<"id">> => 0, <<"max">> => 20 },
@@ -1660,7 +1598,7 @@ range_limited_route_filtering_tc() ->
         lists:seq(1, 10)
     ).
 
-strategy_suite_tc_() ->
+strategy_suite_test_parallel_() ->
     lists:map(
         fun(Strategy) ->
             {foreach,
@@ -1685,7 +1623,7 @@ strategy_suite_tc_() ->
 
 %% @doc Ensure that `By-Base' always chooses the same node for the same
 %% hashpath.
-by_base_determinism_tc() ->
+by_base_determinism_test_parallel() ->
     FirstN = 5,
     Nodes = generate_nodes(5),
     HashPaths = generate_hashpaths(100),
@@ -1727,7 +1665,7 @@ unique_nodes(Simulation) ->
         Simulation
     ).
 
-route_template_message_matches_tc() ->
+route_template_message_matches_test_parallel() ->
     Routes = [
         #{
             <<"template">> => #{ <<"other-key">> => <<"other-value">> },
@@ -1760,7 +1698,7 @@ route_template_message_matches_tc() ->
         )
     ).
 
-route_regex_matches_tc() ->
+route_regex_matches_test_parallel() ->
     Routes = [
         #{
             <<"template">> => <<"/.*/compute">>,
@@ -1784,7 +1722,7 @@ route_regex_matches_tc() ->
         route(#{ <<"path">> => <<"/a/b/c/bad-key">> }, #{ routes => Routes })
     ).
 
-explicit_route_tc() ->
+explicit_route_test_parallel() ->
     Routes = [
         #{
             <<"template">> => <<"*">>,
@@ -1819,7 +1757,7 @@ explicit_route_tc() ->
         )
     ).
 
-device_call_from_singleton_tc() ->
+device_call_from_singleton_test_parallel() ->
     % Try with a real-world example, taken from a GET request to the router.
     NodeOpts = #{ routes => Routes = [#{
         <<"template">> => <<"/some/path">>,
@@ -1834,7 +1772,7 @@ device_call_from_singleton_tc() ->
     ).
     
 
-get_routes_tc() ->
+get_routes_test_parallel() ->
     Node = hb_http_server:start_node(
         #{
             force_signed => false,
@@ -1852,7 +1790,7 @@ get_routes_tc() ->
     {ok, Recvd} = Res,
     ?assertMatch(<<"our_node">>, Recvd).
 
-add_route_tc() ->
+add_route_test_parallel() ->
     Owner = ar_wallet:new(),
     Node = hb_http_server:start_node(
         #{
@@ -1890,7 +1828,7 @@ add_route_tc() ->
 
 %% @doc Test that the `preprocess/3' function re-routes a request to remote
 %% peers via `~relay@1.0', according to the node's routing table.
-request_hook_reroute_to_nearest_tc() ->
+request_hook_reroute_to_nearest_test_parallel() ->
     Peer1 = hb_http_server:start_node(#{ priv_wallet => W1 = ar_wallet:new() }),
     Peer2 = hb_http_server:start_node(#{ priv_wallet => W2 = ar_wallet:new() }),
     Address1 = hb_util:human_id(ar_wallet:to_address(W1)),
@@ -1948,7 +1886,7 @@ request_hook_reroute_to_nearest_tc() ->
     ),
     ?assert(HasValidSigner).
 
-route_nearest_integer_preserves_opts_tc() ->
+route_nearest_integer_preserves_opts_test_parallel() ->
     Routes =
         [
             #{
@@ -2015,7 +1953,7 @@ route_nearest_integer_preserves_opts_tc() ->
         SelectedURIs
     ).
 
-route_multirequest_parallel_limit_tc_() ->
+route_multirequest_parallel_limit_test_parallel_() ->
     {timeout, 30, fun route_multirequest_parallel_limit/0}.
 route_multirequest_parallel_limit() ->
     DelayMs = 300,
@@ -2092,7 +2030,7 @@ route_multirequest_parallel_limit() ->
 %% typical config.json) resolves every request type correctly: single-node
 %% prefix routes, multi-node All-strategy routes, Nearest-Integer chunk
 %% routes, match/with regex routes, and fallback routes.
-full_route_config_tc() ->
+full_route_config_test_parallel() ->
     Routes =
         [
             #{

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -51,36 +51,31 @@
 ]).
 -endif.
 
-%% @doc Run most tests in parallel. The benchmark suite picks a random
-%% port and seeds rand globally, so run it by itself after the parallel
-%% batch to avoid port contention and seed corruption.
+%% @doc Run every test in this module in parallel. The benchmark suite
+%% lets the OS pick ports and uses per-test `hb_test_utils:test_store/1',
+%% so it carries no more shared state than any other test in the batch.
 all_tests_test_() ->
-    ParallelSafe = [
-        status_tc,
-        register_new_process_tc,
-        schedule_message_and_get_slot_tc,
-        redirect_to_hint_tc,
-        redirect_from_graphql_tc_,
-        get_local_schedule_tc,
-        http_get_schedule_redirect_tc_,
-        http_post_schedule_tc_,
-        http_get_schedule_tc_,
-        http_get_legacy_schedule_tc_,
-        http_get_legacy_slot_tc_,
-        http_get_legacy_schedule_slot_range_tc_,
-        http_get_legacy_schedule_as_aos2_tc_,
-        http_get_json_schedule_tc_
-    ],
-    {inorder,
+    {inparallel,
         [
-            {inparallel,
-                [
-                    {atom_to_list(F), fun ?MODULE:F/0}
-                ||
-                    F <- ParallelSafe
-                ]
-            },
-            {"benchmark_suite_tc_", fun ?MODULE:benchmark_suite_tc_/0}
+            {atom_to_list(F), fun ?MODULE:F/0}
+        ||
+            F <- [
+                status_tc,
+                register_new_process_tc,
+                schedule_message_and_get_slot_tc,
+                redirect_to_hint_tc,
+                redirect_from_graphql_tc_,
+                get_local_schedule_tc,
+                http_get_schedule_redirect_tc_,
+                http_post_schedule_tc_,
+                http_get_schedule_tc_,
+                http_get_legacy_schedule_tc_,
+                http_get_legacy_slot_tc_,
+                http_get_legacy_schedule_slot_range_tc_,
+                http_get_legacy_schedule_as_aos2_tc_,
+                http_get_json_schedule_tc_,
+                benchmark_suite_tc_
+            ]
         ]
     }.
 %%% The maximum number of assignments that we will query/return at a time.
@@ -1658,13 +1653,10 @@ http_init() -> http_init(#{}).
 http_init(Opts) ->
     start(),
     Wallet = ar_wallet:new(),
-    %% Each test gets its own volatile store instance (via a unique name)
-    %% layered over a gateway store, so parallel HTTP scheduler tests do
-    %% not share `hb_store_volatile' ETS state.
     ExtendedOpts = Opts#{
         priv_wallet => Wallet,
         store => [
-            hb_test_utils:test_store(hb_store_volatile, <<"scheduler-http">>),
+            hb_test_utils:test_store(),
             #{ <<"store-module">> => hb_store_gateway, <<"store">> => [] }
         ]
     },
@@ -1988,31 +1980,23 @@ many_clients(Opts) ->
     ?assert(Iterations > 10).
 
 benchmark_suite_tc_() ->
-	{timeout, 10, fun() -> 
-		rand:seed(exsplus, erlang:timestamp()),
-		Port = 30000 + rand:uniform(10000),
-		Bench = [
-			{benchmark, "benchmark", fun single_resolution/1},
-			{multihttp_benchmark, "multihttp_benchmark", fun many_clients/1}
-		],
-		filelib:ensure_dir(
-			binary_to_list(Base = <<"cache-TEST/run-">>)
-		),
-		hb_test_utils:suite_with_opts(Bench, benchmark_suite(Port, Base))
-	end}.
+    {timeout, 10, fun() ->
+        Bench = [
+            {benchmark, "benchmark", fun single_resolution/1},
+            {multihttp_benchmark, "multihttp_benchmark", fun many_clients/1}
+        ],
+        hb_test_utils:suite_with_opts(Bench, benchmark_suite())
+    end}.
 
-benchmark_suite(Port, Base) ->
-    PortBin = integer_to_binary(Port),
+benchmark_suite() ->
     [
         #{
             name => fs,
             requires => [hb_store_fs],
             opts => #{
-                store => #{ <<"store-module">> => hb_store_fs, 
-                    <<"name">> => <<Base/binary, PortBin/binary, "-A">>
-                },
+                store => hb_test_utils:test_store(hb_store_fs),
                 scheduling_mode => local_confirmation,
-                port => Port
+                port => 0
             },
             desc => <<"FS store, local conf.">>
         },
@@ -2020,11 +2004,9 @@ benchmark_suite(Port, Base) ->
             name => fs_aggressive,
             requires => [hb_store_fs],
             opts => #{
-                store => #{ <<"store-module">> => hb_store_fs, 
-                    <<"name">> => <<Base/binary, PortBin/binary, "-B">>
-                },
+                store => hb_test_utils:test_store(hb_store_fs),
                 scheduling_mode => aggressive,
-                port => Port + 1
+                port => 0
             },
             desc => <<"FS store, aggressive conf.">>
         },
@@ -2032,11 +2014,9 @@ benchmark_suite(Port, Base) ->
             name => rocksdb,
             requires => [hb_store_rocksdb],
             opts => #{
-                store => #{ <<"store-module">> => hb_store_rocksdb, 
-                    <<"name">> => <<Base/binary, PortBin/binary, "-C">>
-                },
+                store => hb_test_utils:test_store(hb_store_rocksdb),
                 scheduling_mode => local_confirmation,
-                port => Port + 2
+                port => 0
             },
             desc => <<"RocksDB store, local conf.">>
         },
@@ -2044,11 +2024,9 @@ benchmark_suite(Port, Base) ->
             name => rocksdb_aggressive,
             requires => [hb_store_rocksdb],
             opts => #{
-                store => #{ <<"store-module">> => hb_store_rocksdb, 
-                    <<"name">> => <<Base/binary, PortBin/binary, "-D">>
-                },
+                store => hb_test_utils:test_store(hb_store_rocksdb),
                 scheduling_mode => aggressive,
-                port => Port + 3
+                port => 0
             },
             desc => <<"RocksDB store, aggressive conf.">>
         },
@@ -2056,14 +2034,7 @@ benchmark_suite(Port, Base) ->
             name => rocksdb_extreme_aggressive_h3,
             requires => [http3],
             opts => #{
-                store => #{ <<"store-module">> => hb_store_rocksdb, 
-                    <<"name">> =>
-                          <<
-                              Base/binary,
-                              "run-",
-                              (integer_to_binary(Port+4))/binary
-                          >>
-                },
+                store => hb_test_utils:test_store(hb_store_rocksdb),
                 scheduling_mode => aggressive,
                 protocol => http3,
                 workers => 100

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -28,6 +28,61 @@
 -export([test_process/0]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
+
+-ifdef(TEST).
+%% Test cases exported so `all_tests_test_/0' can run them in parallel via
+%% `fun ?MODULE:name/0'.
+-export([
+    status_tc/0,
+    register_new_process_tc/0,
+    schedule_message_and_get_slot_tc/0,
+    redirect_to_hint_tc/0,
+    redirect_from_graphql_tc_/0,
+    get_local_schedule_tc/0,
+    http_get_schedule_redirect_tc_/0,
+    http_post_schedule_tc_/0,
+    http_get_schedule_tc_/0,
+    http_get_legacy_schedule_tc_/0,
+    http_get_legacy_slot_tc_/0,
+    http_get_legacy_schedule_slot_range_tc_/0,
+    http_get_legacy_schedule_as_aos2_tc_/0,
+    http_get_json_schedule_tc_/0,
+    benchmark_suite_tc_/0
+]).
+-endif.
+
+%% @doc Run most tests in parallel. The benchmark suite picks a random
+%% port and seeds rand globally, so run it by itself after the parallel
+%% batch to avoid port contention and seed corruption.
+all_tests_test_() ->
+    ParallelSafe = [
+        status_tc,
+        register_new_process_tc,
+        schedule_message_and_get_slot_tc,
+        redirect_to_hint_tc,
+        redirect_from_graphql_tc_,
+        get_local_schedule_tc,
+        http_get_schedule_redirect_tc_,
+        http_post_schedule_tc_,
+        http_get_schedule_tc_,
+        http_get_legacy_schedule_tc_,
+        http_get_legacy_slot_tc_,
+        http_get_legacy_schedule_slot_range_tc_,
+        http_get_legacy_schedule_as_aos2_tc_,
+        http_get_json_schedule_tc_
+    ],
+    {inorder,
+        [
+            {inparallel,
+                [
+                    {atom_to_list(F), fun ?MODULE:F/0}
+                ||
+                    F <- ParallelSafe
+                ]
+            },
+            {"benchmark_suite_tc_", fun ?MODULE:benchmark_suite_tc_/0}
+        ]
+    }.
 %%% The maximum number of assignments that we will query/return at a time.
 -define(MAX_ASSIGNMENT_QUERY_LEN, 1000).
 %%% The timeout for a lookahead worker.
@@ -1443,7 +1498,7 @@ test_process(Address) ->
         <<"test-random-seed">> => rand:uniform(1337)
     }.
 
-status_test() ->
+status_tc() ->
     start(),
     ?assertMatch(
         #{<<"processes">> := Processes,
@@ -1452,7 +1507,7 @@ status_test() ->
         hb_ao:get(status, test_process())
     ).
 
-register_new_process_test() ->
+register_new_process_tc() ->
     start(),
     Opts = #{ priv_wallet => hb:wallet() },
     Base = hb_message:commit(test_process(Opts), Opts),
@@ -1478,7 +1533,7 @@ register_new_process_test() ->
         )
     ).
 
-schedule_message_and_get_slot_test() ->
+schedule_message_and_get_slot_tc() ->
     start(),
     Base = hb_message:commit(test_process(), #{ priv_wallet => hb:wallet() }),
     Req = #{
@@ -1503,7 +1558,7 @@ schedule_message_and_get_slot_test() ->
             when CurrentSlot > 0,
         hb_ao:resolve(Base, Res, #{})).
 
-redirect_to_hint_test() ->
+redirect_to_hint_tc() ->
     start(),
     RandAddr = hb_util:human_id(crypto:strong_rand_bytes(32)),
     TestLoc = <<"http://test.computer">>,
@@ -1529,7 +1584,7 @@ redirect_to_hint_test() ->
         )
     ).
 
-redirect_from_graphql_test_() ->
+redirect_from_graphql_tc_() ->
     {timeout, 60, fun redirect_from_graphql/0}.
 redirect_from_graphql() ->
     start(),
@@ -1564,7 +1619,7 @@ redirect_from_graphql() ->
         )
     ).
 
-get_local_schedule_test() ->
+get_local_schedule_tc() ->
     start(),
     Base = hb_message:commit(test_process(), #{ priv_wallet => hb:wallet() }),
     Req = #{
@@ -1603,16 +1658,16 @@ http_init() -> http_init(#{}).
 http_init(Opts) ->
     start(),
     Wallet = ar_wallet:new(),
-	ExtendedOpts = Opts#{
-		priv_wallet => Wallet,
-		store => [
-			#{
-                <<"store-module">> => hb_store_volatile,
-                <<"name">> => <<"cache-TEST/volatile">>
-            },
-			#{ <<"store-module">> => hb_store_gateway, <<"store">> => [] }
-		]
-	},
+    %% Each test gets its own volatile store instance (via a unique name)
+    %% layered over a gateway store, so parallel HTTP scheduler tests do
+    %% not share `hb_store_volatile' ETS state.
+    ExtendedOpts = Opts#{
+        priv_wallet => Wallet,
+        store => [
+            hb_test_utils:test_store(hb_store_volatile, <<"scheduler-http">>),
+            #{ <<"store-module">> => hb_store_gateway, <<"store">> => [] }
+        ]
+    },
     Node = hb_http_server:start_node(ExtendedOpts),
     {Node, ExtendedOpts}.
 
@@ -1660,7 +1715,7 @@ http_get_schedule(N, PMsg, From, To, Format) ->
         <<"accept">> => Format
     }, #{ priv_wallet => Wallet }), #{}).
 
-http_get_schedule_redirect_test_() ->
+http_get_schedule_redirect_tc_() ->
     {timeout, 60, fun http_get_schedule_redirect/0}.
 http_get_schedule_redirect() ->
     Opts =
@@ -1678,7 +1733,7 @@ http_get_schedule_redirect() ->
     Res = hb_http:get(N, <<"/", ProcID/binary, "/schedule">>, Opts),
     ?assertMatch({ok, #{ <<"location">> := Location }} when is_binary(Location), Res).
 
-http_post_schedule_test_() ->
+http_post_schedule_tc_() ->
     {timeout, 60, fun http_post_schedule/0}.
 http_post_schedule() ->
     start(),
@@ -1700,7 +1755,7 @@ http_post_schedule() ->
     ?assertEqual(<<"test-message">>, hb_ao:get(<<"body/inner">>, Res2, Opts)),
     ?assertMatch({ok, #{ <<"current">> := 1 }}, http_get_slot(N, PMsg)).
 
-http_get_schedule_test_() ->
+http_get_schedule_tc_() ->
 	{timeout, 20, fun() ->
 		{Node, Opts} = http_init(),
 		PMsg = hb_message:commit(test_process(Opts), Opts),
@@ -1744,7 +1799,7 @@ http_get_schedule_test_() ->
 			end}.
     
 
-http_get_legacy_schedule_test_() ->
+http_get_legacy_schedule_tc_() ->
 	    {timeout, 60, fun() ->
 	        Target = <<"hGLuIZscb7b_2UBnDE_WoyIJF0sH6BU9u4veyEqE8g4">>,
 	        {Node, Opts} = http_init(),
@@ -1754,7 +1809,7 @@ http_get_legacy_schedule_test_() ->
 	        ?assertMatch(#{ <<"assignments">> := As } when map_size(As) > 0, LoadedRes)
 	    end}.
 
-http_get_legacy_slot_test_() ->
+http_get_legacy_slot_tc_() ->
     {timeout, 60, fun() ->
         Target = <<"hGLuIZscb7b_2UBnDE_WoyIJF0sH6BU9u4veyEqE8g4">>,
         {Node, Opts} = http_init(),
@@ -1762,7 +1817,7 @@ http_get_legacy_slot_test_() ->
         ?assertMatch({ok, #{ <<"current">> := Slot }} when Slot > 0, Res)
     end}.
 
-http_get_legacy_schedule_slot_range_test_() ->
+http_get_legacy_schedule_slot_range_tc_() ->
 	    {timeout, 60, fun() ->
 	        Target = <<"hGLuIZscb7b_2UBnDE_WoyIJF0sH6BU9u4veyEqE8g4">>,
 	        {Node, Opts} = http_init(),
@@ -1774,7 +1829,7 @@ http_get_legacy_schedule_slot_range_test_() ->
 	        ?assertMatch(#{ <<"assignments">> := As } when map_size(As) == 5, LoadedRes)
 	    end}.
 
-http_get_legacy_schedule_as_aos2_test_() ->
+http_get_legacy_schedule_as_aos2_tc_() ->
     {timeout, 60, fun() ->
         Target = <<"hGLuIZscb7b_2UBnDE_WoyIJF0sH6BU9u4veyEqE8g4">>,
         {Node, Opts} = http_init(),
@@ -1824,7 +1879,7 @@ http_post_legacy_schedule_test_disabled() ->
         )
     end}.
 
-http_get_json_schedule_test_() ->
+http_get_json_schedule_tc_() ->
 	{timeout, 60, fun() ->
 		{Node, Opts} = http_init(),
 		PMsg = hb_message:commit(test_process(Opts), Opts),
@@ -1933,7 +1988,7 @@ many_clients(Opts) ->
     ?event(bench, {res, Res}),
     ?assert(Iterations > 10).
 
-benchmark_suite_test_() ->
+benchmark_suite_tc_() ->
 	{timeout, 10, fun() -> 
 		rand:seed(exsplus, erlang:timestamp()),
 		Port = 30000 + rand:uniform(10000),

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -1789,7 +1789,6 @@ http_get_schedule_tc_() ->
 					lists:seq(1, 3)
 				),
 				?assertMatch({ok, #{ <<"current">> := 3 }}, http_get_slot(Node, PMsg)),
-			        ?debug_wait(100),
 				{ok, Schedule} = http_get_schedule(Node, PMsg, 0, 3),
 				Assignments = hb_ao:get(<<"assignments">>, Schedule, Opts),
 				?assertEqual(

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -29,55 +29,6 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--ifdef(TEST).
-%% Test cases exported so `all_tests_test_/0' can run them in parallel via
-%% `fun ?MODULE:name/0'.
--export([
-    status_tc/0,
-    register_new_process_tc/0,
-    schedule_message_and_get_slot_tc/0,
-    redirect_to_hint_tc/0,
-    redirect_from_graphql_tc_/0,
-    get_local_schedule_tc/0,
-    http_get_schedule_redirect_tc_/0,
-    http_post_schedule_tc_/0,
-    http_get_schedule_tc_/0,
-    http_get_legacy_schedule_tc_/0,
-    http_get_legacy_slot_tc_/0,
-    http_get_legacy_schedule_slot_range_tc_/0,
-    http_get_legacy_schedule_as_aos2_tc_/0,
-    http_get_json_schedule_tc_/0,
-    benchmark_suite_tc_/0
-]).
--endif.
-
-%% @doc Run every test in this module in parallel. The benchmark suite
-%% lets the OS pick ports and uses per-test `hb_test_utils:test_store/1',
-%% so it carries no more shared state than any other test in the batch.
-all_tests_test_() ->
-    {inparallel,
-        [
-            {atom_to_list(F), fun ?MODULE:F/0}
-        ||
-            F <- [
-                status_tc,
-                register_new_process_tc,
-                schedule_message_and_get_slot_tc,
-                redirect_to_hint_tc,
-                redirect_from_graphql_tc_,
-                get_local_schedule_tc,
-                http_get_schedule_redirect_tc_,
-                http_post_schedule_tc_,
-                http_get_schedule_tc_,
-                http_get_legacy_schedule_tc_,
-                http_get_legacy_slot_tc_,
-                http_get_legacy_schedule_slot_range_tc_,
-                http_get_legacy_schedule_as_aos2_tc_,
-                http_get_json_schedule_tc_,
-                benchmark_suite_tc_
-            ]
-        ]
-    }.
 %%% The maximum number of assignments that we will query/return at a time.
 -define(MAX_ASSIGNMENT_QUERY_LEN, 1000).
 %%% The timeout for a lookahead worker.
@@ -1493,7 +1444,7 @@ test_process(Address) ->
         <<"test-random-seed">> => rand:uniform(1337)
     }.
 
-status_tc() ->
+status_test_parallel() ->
     start(),
     ?assertMatch(
         #{<<"processes">> := Processes,
@@ -1502,7 +1453,7 @@ status_tc() ->
         hb_ao:get(status, test_process())
     ).
 
-register_new_process_tc() ->
+register_new_process_test_parallel() ->
     start(),
     Opts = #{ priv_wallet => hb:wallet() },
     Base = hb_message:commit(test_process(Opts), Opts),
@@ -1528,7 +1479,7 @@ register_new_process_tc() ->
         )
     ).
 
-schedule_message_and_get_slot_tc() ->
+schedule_message_and_get_slot_test_parallel() ->
     start(),
     Base = hb_message:commit(test_process(), #{ priv_wallet => hb:wallet() }),
     Req = #{
@@ -1553,7 +1504,7 @@ schedule_message_and_get_slot_tc() ->
             when CurrentSlot > 0,
         hb_ao:resolve(Base, Res, #{})).
 
-redirect_to_hint_tc() ->
+redirect_to_hint_test_parallel() ->
     start(),
     RandAddr = hb_util:human_id(crypto:strong_rand_bytes(32)),
     TestLoc = <<"http://test.computer">>,
@@ -1579,7 +1530,7 @@ redirect_to_hint_tc() ->
         )
     ).
 
-redirect_from_graphql_tc_() ->
+redirect_from_graphql_test_parallel_() ->
     {timeout, 60, fun redirect_from_graphql/0}.
 redirect_from_graphql() ->
     start(),
@@ -1614,7 +1565,7 @@ redirect_from_graphql() ->
         )
     ).
 
-get_local_schedule_tc() ->
+get_local_schedule_test_parallel() ->
     start(),
     Base = hb_message:commit(test_process(), #{ priv_wallet => hb:wallet() }),
     Req = #{
@@ -1707,7 +1658,7 @@ http_get_schedule(N, PMsg, From, To, Format) ->
         <<"accept">> => Format
     }, #{ priv_wallet => Wallet }), #{}).
 
-http_get_schedule_redirect_tc_() ->
+http_get_schedule_redirect_test_parallel_() ->
     {timeout, 60, fun http_get_schedule_redirect/0}.
 http_get_schedule_redirect() ->
     Opts =
@@ -1725,7 +1676,7 @@ http_get_schedule_redirect() ->
     Res = hb_http:get(N, <<"/", ProcID/binary, "/schedule">>, Opts),
     ?assertMatch({ok, #{ <<"location">> := Location }} when is_binary(Location), Res).
 
-http_post_schedule_tc_() ->
+http_post_schedule_test_parallel_() ->
     {timeout, 60, fun http_post_schedule/0}.
 http_post_schedule() ->
     start(),
@@ -1747,7 +1698,7 @@ http_post_schedule() ->
     ?assertEqual(<<"test-message">>, hb_ao:get(<<"body/inner">>, Res2, Opts)),
     ?assertMatch({ok, #{ <<"current">> := 1 }}, http_get_slot(N, PMsg)).
 
-http_get_schedule_tc_() ->
+http_get_schedule_test_parallel_() ->
 	{timeout, 20, fun() ->
 		{Node, Opts} = http_init(),
 		PMsg = hb_message:commit(test_process(Opts), Opts),
@@ -1790,7 +1741,7 @@ http_get_schedule_tc_() ->
 			end}.
     
 
-http_get_legacy_schedule_tc_() ->
+http_get_legacy_schedule_test_parallel_() ->
 	    {timeout, 60, fun() ->
 	        Target = <<"hGLuIZscb7b_2UBnDE_WoyIJF0sH6BU9u4veyEqE8g4">>,
 	        {Node, Opts} = http_init(),
@@ -1800,7 +1751,7 @@ http_get_legacy_schedule_tc_() ->
 	        ?assertMatch(#{ <<"assignments">> := As } when map_size(As) > 0, LoadedRes)
 	    end}.
 
-http_get_legacy_slot_tc_() ->
+http_get_legacy_slot_test_parallel_() ->
     {timeout, 60, fun() ->
         Target = <<"hGLuIZscb7b_2UBnDE_WoyIJF0sH6BU9u4veyEqE8g4">>,
         {Node, Opts} = http_init(),
@@ -1808,7 +1759,7 @@ http_get_legacy_slot_tc_() ->
         ?assertMatch({ok, #{ <<"current">> := Slot }} when Slot > 0, Res)
     end}.
 
-http_get_legacy_schedule_slot_range_tc_() ->
+http_get_legacy_schedule_slot_range_test_parallel_() ->
 	    {timeout, 60, fun() ->
 	        Target = <<"hGLuIZscb7b_2UBnDE_WoyIJF0sH6BU9u4veyEqE8g4">>,
 	        {Node, Opts} = http_init(),
@@ -1820,7 +1771,7 @@ http_get_legacy_schedule_slot_range_tc_() ->
 	        ?assertMatch(#{ <<"assignments">> := As } when map_size(As) == 5, LoadedRes)
 	    end}.
 
-http_get_legacy_schedule_as_aos2_tc_() ->
+http_get_legacy_schedule_as_aos2_test_parallel_() ->
     {timeout, 60, fun() ->
         Target = <<"hGLuIZscb7b_2UBnDE_WoyIJF0sH6BU9u4veyEqE8g4">>,
         {Node, Opts} = http_init(),
@@ -1870,7 +1821,7 @@ http_post_legacy_schedule_test_disabled() ->
         )
     end}.
 
-http_get_json_schedule_tc_() ->
+http_get_json_schedule_test_parallel_() ->
 	{timeout, 60, fun() ->
 		{Node, Opts} = http_init(),
 		PMsg = hb_message:commit(test_process(Opts), Opts),
@@ -1979,7 +1930,7 @@ many_clients(Opts) ->
     ?event(bench, {res, Res}),
     ?assert(Iterations > 10).
 
-benchmark_suite_tc_() ->
+benchmark_suite_test_parallel_() ->
     {timeout, 10, fun() ->
         Bench = [
             {benchmark, "benchmark", fun single_resolution/1},

--- a/src/dev_scheduler_cache.erl
+++ b/src/dev_scheduler_cache.erl
@@ -236,17 +236,27 @@ concurrent_read_write_test() ->
     ProcID = hb_util:human_id(crypto:strong_rand_bytes(32)),
     Parent = self(),
     ?event(testing, {concurrent_test_proc_id, ProcID}),
-    spawn_link(fun() ->
-        lists:foreach(fun(Slot) ->
-            Assignment = #{
+    MkAssignment =
+        fun(Slot) ->
+            #{
                 <<"variant">> => <<"ao.N.1">>,
                 <<"process">> => ProcID,
                 <<"slot">> => Slot,
-                <<"hash-chain">> => <<"race-test-", (integer_to_binary(Slot))/binary>>
-            },
-            write(Assignment, Opts),
+                <<"hash-chain">> =>
+                    <<"race-test-", (integer_to_binary(Slot))/binary>>
+            }
+        end,
+    %% Pre-write slot 1 synchronously so readers always have at least
+    %% one assignment available; otherwise under heavy CPU contention the
+    %% 10 reader processes can blast through their 100 reads before the
+    %% writer's first `write/2' lands, causing `TotalSuccessfulReads > 0'
+    %% to fail spuriously.
+    write(MkAssignment(1), Opts),
+    spawn_link(fun() ->
+        lists:foreach(fun(Slot) ->
+            write(MkAssignment(Slot), Opts),
             timer:sleep(1)
-        end, lists:seq(1, 100)),
+        end, lists:seq(2, 100)),
         ?event(testing, {writer_completed}),
         Parent ! writer_done
     end),

--- a/src/hb_name.erl
+++ b/src/hb_name.erl
@@ -249,5 +249,13 @@ all_test() ->
     BaseRegistered = length(hb_name:all()),
     spawn_test_workers(random),
     ?assertEqual(BaseRegistered + ?CONCURRENT_REGISTRATIONS, length(hb_name:all())),
-    timer:sleep(1000),
-    ?assertEqual(BaseRegistered, length(hb_name:all())).
+    %% Workers stay alive 500 ms then exit; their names are unregistered
+    %% once the `hb_name' cleanup reaper notices. Poll rather than sleep
+    %% a flat second.
+    ?assertEqual(
+        BaseRegistered,
+        hb_util:wait_until(
+            fun() -> length(hb_name:all()) =:= BaseRegistered end,
+            2000
+        ) andalso length(hb_name:all())
+    ).

--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -501,7 +501,6 @@ remote_hyperbeam_node_ans104_test() ->
             store => hb_test_utils:test_store()
         },
     Server = hb_http_server:start_node(ServerOpts),
-    ?debug_wait(1000),
     Msg =
         hb_message:commit(
             #{
@@ -526,7 +525,6 @@ remote_hyperbeam_node_ans104_test() ->
                     }
                 ]
         },
-    ?debug_wait(1000),
     {ok, Req} = hb_cache:read(ID, ClientOpts),
     ?assert(hb_message:verify(Req)),
     ?assert(hb_message:match(Msg, Req)).

--- a/src/hb_store_volatile.erl
+++ b/src/hb_store_volatile.erl
@@ -55,9 +55,15 @@ owner_loop(StoreOpts) ->
     end.
 
 maybe_start_ttl_timer(StoreOpts, PID) ->
-    case maps:get(<<"max-ttl">>, StoreOpts, infinity) of
-        infinity -> skip;
-        MaxTTL -> timer:send_after(hb_util:int(MaxTTL) * 1000, PID, reset)
+    case maps:get(<<"max-ttl-ms">>, StoreOpts, undefined) of
+        undefined ->
+            case maps:get(<<"max-ttl">>, StoreOpts, infinity) of
+                infinity -> skip;
+                MaxTTL ->
+                    timer:send_after(hb_util:int(MaxTTL) * 1000, PID, reset)
+            end;
+        MaxTTLMs ->
+            timer:send_after(hb_util:int(MaxTTLMs), PID, reset)
     end.
 
 %% @doc Stop the ETS owner process (which also drops the table).
@@ -246,15 +252,15 @@ max_ttl_test() ->
         #{
             <<"store-module">> => ?MODULE,
             <<"name">> => <<"ets-max-ttl-test">>,
-            <<"max-ttl">> => 1
+            <<"max-ttl-ms">> => 100
         },
     hb_store:start(StoreOpts),
     hb_store:write(StoreOpts, <<"a">>, <<"b">>),
     ?assertEqual({ok, <<"b">>}, hb_store:read(StoreOpts, <<"a">>)),
-    timer:sleep(1250),
+    timer:sleep(200),
     ?assertEqual(not_found, hb_store:read(StoreOpts, <<"a">>)),
     hb_store:write(StoreOpts, <<"a">>, <<"c">>),
     ?assertEqual({ok, <<"c">>}, hb_store:read(StoreOpts, <<"a">>)),
-    timer:sleep(1250),
+    timer:sleep(200),
     ?assertEqual(not_found, hb_store:read(StoreOpts, <<"a">>)),
     hb_store:stop(StoreOpts).

--- a/src/hb_test_utils.erl
+++ b/src/hb_test_utils.erl
@@ -26,11 +26,9 @@ test_store(Mod, Tag) ->
         <<
             "cache-TEST/run-",
             Tag/binary, "-",
-            (integer_to_binary(erlang:system_time(millisecond)))/binary
+            (integer_to_binary(erlang:system_time(microsecond)))/binary, "-",
+            (hb_util:encode(crypto:strong_rand_bytes(6)))/binary
         >>,
-    % Wait a tiny interval to ensure that any further tests will get their own
-    % directory.
-    timer:sleep(1),
     filelib:ensure_dir(binary_to_list(TestDir)),
     #{ <<"store-module">> => Mod, <<"name">> => TestDir }.
 
@@ -41,48 +39,79 @@ test_store(Mod, Tag) ->
 %% Each element may also contain a `skip' key with a list of test names to skip.
 %% They can also contain a `desc' key with a description of the options.
 suite_with_opts(Suite, OptsList) ->
-    lists:filtermap(
-        fun(OptSpec = #{ name := _Name, opts := Opts, desc := ODesc}) ->
-            Store = hb_opts:get(store, hb_opts:get(store), Opts),
-            Skip = hb_maps:get(skip, OptSpec, [], Opts),
-            case satisfies_requirements(OptSpec) of
-                true ->
-                    Each = 
-                        {foreach,
-                            fun() ->
-                                ?event({starting, Store}),
-                                % Create and set a random server ID for the test
-                                % process.
-                                hb_http_server:set_proc_server_id(
-                                    hb_util:human_id(crypto:strong_rand_bytes(32))
-                                ),
-                                hb_store:reset(Store),
-                                hb_store:start(Store)
-                            end,
-                            fun(_) ->
-                                hb_store:reset(Store),
-                                ok
-                            end,
+    {inparallel,
+        lists:filtermap(
+            fun(OptSpec = #{ name := _Name, opts := Opts, desc := ODesc}) ->
+                Skip = hb_maps:get(skip, OptSpec, [], Opts),
+                case satisfies_requirements(OptSpec) of
+                    true ->
+                        Tests =
                             [
-                                {
-                                    hb_util:list(ODesc)
-                                        ++ ": "
-                                        ++ hb_util:list(TestDesc),
-                                    fun() -> Test(Opts) end}
+                                {TestDesc, Test}
                             ||
-                                {TestAtom, TestDesc, Test} <- Suite, 
+                                {TestAtom, TestDesc, Test} <- Suite,
                                     not lists:member(TestAtom, Skip)
-                            ]
-                        },
-                    case maps:get(parallel, OptSpec, true) of
-                        true -> {true, {inparallel, Each}};
-                        false -> {true, Each}
-                    end;
-                false -> false
-            end
-        end,
-        OptsList
-    ).
+                            ],
+                        % Each test gets its own fresh store so that parallel
+                        % tests do not race on a shared store's reset/write
+                        % operations. We use `foreach' with a setup that returns
+                        % the per-test Opts (with its own store) and a cleanup
+                        % that resets that store. Each test's generator takes
+                        % the fresh Opts as its argument.
+                        Each =
+                            {foreach,
+                                fun() ->
+                                    FreshStore = fresh_store(Opts),
+                                    FreshOpts = Opts#{ store => FreshStore },
+                                    hb_http_server:set_proc_server_id(
+                                        hb_util:human_id(
+                                            crypto:strong_rand_bytes(32)
+                                        )
+                                    ),
+                                    hb_store:start(FreshStore),
+                                    FreshOpts
+                                end,
+                                fun(FreshOpts) ->
+                                    FreshStore = maps:get(store, FreshOpts),
+                                    hb_store:reset(FreshStore),
+                                    ok
+                                end,
+                                [
+                                    fun(FreshOpts) ->
+                                        {
+                                            hb_util:list(ODesc)
+                                                ++ ": "
+                                                ++ hb_util:list(TestDesc),
+                                            fun() -> Test(FreshOpts) end
+                                        }
+                                    end
+                                ||
+                                    {TestDesc, Test} <- Tests
+                                ]
+                            },
+                        case maps:get(parallel, OptSpec, true) of
+                            true -> {true, {inparallel, Each}};
+                            false -> {true, Each}
+                        end;
+                    false -> false
+                end
+            end,
+            OptsList
+        )
+    }.
+
+%% @doc Derive a fresh store for a single test based on the options' store
+%% template. For `hb_store_volatile' stores (the default test store), each
+%% test gets its own ETS-backed instance with a unique name so there is no
+%% shared state between tests in the same OptSpec.
+fresh_store(Opts) ->
+    case hb_opts:get(store, undefined, Opts) of
+        #{ <<"store-module">> := Mod } when is_atom(Mod) ->
+            Tag = hb_util:encode(crypto:strong_rand_bytes(6)),
+            test_store(Mod, Tag);
+        _ ->
+            test_store(?DEFAULT_STORE_MODULE)
+    end.
 
 %% @doc Determine if the environment satisfies the given test requirements.
 %% Requirements is a list of atoms, each corresponding to a module that must


### PR DESCRIPTION
Improves test performance and reliability by enabling parallel execution across multiple modules (introduced in the last PR), and ensuring better test isolation.

- Refactors test suites in modules such as `dev_arweave`, `dev_bundler`, `dev_router`, `dev_scheduler`, `dev_process_test_vectors`, and others to run in parallel with the new `_test_parallel` parse transform.
- Introduces per-test store isolation by providing a fresh store instance for each test, preventing interference and race conditions between concurrent runs.
- Separates timing-sensitive tests in `dev_bundler` into a serial execution group to ensure accurate assertions under CPU contention.
- Addresses specific race conditions in `dev_scheduler_cache` and `hb_name`.
- Removes unnecessary `?debug_wait` calls in various test files.
- Updates `dev_bundler`'s server naming logic to derive names from the HTTP server's wallet, ensuring unique bundler instances per HTTP server node for test isolation.
- Refines `hb_store_volatile` TTL test granularity by using milliseconds.