### PR TITLE
fix: foundational query/mempool fixes for `feat/mempool-offsets`

### DIFF
--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -382,14 +382,15 @@ post_chunk(Request, Opts) ->
 %% global Arweave data tree, or relative to the start of a specific pending
 %% transaction.
 get_chunk(_Base, Request, Opts) ->
+    HasExplicitLength = hb_maps:is_key(<<"length">>, Request, Opts),
     {ok, Offset, Length, MaybeRelativeTXID} = extract_chunk_params(Request, Opts),
     case fetch_chunk_range(Offset, Length, MaybeRelativeTXID, Opts) of
         {ok, Chunks} ->
             Data = hb_util:bin(Chunks),
-            case Length of
-                undefined ->
+            case HasExplicitLength of
+                false ->
                     {ok, Data};
-                Length ->
+                true ->
                     {
                         ok,
                         binary:part(Data, 0, min(hb_util:int(Length), byte_size(Data)))
@@ -402,7 +403,7 @@ get_chunk(_Base, Request, Opts) ->
 %% @doc Extract the parameters from a chunk request. Supports both global offsets
 %% and relative offset+parent ID pairs.
 extract_chunk_params(Request, Opts) ->
-    Length = hb_maps:get(<<"length">>, Request, undefined, Opts),
+    Length = hb_maps:get(<<"length">>, Request, 1, Opts),
     case hb_maps:find(<<"offset">>, Request, Opts) of
         {ok, RelativeInfo} when is_map(RelativeInfo) ->
             {ok, RelativeOffset} = hb_maps:find(<<"offset">>, RelativeInfo, Opts),
@@ -1911,6 +1912,12 @@ get_mid_chunk_pre_split_test() ->
         hb_util:encode(crypto:hash(sha256, Data))
     ),
     ok.
+
+extract_chunk_params_default_length_test() ->
+    ?assertEqual(
+        {ok, 123, 1, undefined},
+        extract_chunk_params(#{ <<"offset">> => 123 }, #{})
+    ).
 
 get_pre_split_small_chunks_test() ->
     TXID = <<"4FnBmvgWmqXWEEprjVqBsV5aRpAgF6_yJX_GTGsSZjY">>,

--- a/src/dev_query_arweave.erl
+++ b/src/dev_query_arweave.erl
@@ -449,7 +449,7 @@ annotate_offsets([], _StoreOpts, _LastOffset, _Ordinate, _Opts) -> [];
 annotate_offsets([ID|IDs], StoreOpts, LastOffset, Ordinate, Opts) ->
     {Offset, Annotated} =
         case hb_store_arweave:read_offset(StoreOpts, ID) of
-            {ok, #{ <<"start-offset">> := StartOffset, <<"length">> := Length }} ->
+            {ok, #{ <<"offset">> := StartOffset, <<"length">> := Length }} ->
                 {
                     StartOffset,
                     #{

--- a/src/dev_query_test_vectors.erl
+++ b/src/dev_query_test_vectors.erl
@@ -740,7 +740,7 @@ transactions_query_ids_preserve_arweave_tx_id_test() ->
     {ok, _Node, Opts} = test_env_with_blocks(1892487, 1892487),
     ID = <<"mT7pIQx9ORnemXoIzWmKwymiZJxtOSvzxm3P44M9C1A">>,
     ?assertMatch(
-        {ok, #{ <<"start-offset">> := _ }},
+        {ok, #{ <<"offset">> := _ }},
         hb_store_arweave:read_offset(hb_store_arweave:store_from_opts(Opts), ID)
     ),
     ?assertMatch(
@@ -772,9 +772,9 @@ transactions_query_cursor_by_offset_test() ->
     EarlierID = <<"xBpOR2KOjYEgv5HmddMlAgYa-yMvfEVl-0XzRIfm2uY">>,
     LaterID = <<"HVr7EpRhlPkbwdnoXKHf25p7BPa0qJOs6C7XueLthA0">>,
     StoreOpts = hb_store_arweave:store_from_opts(Opts),
-    {ok, #{ <<"start-offset">> := EarlierOffset }} =
+    {ok, #{ <<"offset">> := EarlierOffset }} =
         hb_store_arweave:read_offset(StoreOpts, EarlierID),
-    {ok, #{ <<"start-offset">> := LaterOffset }} =
+    {ok, #{ <<"offset">> := LaterOffset }} =
         hb_store_arweave:read_offset(StoreOpts, LaterID),
     Query =
         <<"""


### PR DESCRIPTION
i started looking into query device compatibility and divergence from the work done (wip) at #857 and i found some regression/issues with dev_query_test_vectors - mainly regressions from feat/mempool-offsets

there was 4 tests failing:
  * `transactions_query_sort_by_block_test`
  * `transactions_query_filter_by_block_test`
  * `transactions_query_ids_preserve_arweave_tx_id_test`
  * `transactions_query_cursor_by_offset_test`

i fixed the first by importing an existing chunk extraction fix from #857 and the 3 other tests were addressed by fixing the regressed `start-offset`

once this PR is merged, i will rebase `impr/mempool-offsets` onto it and continue the query-device work for mixed confirmed + mempool offsets (will share more details in the open PR thread over there)

```bash
======================== EUnit ========================
module 'dev_query_test_vectors'
  dev_query_test_vectors: simple_blocks_query_test...[2.559 s] ok
  dev_query_test_vectors: block_by_height_query_test...[1.081 s] ok
  dev_query_test_vectors: simple_ans104_query_test...[0.054 s] ok
  dev_query_test_vectors: transactions_query_tags_test...[0.040 s] ok
  dev_query_test_vectors: transactions_query_owners_test...[0.043 s] ok
  dev_query_test_vectors: transactions_query_recipients_test...[0.048 s] ok
  dev_query_test_vectors: transactions_query_ids_test...[0.064 s] ok
  dev_query_test_vectors: transactions_query_combined_test...[0.177 s] ok
  dev_query_test_vectors: transactions_query_sort_by_block_test...[3.557 s] ok
  dev_query_test_vectors: transactions_query_filter_by_block_test...[4.857 s] ok
  dev_query_test_vectors: transactions_query_filter_by_block_excludes_unknown_offsets_test...[2.457 s] ok
  dev_query_test_vectors: transactions_query_filter_by_block_can_ignore_ranges_test...[2.425 s] ok
  dev_query_test_vectors: transactions_query_ids_preserve_arweave_tx_id_test...[15.867 s] ok
  dev_query_test_vectors: transactions_query_cursor_by_offset_test...[4.081 s] ok
  dev_query_test_vectors: transaction_query_by_id_test...[0.048 s] ok
  dev_query_test_vectors: transaction_query_full_test...[0.048 s] ok
  dev_query_test_vectors: transaction_query_not_found_test...[0.034 s] ok
  dev_query_test_vectors: transaction_query_with_anchor_test...[0.048 s] ok
  [done in 37.543 s]
=======================================================
  All 18 tests passed.
  ```