### PR TITLE
feat: luerl metatables use ao set, get

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -188,7 +188,7 @@
     {prometheus_httpd,  "2.1.15"},
     {prometheus,        "6.0.3"},
 	{graphql, "0.17.1", {pkg, graphql_erl}},
-    {luerl, "1.3.0"},
+    {luerl, {git, "https://github.com/permaweb/luerl.git", {ref, "40f25fa48f06530786bf2adacea966ad51888f12"}}},
     {hackney, "1.25.0"},
     {eqwalizer_support,
         {git_subdir,

--- a/src/preloaded/vm/dev_lua.erl
+++ b/src/preloaded/vm/dev_lua.erl
@@ -815,7 +815,7 @@ lua_metatable_get_now_test() ->
         hb_ao:resolve(
             Process,
             <<"now">>,
-            #{ process_now_from_cache => always }
+            #{ <<"process-now-from-cache">> => always }
         ),
     ?assertMatch(
         {failure, <<"No cached state available.">>},
@@ -841,7 +841,7 @@ lua_metatable_get_now_test() ->
         hb_ao:resolve(
             Process,
             <<"now/at-slot">>,
-            #{ process_now_from_cache => always }
+            #{ <<"process-now-from-cache">> => always }
         ),
     ?assertMatch(14, NowFromCacheAfter).
     

--- a/src/preloaded/vm/dev_lua.erl
+++ b/src/preloaded/vm/dev_lua.erl
@@ -844,6 +844,46 @@ lua_metatable_get_now_test() ->
             #{ <<"process-now-from-cache">> => always }
         ),
     ?assertMatch(14, NowFromCacheAfter).
+
+lua_request_metatable_test() ->
+    Opts = #{
+        <<"preloaded-store">> => hb_opts:get(<<"preloaded-store">>, #{}),
+        <<"preloaded-devices-index">> =>
+            hb_opts:get(<<"preloaded-devices-index">>, undefined),
+        store => [hb_test_utils:test_store()],
+        priv_wallet => hb:wallet()
+    },
+    {ok, Script} = file:read_file("test/test.lua"),
+    Base =
+        #{
+            <<"device">> => <<"lua@5.3a">>,
+            <<"module">> => #{
+                <<"content-type">> => <<"application/lua">>,
+                <<"body">> => Script
+            }
+        },
+    TestDevice =
+        #{
+            <<"device">> => <<"test-device@1.0">>,
+            <<"connect">> => <<"connected">>,
+            <<"result">> => <<"base:">>,
+            <<"append-prefix">> => <<"via-">>
+        },
+    {ok, Res} =
+        hb_ao:resolve_many(
+            [
+                Base,
+                #{
+                    <<"path">> => <<"request_metatable_test">>,
+                    <<"parameters">> => [TestDevice, #{}, #{}]
+                }
+            ],
+            Opts
+        ),
+    ?assertEqual(<<"connected">>, hb_ao:get(<<"string_get">>, Res, Opts)),
+    ?assertEqual(<<"connected">>, hb_ao:get(<<"tuple_get">>, Res, Opts)),
+    ?assertEqual(<<"base:via-tuple">>, hb_ao:get(<<"tuple_resolve">>, Res, Opts)),
+    ?assertEqual(<<"base:via-map">>, hb_ao:get(<<"req_resolve">>, Res, Opts)).
     
 %% @doc Call a non-compute key on a Lua device message and ensure that the
 %% function of the same name in the script is called.

--- a/src/preloaded/vm/dev_lua.erl
+++ b/src/preloaded/vm/dev_lua.erl
@@ -3,7 +3,7 @@
 -implements(<<"lua@5.3a">>).
 -export([info/1, init/3, snapshot/3, normalize/3, functions/3]).
 %%% Public Utilities
--export([encode/2, decode/2]).
+-export([encode/2, decode/2, encode_value/3]).
 -export([pure_lua_process_benchmark/1]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -318,19 +318,72 @@ compute(Key, RawBase, RawReq, Opts) ->
             {req, Req}
         }
     ),
-    process_response(
-        try luerl:call_function_dec(
-            [Function],
-            encode(ResolvedParams, Opts),
-            State
-        )
+    {EncodedParams, State2} = encode_params(ResolvedParams, State, Opts),
+    ?event(debug_lua, {encoded_args, {luerl_args, EncodedParams}, {state, State2}}),
+    Response =
+        try 
+            case luerl:call_function([Function], EncodedParams, State2) of
+                {ok, Res, State3} ->
+                    {ok, luerl:decode_list(Res, State3), State3};
+                LuaError ->
+                    LuaError
+            end
         catch
             _:Reason:Stacktrace -> {error, Reason, Stacktrace}
         end,
+    process_response(
+        Response,
         OldPriv,
 		Opts
     ).
 
+
+%% @doc Encode a list of parameters for a Lua function call using encode_value/3.
+encode_params(Params, State, Opts) ->
+    lists:mapfoldl(
+        fun(Param, AccState) -> encode_value(Param, AccState, Opts) end,
+        State,
+        Params
+    ).
+
+%% @doc Recursively encode a single Erlang value for Lua:
+%%  Lists -> luerl integer-keyed table, each element recursively encoded
+%%  Maps -> encoded with encode_table to ensure metatable is set
+%%  Other -> primitive luerl encode
+encode_value(Value, State, Opts) when is_list(Value) ->
+    encode_list(Value, State, Opts);
+encode_value(Value, State, Opts) when is_map(Value) ->
+    encode_table(Value, State, Opts);
+encode_value(Value, State, Opts) ->
+    luerl:encode(do_encode(Value, Opts), State).
+
+%% @doc Encode a list of values for a Lua table.
+encode_list(List, State, Opts) ->
+    {EncodedElems, State1} =
+        lists:mapfoldl(
+            fun(Elem, S) -> encode_value(Elem, S, Opts) end,
+            State,
+            List
+        ),
+    Indexed = lists:zip(lists:seq(1, length(EncodedElems)), EncodedElems),
+    luerl_heap:alloc_table(Indexed, State1).
+
+%% @doc Encode a map of values for a Lua table.
+encode_table(Table, State, Opts) ->
+    FlatEntries = [{K, V} || {K, V} <- maps:to_list(Table)],
+    {Entries, State1} = 
+        lists:mapfoldl(
+            fun({K, V}, AccSt) ->
+                {EncodedV, NextSt} = encode_value(V, AccSt, Opts),
+                {{K, EncodedV}, NextSt}
+            end,
+            State,
+            FlatEntries
+        ),
+    {TableRef, State2} = luerl_heap:alloc_table(Entries, State1),
+    {MetaRef, State3} = dev_lua_lib:make_table_meta(State2, Opts),
+    State4 = luerl_heap:set_metatable(TableRef, MetaRef, State3),
+    {TableRef, State4}.
 %% @doc Process a response to a Luerl invocation. Returns the typical AO-Core
 %% HyperBEAM response format.
 process_response({ok, [Result], NewState}, Priv, Opts) ->
@@ -664,6 +717,53 @@ direct_benchmark_test() ->
         Iterations,
         BenchTime
     ).
+
+lua_trie_metatable_test() ->
+    Opts = #{
+        store => [hb_test_utils:test_store()],
+        priv_wallet => hb:wallet()
+    },
+    {ok, Script} = file:read_file("test/test.lua"),
+    Trie = hb_ao:set(
+        #{ <<"device">> => <<"trie@1.0">> },
+        #{
+            <<"toronto">> => 42,
+            <<"to">> => 1,
+            <<"tor">> => 2,
+            <<"torrent">> => 3
+        },
+        Opts
+    ),
+    LuaMsg =
+        #{
+            <<"device">> => <<"lua@5.3a">>,
+            <<"module">> => #{
+                <<"content-type">> => <<"application/lua">>,
+                <<"body">> => Script
+            }
+        },
+    {ok, Res} = 
+        hb_ao:resolve_many(
+            [
+                LuaMsg,
+                #{
+                    <<"path">> => <<"trie_proxy_test">>,
+                    <<"parameters">> => [Trie, #{}, #{}]
+                }
+            ],
+            Opts
+        ),
+    % "toronto" was only reachable via trie traversal; must survive the round-trip.
+    ?assertEqual(42, hb_ao:get(<<"toronto">>, Res, Opts)),
+    % "to" was set to the fetched toronto value (42), overwriting the original (1).
+    ?assertEqual(1, hb_ao:get(<<"to">>, Res, Opts)),
+    % "toro" was set to the fetched toronto value (42), overwriting the original (2).
+    % Unrelated trie keys must be untouched.
+    ?assertEqual(2, hb_ao:get(<<"tor">>, Res, Opts)),
+    ?assertEqual(42, hb_ao:get(<<"toro">>, Res, Opts)),
+    ?assertEqual(3, hb_ao:get(<<"torrent">>, Res, Opts)),
+    % Assert that the table is still in trie form. Toro will be nested.
+    ?assertNot(maps:is_key(<<"toro">>, Res)).
 
 %% @doc Call a non-compute key on a Lua device message and ensure that the
 %% function of the same name in the script is called.

--- a/src/preloaded/vm/dev_lua.erl
+++ b/src/preloaded/vm/dev_lua.erl
@@ -495,6 +495,8 @@ do_decode(Msg, Opts) when is_map(Msg) ->
         false ->
             Msg
     end;
+do_decode(<<"__erl_pid__:", Rest/binary>>, _Opts) ->
+    list_to_pid(binary_to_list(Rest));
 do_decode(Other, _Opts) ->
     Other.
 
@@ -514,6 +516,8 @@ do_encode(List, Opts) when is_list(List) ->
         lists:map(fun(V) -> do_encode(V, Opts) end, List),
         Opts
     );
+do_encode(Pid, _Opts) when is_pid(Pid) ->
+    <<"__erl_pid__:", (hb_util:bin(erlang:pid_to_list(Pid)))/binary>>;
 do_encode(Atom, _Opts) when is_atom(Atom) and (Atom /= false) and (Atom /= true)->
     hb_util:bin(Atom);
 do_encode(Other, _Opts) ->
@@ -747,24 +751,100 @@ lua_trie_metatable_test() ->
             [
                 LuaMsg,
                 #{
-                    <<"path">> => <<"trie_proxy_test">>,
+                    <<"path">> => <<"trie_metatable_test">>,
                     <<"parameters">> => [Trie, #{}, #{}]
                 }
             ],
             Opts
         ),
-    % "toronto" was only reachable via trie traversal; must survive the round-trip.
-    ?assertEqual(42, hb_ao:get(<<"toronto">>, Res, Opts)),
-    % "to" was set to the fetched toronto value (42), overwriting the original (1).
     ?assertEqual(1, hb_ao:get(<<"to">>, Res, Opts)),
-    % "toro" was set to the fetched toronto value (42), overwriting the original (2).
-    % Unrelated trie keys must be untouched.
     ?assertEqual(2, hb_ao:get(<<"tor">>, Res, Opts)),
-    ?assertEqual(42, hb_ao:get(<<"toro">>, Res, Opts)),
     ?assertEqual(3, hb_ao:get(<<"torrent">>, Res, Opts)),
+    % "toro" was set to the fetched toronto value (42).
+    ?assertEqual(42, hb_ao:get(<<"toro">>, Res, Opts)),
+    % "toronto" was set to 100, overwriting the original (42).
+    ?assertEqual(100, hb_ao:get(<<"toronto">>, Res, Opts)),
     % Assert that the table is still in trie form. Toro will be nested.
     ?assertNot(maps:is_key(<<"toro">>, Res)).
 
+lua_map_metatable_overwrite_test() ->
+    Opts = #{
+        store => [hb_test_utils:test_store()],
+        priv_wallet => hb:wallet()
+    },
+    {ok, Script} = file:read_file("test/test.lua"),
+    Base =
+        #{
+            <<"device">> => <<"lua@5.3a">>,
+            <<"module">> => #{
+                <<"content-type">> => <<"application/lua">>,
+                <<"body">> => Script
+            }
+        },
+    Params =
+        [
+            #{ <<"a">> => 1, <<"b">> => 2, <<"c">> => 3 },
+            #{},
+            #{}
+        ],
+    {ok, Res} =
+        hb_ao:resolve_many(
+            [
+                Base,
+                #{
+                    <<"path">> => <<"map_metatable_overwrite_test">>,
+                    <<"parameters">> => Params
+                }
+            ],
+            Opts
+        ),
+    ?assertEqual(100, hb_ao:get(<<"a">>, Res, Opts)),
+    ?assertEqual(2, hb_ao:get(<<"b">>, Res, Opts)),
+    ?assertEqual(3, hb_ao:get(<<"c">>, Res, Opts)),
+    ?assertEqual(4, hb_ao:get(<<"d">>, Res, Opts)).
+
+lua_metatable_get_now_test() ->
+    Process = generate_lua_process("test/test.lua", #{}),
+    {ok, _} = hb_cache:write(Process, #{}),
+    Message = generate_test_message(Process, #{}, <<"return 1+1">>),
+    lists:foreach(
+        fun(_) -> hb_ao:resolve(Process, Message, #{}) end,
+        lists:seq(1, 15)
+    ),
+    NowFromCacheBefore =
+        hb_ao:resolve(
+            Process,
+            <<"now">>,
+            #{ process_now_from_cache => always }
+        ),
+    ?assertMatch(
+        {failure, <<"No cached state available.">>},
+        NowFromCacheBefore
+    ),
+    {ok, Res} =
+        hb_ao:resolve_many(
+            [
+                Process#{ <<"device">> => <<"lua@5.3a">> },
+                #{
+                    <<"path">> => <<"get_now_test">>,
+                    <<"parameters">> => [Process, #{}, #{}]
+                }
+            ],
+            #{}
+        ),
+    ?assert(hb_ao:get(<<"executed_now">>, Res, #{})),
+    ?assertMatch(14, hb_ao:get(<<"found_now/at-slot">>, Res, #{})),
+    % TODO: Possible bug in dev_process_cache, needs 100ms to catch up
+    % (otherwise serving slot 11,12,13,etc.)
+    timer:sleep(100),
+    {ok, NowFromCacheAfter} =
+        hb_ao:resolve(
+            Process,
+            <<"now/at-slot">>,
+            #{ process_now_from_cache => always }
+        ),
+    ?assertMatch(14, NowFromCacheAfter).
+    
 %% @doc Call a non-compute key on a Lua device message and ensure that the
 %% function of the same name in the script is called.
 invoke_non_compute_key_test() ->

--- a/src/preloaded/vm/dev_lua_lib.erl
+++ b/src/preloaded/vm/dev_lua_lib.erl
@@ -16,25 +16,18 @@
 %%% Lua environment, except for the `install/3' function, which is used to
 %%% install the library in the first place.
 -export([get/3, resolve/3, set/3, event/3, install/3]).
+-export([make_table_meta/2]).
 -include("include/hb.hrl").
 
 %%% The set of devices that must be included in the device sandbox for an
 %%% execution that is able to perform AO-Core resolutions. Without the following
 %%% devices, all resolutions will fail.
 -define(MINIMAL_AO_CORE_DEVICES, [<<"structured@1.0">>]).
--define(LIBRARY_FUNCTIONS, [
-    {get, fun get/3},
-    {resolve, fun resolve/3},
-    {set, fun set/3},
-    {event, fun event/3}
-]).
 
 %% @doc Install the library into the given Lua environment.
 install(Base, State, Opts) ->
-    % Compute the device-name allowlist for the Lua sandbox. When the
-    % caller provides a `device-sandbox' field, only those names plus
-    % the minimal-AO-Core set are admissible; otherwise we leave the
-    % allowlist undefined (no restriction).
+    % Calculate and set the new `preloaded_devices' option.
+    AllDevs = hb_opts:get(preloaded_devices, Opts),
     DevSandboxDef =
         hb_ao:get(
             <<"device-sandbox">>,
@@ -42,19 +35,31 @@ install(Base, State, Opts) ->
             false,
             Opts
         ),
-    AdmissibleNames =
+    AdmissibleDevs =
         case DevSandboxDef of
-            false -> all;
+            false -> AllDevs;
             DevNames ->
-                hb_util:message_to_ordered_list(
-                    hb_util:unique(DevNames ++ ?MINIMAL_AO_CORE_DEVICES)
+                lists:map(
+                    fun(Name) ->
+                        [Dev] =
+                            lists:filter(
+                                fun(X) ->
+                                    hb_ao:get(<<"name">>, X, Opts) == Name
+                                end,
+                                AllDevs
+                            ),
+                        Dev
+                    end,
+                    hb_util:message_to_ordered_list(
+                        hb_util:unique(DevNames ++ ?MINIMAL_AO_CORE_DEVICES)
+                    )
                 )
         end,
-    ?event({adding_ao_core_resolver, {device_sandbox, AdmissibleNames}}),
+    ?event({adding_ao_core_resolver, {device_sandbox, AdmissibleDevs}}),
     ExecOpts =
         Opts#{
-            <<"admissible-devices">> => AdmissibleNames,
-            <<"hashpath">> => ignore
+            preloaded_devices => AdmissibleDevs,
+            hashpath => ignore
         },
     % Initialize the AO-Core resolver.
     BaseAOTable =
@@ -73,10 +78,9 @@ install(Base, State, Opts) ->
             dev_lua:encode(BaseAOTable, Opts),
             State
         ),
-    {
-        ok,
+    State3 = 
         lists:foldl(
-            fun({FuncName, Func}, StateIn) ->
+            fun(FuncName, StateIn) ->
                 {ok, StateOut} =
                     luerl:set_table_keys_dec(
                         [ao, FuncName],
@@ -95,7 +99,7 @@ install(Base, State, Opts) ->
                                 ),
                             % Call the function with the decoded arguments.
                             {Res, ResState} =
-                                Func(Args, ImportState, ExecOpts),
+                                ?MODULE:FuncName(Args, ImportState, ExecOpts),
                             % Encode the response for return to Lua
                             return(Res, ResState, Opts)
                         end,
@@ -104,9 +108,158 @@ install(Base, State, Opts) ->
                 StateOut
             end,
             State2,
-            ?LIBRARY_FUNCTIONS
-        )
-    }.
+            [
+                FuncName
+            ||
+                {FuncName, _} <- dev_lua_lib:module_info(exports),
+                FuncName /= module_info,
+                FuncName /= ?FUNCTION_NAME
+            ]
+        ),
+    % Install a type-level metatable for all luerl tables so that any table
+    % created in Lua routes reads through hb_ao:get and writes through hb_ao:set.
+    % Per-table metatables (set by encode_proxy) take precedence.
+    GetFun =
+        fun([RawTable, Key], S) ->
+            Table = dev_lua:decode(luerl:decode(RawTable, S), Opts),
+            ?event(debug_lua_getindex, {global_get, {table, Table}, {key, Key}}),
+            case hb_ao:get(Key, Table, Opts) of
+                not_found -> 
+                    ?event(
+                        debug_lua_getindex,
+                        {global_get_not_found, {key, Key}}
+                    ),
+                    {[nil], S};
+                R ->
+                    ?event(
+                        debug_lua_getindex,
+                        {global_get_found, {key, Key}, {result, R}}
+                    ),
+                    {Encoded, S2} = dev_lua:encode_value(R, S, Opts),
+                    {[Encoded], S2}
+            end
+        end,
+    SetFun =
+        fun([RawTable, Key, Value], S) ->
+            Table = dev_lua:decode(luerl:decode(RawTable, S), Opts),
+            DecodedValue = dev_lua:decode(luerl:decode(Value, S), Opts),
+            ?event(
+                debug_lua_setindex,
+                {global_set,{table, Table}, {key, Key}, {value, DecodedValue}}
+            ),
+            SetResult =
+                hb_cache:ensure_all_loaded(
+                    hb_ao:set(Table, #{ Key => DecodedValue }, Opts),
+                    Opts
+                ),
+            ?event(debug_lua_setindex, {set_result, {set_result, SetResult}}),
+            %% Clear all data keys from the table (preserving the metatable ref)
+            %% then write SetResult entries using raw writes
+            S1 =
+                luerl_heap:upd_table(
+                    RawTable,
+                    fun({table, _A, _D, Meta}) ->
+                        {table, array:new([{default, nil}]), ttdict:new(), Meta}
+                    end,
+                    S
+                ),
+            ?event(debug_lua_setindex, {updated_table, {updated_table, S1}}),
+            S2 = 
+                maps:fold(
+                    fun(K, V, SAcc) ->
+                        {EncodedV, SAcc2} = dev_lua:encode_value(V, SAcc, Opts),
+                        luerl_heap:raw_set_table_key(RawTable, K, EncodedV, SAcc2)
+                    end,
+                    S1,
+                    SetResult
+                ),
+            ?event(debug_lua_setindex, {done_set_result_encoded}),
+            {[], S2}
+        end,
+    {GetRef, State4} = luerl:encode(GetFun, State3),
+    {SetRef, State5} = luerl:encode(SetFun, State4),
+    {MetaRef, State6} =
+        luerl_heap:alloc_table(
+            [{<<"__index">>, GetRef}, {<<"__newindex">>, SetRef}],
+            State5
+        ),
+    %% We want to remove the custom metatable from lua-reserved util tables.
+    {EmptyMeta, State7} = luerl_heap:alloc_table([], State6),
+    GRef = luerl_heap:get_global(State7),
+    State8 = luerl_heap:set_metatable(GRef, EmptyMeta, State7),
+    StdTables = 
+        [
+            <<"ao">>, <<"string">>, <<"table">>, <<"math">>, <<"os">>,
+            <<"io">>, <<"package">>, <<"coroutine">>, <<"state">>
+        ],
+    State9 = 
+        lists:foldl(
+            fun(Name, SAcc) ->
+                case luerl_heap:raw_get_table_key(GRef, Name, SAcc) of
+                    nil -> SAcc;
+                    Tref when is_tuple(Tref), element(1, Tref) =:= tref ->
+                        luerl_heap:set_metatable(Tref, EmptyMeta, SAcc);
+                    _ -> SAcc
+                end
+            end,
+            State8,
+            StdTables
+        ),
+    {ok, luerl_heap:set_table_type_meta(MetaRef, State9)}.
+
+%% @doc Build the __index/__newindex metatable for a luerl state without
+%% allocating or populating the table itself. Used to inject hb_ao:get and
+%% hb_ao:set into the Lua environment, for all gets and sets using the 
+%% lua metatable (__index/__newindex).
+make_table_meta(St0, Opts) ->
+    GetFun =
+        fun([RawTable, Key], S) ->
+            Table = dev_lua:decode(luerl:decode(RawTable, S), Opts),
+            case hb_ao:get(Key, Table, Opts) of
+                not_found ->
+                    {[nil], S};
+                R ->
+                    {Encoded, S2} = dev_lua:encode_value(R, S, Opts),
+                    {[Encoded], S2}
+            end
+        end,
+    SetFun =
+        fun([RawTable, Key, RawValue], S) ->
+            Table = dev_lua:decode(luerl:decode(RawTable, S), Opts),
+            Value = dev_lua:decode(luerl:decode(RawValue, S), Opts),
+            SetResult =
+                hb_cache:ensure_all_loaded(
+                    hb_ao:set(Table, #{ Key => Value }, Opts),
+                    Opts
+                ),
+            %% Clear all data keys from the table (preserving the metatable ref)
+            %% then write SetResult entries using raw writes to bypass __newindex.
+            S1 =
+                luerl_heap:upd_table(
+                    RawTable,
+                    fun({table, _A, _D, Meta}) ->
+                        {table, array:new([{default, nil}]), ttdict:new(), Meta}
+                    end,
+                    S
+                ),
+            S2 =
+                maps:fold(
+                    fun(K, V, SAcc) ->
+                        {EncodedV, SAcc2} = dev_lua:encode_value(V, SAcc, Opts),
+                        luerl_heap:raw_set_table_key(RawTable, K, EncodedV, SAcc2)
+                    end,
+                    S1,
+                    SetResult
+                ),
+            ?event(debug_lua, {set_result_encoded}),
+            {[], S2}
+        end,
+    {GetFunRef, St1} = luerl:encode(GetFun, St0),
+    {SetFunRef, St2} = luerl:encode(SetFun, St1),
+    luerl_heap:alloc_table(
+        [{<<"__index">>, GetFunRef}, {<<"__newindex">>, SetFunRef}],
+        St2
+    ).
 
 %% @doc Helper function for returning a result from a Lua function.
 return(Result, ExecState, Opts) ->
@@ -181,7 +334,7 @@ event([Event], ExecState, Opts) ->
     event([global, Event], ExecState, Opts);
 event([Group, Event], State, Opts) when is_list(Event) ->
     event([Group, list_to_tuple(Event)], State, Opts);
-event([Group, Event], ExecState, _Opts) ->
+event([Group, Event], ExecState, Opts) ->
     ?event(
         lua_event,
         {event,

--- a/src/preloaded/vm/dev_lua_lib.erl
+++ b/src/preloaded/vm/dev_lua_lib.erl
@@ -123,32 +123,15 @@ install(Base, State, Opts) ->
             ||
                 {FuncName, _} <- dev_lua_lib:module_info(exports),
                 FuncName /= module_info,
-                FuncName /= ?FUNCTION_NAME
+                FuncName /= ?FUNCTION_NAME,
+                FuncName /= make_table_meta
             ]
         ),
-    % Install a type-level metatable for all luerl tables so that any table
-    % created in Lua routes reads through hb_ao:get and writes through hb_ao:set.
-    % Per-table metatables (set by encode_table) take precedence.
+    % Build table index/set handlers for AO metatables. Encoded AO messages
+    % receive these through per-table metatables in encode_table.
     GetFun =
         fun([RawTable, Key], S) ->
-            Table = dev_lua:decode(luerl:decode(RawTable, S), Opts),
-            ?event(debug_lua_getindex, {global_get, {table, Table}, {key, Key}}),
-            case hb_ao:get(Key, Table, Opts) of
-                not_found -> 
-                    ?event(
-                        debug_lua_getindex,
-                        {global_get_not_found, {key, Key}}
-                    ),
-                    {[nil], S};
-                R ->
-                    ?event(
-                        debug_lua_getindex,
-                        {global_get_found, {key, Key}, {result, R}}
-                    ),
-                    Encodable = if is_map(R) -> hb_private:reset(R); true -> R end,
-                    {Encoded, S2} = dev_lua:encode_value(Encodable, S, Opts),
-                    {[Encoded], S2}
-            end
+            table_index(RawTable, Key, S, Opts)
         end,
     SetFun =
         fun([RawTable, Key, Value], S) ->
@@ -225,15 +208,7 @@ install(Base, State, Opts) ->
 make_table_meta(St0, Opts) ->
     GetFun =
         fun([RawTable, Key], S) ->
-            Table = dev_lua:decode(luerl:decode(RawTable, S), Opts),
-            case hb_ao:get(Key, Table, Opts) of
-                not_found ->
-                    {[nil], S};
-                R ->
-                    Encodable = if is_map(R) -> hb_private:reset(R); true -> R end,
-                    {Encoded, S2} = dev_lua:encode_value(Encodable, S, Opts),
-                    {[Encoded], S2}
-            end
+            table_index(RawTable, Key, S, Opts)
         end,
     SetFun =
         fun([RawTable, Key, RawValue], S) ->
@@ -272,6 +247,50 @@ make_table_meta(St0, Opts) ->
         [{<<"__index">>, GetFunRef}, {<<"__newindex">>, SetFunRef}],
         St2
     ).
+
+table_index(RawTable, RawKey, State, Opts) ->
+    Table = dev_lua:decode(luerl:decode(RawTable, State), Opts),
+    Key = dev_lua:decode(luerl:decode(RawKey, State), Opts),
+    ?event(debug_lua_getindex, {global_get, {table, Table}, {key, Key}}),
+    Action = table_key_action(Key, Opts),
+    Result =
+        case Action of
+            {get, Path} ->
+                value_result(hb_ao:get(Path, Table, Opts));
+            {resolve, Req} ->
+                hb_ao:resolve(Table, Req, Opts);
+            false ->
+                value_result(hb_ao:get(Key, Table, Opts))
+        end,
+    encode_index_result(Result, State, Opts).
+
+table_key_action([Path], _Opts) ->
+    {get, Path};
+table_key_action([Path, Req], Opts) when is_map(Req) ->
+    {resolve, (hb_ao:normalize_keys(Req, Opts))#{ <<"path">> => hb_path:to_binary(Path) }};
+table_key_action(Req, Opts) when is_map(Req) ->
+    {resolve, hb_ao:normalize_keys(Req, Opts)};
+table_key_action(_Key, _Opts) ->
+    false.
+
+value_result(not_found) ->
+    not_found;
+value_result(Value) ->
+    {ok, Value}.
+
+encode_index_result(not_found, State, _Opts) ->
+    {[nil], State};
+encode_index_result({error, _Reason}, State, _Opts) ->
+    {[nil], State};
+encode_index_result({ok, Result}, State, Opts) ->
+    ?event(debug_lua_getindex, {global_get_found, {result, Result}}),
+    Encodable =
+        case is_map(Result) of
+            true -> hb_private:reset(Result);
+            false -> Result
+        end,
+    {Encoded, State2} = dev_lua:encode_value(Encodable, State, Opts),
+    {[Encoded], State2}.
 
 %% @doc Helper function for returning a result from a Lua function.
 return(Result, ExecState, Opts) ->

--- a/src/preloaded/vm/dev_lua_lib.erl
+++ b/src/preloaded/vm/dev_lua_lib.erl
@@ -118,7 +118,7 @@ install(Base, State, Opts) ->
         ),
     % Install a type-level metatable for all luerl tables so that any table
     % created in Lua routes reads through hb_ao:get and writes through hb_ao:set.
-    % Per-table metatables (set by encode_proxy) take precedence.
+    % Per-table metatables (set by encode_table) take precedence.
     GetFun =
         fun([RawTable, Key], S) ->
             Table = dev_lua:decode(luerl:decode(RawTable, S), Opts),
@@ -135,7 +135,8 @@ install(Base, State, Opts) ->
                         debug_lua_getindex,
                         {global_get_found, {key, Key}, {result, R}}
                     ),
-                    {Encoded, S2} = dev_lua:encode_value(R, S, Opts),
+                    Encodable = if is_map(R) -> hb_private:reset(R); true -> R end,
+                    {Encoded, S2} = dev_lua:encode_value(Encodable, S, Opts),
                     {[Encoded], S2}
             end
         end,
@@ -219,7 +220,8 @@ make_table_meta(St0, Opts) ->
                 not_found ->
                     {[nil], S};
                 R ->
-                    {Encoded, S2} = dev_lua:encode_value(R, S, Opts),
+                    Encodable = if is_map(R) -> hb_private:reset(R); true -> R end,
+                    {Encoded, S2} = dev_lua:encode_value(Encodable, S, Opts),
                     {[Encoded], S2}
             end
         end,

--- a/src/preloaded/vm/dev_lua_lib.erl
+++ b/src/preloaded/vm/dev_lua_lib.erl
@@ -24,10 +24,17 @@
 %%% devices, all resolutions will fail.
 -define(MINIMAL_AO_CORE_DEVICES, [<<"structured@1.0">>]).
 
+normalize_preloaded_devices(PreloadedDevices) when is_list(PreloadedDevices) ->
+    PreloadedDevices;
+normalize_preloaded_devices(PreloadedDevices) when is_map(PreloadedDevices) ->
+    maps:values(PreloadedDevices);
+normalize_preloaded_devices(_PreloadedDevices) ->
+    [].
+
 %% @doc Install the library into the given Lua environment.
 install(Base, State, Opts) ->
     % Calculate and set the new `preloaded_devices' option.
-    AllDevs = hb_opts:get(preloaded_devices, Opts),
+    AllDevs = normalize_preloaded_devices(hb_opts:get(preloaded_devices, [], Opts)),
     DevSandboxDef =
         hb_ao:get(
             <<"device-sandbox">>,
@@ -39,16 +46,19 @@ install(Base, State, Opts) ->
         case DevSandboxDef of
             false -> AllDevs;
             DevNames ->
-                lists:map(
+                lists:flatmap(
                     fun(Name) ->
-                        [Dev] =
+                        case
                             lists:filter(
                                 fun(X) ->
                                     hb_ao:get(<<"name">>, X, Opts) == Name
                                 end,
                                 AllDevs
-                            ),
-                        Dev
+                            )
+                        of
+                            [Dev] -> [Dev];
+                            _ -> []
+                        end
                     end,
                     hb_util:message_to_ordered_list(
                         hb_util:unique(DevNames ++ ?MINIMAL_AO_CORE_DEVICES)
@@ -179,21 +189,21 @@ install(Base, State, Opts) ->
         end,
     {GetRef, State4} = luerl:encode(GetFun, State3),
     {SetRef, State5} = luerl:encode(SetFun, State4),
-    {MetaRef, State6} =
+    {_, State6} =
         luerl_heap:alloc_table(
             [{<<"__index">>, GetRef}, {<<"__newindex">>, SetRef}],
             State5
         ),
     %% We want to remove the custom metatable from lua-reserved util tables.
     {EmptyMeta, State7} = luerl_heap:alloc_table([], State6),
-    GRef = luerl_heap:get_global(State7),
-    State8 = luerl_heap:set_metatable(GRef, EmptyMeta, State7),
+    {ok, GRef, State8} = luerl:get_table_keys([<<"_G">>], State7),
+    State9 = luerl_heap:set_metatable(GRef, EmptyMeta, State8),
     StdTables = 
         [
             <<"ao">>, <<"string">>, <<"table">>, <<"math">>, <<"os">>,
             <<"io">>, <<"package">>, <<"coroutine">>, <<"state">>
         ],
-    State9 = 
+    State10 = 
         lists:foldl(
             fun(Name, SAcc) ->
                 case luerl_heap:raw_get_table_key(GRef, Name, SAcc) of
@@ -203,10 +213,10 @@ install(Base, State, Opts) ->
                     _ -> SAcc
                 end
             end,
-            State8,
+            State9,
             StdTables
         ),
-    {ok, luerl_heap:set_table_type_meta(MetaRef, State9)}.
+    {ok, State10}.
 
 %% @doc Build the __index/__newindex metatable for a luerl state without
 %% allocating or populating the table itself. Used to inject hb_ao:get and

--- a/test/test.lua
+++ b/test/test.lua
@@ -161,3 +161,13 @@ function inc(base, req, opts)
     base.count = base.count + 1
     return base
 end
+
+--- @function trie_proxy_test
+--- @tparam table base A trie@1.0 message passed as the first argument.
+--- Reads "toronto" via trie traversal (__index -> dev_trie:get), then
+--- writes its value to "to" (an overlapping prefix key) via __newindex.
+function trie_proxy_test(base, req, opts)
+    local fetched = base["toronto"]
+    base["toro"] = fetched
+    return base
+end

--- a/test/test.lua
+++ b/test/test.lua
@@ -181,3 +181,12 @@ function get_now_test(base, req, opts)
     base.executed_now = true
     return base
 end
+
+function request_metatable_test(base, req, opts)
+    return {
+        string_get = base["connect"],
+        tuple_get = base[{ "connect" }],
+        tuple_resolve = base[{ "append", { bin = "tuple" }}].result,
+        req_resolve = base[{ path = "append", bin = "map" }].result
+    }
+end

--- a/test/test.lua
+++ b/test/test.lua
@@ -162,12 +162,22 @@ function inc(base, req, opts)
     return base
 end
 
---- @function trie_proxy_test
---- @tparam table base A trie@1.0 message passed as the first argument.
---- Reads "toronto" via trie traversal (__index -> dev_trie:get), then
---- writes its value to "to" (an overlapping prefix key) via __newindex.
-function trie_proxy_test(base, req, opts)
+function trie_metatable_test(base, req, opts)
     local fetched = base["toronto"]
     base["toro"] = fetched
+    base["toronto"] = 100
+    return base
+end
+
+function map_metatable_overwrite_test(base, req, opts)
+    base["a"] = 100
+    base["d"] = 4
+    return base
+end
+
+function get_now_test(base, req, opts)
+    local now = base.now
+    base.found_now = now
+    base.executed_now = true
     return base
 end


### PR DESCRIPTION
- Introduces __index / __newindex metatables in the Lua runtime so Lua table access calls  hb_ao:get and hb_ao:set.
- Improves lua / luerl encoding/decoding 
- Expands test coverage around metatable behavior