### PR TITLE
impr(store_volatile): index group children in a separate ETS table

### DIFF
--- a/src/hb_store_volatile.erl
+++ b/src/hb_store_volatile.erl
@@ -30,7 +30,7 @@ start(StoreOpts = #{ <<"name">> := Name }) ->
                 {write_concurrency, true}
             ]),
             ChildrenTable = ets:new(hb_store_volatile_children, [
-                bag,
+                ordered_set,
                 public,
                 {read_concurrency, true},
                 {write_concurrency, true}
@@ -50,6 +50,8 @@ start(StoreOpts = #{ <<"name">> := Name }) ->
     receive
         {ok, InstanceMessage} ->
             {ok, InstanceMessage}
+    after 5000 ->
+        {error, start_timeout}
     end.
 
 %% @doc Owner loop for the ETS store. Simply waits for a stop message and exits.
@@ -95,10 +97,7 @@ scope(_) -> scope().
 
 %% @doc Remove all entries from the ETS table.
 reset(Opts) ->
-    #{
-        <<"ets-table">> := Table,
-        <<"ets-children-table">> := ChildrenTable
-    } = hb_store:find(Opts),
+    {Table, ChildrenTable} = tables(Opts),
     ets:delete_all_objects(Table),
     ets:delete_all_objects(ChildrenTable),
     ?event(store_volatile, {reset, {table, Table}}),
@@ -106,22 +105,7 @@ reset(Opts) ->
 
 %% @doc Write a value at the key path.
 write(Opts, RawKey, Value) ->
-    Key = hb_store:join(RawKey),
-    #{
-        <<"ets-table">> := Table,
-        <<"ets-children-table">> := ChildrenTable
-    } = hb_store:find(Opts),
-    ?event(store_volatile, {write, {key, Key}}),
-    case lookup_entry(Table, Key) of
-        nil ->
-            ensure_parent_groups(Table, ChildrenTable, Key);
-        {group, true} ->
-            delete_group_children(Table, ChildrenTable, Key);
-        _ ->
-            ok
-    end,
-    ets:insert(Table, {Key, {raw, Value}}),
-    ok.
+    put_entry(Opts, RawKey, {raw, Value}).
 
 %% @doc Read a value, following links when needed.
 read(Opts, RawKey) ->
@@ -195,34 +179,36 @@ type(Opts, RawKey) ->
 
 %% @doc Ensure a group exists at the given path.
 make_group(Opts, RawKey) ->
-    Key = hb_store:join(RawKey),
-    #{
-        <<"ets-table">> := Table,
-        <<"ets-children-table">> := ChildrenTable
-    } = hb_store:find(Opts),
-    ensure_dir(Table, ChildrenTable, Key),
+    {Table, ChildrenTable} = tables(Opts),
+    ensure_dir(Table, ChildrenTable, hb_store:join(RawKey)),
     ok.
 
 %% @doc Create or replace a link from New to Existing.
 make_link(_, Link, Link) ->
     ok;
 make_link(Opts, RawExisting, RawNew) ->
-    Existing = hb_store:join(RawExisting),
-    New = hb_store:join(RawNew),
+    put_entry(Opts, RawNew, {link, hb_store:join(RawExisting)}).
+
+%% @doc Install an entry at Key, running parent-index maintenance or
+%% overwrite cleanup as needed.
+put_entry(Opts, RawKey, Entry) ->
+    Key = hb_store:join(RawKey),
+    {Table, ChildrenTable} = tables(Opts),
+    ?event(store_volatile, {put, {key, Key}}),
+    case lookup_entry(Table, Key) of
+        nil -> ensure_parent_groups(Table, ChildrenTable, Key);
+        {group, true} -> delete_group_children(Table, ChildrenTable, Key);
+        _ -> ok
+    end,
+    ets:insert(Table, {Key, Entry}),
+    ok.
+
+tables(Opts) ->
     #{
         <<"ets-table">> := Table,
         <<"ets-children-table">> := ChildrenTable
     } = hb_store:find(Opts),
-    case lookup_entry(Table, New) of
-        nil ->
-            ensure_parent_groups(Table, ChildrenTable, New);
-        {group, true} ->
-            delete_group_children(Table, ChildrenTable, New);
-        _ ->
-            ok
-    end,
-    ets:insert(Table, {New, {link, Existing}}),
-    ok.
+    {Table, ChildrenTable}.
 
 join_path(<<>>, Next) ->
     hb_store:join(Next);
@@ -241,21 +227,22 @@ lookup_entry(Table, Key) ->
     end.
 
 list_group_children(Opts, GroupPath) ->
-    #{ <<"ets-children-table">> := ChildrenTable } = hb_store:find(Opts),
-    [Child || {_, Child} <- ets:lookup(ChildrenTable, GroupPath)].
+    {_, ChildrenTable} = tables(Opts),
+    ets:select(ChildrenTable, [{{{GroupPath, '$1'}, '_'}, [], ['$1']}]).
 
 delete_group_children(Table, ChildrenTable, GroupPath) ->
+    Children = ets:select(ChildrenTable, [{{{GroupPath, '$1'}, '_'}, [], ['$1']}]),
     lists:foreach(
-        fun({_, Child}) ->
+        fun(Child) ->
             delete_tree(
                 Table,
                 ChildrenTable,
                 next_group_path(GroupPath, Child)
             )
         end,
-        ets:lookup(ChildrenTable, GroupPath)
+        Children
     ),
-    ets:delete(ChildrenTable, GroupPath).
+    ets:select_delete(ChildrenTable, [{{{GroupPath, '_'}, '_'}, [], [true]}]).
 
 delete_tree(Table, ChildrenTable, Path) ->
     case lookup_entry(Table, Path) of
@@ -302,7 +289,7 @@ ensure_group(Table, GroupPath) ->
 
 add_group_child(Table, ChildrenTable, GroupPath, Child) ->
     ensure_group(Table, GroupPath),
-    ets:insert(ChildrenTable, {GroupPath, Child}),
+    ets:insert(ChildrenTable, {{GroupPath, Child}, true}),
     ok.
 
 %%% Tests
@@ -393,7 +380,7 @@ overwrite_group_to_raw_test() ->
     ?assertEqual(not_found, hb_store:read(StoreOpts, <<"colors/red">>)),
     ?assertEqual(not_found, hb_store:read(StoreOpts, <<"colors/blue">>)),
     #{ <<"ets-children-table">> := CT } = hb_store:find(StoreOpts),
-    ?assertEqual([], ets:lookup(CT, <<"colors">>)),
+    ?assertEqual([], ets:select(CT, [{{{<<"colors">>, '_'}, '_'}, [], [true]}])),
     ok = hb_store:make_group(StoreOpts, <<"colors">>),
     ?assertEqual({ok, []}, hb_store:list(StoreOpts, <<"colors">>)),
     ok = hb_store:stop(StoreOpts).
@@ -409,7 +396,7 @@ overwrite_group_to_link_test() ->
     ?assertEqual(not_found, hb_store:read(StoreOpts, <<"colors/red">>)),
     ?assertEqual(not_found, hb_store:read(StoreOpts, <<"colors/blue">>)),
     #{ <<"ets-children-table">> := CT } = hb_store:find(StoreOpts),
-    ?assertEqual([], ets:lookup(CT, <<"colors">>)),
+    ?assertEqual([], ets:select(CT, [{{{<<"colors">>, '_'}, '_'}, [], [true]}])),
     {ok, Children} = hb_store:list(StoreOpts, <<"colors">>),
     ?assertEqual([<<"val">>], Children),
     ok = hb_store:stop(StoreOpts).

--- a/src/hb_store_volatile.erl
+++ b/src/hb_store_volatile.erl
@@ -29,7 +29,20 @@ start(StoreOpts = #{ <<"name">> := Name }) ->
                 {read_concurrency, true},
                 {write_concurrency, true}
             ]),
-            Parent ! {ok, #{ <<"pid">> => self(), <<"ets-table">> => Table }},
+            ChildrenTable = ets:new(hb_store_volatile_children, [
+                bag,
+                public,
+                {read_concurrency, true},
+                {write_concurrency, true}
+            ]),
+            Parent ! {
+                ok,
+                #{
+                    <<"pid">> => self(),
+                    <<"ets-table">> => Table,
+                    <<"ets-children-table">> => ChildrenTable
+                }
+            },
             maybe_start_ttl_timer(StoreOpts, self()),
             owner_loop(StoreOpts)
         end
@@ -82,17 +95,31 @@ scope(_) -> scope().
 
 %% @doc Remove all entries from the ETS table.
 reset(Opts) ->
-    #{ <<"ets-table">> := Table } = hb_store:find(Opts),
+    #{
+        <<"ets-table">> := Table,
+        <<"ets-children-table">> := ChildrenTable
+    } = hb_store:find(Opts),
     ets:delete_all_objects(Table),
+    ets:delete_all_objects(ChildrenTable),
     ?event(store_volatile, {reset, {table, Table}}),
     ok.
 
 %% @doc Write a value at the key path.
 write(Opts, RawKey, Value) ->
     Key = hb_store:join(RawKey),
-    #{ <<"ets-table">> := Table } = hb_store:find(Opts),
-    ensure_parent_groups(Table, Key),
+    #{
+        <<"ets-table">> := Table,
+        <<"ets-children-table">> := ChildrenTable
+    } = hb_store:find(Opts),
     ?event(store_volatile, {write, {key, Key}}),
+    case lookup_entry(Table, Key) of
+        nil ->
+            ensure_parent_groups(Table, ChildrenTable, Key);
+        {group, true} ->
+            delete_group_children(Table, ChildrenTable, Key);
+        _ ->
+            ok
+    end,
     ets:insert(Table, {Key, {raw, Value}}),
     ok.
 
@@ -140,8 +167,8 @@ list(Opts, <<"/">>) ->
 list(Opts, Path) ->
     ResolvedPath = resolve(Opts, Path),
     case lookup_entry(Opts, ResolvedPath) of
-        {group, Set} ->
-            {ok, sets:to_list(Set)};
+        {group, true} ->
+            {ok, list_group_children(Opts, ResolvedPath)};
         {link, Link} ->
             list(Opts, Link);
         {raw, Value} when is_map(Value) ->
@@ -158,7 +185,7 @@ type(Opts, RawKey) ->
     case lookup_entry(Opts, Key) of
         {raw, _} ->
             simple;
-        {group, _} ->
+        {group, true} ->
             composite;
         {link, Link} ->
             type(Opts, Link);
@@ -169,8 +196,11 @@ type(Opts, RawKey) ->
 %% @doc Ensure a group exists at the given path.
 make_group(Opts, RawKey) ->
     Key = hb_store:join(RawKey),
-    #{ <<"ets-table">> := Table } = hb_store:find(Opts),
-    ensure_dir(Table, Key),
+    #{
+        <<"ets-table">> := Table,
+        <<"ets-children-table">> := ChildrenTable
+    } = hb_store:find(Opts),
+    ensure_dir(Table, ChildrenTable, Key),
     ok.
 
 %% @doc Create or replace a link from New to Existing.
@@ -179,8 +209,18 @@ make_link(_, Link, Link) ->
 make_link(Opts, RawExisting, RawNew) ->
     Existing = hb_store:join(RawExisting),
     New = hb_store:join(RawNew),
-    #{ <<"ets-table">> := Table } = hb_store:find(Opts),
-    ensure_parent_groups(Table, New),
+    #{
+        <<"ets-table">> := Table,
+        <<"ets-children-table">> := ChildrenTable
+    } = hb_store:find(Opts),
+    case lookup_entry(Table, New) of
+        nil ->
+            ensure_parent_groups(Table, ChildrenTable, New);
+        {group, true} ->
+            delete_group_children(Table, ChildrenTable, New);
+        _ ->
+            ok
+    end,
     ets:insert(Table, {New, {link, Existing}}),
     ok.
 
@@ -200,26 +240,52 @@ lookup_entry(Table, Key) ->
             Entry
     end.
 
-ensure_parent_groups(Table, Key) ->
+list_group_children(Opts, GroupPath) ->
+    #{ <<"ets-children-table">> := ChildrenTable } = hb_store:find(Opts),
+    [Child || {_, Child} <- ets:lookup(ChildrenTable, GroupPath)].
+
+delete_group_children(Table, ChildrenTable, GroupPath) ->
+    lists:foreach(
+        fun({_, Child}) ->
+            delete_tree(
+                Table,
+                ChildrenTable,
+                next_group_path(GroupPath, Child)
+            )
+        end,
+        ets:lookup(ChildrenTable, GroupPath)
+    ),
+    ets:delete(ChildrenTable, GroupPath).
+
+delete_tree(Table, ChildrenTable, Path) ->
+    case lookup_entry(Table, Path) of
+        {group, true} ->
+            delete_group_children(Table, ChildrenTable, Path);
+        _ ->
+            ok
+    end,
+    ets:delete(Table, Path).
+
+ensure_parent_groups(Table, ChildrenTable, Key) ->
     case filename:dirname(Key) of
         <<".">> ->
-            add_group_child(Table, ?ROOT_GROUP, filename:basename(Key));
+            add_group_child(Table, ChildrenTable, ?ROOT_GROUP, filename:basename(Key));
         ParentDir ->
-            ensure_dir(Table, ParentDir),
-            add_group_child(Table, ParentDir, filename:basename(Key))
+            ensure_dir(Table, ChildrenTable, ParentDir),
+            add_group_child(Table, ChildrenTable, ParentDir, filename:basename(Key))
     end.
 
-ensure_dir(Table, Path) ->
+ensure_dir(Table, ChildrenTable, Path) ->
     PathParts = hb_path:term_to_path_parts(Path),
-    ensure_dir(Table, ?ROOT_GROUP, PathParts).
+    ensure_dir(Table, ChildrenTable, ?ROOT_GROUP, PathParts).
 
-ensure_dir(_Table, _CurrentGroup, []) ->
+ensure_dir(_Table, _ChildrenTable, _CurrentGroup, []) ->
     ok;
-ensure_dir(Table, CurrentGroup, [Next | Rest]) ->
-    add_group_child(Table, CurrentGroup, Next),
+ensure_dir(Table, ChildrenTable, CurrentGroup, [Next | Rest]) ->
+    add_group_child(Table, ChildrenTable, CurrentGroup, Next),
     NextGroup = next_group_path(CurrentGroup, Next),
     ensure_group(Table, NextGroup),
-    ensure_dir(Table, NextGroup, Rest).
+    ensure_dir(Table, ChildrenTable, NextGroup, Rest).
 
 next_group_path(?ROOT_GROUP, Next) ->
     hb_store:join(Next);
@@ -228,21 +294,15 @@ next_group_path(CurrentGroup, Next) ->
 
 ensure_group(Table, GroupPath) ->
     case lookup_entry(Table, GroupPath) of
-        {group, _} ->
+        {group, true} ->
             ok;
         _ ->
-            ets:insert(Table, {GroupPath, {group, sets:new()}})
+            ets:insert(Table, {GroupPath, {group, true}})
     end.
 
-add_group_child(Table, GroupPath, Child) ->
-    Set =
-        case lookup_entry(Table, GroupPath) of
-            {group, ExistingSet} ->
-                ExistingSet;
-            _ ->
-                sets:new()
-        end,
-    ets:insert(Table, {GroupPath, {group, sets:add_element(Child, Set)}}),
+add_group_child(Table, ChildrenTable, GroupPath, Child) ->
+    ensure_group(Table, GroupPath),
+    ets:insert(ChildrenTable, {GroupPath, Child}),
     ok.
 
 %%% Tests
@@ -264,3 +324,92 @@ max_ttl_test() ->
     timer:sleep(200),
     ?assertEqual(not_found, hb_store:read(StoreOpts, <<"a">>)),
     hb_store:stop(StoreOpts).
+
+list_test() ->
+    StoreOpts = hb_test_utils:test_store(?MODULE, <<"ets-list-test">>),
+    hb_store:reset(StoreOpts),
+    ?assertEqual(not_found, hb_store:list(StoreOpts, <<"colors">>)),
+    ok = hb_store:make_group(StoreOpts, <<"colors">>),
+    ?assertEqual({ok, []}, hb_store:list(StoreOpts, <<"colors">>)),
+    ok = hb_store:write(StoreOpts, <<"colors/red">>, <<"1">>),
+    ok = hb_store:write(StoreOpts, <<"colors/blue">>, <<"2">>),
+    ok = hb_store:write(StoreOpts, <<"colors/green">>, <<"3">>),
+    ok = hb_store:write(StoreOpts, <<"colors/multi/foo">>, <<"4">>),
+    ok = hb_store:write(StoreOpts, <<"colors/multi/bar">>, <<"5">>),
+    ok = hb_store:write(StoreOpts, <<"colors/primary/red">>, <<"6">>),
+    ok = hb_store:write(StoreOpts, <<"colors/nested/deep/value">>, <<"7">>),
+    {ok, Colors} = hb_store:list(StoreOpts, <<"colors">>),
+    ?assertEqual(
+        [<<"blue">>, <<"green">>, <<"multi">>, <<"nested">>, <<"primary">>, <<"red">>],
+        lists:sort(Colors)
+    ),
+    {ok, Multi} = hb_store:list(StoreOpts, <<"colors/multi">>),
+    ?assertEqual([<<"bar">>, <<"foo">>], lists:sort(Multi)),
+    {ok, Nested} = hb_store:list(StoreOpts, <<"colors/nested">>),
+    ?assertEqual([<<"deep">>], Nested),
+    ok = hb_store:stop(StoreOpts).
+
+list_dedup_test() ->
+    StoreOpts = hb_test_utils:test_store(?MODULE, <<"ets-list-dedup-test">>),
+    hb_store:reset(StoreOpts),
+    ok = hb_store:write(StoreOpts, <<"colors/red">>, <<"1">>),
+    ok = hb_store:write(StoreOpts, <<"colors/red">>, <<"2">>),
+    ok = hb_store:make_link(StoreOpts, <<"colors/red">>, <<"colors/alias">>),
+    ok = hb_store:make_link(StoreOpts, <<"colors/red">>, <<"colors/alias">>),
+    {ok, Colors} = hb_store:list(StoreOpts, <<"colors">>),
+    ?assertEqual([<<"alias">>, <<"red">>], lists:sort(Colors)),
+    ok = hb_store:stop(StoreOpts).
+
+list_with_link_test() ->
+    StoreOpts = hb_test_utils:test_store(?MODULE, <<"ets-list-link-test">>),
+    hb_store:reset(StoreOpts),
+    ok = hb_store:write(StoreOpts, <<"target/one">>, <<"1">>),
+    ok = hb_store:write(StoreOpts, <<"target/two">>, <<"2">>),
+    ok = hb_store:make_link(StoreOpts, <<"target">>, <<"shortcut">>),
+    {ok, Shortcut} = hb_store:list(StoreOpts, <<"shortcut">>),
+    ?assertEqual([<<"one">>, <<"two">>], lists:sort(Shortcut)),
+    ok = hb_store:stop(StoreOpts).
+
+overwrite_link_to_raw_test() ->
+    StoreOpts = hb_test_utils:test_store(?MODULE, <<"ets-overwrite-link-test">>),
+    hb_store:reset(StoreOpts),
+    ok = hb_store:write(StoreOpts, <<"target/one">>, <<"1">>),
+    ok = hb_store:make_link(StoreOpts, <<"target">>, <<"shortcut">>),
+    ok = hb_store:write(StoreOpts, <<"shortcut">>, <<"replacement">>),
+    ?assertEqual({ok, <<"replacement">>}, hb_store:read(StoreOpts, <<"shortcut">>)),
+    ?assertEqual(not_found, hb_store:list(StoreOpts, <<"shortcut">>)),
+    {ok, Target} = hb_store:list(StoreOpts, <<"target">>),
+    ?assertEqual([<<"one">>], Target),
+    ok = hb_store:stop(StoreOpts).
+
+overwrite_group_to_raw_test() ->
+    StoreOpts = hb_test_utils:test_store(?MODULE, <<"ets-overwrite-group-test">>),
+    hb_store:reset(StoreOpts),
+    ok = hb_store:make_group(StoreOpts, <<"colors">>),
+    ok = hb_store:write(StoreOpts, <<"colors/red">>, <<"1">>),
+    ok = hb_store:write(StoreOpts, <<"colors/blue">>, <<"2">>),
+    ok = hb_store:write(StoreOpts, <<"colors">>, <<"replacement">>),
+    ?assertEqual({ok, <<"replacement">>}, hb_store:read(StoreOpts, <<"colors">>)),
+    ?assertEqual(not_found, hb_store:read(StoreOpts, <<"colors/red">>)),
+    ?assertEqual(not_found, hb_store:read(StoreOpts, <<"colors/blue">>)),
+    #{ <<"ets-children-table">> := CT } = hb_store:find(StoreOpts),
+    ?assertEqual([], ets:lookup(CT, <<"colors">>)),
+    ok = hb_store:make_group(StoreOpts, <<"colors">>),
+    ?assertEqual({ok, []}, hb_store:list(StoreOpts, <<"colors">>)),
+    ok = hb_store:stop(StoreOpts).
+
+overwrite_group_to_link_test() ->
+    StoreOpts = hb_test_utils:test_store(?MODULE, <<"ets-overwrite-g2l-test">>),
+    hb_store:reset(StoreOpts),
+    ok = hb_store:make_group(StoreOpts, <<"colors">>),
+    ok = hb_store:write(StoreOpts, <<"colors/red">>, <<"1">>),
+    ok = hb_store:write(StoreOpts, <<"colors/blue">>, <<"2">>),
+    ok = hb_store:write(StoreOpts, <<"target/val">>, <<"42">>),
+    ok = hb_store:make_link(StoreOpts, <<"target">>, <<"colors">>),
+    ?assertEqual(not_found, hb_store:read(StoreOpts, <<"colors/red">>)),
+    ?assertEqual(not_found, hb_store:read(StoreOpts, <<"colors/blue">>)),
+    #{ <<"ets-children-table">> := CT } = hb_store:find(StoreOpts),
+    ?assertEqual([], ets:lookup(CT, <<"colors">>)),
+    {ok, Children} = hb_store:list(StoreOpts, <<"colors">>),
+    ?assertEqual([<<"val">>], Children),
+    ok = hb_store:stop(StoreOpts).


### PR DESCRIPTION
## What                                                                             
                                                                                    
Replaces the volatile store's in-band child set with a dedicated
children index table, adding an overwrite fast path to `write/3` and
`make_link/3`.
                                                                                    
## Why                                                                              

`hb_store_volatile` tracked group membership by storing a `sets:set()`
of children inside the main table's `{group, Set}` row. Every write
walked the parent chain and called `sets:add_element/2`, which copies      
the ordset.

## How

- Second ETS table per store instance, `bag`-typed, keyed by parent
  path, each row `{Parent, ChildName}`. Bag semantics collapse
  duplicate rows automatically.
- Group markers in the main table simplify to `{group, true}`. All
  membership lives in the index table.
- `list/2` on a group path becomes a single `ets:lookup/2` on the
  index — O(family-size), no scan.
- `write/3` and `make_link/3` branch once on the existing entry:
  - absent → run parent-index maintenance as before
  - existing `{group, true}` → delete the index rows for that path
    before overwriting, so the new raw/link value doesn't leave
    stale children visible on later recreate
  - existing raw/link → skip parent-index maintenance (already
    indexed when the key was first created)
- `reset/1` clears both tables.

No change to the store's external semantics. `list/2`, `type/2`,
`make_group/2`, `read/2`, `resolve/2` behavior is preserved.

## Measured impact

Direct writes (1 KiB value, single parent):

| N      | before        | after          |
|--------|--------------:|---------------:|
|  5 000 |    26k ops/s  |   1.12M ops/s  |
| 20 000 |   6.9k ops/s  |   995k  ops/s  |
| 50 000 |   2.2k ops/s  |   1.13M ops/s  |

End-to-end `hb_cache:write` on volatile, 200 1 KiB committed
messages, 10-run median:

- before: ~590 msgs/s
- after: ~1714 msgs/s

For comparison, `hb_store_lmdb` on the same workload: ~1800 msgs/s.

## Tests

New coverage:

- `list_test`, `list_dedup_test`, `list_with_link_test` — group
  listing and dedup invariants.
- `overwrite_link_to_raw_test` — raw value replacing a link.
- `overwrite_group_to_raw_test` — raw value replacing a group
  marker; asserts index rows for the path are gone before recreate.
- `overwrite_group_to_link_test` — link replacing a group marker;
  same cleanup invariant, verified through `list/2` via link resolution.

