### PR TITLE
impr: Normalize node `Opts` to be a standard AO-Core message

### DIFF
--- a/src/dev_apply.erl
+++ b/src/dev_apply.erl
@@ -248,7 +248,7 @@ resolve_with_prefix_test() ->
             Node,
             <<"/~meta@1.0/info/request:debug-info~apply@1.0">>,
             #{
-                <<"debug-info">> => <<"short_trace_len">>
+                <<"debug-info">> => <<"short-trace-len">>
             },
             #{}
         )

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -16,7 +16,7 @@
 -define(IS_BLOCK_ID(X), (is_binary(X) andalso byte_size(X) == 64)).
 
 all_parallel_test_() ->
-    hb_test_parallel:all(?MODULE, 15).
+    {timeout, 15, hb_test_parallel:all(?MODULE)}.
 
 %% @doc Route unknown keys through offset resolution first, then fall back to
 %% the message device for direct key access.
@@ -205,7 +205,7 @@ head_raw_tx(TXID, StartOffset, Length, Opts) ->
             StructuredTXHeader,
             <<"application/octet-stream">>,
             Opts#{
-                cache_control =>
+                <<"cache-control">> =>
                     [<<"no-cache">>, <<"no-store">>]
             }
         ),
@@ -328,7 +328,7 @@ parse_range_params(<<"bytes ", ByteDescriptor/binary>>, _Opts) ->
     [Start, End] = binary:split(ByteRange, <<"-">>),
     {ok, hb_util:int(Start), hb_util:int(End)};
 parse_range_params(Msg, Opts) ->
-    case hb_ao:resolve(Msg, <<"range">>, Opts#{ hashpath => ignore }) of
+    case hb_ao:resolve(Msg, <<"range">>, Opts#{ <<"hashpath">> => ignore }) of
         {ok, Str} -> parse_range_params(Str, Opts);
         _ -> false
     end.
@@ -886,7 +886,7 @@ request(Method, Path, Extra, LogExtra, Opts) ->
                 <<"method">> => Method
             },
             Opts#{
-                cache_control => [<<"no-cache">>, <<"no-store">>]
+                <<"cache-control">> => [<<"no-cache">>, <<"no-store">>]
             }
         ),
     to_message(Path, Method, best_response(Res), LogExtra, Opts).

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -15,9 +15,6 @@
 
 -define(IS_BLOCK_ID(X), (is_binary(X) andalso byte_size(X) == 64)).
 
-all_parallel_test_() ->
-    {timeout, 15, hb_test_parallel:all(?MODULE)}.
-
 %% @doc Route unknown keys through offset resolution first, then fall back to
 %% the message device for direct key access.
 info() ->

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -15,6 +15,9 @@
 
 -define(IS_BLOCK_ID(X), (is_binary(X) andalso byte_size(X) == 64)).
 
+all_parallel_test_() ->
+    hb_test_parallel:all(?MODULE, 15).
+
 %% @doc Route unknown keys through offset resolution first, then fall back to
 %% the message device for direct key access.
 info() ->

--- a/src/dev_arweave_offset.erl
+++ b/src/dev_arweave_offset.erl
@@ -7,7 +7,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 all_parallel_test_() ->
-    hb_test_parallel:all(?MODULE, 15).
+    {timeout, 15, hb_test_parallel:all(?MODULE)}.
 
 %% @doc Resolve either a message at an Arweave offset, or a direct key from the
 %% base message if the key is not an integer.

--- a/src/dev_arweave_offset.erl
+++ b/src/dev_arweave_offset.erl
@@ -6,9 +6,6 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-all_parallel_test_() ->
-    {timeout, 15, hb_test_parallel:all(?MODULE)}.
-
 %% @doc Resolve either a message at an Arweave offset, or a direct key from the
 %% base message if the key is not an integer.
 get(Key, Base, Request, Opts) ->

--- a/src/dev_arweave_offset.erl
+++ b/src/dev_arweave_offset.erl
@@ -6,6 +6,9 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+all_parallel_test_() ->
+    hb_test_parallel:all(?MODULE, 15).
+
 %% @doc Resolve either a message at an Arweave offset, or a direct key from the
 %% base message if the key is not an integer.
 get(Key, Base, Request, Opts) ->

--- a/src/dev_cache.erl
+++ b/src/dev_cache.erl
@@ -50,7 +50,7 @@ read(_M1, M2, Opts) ->
             % The cache does not have this ID,but it may still be an explicit
             % `data/' path.
             % Store = hb_opts:get(store, [], Opts),
-            Store = maps:get(store, Opts),
+            Store = hb_opts:get(store, no_store, Opts),
             ?event(dev_cache, {read, {location, Location}, {store, Store}}),
             hb_store:read(Store, Location, Opts);
         {error, _} = Error ->
@@ -241,25 +241,25 @@ setup_test_env() ->
     Address = hb_util:human_id(ar_wallet:to_address(Wallet)),
     ?event(dev_cache, {setup_test_env, {address, Address}}),
     Node = hb_http_server:start_node(#{ 
-        cache_control => [<<"no-cache">>, <<"no-store">>],
-        store => LocalStore,
-        cache_writers => [
-			Address,
-			hb_util:human_id(ar_wallet:to_address(hb:wallet()))
-		],
-        store_all_signed => false
+        <<"cache-control">> => [<<"no-cache">>, <<"no-store">>],
+        <<"store">> => LocalStore,
+        <<"cache-writers">> => [
+				Address,
+				hb_util:human_id(ar_wallet:to_address(hb:wallet()))
+			],
+        <<"store-all-signed">> => false
     }),
     ?event(dev_cache, {setup_test_env, {node_started, Node}}),
     TestOpts = #{
-        cache_control => [<<"no-cache">>, <<"no-store">>],
-        store_all_signed => false,
-        store => [
+        <<"cache-control">> => [<<"no-cache">>, <<"no-store">>],
+        <<"store-all-signed">> => false,
+        <<"store">> => [
             #{
                 <<"store-module">> => hb_store_remote_node,
                 <<"node">> => Node,
-                priv_wallet => Wallet
+                <<"priv-wallet">> => Wallet
             }
-	    ]
+		    ]
     },
     {ok, TestOpts, [LocalStore, Wallet, Address, Node]}.
 

--- a/src/dev_copycat_arweave.erl
+++ b/src/dev_copycat_arweave.erl
@@ -1033,32 +1033,77 @@ negative_from_index_test_parallel() ->
     OffsetFromTip = Tip - StartBlock,
     ?assert(OffsetFromTip > 0),
     NegativeFrom = <<"-", (hb_util:bin(OffsetFromTip))/binary>>,
-    {ok, StopBlock} =
-        hb_ao:resolve(
-            <<
-                "~copycat@1.0/arweave&"
-                "from=", (hb_util:bin(StopBlock))/binary, "&"
-                "to=", (hb_util:bin(StopBlock))/binary, "&"
-                "mode=write"
-            >>,
-            Opts
-        ),
-    {ok, StopBlock} =
-        hb_ao:resolve(
-            <<
-                "~copycat@1.0/arweave&"
-                "from=", NegativeFrom/binary, "&"
-                "mode=write"
-            >>,
-            Opts
-        ),
-    ?assert(has_any_indexed_tx(StartBlock, Opts)),
-    NextBlock = highest_contiguous_indexed_block(StopBlock, 50, Opts),
-    ?assertEqual(StartBlock, NextBlock),
-    assert_indexed_range(NextBlock, StopBlock, Opts),
-    ?assertNot(has_any_indexed_tx(StopBlock - 1, Opts)),
-    ?assertNot(has_any_indexed_tx(NextBlock + 1, Opts)),
-    ok.
+    {ok, MockURL, MockHandle} = hb_mock_server:start([
+        {"/block/current", block_current,
+            {200, <<"{\"height\": ", (hb_util:bin(Tip))/binary, "}">>}}
+    ]),
+    StableOpts =
+        Opts#{
+            arweave_index_blocks => false,
+            routes => [
+                #{
+                    <<"template">> => <<"^/arweave/block/current$">>,
+                    <<"nodes">> => [
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"with">> => MockURL,
+                            <<"opts">> => #{ http_client => httpc }
+                        }
+                    ],
+                    <<"parallel">> => true,
+                    <<"stop-after">> => true,
+                    <<"admissible-status">> => 200
+                },
+                #{
+                    <<"template">> => <<"^/arweave">>,
+                    <<"nodes">> => [
+                        #{
+                            <<"match">> => <<"^/arweave">>,
+                            <<"with">> =>
+                                hb_opts:get(
+                                    gateway,
+                                    <<"https://arweave.net">>,
+                                    Opts
+                                ),
+                            <<"opts">> => #{ http_client => httpc }
+                        }
+                    ],
+                    <<"parallel">> => true,
+                    <<"stop-after">> => true,
+                    <<"admissible-status">> => 200
+                }
+            ]
+        },
+    try
+        {ok, StopBlock} =
+            hb_ao:resolve(
+                <<
+                    "~copycat@1.0/arweave&"
+                    "from=", (hb_util:bin(StopBlock))/binary, "&"
+                    "to=", (hb_util:bin(StopBlock))/binary, "&"
+                    "mode=write"
+                >>,
+                StableOpts
+            ),
+        {ok, StopBlock} =
+            hb_ao:resolve(
+                <<
+                    "~copycat@1.0/arweave&"
+                    "from=", NegativeFrom/binary, "&"
+                    "mode=write"
+                >>,
+                StableOpts
+            ),
+        ?assert(has_any_indexed_tx(StartBlock, StableOpts)),
+        NextBlock = highest_contiguous_indexed_block(StopBlock, 50, StableOpts),
+        ?assertEqual(StartBlock, NextBlock),
+        assert_indexed_range(NextBlock, StopBlock, StableOpts),
+        ?assertNot(has_any_indexed_tx(StopBlock - 1, StableOpts)),
+        ?assertNot(has_any_indexed_tx(NextBlock + 1, StableOpts)),
+        ok
+    after
+        hb_mock_server:stop(MockHandle)
+    end.
 
 setup_index_opts() ->
     TestStore = hb_test_utils:test_store(),

--- a/src/dev_green_zone.erl
+++ b/src/dev_green_zone.erl
@@ -275,10 +275,17 @@ key(_M1, _M2, Opts) ->
     % Retrieve the shared AES key and the node's wallet.
     GreenZoneAES = hb_opts:get(priv_green_zone_aes, undefined, Opts),
     Identities = hb_opts:get(identities, #{}, Opts),
-    Wallet = case maps:find(<<"green-zone">>, Identities) of
-        {ok, #{priv_wallet := GreenZoneWallet}} -> GreenZoneWallet;
-        _ -> hb_opts:get(priv_wallet, undefined, Opts)
-    end,
+    Wallet =
+        case maps:find(<<"green-zone">>, Identities) of
+            {ok, IdentityOpts} ->
+                hb_opts:get(
+                    priv_wallet,
+                    hb_opts:get(priv_wallet, undefined, Opts),
+                    IdentityOpts
+                );
+            _ ->
+                hb_opts:get(priv_wallet, undefined, Opts)
+        end,
     {{KeyType, Priv, Pub}, _PubKey} = Wallet,
     ?event(green_zone, 
         {get_key, wallet, hb_util:human_id(ar_wallet:to_address(Pub))}),

--- a/src/dev_hook.erl
+++ b/src/dev_hook.erl
@@ -144,7 +144,12 @@ execute_handlers(HookName, [Handler|Rest], Req, Opts) ->
 
 %% @doc Execute a single handler
 %% Handlers are expressed as messages that can be resolved via AO.
-execute_handler(<<"step">>, Handler, Req, Opts = #{ on := On = #{ <<"step">> := _ }}) ->
+execute_handler(
+    <<"step">>,
+    Handler,
+    Req,
+    Opts = #{ <<"on">> := On = #{ <<"step">> := _ }}
+) ->
     % The `step' hook is a special case: It is executed during the course of
     % a resolution, and as such, the key must be removed from the node message
     % before execution of the handler. Failure to do so will result in infinite
@@ -153,7 +158,7 @@ execute_handler(<<"step">>, Handler, Req, Opts = #{ on := On = #{ <<"step">> := 
         <<"step">>,
         maps:remove(<<"step">>, Handler),
         Req,
-        Opts#{ on => maps:remove(<<"step">>, On) }
+        Opts#{ <<"on">> => maps:remove(<<"step">>, On) }
     );
 execute_handler(HookName, Handler, Req, Opts) ->
     try
@@ -202,7 +207,7 @@ execute_handler(HookName, Handler, Req, Opts) ->
             hb_ao:resolve(
                 PreparedBase,
                 PreparedReq,
-                Opts#{ hashpath => ignore }
+                Opts#{ <<"hashpath">> => ignore }
             ),
         ?event(hook,
             {handler_result,
@@ -257,7 +262,7 @@ single_handler_test() ->
         }
     },
     Req = #{ <<"test">> => <<"value">> },
-    Opts = #{ on => #{ <<"test-hook">> => Handler }},
+    Opts = #{ <<"on">> => #{ <<"test-hook">> => Handler }},
     {ok, Result} = on(<<"test-hook">>, Req, Opts),
     ?assertEqual(true, maps:get(<<"handler_executed">>, Result)).
 
@@ -281,7 +286,7 @@ multiple_handlers_test() ->
         }
     },
     Req = #{ <<"test">> => <<"value">> },
-    Opts = #{ on => #{ <<"test-hook">> => [Handler1, Handler2] }},
+    Opts = #{ <<"on">> => #{ <<"test-hook">> => [Handler1, Handler2] }},
     {ok, Result} = on(<<"test-hook">>, Req, Opts),
     ?assertEqual(true, maps:get(<<"handler1">>, Result)),
     ?assertEqual(true, maps:get(<<"handler2">>, Result)).
@@ -314,6 +319,6 @@ halt_on_error_test() ->
         }
     },
     Req = #{ <<"test">> => <<"value">> },
-    Opts = #{ on => #{ <<"test-hook">> => [Handler1, Handler2, Handler3] }},
+    Opts = #{ <<"on">> => #{ <<"test-hook">> => [Handler1, Handler2, Handler3] }},
     {error, Result} = on(<<"test-hook">>, Req, Opts),
     ?assertEqual(<<"Error in handler2">>, Result).

--- a/src/dev_hyperbuddy.erl
+++ b/src/dev_hyperbuddy.erl
@@ -11,7 +11,7 @@
 %% Each filename must point to a path relative to the HyperBEAM instance's
 %% build subdirectory as follows: `priv/html/hyperbuddy@1.0'.
 info(Opts) ->
-    ServedRoutes = hb_maps:get(hyperbuddy_serve, Opts, #{}, Opts),
+    ServedRoutes = hb_opts:get(hyperbuddy_serve, #{}, Opts),
     #{
         default => fun serve/4,
         serve => ServedRoutes#{
@@ -128,9 +128,9 @@ format(Base, Req, Opts) ->
                     hb_format:message(
                         MsgLoaded,
                         Opts#{
-                            linkify_mode => discard,
-                            cache_control => [<<"no-cache">>, <<"no-store">>],
-                            debug_print_truncate => TruncateKeys
+                            <<"linkify-mode">> => discard,
+                            <<"cache-control">> => [<<"no-cache">>, <<"no-store">>],
+                            <<"debug-print-truncate">> => TruncateKeys
                         }
                     )
                 )

--- a/src/dev_local_name.erl
+++ b/src/dev_local_name.erl
@@ -74,7 +74,7 @@ direct_register(Req, Opts) ->
 
 %% @doc Returns a message containing all known names.
 find_names(Opts) ->
-    case hb_opts:get(local_names, not_found, Opts#{ only => local }) of
+    case hb_opts:get(local_names, not_found, Opts#{ <<"only">> => local }) of
         not_found ->
             find_names(load_names(Opts));
         LocalNames ->
@@ -106,14 +106,14 @@ load_names(Opts) ->
 %% use this new message, removing the need to look up the names from non-volatile
 %% storage.
 update_names(LocalNames, Opts) ->
-    hb_http_server:set_opts(NewOpts = Opts#{ local_names => LocalNames }),
+    hb_http_server:set_opts(NewOpts = Opts#{ <<"local-names">> => LocalNames }),
     NewOpts.
 
 %%% Tests
 
 generate_test_opts() ->
     Opts = #{
-        priv_wallet => ar_wallet:new()
+        <<"priv-wallet">> => ar_wallet:new()
     },
     Opts.
 
@@ -161,7 +161,7 @@ unauthorized_test() ->
             #{},
             hb_message:commit(
                 #{ <<"key">> => <<"name1">>, <<"value">> => <<"value1">> },
-                Opts#{ priv_wallet => ar_wallet:new() }
+                Opts#{ <<"priv-wallet">> => ar_wallet:new() }
             ),
             Opts
         )

--- a/src/dev_lua.erl
+++ b/src/dev_lua.erl
@@ -289,7 +289,7 @@ compute(Key, RawBase, RawReq, Opts) ->
                 {{as, <<"message@1.0">>, Base}, <<"function">>}
             ],
             Key,
-            Opts#{ hashpath => ignore }
+            Opts#{ <<"hashpath">> => ignore }
         ),
     ?event(debug_lua, function_found),
     Params =
@@ -304,7 +304,7 @@ compute(Key, RawBase, RawReq, Opts) ->
                 Req,
                 #{}
             ],
-            Opts#{ hashpath => ignore }
+            Opts#{ <<"hashpath">> => ignore }
         ),
     ?event(debug_lua, parameters_found),
     % Resolve all hyperstate links
@@ -383,7 +383,7 @@ snapshot(Base, _Req, Opts) ->
 
 %% @doc Restore the Lua state from a snapshot, if it exists.
 normalize(Base, _Req, RawOpts) ->
-    Opts = RawOpts#{ hashpath => ignore },
+    Opts = RawOpts#{ <<"hashpath">> => ignore },
     case hb_private:get(<<"state">>, Base, Opts) of
         not_found ->
             DeviceKey =
@@ -519,7 +519,7 @@ simple_invocation_test() ->
 
 post_invocation_message_validation_test() ->
     {ok, Script} = file:read_file("test/test.lua"),
-    Opts = #{ priv_wallet => hb:wallet() },
+    Opts = #{ <<"priv-wallet">> => hb:wallet() },
     Base =
         hb_message:commit(
             #{
@@ -694,8 +694,8 @@ lua_http_hook_test() ->
     {ok, Module} = file:read_file("test/test.lua"),
     Node = hb_http_server:start_node(
         #{
-            priv_wallet => ar_wallet:new(),
-            on => #{
+            <<"priv-wallet">> => ar_wallet:new(),
+            <<"on">> => #{
                 <<"request">> =>
                     #{
                         <<"device">> => <<"lua@5.3a">>,
@@ -714,17 +714,17 @@ pure_lua_process_test() ->
     Process = generate_lua_process("test/test.lua", #{}),
     {ok, _} = hb_cache:write(Process, #{}),
     Message = generate_test_message(Process, #{}),
-    {ok, _} = hb_ao:resolve(Process, Message, #{ hashpath => ignore }),
+    {ok, _} = hb_ao:resolve(Process, Message, #{ <<"hashpath">> => ignore }),
     {ok, Results} = hb_ao:resolve(Process, <<"now">>, #{}),
     ?assertEqual(42, hb_ao:get(<<"results/output/body">>, Results, #{})).
 
 %% @doc Call a process whose `execution-device' is set to `lua@5.3a'.
 pure_lua_restore_test() ->
-    Opts = #{ process_cache_frequency => 1 },
+    Opts = #{ <<"process-cache-frequency">> => 1 },
     Process = generate_lua_process("test/test.lua", Opts),
     {ok, _} = hb_cache:write(Process, Opts),
     Message = generate_test_message(Process, Opts, #{ <<"path">> => <<"inc">>}),
-    {ok, _} = hb_ao:resolve(Process, Message, Opts#{ hashpath => ignore }),
+    {ok, _} = hb_ao:resolve(Process, Message, Opts#{ <<"hashpath">> => ignore }),
     {ok, Count1} = hb_ao:resolve(Process, <<"now/count">>, Opts),
     ?assertEqual(1, Count1),
     hb_ao:resolve(
@@ -740,7 +740,7 @@ pure_lua_process_benchmark_test_() ->
         30,
         fun() ->
             pure_lua_process_benchmark(#{
-                process_snapshot_slots => 50
+                <<"process-snapshot-slots">> => 50
             })
     end}.
 pure_lua_process_benchmark(Opts) ->
@@ -751,7 +751,7 @@ pure_lua_process_benchmark(Opts) ->
     Message = generate_test_message(Process, Opts),
     lists:foreach(
         fun(X) ->
-            hb_ao:resolve(Process, Message, Opts#{ hashpath => ignore }),
+            hb_ao:resolve(Process, Message, Opts#{ <<"hashpath">> => ignore }),
             ?event(debug_lua, {scheduled, X})
         end,
         lists:seq(1, BenchMsgs)
@@ -770,17 +770,17 @@ pure_lua_process_benchmark(Opts) ->
     ?assert(ExecMs =< 500).
 
 invoke_aos_test() ->
-    Opts = #{ priv_wallet => hb:wallet() },
+    Opts = #{ <<"priv-wallet">> => hb:wallet() },
     Process = generate_lua_process("test/hyper-aos.lua", Opts),
     {ok, _Proc} = hb_cache:write(Process, Opts),
     Message = generate_test_message(Process, Opts),
-    {ok, _Assignment} = hb_ao:resolve(Process, Message, Opts#{ hashpath => ignore }),
+    {ok, _Assignment} = hb_ao:resolve(Process, Message, Opts#{ <<"hashpath">> => ignore }),
     {ok, Results} = hb_ao:resolve(Process, <<"now/results/output">>, Opts),
     ?assertEqual(<<"1">>, hb_ao:get(<<"data">>, Results, #{})),
     ?assertEqual(<<"aos> ">>, hb_ao:get(<<"prompt">>, Results, #{})).
 
 aos_authority_not_trusted_test() ->
-    Opts = #{ priv_wallet => ar_wallet:new() },
+    Opts = #{ <<"priv-wallet">> => ar_wallet:new() },
     Process = generate_lua_process("test/hyper-aos.lua", Opts),
     ProcID = hb_message:id(Process, all),
     {ok, _} = hb_cache:write(Process, Opts),
@@ -804,7 +804,7 @@ aos_authority_not_trusted_test() ->
         Opts
     ),
     ?event({message, Message}),
-    {ok, _} = hb_ao:resolve(Process, Message, Opts#{ hashpath => ignore }),
+    {ok, _} = hb_ao:resolve(Process, Message, Opts#{ <<"hashpath">> => ignore }),
     {ok, Results} = hb_ao:resolve(Process, <<"now/results/output/data">>, Opts),
     ?assertEqual(<<"Message is not trusted.">>, Results).
 
@@ -813,9 +813,9 @@ aos_process_benchmark_test_() ->
     {timeout, 30, fun() ->
         BenchMsgs = 6,
         Opts = #{
-            process_async_cache => true,
-            hashpath => ignore,
-            process_snapshot_slots => 50
+            <<"process-async-cache">> => true,
+            <<"hashpath">> => ignore,
+            <<"process-snapshot-slots">> => 50
         },
         Process = generate_lua_process("test/hyper-aos.lua", Opts),
         Message = generate_test_message(Process, Opts),
@@ -848,7 +848,7 @@ aos_process_benchmark_test_() ->
 
 %% @doc Generate a Lua process message.
 generate_lua_process(File, Opts) ->
-    NormOpts = Opts#{ priv_wallet => hb_opts:get(priv_wallet, hb:wallet(), Opts) },
+    NormOpts = Opts#{ <<"priv-wallet">> => hb_opts:get(priv_wallet, hb:wallet(), Opts) },
     Wallet = hb_opts:get(priv_wallet, hb:wallet(), NormOpts),
     Address = hb_util:human_id(ar_wallet:to_address(Wallet)),
     {ok, Module} = file:read_file(File),
@@ -902,7 +902,7 @@ generate_test_message(Process, Opts, ToEval) when is_binary(ToEval) ->
     );
 generate_test_message(Process, Opts, MsgBase) ->
     ProcID = hb_message:id(Process, all),
-    NormOpts = Opts#{ priv_wallet => hb_opts:get(priv_wallet, hb:wallet(), Opts) },
+    NormOpts = Opts#{ <<"priv-wallet">> => hb_opts:get(priv_wallet, hb:wallet(), Opts) },
     hb_message:commit(#{
             <<"path">> => <<"schedule">>,
             <<"method">> => <<"POST">>,

--- a/src/dev_lua_test_ledgers.erl
+++ b/src/dev_lua_test_ledgers.erl
@@ -70,7 +70,7 @@ ledger(Script, Extra, Opts) ->
                 },
                 ModExtra
             ),
-            Opts#{ priv_wallet => HostWallet }
+            Opts#{ <<"priv-wallet">> => HostWallet }
         ),
     hb_cache:write(Proc, Opts),
     Proc.
@@ -113,7 +113,7 @@ subledger(Root, Extra, Opts) ->
                 },
                 Extra
             ),
-            Opts#{ priv_wallet => hb_opts:get(priv_wallet, hb:wallet(), Opts) }
+            Opts#{ <<"priv-wallet">> => hb_opts:get(priv_wallet, hb:wallet(), Opts) }
         ),
     hb_cache:write(Proc, Opts),
     Proc.
@@ -136,21 +136,21 @@ transfer(ProcMsg, Sender, Recipient, Quantity, Route, Opts) ->
         hb_message:commit(#{
             <<"path">> => <<"push">>,
             <<"body">> =>
-                hb_message:commit(MaybeRoute#{
+                    hb_message:commit(MaybeRoute#{
                         <<"action">> => <<"Transfer">>,
                         <<"target">> => hb_message:id(ProcMsg, all),
                         <<"recipient">> => hb_util:human_id(Recipient),
                         <<"quantity">> => Quantity
                     },
-                    Opts#{ priv_wallet => Sender }
+                    Opts#{ <<"priv-wallet">> => Sender }
                 )
             },
-            Opts#{ priv_wallet => Sender }
+            Opts#{ <<"priv-wallet">> => Sender }
         ),
     hb_ao:resolve(
         ProcMsg,
         Xfer,
-        Opts#{ priv_wallet => hb_opts:get(priv_wallet, hb:wallet(), Opts) }
+        Opts#{ <<"priv-wallet">> => hb_opts:get(priv_wallet, hb:wallet(), Opts) }
     ).
 
 %% @doc Request that a peer register with a without sub-ledger.
@@ -159,7 +159,7 @@ register(ProcMsg, Peer, Opts) when is_map(Peer) ->
 register(ProcMsg, PeerID, RawOpts) ->
     Opts =
         RawOpts#{
-            priv_wallet => hb_opts:get(priv_wallet, hb:wallet(), RawOpts)
+            <<"priv-wallet">> => hb_opts:get(priv_wallet, hb:wallet(), RawOpts)
         },
     Reg =
         hb_message:commit(
@@ -761,10 +761,10 @@ multischeduler() ->
     Scheduler2 = ar_wallet:new(),
     Scheduler3 = ar_wallet:new(),
     Opts = BaseOpts#{
-        priv_wallet => NodeWallet,
-        identities => #{
+        <<"priv-wallet">> => NodeWallet,
+        <<"identities">> => #{
             <<"extra-scheduler">> => #{
-                priv_wallet => Scheduler2
+                <<"priv-wallet">> => Scheduler2
             }
         }
     },
@@ -793,7 +793,7 @@ multischeduler() ->
     ?assertEqual(100, balance(RootLedger, Bob, Opts)),
     % Create a new process with with the same schedulers, but do not provide
     % the extra scheduler in the `identities' map.
-    OptsWithoutHostWallet = maps:remove(priv_wallet, Opts),
+    OptsWithoutHostWallet = maps:remove(<<"priv-wallet">>, Opts),
     RootLedger2 =
         ledger(
             <<"scripts/hyper-token.lua">>,
@@ -808,7 +808,7 @@ multischeduler() ->
     % The transfer should succeed if:
     % - Set the `authority-required' field to contain the host wallet, while
     % - Setting the `authority-match' field to 1.
-    OptsWithoutExtraScheduler = #{ priv_wallet => NodeWallet },
+    OptsWithoutExtraScheduler = #{ <<"priv-wallet">> => NodeWallet },
     RootLedger3 =
         ledger(
             <<"scripts/hyper-token.lua">>,
@@ -825,15 +825,15 @@ multischeduler() ->
     % creating a subledger that has two different schedulers, excluding the
     % host wallet.
     OptsWithSchedulers = OptsWithoutExtraScheduler#{
-        identities => #{
+        <<"identities">> => #{
             <<"scheduler-1">> => #{
-                priv_wallet => Scheduler3
+                <<"priv-wallet">> => Scheduler3
             },
             <<"scheduler-2">> => #{
-                priv_wallet => Scheduler2
+                <<"priv-wallet">> => Scheduler2
             },
             <<"scheduler-3">> => #{
-                priv_wallet => Scheduler3
+                <<"priv-wallet">> => Scheduler3
             }
         }
     },
@@ -926,9 +926,11 @@ comma_separated_scheduler_list_test() ->
     Scheduler2 = ar_wallet:new(),
     Alice = ar_wallet:new(),
     Bob = ar_wallet:new(),
-    Opts = (test_opts())#{ priv_wallet => NodeWallet, identities => #{
+    Opts = (test_opts())#{
+        <<"priv-wallet">> => NodeWallet,
+        <<"identities">> => #{
         <<"extra-scheduler">> => #{
-            priv_wallet => Scheduler2
+            <<"priv-wallet">> => Scheduler2
         }
     } },
     Ledger =

--- a/src/dev_meta.erl
+++ b/src/dev_meta.erl
@@ -149,7 +149,7 @@ add_dynamic_keys(NodeMsg) ->
             Wallet ->
                 %% Create a new map with address and merge it (overwriting existing)
                 Address = hb_util:id(ar_wallet:to_address(Wallet)),
-                NodeMsg#{ address => Address, <<"address">> => Address }
+                NodeMsg#{ <<"address">> => Address }
         end,
     add_identity_addresses(UpdatedNodeMsg).
 
@@ -248,7 +248,7 @@ handle_resolve(Req, Msgs, NodeMsg) ->
             Res =
                 hb_ao:resolve_many(
                     PreProcessedMsg,
-                    HTTPOpts#{ force_message => true }
+                    HTTPOpts#{ <<"force-message">> => true }
                 ),
             {ok, StatusEmbeddedRes} = embed_status(Res, NodeMsg),
             AfterResolveOpts = hb_http_server:get_opts(NodeMsg),
@@ -475,7 +475,7 @@ config_test() ->
 	StoreOpts = hb_test_utils:test_store(),
     Node = hb_http_server:start_node(Opts = #{ test_config_item => <<"test">>, store => StoreOpts }),
     {ok, Res} = hb_http:get(Node, <<"/~meta@1.0/info">>, Opts),
-    ?assertEqual(<<"test">>, hb_ao:get(<<"test_config_item">>, Res, Opts)).
+    ?assertEqual(<<"test">>, hb_ao:get(<<"test-config-item">>, Res, Opts)).
 
 %% @doc Test that we can't get the node message if the requested key is private.
 priv_inaccessible_test() ->
@@ -487,14 +487,14 @@ priv_inaccessible_test() ->
     ),
     {ok, Res} = hb_http:get(Node, <<"/~meta@1.0/info">>, #{}),
     ?event({res, Res}),
-    ?assertEqual(<<"test">>, hb_ao:get(<<"test_config_item">>, Res, #{})),
-    ?assertEqual(not_found, hb_ao:get(<<"priv_key">>, Res, #{})).
+    ?assertEqual(<<"test">>, hb_ao:get(<<"test-config-item">>, Res, #{})),
+    ?assertEqual(not_found, hb_ao:get(<<"priv-key">>, Res, #{})).
 
 %% @doc Test that we can't set the node message if the request is not signed by
 %% the owner of the node.
 unauthorized_set_node_msg_fails_test() ->
 	StoreOpts = hb_test_utils:test_store(),
-    Node = hb_http_server:start_node(Opts = #{ store => StoreOpts, priv_wallet => ar_wallet:new() }),
+    Node = hb_http_server:start_node(Opts = #{ store => StoreOpts, <<"priv-wallet">> => ar_wallet:new() }),
     {error, _} =
         hb_http:post(
             Node,
@@ -503,13 +503,13 @@ unauthorized_set_node_msg_fails_test() ->
                     <<"path">> => <<"/~meta@1.0/info">>,
                     <<"evil_config_item">> => <<"BAD">>
                 },
-                Opts#{ priv_wallet => ar_wallet:new() }
+                Opts#{ <<"priv-wallet">> => ar_wallet:new() }
             ),
             #{}
-        ),
+    ),
     {ok, Res} = hb_http:get(Node, <<"/~meta@1.0/info">>, Opts),
-    ?assertEqual(not_found, hb_ao:get(<<"evil_config_item">>, Res, Opts)),
-    ?assertEqual(0, length(hb_ao:get(<<"node_history">>, Res, [], Opts))).
+    ?assertEqual(not_found, hb_ao:get(<<"evil-config-item">>, Res, Opts)),
+    ?assertEqual(0, length(hb_ao:get(<<"node-history">>, Res, [], Opts))).
 
 %% @doc Test that we can set the node message if the request is signed by the
 %% owner of the node.
@@ -531,15 +531,15 @@ authorized_set_node_msg_succeeds_test() ->
                     <<"path">> => <<"/~meta@1.0/info">>,
                     <<"test_config_item">> => <<"test2">>
                 },
-                Opts#{ priv_wallet => Owner }
+                Opts#{ <<"priv-wallet">> => Owner }
             ),
             Opts
-        ),
+    ),
     ?event({res, SetRes}),
     {ok, Res} = hb_http:get(Node, <<"/~meta@1.0/info">>, Opts),
     ?event({res, Res}),
-    ?assertEqual(<<"test2">>, hb_ao:get(<<"test_config_item">>, Res, Opts)),
-    ?assertEqual(1, length(hb_ao:get(<<"node_history">>, Res, [], Opts))).
+    ?assertEqual(<<"test2">>, hb_ao:get(<<"test-config-item">>, Res, Opts)),
+    ?assertEqual(1, length(hb_ao:get(<<"node-history">>, Res, [], Opts))).
 
 %% @doc Test that an uninitialized node will not run computation.
 uninitialized_node_test() ->
@@ -569,14 +569,14 @@ permanent_node_message_test() ->
                     <<"test_config_item">> => <<"test2">>,
                     initialized => <<"permanent">>
                 },
-                Opts#{ priv_wallet => Owner }
+                Opts#{ <<"priv-wallet">> => Owner }
             ),
             Opts
-        ),
+    ),
     ?event({set_res, SetRes1}),
     {ok, Res} = hb_http:get(Node, #{ <<"path">> => <<"/~meta@1.0/info">> }, Opts),
     ?event({get_res, Res}),
-    ?assertEqual(<<"test2">>, hb_ao:get(<<"test_config_item">>, Res, Opts)),
+    ?assertEqual(<<"test2">>, hb_ao:get(<<"test-config-item">>, Res, Opts)),
     {error, SetRes2} =
         hb_http:post(
             Node,
@@ -585,15 +585,15 @@ permanent_node_message_test() ->
                     <<"path">> => <<"/~meta@1.0/info">>,
                     <<"test_config_item">> => <<"bad_value">>
                 },
-                Opts#{ priv_wallet => Owner }
+                Opts#{ <<"priv-wallet">> => Owner }
             ),
             Opts
         ),
     ?event({set_res, SetRes2}),
     {ok, Res2} = hb_http:get(Node, #{ <<"path">> => <<"/~meta@1.0/info">> }, Opts),
     ?event({get_res, Res2}),
-    ?assertEqual(<<"test2">>, hb_ao:get(<<"test_config_item">>, Res2, Opts)),
-    ?assertEqual(1, length(hb_ao:get(<<"node_history">>, Res2, [], Opts))).
+    ?assertEqual(<<"test2">>, hb_ao:get(<<"test-config-item">>, Res2, Opts)),
+    ?assertEqual(1, length(hb_ao:get(<<"node-history">>, Res2, [], Opts))).
 
 %% @doc Test that we can claim the node correctly and set the node message after.
 claim_node_test() ->
@@ -615,7 +615,7 @@ claim_node_test() ->
                     <<"path">> => <<"/~meta@1.0/info">>,
                     <<"operator">> => hb_util:human_id(Address)
                 },
-                Opts#{ priv_wallet => Owner}
+                Opts#{ <<"priv-wallet">> => Owner}
             ),
             Opts
         ),
@@ -631,22 +631,22 @@ claim_node_test() ->
                     <<"path">> => <<"/~meta@1.0/info">>,
                     <<"test_config_item">> => <<"test2">>
                 },
-                Opts#{ priv_wallet => Owner }
+                Opts#{ <<"priv-wallet">> => Owner }
             ),
             Opts
         ),
     ?event({res, SetRes2}),
     {ok, Res2} = hb_http:get(Node, <<"/~meta@1.0/info">>, Opts),
     ?event({res, Res2}),
-    ?assertEqual(<<"test2">>, hb_ao:get(<<"test_config_item">>, Res2, Opts)),
-    ?assertEqual(2, length(hb_ao:get(<<"node_history">>, Res2, [], Opts))).
+    ?assertEqual(<<"test2">>, hb_ao:get(<<"test-config-item">>, Res2, Opts)),
+    ?assertEqual(2, length(hb_ao:get(<<"node-history">>, Res2, [], Opts))).
 
 %% Test that we can use a hook upon a request.
 request_response_hooks_test() ->
     Parent = self(),
     Node = hb_http_server:start_node(
         #{
-            on =>
+            <<"on">> =>
                 #{
                     <<"request">> =>
                         #{
@@ -669,7 +669,7 @@ request_response_hooks_test() ->
                             }
                         }
                 },
-            http_extra_opts => #{
+            <<"http-extra-opts">> => #{
                 <<"cache-control">> => [<<"no-store">>, <<"no-cache">>]
             }
         }),
@@ -688,7 +688,7 @@ request_response_hooks_test() ->
 halt_request_test() ->
     Node = hb_http_server:start_node(
         #{
-            on =>
+            <<"on">> =>
                 #{
                     <<"request">> =>
                         #{
@@ -708,7 +708,7 @@ halt_request_test() ->
 modify_request_test() ->
     Node = hb_http_server:start_node(
         #{
-            on =>
+            <<"on">> =>
                 #{
                     <<"request">> =>
                         #{

--- a/src/dev_node_process.erl
+++ b/src/dev_node_process.erl
@@ -144,6 +144,7 @@ generate_test_opts() ->
 generate_test_opts(Name, Def) ->
     #{
         node_processes => #{ Name => Def },
+        store => [hb_test_utils:test_store(hb_store_lmdb)],
         priv_wallet => ar_wallet:new()
     }.
 

--- a/src/dev_poda.erl
+++ b/src/dev_poda.erl
@@ -132,8 +132,9 @@ validate_stage(3, Content, Commitments, Opts = #{ <<"quorum">> := Quorum }) ->
 validate_commitment(Msg, Comm, Opts) ->
     MsgID = hb_util:encode(ar_bundles:id(Msg, unsigned)),
     AttSigner = hb_util:encode(ar_bundles:signer(Comm)),
-    ?event({poda_commitment, {signer, AttSigner, hb_maps:get(authorities, Opts, undefined, Opts)}, {msg_id, MsgID}}),
-    ValidSigner = lists:member(AttSigner, hb_maps:get(authorities, Opts, undefined, Opts)),
+    Authorities = hb_opts:get(authorities, undefined, Opts),
+    ?event({poda_commitment, {signer, AttSigner, Authorities}, {msg_id, MsgID}}),
+    ValidSigner = lists:member(AttSigner, Authorities),
     ValidSignature = ar_bundles:verify_item(Comm),
     RelevantMsg = ar_bundles:id(Comm, unsigned) == MsgID orelse
         (lists:keyfind(<<"commitment-for">>, 1, Comm#tx.tags)

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -840,16 +840,16 @@ test_push_as_identity() ->
     ComputeID = hb_util:human_id(ComputeWallet),
     TestStore = [hb_test_utils:test_store(hb_store_lmdb)],
     Opts = #{
-        priv_wallet => DefaultWallet,
-        cache_control => <<"always">>,
+        <<"priv-wallet">> => DefaultWallet,
+        <<"cache-control">> => <<"always">>,
         store => TestStore,
-        identities => #{
+        <<"identities">> => #{
             SchedulingID => #{
-                priv_wallet => SchedulingWallet,
+                <<"priv-wallet">> => SchedulingWallet,
                 store => [hb_test_utils:test_store(hb_store_lmdb)]
             },
             ComputeID => #{
-                priv_wallet => ComputeWallet
+                <<"priv-wallet">> => ComputeWallet
             }
         }
     },

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -796,10 +796,10 @@ genesis_wasm_tests() -> [].
 test_full_push() ->
     dev_process_test_vectors:init(),
     Opts = #{
-        process_async_cache => false,
-        priv_wallet => hb:wallet(),
-        cache_control => <<"always">>,
-        store => [hb_test_utils:test_store(hb_store_lmdb)]
+        <<"process-async-cache">> => false,
+        <<"priv-wallet">> => hb:wallet(),
+        <<"cache-control">> => <<"always">>,
+        <<"store">> => [hb_test_utils:test_store(hb_store_lmdb)]
     },
     Base = dev_process_test_vectors:aos_process(Opts),
     hb_cache:write(Base, Opts),
@@ -914,9 +914,9 @@ test_push_as_identity() ->
 test_multi_process_push() ->
     dev_process_test_vectors:init(),
     Opts = #{
-        priv_wallet => hb:wallet(),
-        cache_control => <<"always">>,
-        store => [hb_test_utils:test_store(hb_store_lmdb)]
+        <<"priv-wallet">> => hb:wallet(),
+        <<"cache-control">> => <<"always">>,
+        <<"store">> => [hb_test_utils:test_store(hb_store_lmdb)]
     },
     Proc1 = dev_process_test_vectors:aos_process(Opts),
     hb_cache:write(Proc1, Opts),
@@ -1054,9 +1054,9 @@ push_with_redirect_hint_test_disabled() ->
 test_push_prompts_encoding_change() ->
     dev_process_test_vectors:init(),
     Opts = #{
-        priv_wallet => hb:wallet(),
-        cache_control => <<"always">>,
-        store =>
+        <<"priv-wallet">> => hb:wallet(),
+        <<"cache-control">> => <<"always">>,
+        <<"store">> =>
             [
                 #{ <<"store-module">> => hb_store_fs, <<"name">> => <<"cache-TEST">> },
                 % Include a gateway store so that we can get the legacynet 
@@ -1275,9 +1275,9 @@ test_oracle_push() ->
 test_nested_push_prompts_encoding_change() ->
     dev_process_test_vectors:init(),
     Opts = #{
-        priv_wallet => hb:wallet(),
-        cache_control => <<"always">>,
-        store => hb_opts:get(store)
+        <<"priv-wallet">> => hb:wallet(),
+        <<"cache-control">> => <<"always">>,
+        <<"store">> => hb_opts:get(store)
     },
     ?event(debug_push, {opts, Opts}),
     Base = dev_process_test_vectors:aos_process(Opts),

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -96,7 +96,7 @@ do_push(PrimaryProcess, Assignment, Opts) ->
             hb_ao:resolve(
                 {as, <<"process@1.0">>, PrimaryProcess},
                     #{ <<"path">> => <<"compute/results">>, <<"slot">> => Slot },
-                    Opts#{ hashpath => ignore }
+                    Opts#{ <<"hashpath">> => ignore }
                 )
         catch
             Class:Reason:Trace ->
@@ -256,7 +256,7 @@ maybe_evaluate_message(Message, Opts) ->
                     [<<"target">>],
                     Message
                 ),
-            ResolveOpts = Opts#{ force_message => true },
+            ResolveOpts = Opts#{ <<"force-message">> => true },
             case hb_ao:resolve(ReqMsg#{ <<"path">> => ResolvePath }, ResolveOpts) of
                 {ok, EvalRes} ->
                     {
@@ -431,7 +431,7 @@ push_downstream_local(TargetID, NextSlotOnProc, Origin, Opts) ->
                     Opts
                 ) - 1
         },
-        Opts#{ cache_control => <<"always">> }
+        Opts#{ <<"cache-control">> => <<"always">> }
     ).
 
 %% @doc Augment the message with from-* keys, if it doesn't already have them.
@@ -441,7 +441,7 @@ normalize_message(MsgToPush, Opts) ->
         #{
             <<"target">> => target_process(MsgToPush, Opts)
         },
-        Opts#{ hashpath => ignore }
+        Opts#{ <<"hashpath">> => ignore }
     ).
 
 %% @doc Find the target process ID for a message to push.
@@ -471,7 +471,7 @@ split_target(RawTarget) ->
 %% keys.
 calculate_base_id(GivenProcess, Opts) ->
     Process =
-        case hb_ao:get(<<"process">>, GivenProcess, Opts#{ hashpath => ignore }) of
+        case hb_ao:get(<<"process">>, GivenProcess, Opts#{ <<"hashpath">> => ignore }) of
             not_found -> GivenProcess;
             Proc -> Proc
         end,
@@ -479,7 +479,7 @@ calculate_base_id(GivenProcess, Opts) ->
         hb_ao:set(
             Process,
             #{ <<"authority">> => unset, <<"scheduler">> => unset },
-            Opts#{ hashpath => ignore }
+            Opts#{ <<"hashpath">> => ignore }
         ),
     {ok, BaseID} =
         hb_ao:resolve(
@@ -549,7 +549,7 @@ schedule_result(TargetProcess, MsgToPush, Codec, Origin, Opts) ->
                 hb_ao:resolve(
                     {as, <<"process@1.0">>, TargetProcess},
                     ScheduleReq,
-                    Opts#{ cache_control => <<"always">> }
+                    Opts#{ <<"cache-control">> => <<"always">> }
                 )
         end,
     ?event(push, {push_sched_result, {status, ErlStatus}, {response, Res}}, Opts),
@@ -605,7 +605,7 @@ augment_message(Origin, ToSched, Opts) ->
                 <<"from-scheduler">> => maps:get(<<"from-scheduler">>, Origin),
                 <<"from-authority">> => maps:get(<<"from-authority">>, Origin)
             },
-            Opts#{ hashpath => ignore }
+            Opts#{ <<"hashpath">> => ignore }
         )
     ).
 

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -842,11 +842,11 @@ test_push_as_identity() ->
     Opts = #{
         <<"priv-wallet">> => DefaultWallet,
         <<"cache-control">> => <<"always">>,
-        store => TestStore,
+        <<"store">> => TestStore,
         <<"identities">> => #{
             SchedulingID => #{
                 <<"priv-wallet">> => SchedulingWallet,
-                store => [hb_test_utils:test_store(hb_store_lmdb)]
+                <<"store">> => [hb_test_utils:test_store(hb_store_lmdb)]
             },
             ComputeID => #{
                 <<"priv-wallet">> => ComputeWallet
@@ -858,8 +858,8 @@ test_push_as_identity() ->
     Base =
         dev_process_test_vectors:aos_process(
             Opts#{
-                authority => ComputeID,
-                scheduler => [SchedulingID, ComputeID]
+                <<"authority">> => ComputeID,
+                <<"scheduler">> => [SchedulingID, ComputeID]
             }
         ),
     ?event({base, Base}),

--- a/src/dev_router.erl
+++ b/src/dev_router.erl
@@ -164,7 +164,7 @@ routes(M1, M2, Opts) ->
                         true ->
                             % Minimize the work performed by AO-Core to make the sort
                             % more efficient.
-                            SortOpts = Opts#{ hashpath => ignore },
+                            SortOpts = Opts#{ <<"hashpath">> => ignore },
                             NewRoutes =
                                 lists:sort(
                                     fun(X, Y) ->
@@ -173,7 +173,7 @@ routes(M1, M2, Opts) ->
                                     end,
                                     [M2|Routes]
                                 ),
-                            ok = hb_http_server:set_opts(Opts#{ routes => NewRoutes }),
+                            ok = hb_http_server:set_opts(Opts#{ <<"routes">> => NewRoutes }),
                             {ok, <<"Route added.">>};
                         false -> {error, not_authorized}
                     end;
@@ -457,7 +457,7 @@ match_routes(ToMatch, Routes, [XKey|Keys], Opts) ->
             <<"template">>,
             XM,
             #{},
-            Opts#{ hashpath => ignore }
+            Opts#{ <<"hashpath">> => ignore }
         ),
     case hb_util:template_matches(ToMatch, Template, Opts) of
         true -> XM#{ <<"reference">> => hb_path:to_binary([<<"routes">>, XKey]) };
@@ -719,7 +719,7 @@ binary_to_bignum(Bin) when ?IS_ID(Bin) ->
 
 %% @doc Preprocess a request to check if it should be relayed to a different node.
 preprocess(Base, RawReq, Opts) ->
-    Req = hb_ao:get(<<"request">>, RawReq, Opts#{ hashpath => ignore }),
+    Req = hb_ao:get(<<"request">>, RawReq, Opts#{ <<"hashpath">> => ignore }),
     ?event(debug_preprocess, {called_preprocess,Req}),
     TemplateRoutes = load_routes(Opts),
     ?event(debug_preprocess, {template_routes, TemplateRoutes}),
@@ -736,7 +736,7 @@ preprocess(Base, RawReq, Opts) ->
                             hb_ao:get(
                                 <<"body">>,
                                 RawReq,
-                                Opts#{ hashpath => ignore }
+                                Opts#{ <<"hashpath">> => ignore }
                             )
                     }};
                 <<"error">> ->
@@ -1866,7 +1866,7 @@ request_hook_reroute_to_nearest_test_parallel() ->
                     hb_http:get(
                         Node,
                         <<"/~meta@1.0/info/address">>,
-                        Opts#{ http_only_result => true }
+                        Opts#{ <<"http-only-result">> => true }
                     )
                 )
             end,

--- a/src/dev_scheduler.erl
+++ b/src/dev_scheduler.erl
@@ -88,7 +88,7 @@ next(Base, Req, Opts) ->
             hb_ao:get(
                 <<"at-slot">>,
                 Base,
-                Opts#{ hashpath => ignore }
+                Opts#{ <<"hashpath">> => ignore }
             )
         ),
     ?event(next_profiling, got_last_processed),
@@ -130,7 +130,7 @@ validate_next_slot(Base, [NextAssignment|Assignments], Lookahead, Last, Opts) ->
             hb_ao:get(
                 <<"slot">>,
                 NextAssignment,
-                Opts#{ hashpath => ignore }
+                Opts#{ <<"hashpath">> => ignore }
             )
         )
         catch
@@ -229,7 +229,7 @@ find_next_assignment(Base, Req, _Schedule, LastSlot, Opts) ->
                         <<"path">> => <<"schedule/assignments">>,
                         <<"from">> => LastSlot
                     },
-                    Opts#{ scheduler_follow_redirects => true }
+                    Opts#{ <<"scheduler-follow-redirects">> => true }
                 ),
             % Convert the assignments to an ordered list of messages,
             % after removing all keys before the last processed slot.
@@ -538,7 +538,7 @@ find_server(ProcID, Base, ToSched, Opts) ->
                                 _ -> [{ToSched, <<"scheduler-location">>}]
                             end,
                             not_found,
-                            Opts#{ hashpath => ignore }
+                            Opts#{ <<"hashpath">> => ignore }
                         ),
                     ?event({sched_loc, SchedLoc}),
                     case SchedLoc of
@@ -574,7 +574,7 @@ find_process_message(ProcID, Base, ToSched, Opts) ->
             <<"process">>,
             Base,
             not_found,
-            Opts#{ hashpath => ignore }
+            Opts#{ <<"hashpath">> => ignore }
         ),
     case MaybeProcessMsg of
         not_found ->
@@ -760,7 +760,7 @@ remote_slot(<<"ao.TN.1">>, ProcID, Node, Opts) ->
     % `/processes/procID/latest' to get the current slot.
     Path = << ProcID/binary, "/latest?process-id=", ProcID/binary>>,
     ?event({getting_slot_from_ao_core_remote, {path, {string, Path}}}),
-    case hb_http:get(Node, Path, Opts#{ http_client => httpc }) of
+    case hb_http:get(Node, Path, Opts#{ <<"http-client">> => httpc }) of
         {ok, Res} ->
             ?event({remote_slot_result, {res, Res}}),
             case hb_util:int(hb_ao:get(<<"status">>, Res, 200, Opts)) of
@@ -962,7 +962,7 @@ do_get_remote_schedule(ProcID, LocalAssignments, From, To, Redirect, Opts) ->
                 >>
         end,
     ?event({getting_remote_schedule, {node, {string, Node}}, {path, {string, Path}}}),
-    case hb_http:get(Node, Path, Opts#{ http_client => httpc, protocol => http2 }) of
+    case hb_http:get(Node, Path, Opts#{ <<"http-client">> => httpc, <<"protocol">> => http2 }) of
         {ok, Res} ->
             case hb_util:int(hb_ao:get(<<"status">>, Res, 200, Opts)) of
                 200 ->
@@ -978,7 +978,7 @@ do_get_remote_schedule(ProcID, LocalAssignments, From, To, Redirect, Opts) ->
                                             <<"body">>,
                                             Res,
                                             <<"">>,
-                                            Opts#{ hashpath => ignore }
+                                            Opts#{ <<"hashpath">> => ignore }
                                         )
                                     ),
                                 cache_remote_schedule(Variant, ProcID, JSONRes, Opts),
@@ -1062,7 +1062,7 @@ cache_remote_schedule(<<"ao.N.1">>, ProcID, Schedule, Opts) ->
         hb_ao:get(
             <<"assignments">>,
             Schedule,
-            Opts#{ hashpath => ignore }
+            Opts#{ <<"hashpath">> => ignore }
         ),
     cache_remote_schedule(common, ProcID, Assignments, Opts);
 cache_remote_schedule(_, _ProcID, Schedule, Opts) ->
@@ -1139,7 +1139,7 @@ filter_json_assignments(JSONRes, To, From, Opts) ->
     JSONRes#{ <<"edges">> => Filtered }.
 
 post_remote_schedule(RawProcID, Redirect, OnlyCommitted, Opts) ->
-    RemoteOpts = Opts#{ http_client => httpc },
+    RemoteOpts = Opts#{ <<"http-client">> => httpc },
     ProcID = without_hint(RawProcID),
     Location = hb_ao:get(<<"location">>, Redirect, Opts),
     Parsed = uri_string:parse(Location),
@@ -1239,7 +1239,7 @@ post_legacy_schedule(ProcID, OnlyCommitted, Node, Opts) ->
                 {path, {string, P}},
                 {process_id, {string, ProcID}}
             }),
-            LegacyOpts = Opts#{ protocol => http2 },
+            LegacyOpts = Opts#{ <<"protocol">> => http2 },
             case hb_http:post(Node, PostMsg, LegacyOpts) of
                 {ok, PostRes} ->
                     ?event({remote_schedule_result, PostRes}),
@@ -1304,7 +1304,7 @@ find_target_id(Base, Req, ToSched, Opts) ->
             end
     end.
 find_target_id(Base, Req, Opts) ->
-    TempOpts = Opts#{ hashpath => ignore },
+    TempOpts = Opts#{ <<"hashpath">> => ignore },
     Res = case hb_ao:resolve(Req, <<"target">>, TempOpts) of
         {ok, Target} ->
             % ID found at Req/target
@@ -1347,15 +1347,15 @@ find_message_to_schedule(Base, Req, Opts) ->
             <<"subject">>,
             Req,
             not_found,
-            Opts#{ hashpath => ignore }
+            Opts#{ <<"hashpath">> => ignore }
         ),
     case Subject of
         <<"base">> -> Base;
         <<"self">> -> Req;
         not_found ->
-            hb_ao:get(<<"body">>, Req, Req, Opts#{ hashpath => ignore });
+            hb_ao:get(<<"body">>, Req, Req, Opts#{ <<"hashpath">> => ignore });
         Subject ->
-            hb_ao:get(Subject, Req, Opts#{ hashpath => ignore })
+            hb_ao:get(Subject, Req, Opts#{ <<"hashpath">> => ignore })
     end.
 
 %% @doc Generate a `GET /schedule' response for a process.
@@ -1605,8 +1605,8 @@ http_init(Opts) ->
     start(),
     Wallet = ar_wallet:new(),
     ExtendedOpts = Opts#{
-        priv_wallet => Wallet,
-        store => [
+        <<"priv-wallet">> => Wallet,
+        <<"store">> => [
             hb_test_utils:test_store(),
             #{ <<"store-module">> => hb_store_gateway, <<"store">> => [] }
         ]
@@ -1641,7 +1641,7 @@ http_get_slot(N, PMsg) ->
         <<"path">> => <<"/~scheduler@1.0/slot">>,
         <<"method">> => <<"GET">>,
         <<"target">> => ID
-    }, #{ priv_wallet => Wallet }), #{}).
+    }, #{ <<"priv-wallet">> => Wallet }), #{}).
 
 http_get_schedule(N, PMsg, From, To) ->
     http_get_schedule(N, PMsg, From, To, <<"application/http">>).
@@ -1656,7 +1656,7 @@ http_get_schedule(N, PMsg, From, To, Format) ->
         <<"from">> => From,
         <<"to">> => To,
         <<"accept">> => Format
-    }, #{ priv_wallet => Wallet }), #{}).
+    }, #{ <<"priv-wallet">> => Wallet }), #{}).
 
 http_get_schedule_redirect_test_parallel_() ->
     {timeout, 60, fun http_get_schedule_redirect/0}.
@@ -1866,7 +1866,7 @@ single_resolution(Opts) ->
     start(),
     BenchTime = 0.25,
     Wallet = hb_opts:get(priv_wallet, hb:wallet(), Opts),
-    Base = test_process(Opts#{ priv_wallet => Wallet }),
+    Base = test_process(Opts#{ <<"priv-wallet">> => Wallet }),
     ?event({benchmark_start, ?MODULE}),
     MsgToSchedule = hb_message:commit(#{
         <<"type">> => <<"Message">>,

--- a/src/dev_scheduler_server.erl
+++ b/src/dev_scheduler_server.erl
@@ -104,8 +104,13 @@ commitment_wallets(ProcMsg, Opts) ->
     lists:filtermap(
         fun(Scheduler) ->
             case hb_opts:as(Scheduler, Opts) of
-                {ok, #{ priv_wallet := Wallet }} -> {true, Wallet};
-                _ -> false
+                {ok, SchedulerOpts} ->
+                    case hb_opts:get(priv_wallet, not_found, SchedulerOpts) of
+                        not_found -> false;
+                        Wallet -> {true, Wallet}
+                    end;
+                _ ->
+                    false
             end
         end,
         dev_scheduler:parse_schedulers(SchedulerVal)
@@ -292,7 +297,7 @@ commit_assignment(BaseAssignment, State) ->
         fun(Wallet, Assignment) ->
             hb_message:commit(
                 Assignment,
-                Opts#{ priv_wallet => Wallet },
+                Opts#{ <<"priv-wallet">> => Wallet },
                 CommittmentSpec
             )
         end,
@@ -341,11 +346,11 @@ new_proc_test() ->
     Wallet = ar_wallet:new(),
     SignedItem = hb_message:commit(
         #{ <<"data">> => <<"test">>, <<"random-key">> => rand:uniform(10000) },
-        #{ priv_wallet => Wallet }
+        #{ <<"priv-wallet">> => Wallet }
     ),
     SignedItem2 = hb_message:commit(
         #{ <<"data">> => <<"test2">> },
-        #{ priv_wallet => Wallet }
+        #{ <<"priv-wallet">> => Wallet }
     ),
     SignedItem3 = hb_message:commit(
         #{
@@ -353,7 +358,7 @@ new_proc_test() ->
             <<"deep-key">> =>
                 #{ <<"data">> => <<"test3">> }
         },
-        #{ priv_wallet => Wallet }
+        #{ <<"priv-wallet">> => Wallet }
     ),
     dev_scheduler_registry:find(hb_message:id(SignedItem, all), SignedItem),
     schedule(ID = hb_message:id(SignedItem, all), SignedItem),

--- a/src/dev_secret.erl
+++ b/src/dev_secret.erl
@@ -568,7 +568,7 @@ commit_message(Message, #{ <<"wallet">> := Key }, Opts) when is_binary(Key) ->
     commit_message(Message, ar_wallet:from_json(Key), Opts);
 commit_message(Message, #{ <<"wallet">> := Key }, Opts) ->
     ?event({committing_with_proxy, {message, Message}, {wallet, Key}}),
-    hb_message:commit(Message, Opts#{ priv_wallet => Key }).
+    hb_message:commit(Message, Opts#{ <<"priv-wallet">> => Key }).
 
 %% @doc Export wallets from a request. The request should contain a source of
 %% wallets (cookies, keys, or wallet names), or a specific list/name of a
@@ -678,7 +678,7 @@ store_wallet(in_memory, KeyID, Details, Opts) ->
     UpdatedWallets = CurrentWallets#{ KeyID => Details },
     ?event({wallet_store, {updated_wallets, UpdatedWallets}}),
     % Update the node's options with the new wallets.
-    hb_http_server:set_opts(Opts#{ priv_wallet_hosted => UpdatedWallets }),
+    hb_http_server:set_opts(Opts#{ <<"priv-wallet-hosted">> => UpdatedWallets }),
     ok;
 store_wallet(non_volatile, KeyID, Details, Opts) ->
     % Find the private store of the node.

--- a/src/dev_simple_pay.erl
+++ b/src/dev_simple_pay.erl
@@ -27,7 +27,7 @@
 %% @doc Estimate the cost of the request, using the rules outlined in the
 %% moduledoc.
 estimate(_Base, EstimateReq, NodeMsg) ->
-    Req = hb_ao:get(<<"request">>, EstimateReq, NodeMsg#{ hashpath => ignore }),
+    Req = hb_ao:get(<<"request">>, EstimateReq, NodeMsg#{ <<"hashpath">> => ignore }),
     case is_operator(Req, NodeMsg) of
         true ->
             ?event(payment,
@@ -95,7 +95,7 @@ apply_price(Seq, _) ->
 %% @doc Calculate the price of a request based on the offered routes, if
 %% applicable.
 price_from_routes(UserRequest, NodeMsg) ->
-    RouterOpts = hb_opts:get(<<"router_opts">>, #{}, NodeMsg),
+    RouterOpts = hb_opts:get(<<"router-opts">>, #{}, NodeMsg),
     Routes = hb_maps:get(<<"offered">>, RouterOpts, [], NodeMsg),
     MatchRes =
         dev_router:match(
@@ -126,7 +126,7 @@ price_from_count(Messages, NodeMsg) ->
 %% will be
 charge(_, RawReq, NodeMsg) ->
     ?event(payment, {charge, RawReq}),
-    Req = hb_ao:get(<<"request">>, RawReq, NodeMsg#{ hashpath => ignore }),
+    Req = hb_ao:get(<<"request">>, RawReq, NodeMsg#{ <<"hashpath">> => ignore }),
     case hb_message:signers(Req, NodeMsg) of
         [] ->
             ?event(payment, {charge, {error, <<"No signers">>}}),
@@ -180,7 +180,7 @@ charge(_, RawReq, NodeMsg) ->
 %% @doc Get the balance of a user in the ledger.
 balance(_, RawReq, NodeMsg) ->
     Target =
-        case hb_ao:get(<<"request">>, RawReq, NodeMsg#{ hashpath => ignore }) of
+        case hb_ao:get(<<"request">>, RawReq, NodeMsg#{ <<"hashpath">> => ignore }) of
             not_found ->
                 case hb_message:signers(RawReq, NodeMsg) of
                     [] -> hb_ao:get(<<"target">>, RawReq, undefined, NodeMsg);
@@ -204,7 +204,7 @@ set_balance(Signer, Amount, NodeMsg) ->
     hb_http_server:set_opts(
         #{},
         NewMsg = NodeMsg#{
-            simple_pay_ledger =>
+            <<"simple-pay-ledger">> =>
                 hb_ao:set(
                     Ledger,
                     NormSigner,
@@ -279,10 +279,10 @@ test_opts(Ledger) ->
         Address,
         Wallet,
         #{
-            simple_pay_ledger => Ledger,
-            simple_pay_price => 10,
-            operator => Address,
-            on => #{
+            <<"simple-pay-ledger">> => Ledger,
+            <<"simple-pay-price">> => 10,
+            <<"operator">> => Address,
+            <<"on">> => #{
                 <<"request">> => ProcessorMsg,
                 <<"response">> => ProcessorMsg
             }
@@ -301,7 +301,7 @@ get_balance_and_top_up_test() ->
             Node,
             Req = hb_message:commit(
                 #{<<"path">> => <<"/~simple-pay@1.0/balance">>},
-                Opts#{ priv_wallet => ClientWallet }
+                Opts#{ <<"priv-wallet">> => ClientWallet }
             ),
             Opts
         ),
@@ -319,7 +319,7 @@ get_balance_and_top_up_test() ->
                     <<"amount">> => 100,
                     <<"recipient">> => ClientAddress
                 },
-                Opts#{ priv_wallet => HostWallet }
+                Opts#{ <<"priv-wallet">> => HostWallet }
             ),
             Opts
         ),
@@ -332,7 +332,7 @@ get_balance_and_top_up_test() ->
             Node,
             hb_message:commit(
                 #{<<"path">> => <<"/~p4@1.0/balance">>},
-                Opts#{ priv_wallet => ClientWallet }
+                Opts#{ <<"priv-wallet">> => ClientWallet }
             ),
             Opts
         ),
@@ -341,7 +341,7 @@ get_balance_and_top_up_test() ->
 apply_price_test() ->
     ClientWallet = ar_wallet:new(),
     ClientAddress = hb_util:human_id(ar_wallet:to_address(ClientWallet)),
-    ClientOpts = #{ priv_wallet => ClientWallet },
+    ClientOpts = #{ <<"priv-wallet">> => ClientWallet },
     {HostAddress, _HostWallet, Opts} =
         test_opts(#{ ClientAddress => 100 }),
     Node = hb_http_server:start_node(Opts),
@@ -366,7 +366,7 @@ apply_price_test() ->
             Node,
             hb_message:commit(
                 #{ <<"path">> => <<"/~p4@1.0/balance">> },
-                Opts#{ priv_wallet => ClientWallet }
+                Opts#{ <<"priv-wallet">> => ClientWallet }
             ),
             Opts
         ),

--- a/src/dev_snp.erl
+++ b/src/dev_snp.erl
@@ -479,8 +479,12 @@ is_debug(Report) ->
 -spec execute_is_trusted(M1 :: term(), Msg :: map(), NodeOpts :: map()) ->
     {ok, boolean()}.
 execute_is_trusted(_M1, Msg, NodeOpts) ->
-    FilteredLocalHashes = get_filtered_local_hashes(Msg, NodeOpts),
-    TrustedSoftware = hb_opts:get(snp_trusted, [#{}], NodeOpts),
+    FilteredLocalHashes = hb_opts:canonicalize(get_filtered_local_hashes(Msg, NodeOpts)),
+    TrustedSoftware =
+        lists:map(
+            fun hb_opts:canonicalize/1,
+            hb_opts:get(snp_trusted, [#{}], NodeOpts)
+        ),
     ?event({trusted_software, {explicit, TrustedSoftware}}),
     IsTrusted = 
         is_software_trusted(
@@ -521,7 +525,10 @@ get_filtered_local_hashes(Msg, NodeOpts) ->
 -spec get_enforced_keys(NodeOpts :: map()) -> [binary()].
 get_enforced_keys(NodeOpts) ->
     lists:map(
-        fun atom_to_binary/1,
+        fun(Key) ->
+            [CanonicalKey] = maps:keys(hb_opts:canonicalize(#{ Key => true })),
+            CanonicalKey
+        end,
         hb_opts:get(snp_enforced_keys, ?COMMITTED_PARAMETERS, NodeOpts)
     ).
 

--- a/src/dev_snp.erl
+++ b/src/dev_snp.erl
@@ -208,7 +208,13 @@ extract_and_normalize_message(M2, NodeOpts) ->
         % Search for a `body' key in the message, and if found use it as the source
         % of the report. If not found, use the message itself as the source.
         ?event({node_opts, {explicit, NodeOpts}}),
-        RawMsg = hb_ao:get(<<"body">>, M2, M2, NodeOpts#{ hashpath => ignore }),
+        RawMsg =
+            hb_ao:get(
+                <<"body">>,
+                M2,
+                M2,
+                NodeOpts#{ <<"hashpath">> => ignore }
+            ),
         ?event({msg, {explicit, RawMsg}}),
         MsgWithJSONReport =
             hb_util:ok(
@@ -272,7 +278,7 @@ extract_and_normalize_message(M2, NodeOpts) ->
 -spec extract_node_message_id(Msg :: map(), NodeOpts :: map()) ->
     {ok, binary()} | {error, missing_node_msg_id}.
 extract_node_message_id(Msg, NodeOpts) ->
-    case {hb_ao:get(<<"node-message">>, Msg, NodeOpts#{ hashpath => ignore }),
+    case {hb_ao:get(<<"node-message">>, Msg, NodeOpts#{ <<"hashpath">> => ignore }),
           hb_ao:get(<<"node-message-id">>, Msg, NodeOpts)} of
         {undefined, undefined} ->
             {error, missing_node_msg_id};
@@ -525,10 +531,7 @@ get_filtered_local_hashes(Msg, NodeOpts) ->
 -spec get_enforced_keys(NodeOpts :: map()) -> [binary()].
 get_enforced_keys(NodeOpts) ->
     lists:map(
-        fun(Key) ->
-            [CanonicalKey] = maps:keys(hb_opts:canonicalize(#{ Key => true })),
-            CanonicalKey
-        end,
+        fun hb_opts:canonical_key/1,
         hb_opts:get(snp_enforced_keys, ?COMMITTED_PARAMETERS, NodeOpts)
     ).
 

--- a/src/dev_whois.erl
+++ b/src/dev_whois.erl
@@ -30,7 +30,7 @@ ensure_host(Opts) ->
             case bootstrap_node_echo(Opts) of
                 {ok, Host} ->
                     % Set the host information in the persisted node message.
-                    hb_http_server:set_opts(NewOpts = Opts#{ node_host => Host }),
+                    hb_http_server:set_opts(NewOpts = Opts#{ <<"node-host">> => Host }),
                     {ok, NewOpts};
                 Error ->
                     Error
@@ -53,14 +53,14 @@ bootstrap_node_echo(Opts) ->
 find_self_test() ->
     BoostrapNode =
         hb_http_server:start_node(#{
-            priv_wallet => ar_wallet:new()
+            <<"priv-wallet">> => ar_wallet:new()
         }),
     PeerNode =
         hb_http_server:start_node(#{
-            port => Port = rand:uniform(40000) + 10000,
-            priv_wallet => ar_wallet:new(),
-            host_bootstrap_node => BoostrapNode,
-            http_client => httpc
+            <<"port">> => Port = rand:uniform(40000) + 10000,
+            <<"priv-wallet">> => ar_wallet:new(),
+            <<"host-bootstrap-node">> => BoostrapNode,
+            <<"http-client">> => httpc
         }),
     ?event({nodes, {peer, PeerNode}, {bootstrap, BoostrapNode}}),
     {ok, ReceivedPeerHost} = hb_http:get(PeerNode, <<"/~whois@1.0/node">>, #{}),

--- a/src/hb.erl
+++ b/src/hb.erl
@@ -115,7 +115,7 @@ top() -> not_available.
 start_mainnet() ->
     start_mainnet(hb_opts:get(port)).
 start_mainnet(Port) when is_integer(Port) ->
-    start_mainnet(#{ port => Port });
+    start_mainnet(#{ <<"port">> => Port });
 start_mainnet(Opts) ->
     application:ensure_all_started([
         kernel,
@@ -132,10 +132,14 @@ start_mainnet(Opts) ->
     hb_http_server:start_node(
         FinalOpts =
             BaseOpts#{
-                store => #{ <<"store-module">> => hb_store_fs, <<"name">> => <<"cache-mainnet">> },
-                priv_wallet => Wallet
+                <<"store">> => #{
+                    <<"store-module">> => hb_store_fs,
+                    <<"name">> => <<"cache-mainnet">>
+                },
+                <<"priv-wallet">> => Wallet
             }
     ),
+    Port = hb_opts:get(port, undefined, FinalOpts),
     Address =
         case hb_opts:get(address, no_address, FinalOpts) of
             no_address -> <<"[ !!! no-address !!! ]">>;
@@ -144,9 +148,9 @@ start_mainnet(Opts) ->
     io:format(
         "Started mainnet node at http://localhost:~p~n"
         "Operator: ~s~n",
-        [hb_maps:get(port, Opts, undefined, Opts), Address]
+        [Port, Address]
     ),
-    <<"http://localhost:", (integer_to_binary(hb_maps:get(port, Opts, undefined, Opts)))/binary>>.
+    <<"http://localhost:", (integer_to_binary(Port))/binary>>.
 
 %%% @doc Start a server with a `simple-pay@1.0' pre-processor.
 start_simple_pay() ->
@@ -155,7 +159,7 @@ start_simple_pay(Addr) ->
     rand:seed(default),
     start_simple_pay(Addr, 10000 + rand:uniform(50000)).
 start_simple_pay(Addr, Port) ->
-    do_start_simple_pay(#{ port => Port, operator => Addr }).
+    do_start_simple_pay(#{ <<"port">> => Port, <<"operator">> => Addr }).
 
 do_start_simple_pay(Opts) ->
     application:ensure_all_started([
@@ -168,7 +172,7 @@ do_start_simple_pay(Opts) ->
         gun,
         os_mon
     ]),
-    Port = hb_maps:get(port, Opts, undefined, Opts),
+    Port = hb_opts:get(port, undefined, Opts),
     Processor =
         #{
             <<"device">> => <<"p4@1.0">>,
@@ -177,7 +181,7 @@ do_start_simple_pay(Opts) ->
         },
     hb_http_server:start_node(
         Opts#{
-            on => #{
+            <<"on">> => #{
                 <<"request">> => Processor,
                 <<"response">> => Processor
             }

--- a/src/hb_ao.erl
+++ b/src/hb_ao.erl
@@ -108,8 +108,7 @@
 -define(TEMP_OPTS,
     [
         <<"add-key">>, <<"force-message">>, <<"cache-control">>,
-        <<"spawn-worker">>,
-        add_key, force_message, cache_control, spawn_worker
+        <<"spawn-worker">>
     ]
 ).
 
@@ -330,7 +329,7 @@ resolve_stage(1, Base, {resolve, Subres}, Opts) ->
     ?event(debug_ao_core, {stage, 1, subresolving_request_message, {subres, Subres}}, Opts),
     % We make sure to unset the `force_message' option so that if the subresolution
     % returns a literal, the rest of `resolve' will normalize it to a path.
-    case resolve_many(Subres, maps:without([<<"force-message">>, force_message], Opts)) of
+    case resolve_many(Subres, maps:without([<<"force-message">>], Opts)) of
         {ok, Req} ->
             ?event(
                 ao_core,
@@ -735,27 +734,17 @@ subresolve(RawBase, DevID, Req, Opts) ->
         case DevID of
             undefined -> Base;
             _ ->
-                case hb_maps:get(<<"device">>, Base, undefined, Opts) of
-                    DevID -> Base;
-                    _ ->
-                        set(
-                            Base,
-                            <<"device">>,
-                            DevID,
-                            hb_maps:without(?TEMP_OPTS, Opts, Opts)
-                        )
-                end
+                set(
+                    Base,
+                    <<"device">>,
+                    DevID,
+                    hb_maps:without(?TEMP_OPTS, Opts, Opts)
+                )
         end,
     % If there is no path but there are elements to the request, we set these on
     % the base message. If there is a path, we do not modify the base message 
     % and instead apply the request message directly.
     case hb_path:from_message(request, Req, Opts) of
-        undefined when Req =:= RawBase, Base2 =:= Base ->
-            ?event(subresolution,
-                {subresolve_unmodified_base, Base2},
-                Opts
-            ),
-            {ok, Base2};
         undefined ->
             Base3 =
                 case map_size(hb_maps:without([<<"path">>], Req, Opts)) of
@@ -1241,14 +1230,16 @@ do_normalize_keys(Map, Opts) ->
 %% @doc The execution options that are used internally by this module
 %% when calling itself.
 internal_opts(Opts) ->
-    BaseOpts = hb_maps:without(?TEMP_OPTS, Opts, Opts),
-    hb_maps:merge(BaseOpts, #{
-        <<"topic">> => hb_opts:get(topic, ao_internal, Opts),
-        <<"hashpath">> => ignore,
-        <<"cache-control">> => [<<"no-cache">>, <<"no-store">>],
-        <<"spawn-worker">> => false,
-        <<"await-inprogress">> => false
-    }).
+    hb_maps:merge(
+        hb_maps:without(?TEMP_OPTS, Opts, Opts),
+        #{
+            <<"topic">> => hb_opts:get(topic, ao_internal, Opts),
+            <<"hashpath">> => ignore,
+            <<"cache-control">> => [<<"no-cache">>, <<"no-store">>],
+            <<"spawn-worker">> => false,
+            <<"await-inprogress">> => false
+        }
+    ).
 
 %% @doc Return the node message that should be used in order to perform
 %% recursive executions.
@@ -1258,22 +1249,13 @@ execution_opts(Opts) ->
 	Opts1 =
         hb_maps:remove(
             <<"trace">>,
-            hb_maps:remove(
-                trace,
-                hb_maps:without(?TEMP_OPTS, Opts, Opts),
-                Opts
-            ),
+            hb_maps:without(?TEMP_OPTS, Opts, Opts),
             Opts
         ),
     % Unless the user has explicitly requested recursive spawning, we
     % unset the spawn_worker option so that we do not spawn a new worker
     % for every resulting execution.
-    case hb_opts:get(spawn_worker, false, Opts1) of
-        recursive -> Opts1;
-        _ ->
-            hb_maps:remove(
-                <<"spawn-worker">>,
-                hb_maps:remove(spawn_worker, Opts1, Opts),
-                Opts
-            )
+    case hb_opts:get(spawn_worker, false, Opts) of
+        recursive -> Opts1#{ <<"spawn-worker">> => recursive };
+        _ -> Opts1
     end.

--- a/src/hb_ao.erl
+++ b/src/hb_ao.erl
@@ -105,7 +105,13 @@
 -export([deep_set/4]).
 -include("include/hb.hrl").
 
--define(TEMP_OPTS, [add_key, force_message, cache_control, spawn_worker]).
+-define(TEMP_OPTS,
+    [
+        <<"add-key">>, <<"force-message">>, <<"cache-control">>,
+        <<"spawn-worker">>,
+        add_key, force_message, cache_control, spawn_worker
+    ]
+).
 
 %% @doc Get the value of a message's key by running its associated device
 %% function. Optionally, takes options that control the runtime environment. 
@@ -324,7 +330,7 @@ resolve_stage(1, Base, {resolve, Subres}, Opts) ->
     ?event(debug_ao_core, {stage, 1, subresolving_request_message, {subres, Subres}}, Opts),
     % We make sure to unset the `force_message' option so that if the subresolution
     % returns a literal, the rest of `resolve' will normalize it to a path.
-    case resolve_many(Subres, maps:without([force_message], Opts)) of
+    case resolve_many(Subres, maps:without([<<"force-message">>, force_message], Opts)) of
         {ok, Req} ->
             ?event(
                 ao_core,
@@ -494,7 +500,7 @@ resolve_stage(5, Base, Req, ExecName, Opts) ->
 			{
 				Func,
 				Opts#{
-					add_key =>
+					<<"add-key">> =>
 						case Status of
 							add_key -> Key;
 							_ -> false
@@ -532,7 +538,7 @@ resolve_stage(6, Func, Base, Req, ExecName, Opts) ->
 	% Execution.
     ExecOpts = execution_opts(Opts),
 	Args =
-		case hb_maps:get(add_key, Opts, false, Opts) of
+		case hb_opts:get(add_key, false, Opts) of
 			false -> [Base, Req, ExecOpts];
 			Key -> [Key, Base, Req, ExecOpts]
 		end,
@@ -596,7 +602,14 @@ resolve_stage(6, Func, Base, Req, ExecName, Opts) ->
         Opts
     ),
     resolve_stage(7, Base, Req, Res, ExecName, Opts);
-resolve_stage(7, Base, Req, {St, Res}, ExecName, Opts = #{ on := On = #{ <<"step">> := _ }}) ->
+resolve_stage(
+    7,
+    Base,
+    Req,
+    {St, Res},
+    ExecName,
+    Opts = #{ <<"on">> := On = #{ <<"step">> := _ }}
+) ->
     ?event(debug_ao_core, {stage, 7, ExecName, executing_step_hook, {on, On}}, Opts),
     % If the `step' hook is defined, we execute it. Note: This function clause
     % matches directly on the `on' key of the `Opts' map. This is in order to
@@ -638,7 +651,7 @@ resolve_stage(9, Base, Req, {ok, Res}, ExecName, Opts) when is_map(Res) ->
     % Cryptographic linking. Now that we have generated the result, we
     % need to cryptographically link the output to its input via a hashpath.
     resolve_stage(10, Base, Req,
-        case hb_opts:get(hashpath, update, Opts#{ only => local }) of
+        case hb_opts:get(hashpath, update, Opts#{ <<"only">> => local }) of
             update ->
                 NormRes = Res,
                 Priv = hb_private:from_message(NormRes),
@@ -694,7 +707,7 @@ resolve_stage(11, Base, Req, Res, ExecName, Opts) ->
 resolve_stage(12, _Base, _Req, {ok, Res} = Res, ExecName, Opts) ->
     ?event(debug_ao_core, {stage, 12, ExecName, maybe_spawn_worker}, Opts),
     % Check if we should fork out a new worker process for the current execution
-    case {is_map(Res), hb_opts:get(spawn_worker, false, Opts#{ prefer => local })} of
+    case {is_map(Res), hb_opts:get(spawn_worker, false, Opts#{ <<"prefer">> => local })} of
         {A, B} when (A == false) or (B == false) ->
             Res;
         {_, _} ->
@@ -722,17 +735,27 @@ subresolve(RawBase, DevID, Req, Opts) ->
         case DevID of
             undefined -> Base;
             _ ->
-                set(
-                    Base,
-                    <<"device">>,
-                    DevID,
-                    hb_maps:without(?TEMP_OPTS, Opts, Opts)
-                )
+                case hb_maps:get(<<"device">>, Base, undefined, Opts) of
+                    DevID -> Base;
+                    _ ->
+                        set(
+                            Base,
+                            <<"device">>,
+                            DevID,
+                            hb_maps:without(?TEMP_OPTS, Opts, Opts)
+                        )
+                end
         end,
     % If there is no path but there are elements to the request, we set these on
     % the base message. If there is a path, we do not modify the base message 
     % and instead apply the request message directly.
     case hb_path:from_message(request, Req, Opts) of
+        undefined when Req =:= RawBase, Base2 =:= Base ->
+            ?event(subresolution,
+                {subresolve_unmodified_base, Base2},
+                Opts
+            ),
+            {ok, Base2};
         undefined ->
             Base3 =
                 case map_size(hb_maps:without([<<"path">>], Req, Opts)) of
@@ -741,7 +764,7 @@ subresolve(RawBase, DevID, Req, Opts) ->
                         set(
 							Base2,
 							set(Req, <<"path">>, unset, Opts),
-							Opts#{ force_message => false }
+							Opts#{ <<"force-message">> => false }
 						)
                 end,
             ?event(subresolution,
@@ -947,7 +970,7 @@ get(Path, {as, Device, Msg}, Default, Opts) ->
         Opts
     );
 get(Path, Msg, Default, Opts) ->
-	case resolve(Msg, #{ <<"path">> => Path }, Opts#{ spawn_worker => false }) of
+	case resolve(Msg, #{ <<"path">> => Path }, Opts#{ <<"spawn-worker">> => false }) of
 		{ok, Value} -> Value;
 		{error, _} -> Default
 	end.
@@ -1218,12 +1241,13 @@ do_normalize_keys(Map, Opts) ->
 %% @doc The execution options that are used internally by this module
 %% when calling itself.
 internal_opts(Opts) ->
-    hb_maps:merge(Opts, #{
-        topic => hb_opts:get(topic, ao_internal, Opts),
-        hashpath => ignore,
-        cache_control => [<<"no-cache">>, <<"no-store">>],
-        spawn_worker => false,
-        await_inprogress => false
+    BaseOpts = hb_maps:without(?TEMP_OPTS, Opts, Opts),
+    hb_maps:merge(BaseOpts, #{
+        <<"topic">> => hb_opts:get(topic, ao_internal, Opts),
+        <<"hashpath">> => ignore,
+        <<"cache-control">> => [<<"no-cache">>, <<"no-store">>],
+        <<"spawn-worker">> => false,
+        <<"await-inprogress">> => false
     }).
 
 %% @doc Return the node message that should be used in order to perform
@@ -1231,11 +1255,25 @@ internal_opts(Opts) ->
 execution_opts(Opts) ->
 	% First, determine the arguments to pass to the function.
 	% While calculating the arguments we unset the add_key option.
-	Opts1 = hb_maps:remove(trace, hb_maps:without(?TEMP_OPTS, Opts, Opts), Opts),
+	Opts1 =
+        hb_maps:remove(
+            <<"trace">>,
+            hb_maps:remove(
+                trace,
+                hb_maps:without(?TEMP_OPTS, Opts, Opts),
+                Opts
+            ),
+            Opts
+        ),
     % Unless the user has explicitly requested recursive spawning, we
     % unset the spawn_worker option so that we do not spawn a new worker
     % for every resulting execution.
-    case hb_maps:get(spawn_worker, Opts1, false, Opts) of
+    case hb_opts:get(spawn_worker, false, Opts1) of
         recursive -> Opts1;
-        _ -> hb_maps:remove(spawn_worker, Opts1, Opts)
+        _ ->
+            hb_maps:remove(
+                <<"spawn-worker">>,
+                hb_maps:remove(spawn_worker, Opts1, Opts),
+                Opts
+            )
     end.

--- a/src/hb_ao_test_vectors.erl
+++ b/src/hb_ao_test_vectors.erl
@@ -122,15 +122,15 @@ test_opts() ->
         #{
             name => normal,
             desc => "Default opts",
-            opts => #{ store => hb_test_utils:test_store() },
+            opts => #{ <<"store">> => hb_test_utils:test_store() },
             skip => []
         },
         #{
             name => without_hashpath,
             desc => "Default without hashpath",
             opts => #{
-                hashpath => ignore,
-                store => hb_test_utils:test_store()
+                <<"hashpath">> => ignore,
+                <<"store">> => hb_test_utils:test_store()
             },
             skip => []
         },
@@ -138,10 +138,10 @@ test_opts() ->
             name => no_cache,
             desc => "No cache read or write",
             opts => #{
-                hashpath => ignore,
-                cache_control => [<<"no-cache">>, <<"no-store">>],
-                spawn_worker => false,
-                store => hb_test_utils:test_store()
+                <<"hashpath">> => ignore,
+                <<"cache-control">> => [<<"no-cache">>, <<"no-store">>],
+                <<"spawn-worker">> => false,
+                <<"store">> => hb_test_utils:test_store()
             },
             skip => [load_as]
         },
@@ -149,10 +149,10 @@ test_opts() ->
             name => only_store,
             desc => "Store, don't read",
             opts => #{
-                hashpath => update,
-                cache_control => [<<"no-cache">>],
-                spawn_worker => false,
-                store => CachedExecStore
+                <<"hashpath">> => update,
+                <<"cache-control">> => [<<"no-cache">>],
+                <<"spawn-worker">> => false,
+                <<"store">> => CachedExecStore
             },
             skip => [
                 denormalized_device_name,
@@ -165,10 +165,10 @@ test_opts() ->
             name => only_if_cached,
             desc => "Only read, don't exec",
             opts => #{
-                hashpath => ignore,
-                cache_control => [<<"only-if-cached">>],
-                spawn_worker => false,
-                store => CachedExecStore
+                <<"hashpath">> => ignore,
+                <<"cache-control">> => [<<"only-if-cached">>],
+                <<"spawn-worker">> => false,
+                <<"store">> => CachedExecStore
             },
             skip => [
                 % Skip test with locally defined device, amongst others.

--- a/src/hb_ao_test_vectors.erl
+++ b/src/hb_ao_test_vectors.erl
@@ -965,7 +965,7 @@ step_hook_test(InitOpts) ->
     Ref = make_ref(),
     Opts =
         InitOpts#{
-            on =>
+            <<"on">> =>
                 #{
                     <<"step">> =>
                         #{

--- a/src/hb_http.erl
+++ b/src/hb_http.erl
@@ -42,7 +42,7 @@ post(Node, Message, Opts) ->
             <<"path">>,
             Message,
             <<"/">>,
-            Opts#{ topic => ao_internal }
+            Opts#{ <<"topic">> => ao_internal }
         ),
         Message,
         Opts
@@ -676,7 +676,7 @@ encode_reply(Status, TABMReq, Message, Opts) ->
                     Message,
                     tabm,
                     <<"structured@1.0">>,
-                    Opts#{ topic => ao_internal }
+                    Opts#{ <<"topic">> => ao_internal }
                 ),
             {ok, EncMessage} =
                 dev_codec_httpsig:to(
@@ -727,7 +727,7 @@ encode_reply(Status, TABMReq, Message, Opts) ->
                                 )
                         },
                         <<"structured@1.0">>,
-                        Opts#{ topic => ao_internal }
+                        Opts#{ <<"topic">> => ao_internal }
                     )
                 )
             };
@@ -760,7 +760,7 @@ encode_reply(Status, TABMReq, Message, Opts) ->
                     Message,
                     #{ <<"device">> => Codec, <<"bundle">> => AcceptBundle },
                     <<"structured@1.0">>,
-                    Opts#{ topic => ao_internal }
+                    Opts#{ <<"topic">> => ao_internal }
                 )
             }
     end.
@@ -833,11 +833,11 @@ default_codec(Opts) ->
 codec_to_content_type(Codec, Opts) ->
     FastOpts =
         Opts#{
-            hashpath => ignore,
-            cache_control => [<<"no-cache">>, <<"no-store">>],
-            cache_lookup_hueristics => false,
-            load_remote_devices => false,
-            error_strategy => continue
+            <<"hashpath">> => ignore,
+            <<"cache-control">> => [<<"no-cache">>, <<"no-store">>],
+            <<"cache-lookup-hueristics">> => false,
+            <<"load-remote-devices">> => false,
+            <<"error-strategy">> => continue
         },
     case hb_ao:get(<<"content-type">>, #{ <<"device">> => Codec }, FastOpts) of
         not_found -> undefined;
@@ -1166,7 +1166,7 @@ record_request_metric(TotalDuration, ReplyDuration, StatusCode) ->
 %%% Tests
 
 test_opts() ->
-    #{ store => hb_test_utils:test_store(), priv_wallet => hb:wallet() }.
+    #{ <<"store">> => hb_test_utils:test_store(), <<"priv-wallet">> => hb:wallet() }.
 
 simple_ao_resolve_unsigned_test() ->
     URL = hb_http_server:start_node(),
@@ -1186,7 +1186,7 @@ simple_ao_resolve_signed_test() ->
 
 nested_ao_resolve_test() ->
     URL = hb_http_server:start_node(),
-    Opts = #{ store => hb_test_utils:test_store(), priv_wallet => hb:wallet() },
+    Opts = #{ <<"store">> => hb_test_utils:test_store(), <<"priv-wallet">> => hb:wallet() },
     {ok, Res} =
         post(
             URL,
@@ -1222,7 +1222,7 @@ wasm_compute_request(ImageFile, Func, Params, ResultPath, Opts) ->
     ).
 
 run_wasm_unsigned_test() ->
-    Node = hb_http_server:start_node(#{ force_signed => false }),
+    Node = hb_http_server:start_node(#{ <<"force-signed">> => false }),
     LocalOpts = test_opts(),
     Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [3.0], LocalOpts),
     {ok, Res} = post(Node, Msg, LocalOpts),
@@ -1231,20 +1231,20 @@ run_wasm_unsigned_test() ->
 
 run_wasm_signed_test() ->
     Opts = test_opts(),
-    URL = hb_http_server:start_node(#{force_signed => true}),
+    URL = hb_http_server:start_node(#{ <<"force-signed">> => true }),
     Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [3.0], <<"">>, Opts),
     {ok, Res} = post(URL, hb_message:commit(Msg, Opts), Opts),
     ?assertEqual(6.0, hb_ao:get(<<"output/1">>, Res, Opts)).
 
 get_deep_unsigned_wasm_state_test() ->
-    URL = hb_http_server:start_node(#{force_signed => false}),
+    URL = hb_http_server:start_node(#{ <<"force-signed">> => false }),
     LocalOpts = test_opts(),
     Msg = wasm_compute_request(<<"test/test-64.wasm">>, <<"fac">>, [3.0], <<"">>, LocalOpts),
     {ok, Res} = post(URL, Msg, LocalOpts),
     ?assertEqual(6.0, hb_ao:get(<<"/output/1">>, Res, LocalOpts)).
 
 get_deep_signed_wasm_state_test() ->
-    URL = hb_http_server:start_node(#{force_signed => true}),
+    URL = hb_http_server:start_node(#{ <<"force-signed">> => true }),
     LocalOpts = test_opts(),
     Msg =
         wasm_compute_request(
@@ -1270,12 +1270,12 @@ ans104_wasm_test() ->
     ServerStore = [hb_test_utils:test_store()],
     ServerOpts =
         #{
-            force_signed => true,
-            store => ServerStore,
-            priv_wallet => ar_wallet:new()
+            <<"force-signed">> => true,
+            <<"store">> => ServerStore,
+            <<"priv-wallet">> => ar_wallet:new()
         },
     ClientStore = [hb_test_utils:test_store()],
-    ClientOpts = #{ store => ClientStore, priv_wallet => hb:wallet() },
+    ClientOpts = #{ <<"store">> => ClientStore, <<"priv-wallet">> => hb:wallet() },
     URL = hb_http_server:start_node(ServerOpts),
     {ok, Bin} = file:read_file(<<"test/test-64.wasm">>),
     Msg =
@@ -1339,7 +1339,7 @@ send_large_signed_request_test() ->
             hb_http_server:start_node(),
             <<"/node-message/short_trace_len">>,
             Req,
-            #{ http_client => gun }
+            #{ <<"http-client">> => gun }
         )
     ).
 

--- a/src/hb_http_multi.erl
+++ b/src/hb_http_multi.erl
@@ -360,7 +360,7 @@ multi(Nodes, Extra) ->
 multirequest_test_() ->
     {setup,
         fun() ->
-            #{fast => good(), slow1 => slow(500), slow2 => slow(500),
+            #{fast => good(), slow1 => slow(750), slow2 => slow(750),
               good1 => good(), good2 => good(), good3 => good()}
         end,
         fun(N) -> {timeout, 30, [
@@ -373,7 +373,7 @@ multirequest_test_() ->
                 ?assertMatch({ok, _},
                     multi([maps:get(fast, N), maps:get(slow1, N), maps:get(slow2, N)],
                         #{<<"parallel">> => true, <<"stop-after">> => true})),
-                ?assert(erlang:monotonic_time(millisecond) - T0 < 500)
+                ?assert(erlang:monotonic_time(millisecond) - T0 < 750)
             end},
             {"parallel broadcast", fun() ->
                 ?assertMatch([_, _, _],

--- a/src/hb_http_multi.erl
+++ b/src/hb_http_multi.erl
@@ -120,7 +120,7 @@ multirequest_opt(Key, Config, Message, Default, Opts) ->
             {Config, Key}
         ],
         Default,
-        Opts#{ hashpath => ignore }
+        Opts#{ <<"hashpath">> => ignore }
     ).
 
 %% @doc Check if a response is admissible, according to the configuration. First,
@@ -350,7 +350,7 @@ dead_node() ->
 
 slow_node_opts(Ms) ->
     #{test_delay => Ms,
-      on => #{<<"request">> =>
+      <<"on">> => #{<<"request">> =>
         #{<<"device">> => <<"test-device@1.0">>, <<"path">> => <<"delay">>}}}.
 
 multi(Nodes, Extra) ->
@@ -396,11 +396,13 @@ multirequest_test_() ->
 parallel_race_stops_at_first_admissible_test_() ->
     {timeout, 30, fun parallel_race_stops_at_first_admissible/0}.
 parallel_race_stops_at_first_admissible() ->
-    Delay = 500,
+    % Leave headroom for local scheduling jitter while still proving we return
+    % before the slow nodes finish.
+    Delay = 750,
     FastURL = hb_http_server:start_node(#{}),
     SlowURL1 = hb_http_server:start_node(slow_node_opts(Delay)),
     SlowURL2 = hb_http_server:start_node(slow_node_opts(Delay)),
-    Routes = maps:get(routes, hb_opts:default_message()),
+    Routes = hb_opts:get(routes, [], hb_opts:default_message()),
     [ArweaveRoute] =
         [R || R <- Routes,
             maps:get(<<"template">>, R, undefined) =:= <<"^/arweave">>,

--- a/src/hb_http_server.erl
+++ b/src/hb_http_server.erl
@@ -61,10 +61,11 @@ start() ->
     maybe_greeter(Loaded, PrivWallet),
     start(
         Loaded#{
-            priv_wallet => PrivWallet,
-            store => UpdatedStoreOpts,
-            port => hb_opts:get(port, 8734, Loaded),
-            cache_writers => [hb_util:human_id(ar_wallet:to_address(PrivWallet))]
+            <<"priv-wallet">> => PrivWallet,
+            <<"store">> => UpdatedStoreOpts,
+            <<"port">> => hb_opts:get(port, 8734, Loaded),
+            <<"cache-writers">> =>
+                [hb_util:human_id(ar_wallet:to_address(PrivWallet))]
         }
     ).
 start(Opts) ->
@@ -152,12 +153,13 @@ new_server(RawNodeMsg) ->
     RawNodeMsgWithDefaults =
         hb_maps:merge(
             hb_opts:default_message_with_env(),
-            RawNodeMsg#{ only => local }
+            hb_opts:canonicalize(RawNodeMsg#{ <<"only">> => local })
         ),
     HookMsg = #{ <<"body">> => RawNodeMsgWithDefaults },
     NodeMsg =
         case dev_hook:on(<<"start">>, HookMsg, RawNodeMsgWithDefaults) of
-            {ok, #{ <<"body">> := NodeMsgAfterHook }} -> NodeMsgAfterHook;
+            {ok, #{ <<"body">> := NodeMsgAfterHook }} ->
+                hb_opts:canonicalize(NodeMsgAfterHook);
             Unexpected ->
                 ?event(http,
                     {failed_to_start_server,
@@ -184,7 +186,7 @@ new_server(RawNodeMsg) ->
         ),
     % Put server ID into node message so it's possible to update current server
     % params.
-    NodeMsgWithID = hb_maps:put(http_server, ServerID, NodeMsg),
+    NodeMsgWithID = hb_maps:put(<<"http-server">>, ServerID, NodeMsg),
     Dispatcher = cowboy_router:compile([{'_', [{'_', ?MODULE, ServerID}]}]),
     ProtoOpts = #{
         env => #{ dispatch => Dispatcher, node_msg => NodeMsgWithID },
@@ -240,7 +242,7 @@ new_server(RawNodeMsg) ->
     % Update the node message with the actual port that was used, in the event
     % that the OS assigned a different port. This happens, for example, when we
     % use port 0.
-    set_opts(NodeMsg#{ port => Port }),
+    set_opts(NodeMsg#{ <<"port">> => Port }),
     ?event(http,
         {http_server_started,
             {listener, Listener},
@@ -304,8 +306,9 @@ http3_conn_sup_loop() ->
 
 start_http2(ServerID, ProtoOpts, NodeMsg) ->
     ?event(http, {start_http2, ServerID}),
-    MaxConnections = maps:get(max_connections, NodeMsg, 10000),
-    NumAcceptors = maps:get(num_acceptors, NodeMsg, erlang:system_info(schedulers) * 4),
+    MaxConnections = hb_opts:get(max_connections, 10000, NodeMsg),
+    NumAcceptors =
+        hb_opts:get(num_acceptors, erlang:system_info(schedulers) * 4, NodeMsg),
     TransportOpts = #{
         socket_opts => [{port, RequestedPort = hb_opts:get(port, 0, NodeMsg)}],
         max_connections => MaxConnections,
@@ -482,11 +485,12 @@ allowed_methods(Req, State) ->
 %% the `Request'. If a server reference exists, updates the Cowboy environment
 %% variable 'node_msg' with the resulting options map.
 set_opts(Opts) ->
-    case hb_opts:get(http_server, no_server_ref, Opts) of
+    CanonicalOpts = hb_opts:canonicalize(Opts),
+    case hb_opts:get(http_server, no_server_ref, CanonicalOpts) of
         no_server_ref ->
             ok;
         ServerRef ->
-            ok = cowboy:set_env(ServerRef, node_msg, Opts)
+            ok = cowboy:set_env(ServerRef, node_msg, CanonicalOpts)
     end.
 set_opts(Request, Opts) ->
     PreparedOpts =
@@ -509,16 +513,19 @@ set_opts(Request, Opts) ->
     ?event(set_opts, {merged_opts, {explicit, MergedOpts}}),
     History =
         hb_opts:get(node_history, [], Opts)
-            ++ [ hb_private:reset(maps:without([node_history], PreparedRequest)) ],
-    FinalOpts = MergedOpts#{
-        http_server => hb_opts:get(http_server, no_server, Opts),
-        node_history => History
-    },
+            ++ [hb_private:reset(maps:without([<<"node-history">>], PreparedRequest))],
+    FinalOpts =
+        hb_opts:canonicalize(
+            MergedOpts#{
+                <<"http-server">> => hb_opts:get(http_server, no_server, Opts),
+                <<"node-history">> => History
+            }
+        ),
     {set_opts(FinalOpts), FinalOpts}.
 
 %% @doc Get the node message for the current process.
 get_opts() ->
-    get_opts(#{ http_server => get(server_id) }).
+    get_opts(#{ <<"http-server">> => get(server_id) }).
 get_opts(NodeMsg) ->
     ServerRef = hb_opts:get(http_server, no_server_ref, NodeMsg),
     cowboy:get_env(ServerRef, node_msg, no_node_msg).
@@ -529,8 +536,9 @@ set_proc_server_id(ServerID) ->
 
 %% @doc Apply the default node message to the given opts map.
 set_default_opts(Opts) ->
+    CanonicalOpts = hb_opts:canonicalize(Opts),
     % Create a temporary opts map that does not include the defaults.
-    TempOpts = Opts#{ only => local },
+    TempOpts = CanonicalOpts#{ <<"only">> => local },
     % Get the port to use for the server. If no port is provided, we use port 0
     % will the operating system assign a free port.
     Port = hb_opts:get(port, 0, TempOpts),
@@ -552,12 +560,12 @@ set_default_opts(Opts) ->
         {store, Store},
         {wallet, Wallet}
     }),
-    Opts#{
-        port => Port,
-        store => Store,
-        priv_wallet => Wallet,
-        address => hb_util:human_id(ar_wallet:to_address(Wallet)),
-        force_signed => true
+    CanonicalOpts#{
+        <<"port">> => Port,
+        <<"store">> => Store,
+        <<"priv-wallet">> => Wallet,
+        <<"address">> => hb_util:human_id(ar_wallet:to_address(Wallet)),
+        <<"force-signed">> => true
     }.
 
 %% @doc Test that we can start the server, send a message, and get a response.
@@ -594,7 +602,7 @@ start_node(Opts) ->
 set_node_opts_test() ->
     Node =
         start_node(#{
-            on => #{
+            <<"on">> => #{
                 <<"start">> => #{
                     <<"device">> =>
                         #{
@@ -617,11 +625,11 @@ set_node_opts_test() ->
 set_opts_test() ->
     DefaultOpts = hb_opts:default_message_with_env(),
     start_node(DefaultOpts#{ 
-        priv_wallet => Wallet = ar_wallet:new(), 
-        port => rand:uniform(10000) + 10000 
+        <<"priv-wallet">> => Wallet = ar_wallet:new(), 
+        <<"port">> => rand:uniform(10000) + 10000 
     }),
     Opts = get_opts(#{ 
-        http_server => hb_util:human_id(ar_wallet:to_address(Wallet))
+        <<"http-server">> => hb_util:human_id(ar_wallet:to_address(Wallet))
     }),
     NodeHistory = hb_opts:get(node_history, [], Opts),
     ?event(debug_node_history, {node_history_length, length(NodeHistory)}),
@@ -659,8 +667,8 @@ restart_server_test() ->
     Wallet = ar_wallet:new(),
     BaseOpts = #{
         <<"test-key">> => <<"server-1">>,
-        priv_wallet => Wallet,
-        protocol => http2
+        <<"priv-wallet">> => Wallet,
+        <<"protocol">> => http2
     },
     _ = start_node(BaseOpts),
     N2 = start_node(BaseOpts#{ <<"test-key">> => <<"server-2">> }),

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -14,7 +14,7 @@
 %%% with a refusal to execute.
 -module(hb_opts).
 -export([get/1, get/2, get/3, as/2, identities/1, load/1, load/2, load_bin/2]).
--export([canonicalize/1]).
+-export([canonicalize/1, canonical_key/1]).
 -export([default_message/0, default_message_with_env/0, mimic_default_types/3]).
 -export([ensure_node_history/2]).
 -export([check_required_opts/2]).
@@ -136,7 +136,12 @@ topic_list_to_atoms("all") -> true;
 topic_list_to_atoms(Str) ->
     lists:map(fun(Topic) -> list_to_atom(Topic) end, string:tokens(Str, ",")).
 
-%% @doc Canonicalize an opts or node message map to lower-case binary dash keys.
+%% @doc Canonicalize an opts or node message term to lower-case binary dash
+%% keys.
+%%
+%% This function is used at the points where a node message is generated,
+%% loaded, or persisted. It is deliberately not part of the hot lookup path in
+%% `get/3'.
 canonicalize(Term) -> canonicalize(root, Term).
 
 canonicalize(_Context, List) when is_list(List) ->
@@ -172,7 +177,7 @@ canonicalize(Context, Map) when is_map(Map) ->
             maps:from_list(
                 lists:map(
                     fun({Key, Value}) ->
-                        CanonKey = canonical_opt_key(Key),
+                        CanonKey = canonical_key(Key),
                         {CanonKey, canonicalize(CanonKey, Value)}
                     end,
                     maps:to_list(Map)
@@ -181,6 +186,17 @@ canonicalize(Context, Map) when is_map(Map) ->
     end;
 canonicalize(_Context, Other) -> Other.
 
+%% @doc Return how `canonicalize/2' should treat a nested map.
+%%
+%% `normal' means the key names are themselves opts/message keys, so we
+%% canonicalize them and recurse into the values.
+%%
+%% `opaque' means the map is dictionary-like user data. We keep the values as
+%% they are and only turn string-like keys into binaries so names/IDs remain
+%% stable.
+%%
+%% `recurse_values' is the middle ground: the top-level keys are names/IDs, but
+%% the values are themselves opts maps that should be canonicalized.
 dictionary_mode(<<"hyperbuddy-serve">>) -> opaque;
 dictionary_mode(<<"identities">>) -> recurse_values;
 dictionary_mode(<<"local-names">>) -> opaque;
@@ -205,50 +221,22 @@ canonical_dictionary_key(Key) when is_list(Key) ->
     end;
 canonical_dictionary_key(Key) -> Key.
 
-canonical_opt_key(Key) when is_atom(Key) ->
-    canonical_opt_key(atom_to_binary(Key, utf8));
-canonical_opt_key(Key) when is_list(Key) ->
+%% @doc Convert a single opts key to lower-case binary dash form.
+canonical_key(Key) when is_atom(Key) ->
+    canonical_key(atom_to_binary(Key, utf8));
+canonical_key(Key) when is_list(Key) ->
     case hb_util:is_string_list(Key) of
-        true -> canonical_opt_key(list_to_binary(Key));
+        true -> canonical_key(list_to_binary(Key));
         false -> Key
     end;
-canonical_opt_key(Key) when is_binary(Key) ->
+canonical_key(Key) when is_binary(Key) ->
     hb_util:to_lower(binary:replace(Key, <<"_">>, <<"-">>, [global]));
-canonical_opt_key(Key) -> Key.
+canonical_key(Key) -> Key.
 
-find_local_opt(Key, Map) ->
-    case maps:find(Key, Map) of
-        {ok, Value} -> {ok, Value};
-        error when is_atom(Key) ->
-            maps:find(canonical_opt_key(Key), Map);
-        error when is_binary(Key) ->
-            try maps:find(hb_util:key_to_atom(Key, existing), Map)
-            catch _:_ -> error
-            end;
-        error ->
-            error
-    end.
-
-find_local_fallback(Key, Map) when is_atom(Key) ->
-    maps:find(canonical_opt_key(Key), Map);
-find_local_fallback(Key, Map) when is_binary(Key) ->
-    try maps:find(hb_util:key_to_atom(Key, existing), Map)
-    catch _:_ -> error
-    end;
-find_local_fallback(_Key, _Map) ->
+find_canonical_key(Key, Opts) when is_atom(Key); is_list(Key) ->
+    maps:find(canonical_key(Key), Opts);
+find_canonical_key(_Key, _Opts) ->
     error.
-
-opt_map_get(Key, Map, Default) ->
-    case find_local_opt(Key, Map) of
-        {ok, Value} -> Value;
-        error -> Default
-    end.
-
-fast_lookup_default(Key, Default, Opts) ->
-    case is_map_key(Key, ?ENV_KEYS) of
-        true -> do_get(Key, Default, Opts);
-        false -> opt_map_get(Key, default_message(), Default)
-    end.
 
 %% @doc Return the default message with all environment variables set.
 default_message_with_env() ->
@@ -256,7 +244,7 @@ default_message_with_env() ->
         fun(Key, _Spec, NodeMsg) ->
             case global_get(Key, undefined, #{}) of
                 undefined -> NodeMsg;
-                Value -> NodeMsg#{ canonical_opt_key(Key) => Value }
+                Value -> NodeMsg#{ canonical_key(Key) => Value }
             end
         end,
         default_message(),
@@ -700,16 +688,27 @@ get(Key, Default, Opts)
         #{ only := global } -> do_get(Key, Default, Opts);
         #{ Key   := Value } -> Value;
         #{ only  := local } ->
-            case find_local_fallback(Key, Opts) of
+            case find_canonical_key(Key, Opts) of
                 {ok, Value} -> Value;
                 error -> Default
             end;
         _ ->
-            case find_local_fallback(Key, Opts) of
+            case find_canonical_key(Key, Opts) of
                 {ok, Value} ->
                     Value;
                 error ->
-                    fast_lookup_default(Key, Default, Opts)
+                    case is_map_key(Key, ?ENV_KEYS) of
+                        true -> do_get(Key, Default, Opts);
+                        false ->
+                            case maps:get(
+                                canonical_key(Key),
+                                default_message(),
+                                '$hb_opts_not_found'
+                            ) of
+                                '$hb_opts_not_found' -> Default;
+                                V -> V
+                            end
+                    end
             end
     end;
 get(Key, Default, Opts) ->
@@ -719,10 +718,13 @@ do_get(Key, Default, Opts = #{ <<"only">> := Only }) ->
 do_get(Key, Default, Opts = #{ <<"prefer">> := Prefer }) ->
     do_get(Key, Default, maps:remove(<<"prefer">>, Opts#{ prefer => Prefer }));
 do_get(Key, Default, Opts = #{ only := local }) ->
-    case find_local_opt(Key, Opts) of
+    case maps:find(Key, Opts) of
         {ok, Value} -> Value;
-        error -> 
-            Default
+        error ->
+            case find_canonical_key(Key, Opts) of
+                {ok, Value} -> Value;
+                error -> Default
+            end
     end;
 do_get(Key, Default, Opts = #{ only := global }) ->
     case global_get(Key, hb_opts_not_found, Opts) of
@@ -803,7 +805,8 @@ normalize_default(Default) -> Default.
 %% @doc An abstraction for looking up configuration variables. In the future,
 %% this is the function that we will want to change to support a more dynamic
 %% configuration system.
-config_lookup(Key, Default, _Opts) -> opt_map_get(Key, default_message(), Default).
+config_lookup(Key, Default, _Opts) ->
+    maps:get(canonical_key(Key), default_message(), Default).
 
 %% @doc Parse a `flat@1.0' encoded file into a map, matching the types of the 
 %% keys to those in the default message.
@@ -869,7 +872,7 @@ load_bin(Device, Bin, Opts) ->
                         Bin,
                         <<"structured@1.0">>,
                         Device,
-                        Opts#{ linkify_mode => false }
+                        Opts#{ <<"linkify-mode">> => false }
                     ),
                     Opts
                 ),

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -14,6 +14,7 @@
 %%% with a refusal to execute.
 -module(hb_opts).
 -export([get/1, get/2, get/3, as/2, identities/1, load/1, load/2, load_bin/2]).
+-export([canonicalize/1]).
 -export([default_message/0, default_message_with_env/0, mimic_default_types/3]).
 -export([ensure_node_history/2]).
 -export([check_required_opts/2]).
@@ -135,13 +136,127 @@ topic_list_to_atoms("all") -> true;
 topic_list_to_atoms(Str) ->
     lists:map(fun(Topic) -> list_to_atom(Topic) end, string:tokens(Str, ",")).
 
+%% @doc Canonicalize an opts or node message map to lower-case binary dash keys.
+canonicalize(Term) -> canonicalize(root, Term).
+
+canonicalize(_Context, List) when is_list(List) ->
+    case hb_util:is_string_list(List) of
+        true -> List;
+        false ->
+            lists:map(
+                fun(Item) -> canonicalize(root, Item) end,
+                List
+            )
+    end;
+canonicalize(Context, Map) when is_map(Map) ->
+    case dictionary_mode(Context) of
+        opaque ->
+            maps:from_list(
+                lists:map(
+                    fun({Key, Value}) ->
+                        {canonical_dictionary_key(Key), Value}
+                    end,
+                    maps:to_list(Map)
+                )
+            );
+        recurse_values ->
+            maps:from_list(
+                lists:map(
+                    fun({Key, Value}) ->
+                        {canonical_dictionary_key(Key), canonicalize(root, Value)}
+                    end,
+                    maps:to_list(Map)
+                )
+            );
+        normal ->
+            maps:from_list(
+                lists:map(
+                    fun({Key, Value}) ->
+                        CanonKey = canonical_opt_key(Key),
+                        {CanonKey, canonicalize(CanonKey, Value)}
+                    end,
+                    maps:to_list(Map)
+                )
+            )
+    end;
+canonicalize(_Context, Other) -> Other.
+
+dictionary_mode(<<"hyperbuddy-serve">>) -> opaque;
+dictionary_mode(<<"identities">>) -> recurse_values;
+dictionary_mode(<<"local-names">>) -> opaque;
+dictionary_mode(<<"balance">>) -> opaque;
+dictionary_mode(<<"balances">>) -> opaque;
+dictionary_mode(<<"commitments">>) -> recurse_values;
+dictionary_mode(<<"node-processes">>) -> recurse_values;
+dictionary_mode(<<"nodes">>) -> recurse_values;
+dictionary_mode(<<"priv-wallet-hosted">>) -> recurse_values;
+dictionary_mode(<<"simple-pay-ledger">>) -> opaque;
+dictionary_mode(<<"state">>) -> opaque;
+dictionary_mode(<<"trusted">>) -> recurse_values;
+dictionary_mode(<<"trusted-nodes">>) -> recurse_values;
+dictionary_mode(_) -> normal.
+
+canonical_dictionary_key(Key) when is_atom(Key) ->
+    atom_to_binary(Key, utf8);
+canonical_dictionary_key(Key) when is_list(Key) ->
+    case hb_util:is_string_list(Key) of
+        true -> list_to_binary(Key);
+        false -> Key
+    end;
+canonical_dictionary_key(Key) -> Key.
+
+canonical_opt_key(Key) when is_atom(Key) ->
+    canonical_opt_key(atom_to_binary(Key, utf8));
+canonical_opt_key(Key) when is_list(Key) ->
+    case hb_util:is_string_list(Key) of
+        true -> canonical_opt_key(list_to_binary(Key));
+        false -> Key
+    end;
+canonical_opt_key(Key) when is_binary(Key) ->
+    hb_util:to_lower(binary:replace(Key, <<"_">>, <<"-">>, [global]));
+canonical_opt_key(Key) -> Key.
+
+find_local_opt(Key, Map) ->
+    case maps:find(Key, Map) of
+        {ok, Value} -> {ok, Value};
+        error when is_atom(Key) ->
+            maps:find(canonical_opt_key(Key), Map);
+        error when is_binary(Key) ->
+            try maps:find(hb_util:key_to_atom(Key, existing), Map)
+            catch _:_ -> error
+            end;
+        error ->
+            error
+    end.
+
+find_local_fallback(Key, Map) when is_atom(Key) ->
+    maps:find(canonical_opt_key(Key), Map);
+find_local_fallback(Key, Map) when is_binary(Key) ->
+    try maps:find(hb_util:key_to_atom(Key, existing), Map)
+    catch _:_ -> error
+    end;
+find_local_fallback(_Key, _Map) ->
+    error.
+
+opt_map_get(Key, Map, Default) ->
+    case find_local_opt(Key, Map) of
+        {ok, Value} -> Value;
+        error -> Default
+    end.
+
+fast_lookup_default(Key, Default, Opts) ->
+    case is_map_key(Key, ?ENV_KEYS) of
+        true -> do_get(Key, Default, Opts);
+        false -> opt_map_get(Key, default_message(), Default)
+    end.
+
 %% @doc Return the default message with all environment variables set.
 default_message_with_env() ->
     maps:fold(
         fun(Key, _Spec, NodeMsg) ->
             case global_get(Key, undefined, #{}) of
                 undefined -> NodeMsg;
-                Value -> NodeMsg#{ Key => Value }
+                Value -> NodeMsg#{ canonical_opt_key(Key) => Value }
             end
         end,
         default_message(),
@@ -157,7 +272,7 @@ default_message_with_env() ->
 default_message() ->
     case erlang:get(default_message) of
         undefined ->
-            Cached = raw_default_message(),
+            Cached = canonicalize(raw_default_message()),
             erlang:put(default_message, Cached),
             Cached;
         Cached -> Cached
@@ -584,15 +699,17 @@ get(Key, Default, Opts)
     case Opts of
         #{ only := global } -> do_get(Key, Default, Opts);
         #{ Key   := Value } -> Value;
-        #{ only  := local } -> Default;
+        #{ only  := local } ->
+            case find_local_fallback(Key, Opts) of
+                {ok, Value} -> Value;
+                error -> Default
+            end;
         _ ->
-            case is_map_key(Key, ?ENV_KEYS) of
-                true -> do_get(Key, Default, Opts);
-                false ->
-                    case maps:get(Key, default_message(), '$hb_opts_not_found') of
-                        '$hb_opts_not_found' -> Default;
-                        V -> V
-                    end
+            case find_local_fallback(Key, Opts) of
+                {ok, Value} ->
+                    Value;
+                error ->
+                    fast_lookup_default(Key, Default, Opts)
             end
     end;
 get(Key, Default, Opts) ->
@@ -602,7 +719,7 @@ do_get(Key, Default, Opts = #{ <<"only">> := Only }) ->
 do_get(Key, Default, Opts = #{ <<"prefer">> := Prefer }) ->
     do_get(Key, Default, maps:remove(<<"prefer">>, Opts#{ prefer => Prefer }));
 do_get(Key, Default, Opts = #{ only := local }) ->
-    case maps:find(Key, Opts) of
+    case find_local_opt(Key, Opts) of
         {ok, Value} -> Value;
         error -> 
             Default
@@ -686,7 +803,7 @@ normalize_default(Default) -> Default.
 %% @doc An abstraction for looking up configuration variables. In the future,
 %% this is the function that we will want to change to support a more dynamic
 %% configuration system.
-config_lookup(Key, Default, _Opts) -> maps:get(Key, default_message(), Default).
+config_lookup(Key, Default, _Opts) -> opt_map_get(Key, default_message(), Default).
 
 %% @doc Parse a `flat@1.0' encoded file into a map, matching the types of the 
 %% keys to those in the default message.
@@ -716,7 +833,7 @@ path_to_device(Path) ->
 
 %% @doc Convert a file extension to a device name.
 extension_to_device(Ext) ->
-    extension_to_device(Ext, maps:get(preloaded_devices, default_message())).
+    extension_to_device(Ext, ?MODULE:get(preloaded_devices, [], default_message())).
 extension_to_device(_, []) -> {error, not_found};
 extension_to_device(Ext, [#{ <<"name">> := Name }|Rest]) ->
     case binary:match(Name, Ext) of
@@ -764,13 +881,13 @@ load_bin(Device, Bin, Opts) ->
     end.
 
 %% @doc Mimic the types of the default message for a given map.
-mimic_default_types(Map, Mode, Opts) ->
+mimic_default_types(Map, _Mode, Opts) ->
     Default = default_message_with_env(),
+    CanonicalMap = canonicalize(Map),
     hb_maps:from_list(lists:map(
         fun({Key, Value}) ->
-            NewKey = try hb_util:key_to_atom(Key, Mode) catch _:_ -> Key end,
             NewValue = 
-                case hb_maps:get(NewKey, Default, not_found, Opts) of
+                case hb_maps:get(Key, Default, not_found, Opts) of
                     not_found -> Value;
                     DefaultValue when is_atom(DefaultValue) ->
                         hb_util:atom(Value);
@@ -782,9 +899,9 @@ mimic_default_types(Map, Mode, Opts) ->
                         Value;
                     _ -> Value
                 end,
-            {NewKey, NewValue}
+            {Key, NewValue}
         end,
-        hb_maps:to_list(Map, Opts)
+        hb_maps:to_list(CanonicalMap, Opts)
     )).
 
 %% @doc Find a given identity from the `identities' map, and return the options
@@ -793,7 +910,13 @@ as(Identity, Opts) ->
     case identities(Opts) of
         #{ Identity := SubOpts } ->
             ?event({found_identity_sub_opts_are, SubOpts}),
-            {ok, maps:merge(Opts, mimic_default_types(SubOpts, new_atoms, Opts))};
+            {ok,
+                hb_maps:merge(
+                    canonicalize(Opts),
+                    mimic_default_types(SubOpts, new_atoms, Opts),
+                    Opts
+                )
+            };
         _ ->
             {error, not_found}
     end.
@@ -807,16 +930,20 @@ as(Identity, Opts) ->
 identities(Opts) ->
     identities(hb:wallet(), Opts).
 identities(Default, Opts) ->
-    Named = ?MODULE:get(identities, #{}, Opts),
+    #{ <<"identities">> := Named } =
+        canonicalize(
+            #{ <<"identities">> => ?MODULE:get(identities, #{}, Opts) }
+        ),
     % Generate an address-based map of identities.
     Addresses =
         maps:from_list(lists:filtermap(
             fun({_Name, SubOpts}) ->
-                case maps:find(priv_wallet, SubOpts) of
-                    {ok, Wallet} ->
+                case hb_opts:get(priv_wallet, not_found, SubOpts) of
+                    not_found ->
+                        false;
+                    Wallet ->
                         Addr = hb_util:human_id(ar_wallet:to_address(Wallet)),
-                        {true, {Addr, SubOpts}};
-                    error -> false
+                        {true, {Addr, SubOpts}}
                 end
             end,
             maps:to_list(Named)
@@ -826,10 +953,11 @@ identities(Default, Opts) ->
     Identities =
         maps:map(
             fun(_NameOrID, SubOpts) ->
-                case maps:find(priv_wallet, SubOpts) of
-                    {ok, Wallet} ->
-                        SubOpts#{ <<"address">> => hb_util:human_id(Wallet) };
-                    error -> SubOpts
+                case hb_opts:get(priv_wallet, not_found, SubOpts) of
+                    not_found ->
+                        SubOpts;
+                    Wallet ->
+                        SubOpts#{ <<"address">> => hb_util:human_id(Wallet) }
                 end
             end,
             maps:merge(Named, Addresses)
@@ -842,10 +970,10 @@ identities(Default, Opts) ->
         error ->
             Identities#{
                 DefaultID => #{
-                    priv_wallet => DefaultWallet
+                    <<"priv-wallet">> => DefaultWallet
                 },
                 <<"default">> => #{
-                    priv_wallet => DefaultWallet
+                    <<"priv-wallet">> => DefaultWallet
                 }
             }
     end.
@@ -1005,26 +1133,33 @@ load_flat_test() ->
     {ok, Conf} = load("test/config.flat", #{}),
     ?event({loaded, {explicit, Conf}}),
     % Ensure we convert types as expected.
-    ?assertEqual(1234, hb_maps:get(port, Conf)),
+    ?assertEqual(1234, hb_maps:get(<<"port">>, Conf)),
     % A binary
-    ?assertEqual(<<"https://ao.computer">>, hb_maps:get(node_host, Conf)),
-    % An atom, where the key contained a header-key `-' rather than a `_'.
-    ?assertEqual(false, hb_maps:get(await_inprogress, Conf)).
+    ?assertEqual(<<"https://ao.computer">>, hb_maps:get(<<"node-host">>, Conf)),
+    ?assertEqual(false, hb_maps:get(<<"await-inprogress">>, Conf)).
 
 load_json_test() ->
     {ok, Conf} = load("test/config.json", #{}),
     ?event(debug_node_msg, {loaded, Conf}),
-    ?assertEqual(1234, hb_maps:get(port, Conf)),
-    ?assertEqual(9001, hb_maps:get(example, Conf)),
+    ?assertEqual(1234, hb_maps:get(<<"port">>, Conf)),
+    ?assertEqual(9001, hb_maps:get(<<"example">>, Conf)),
     % A binary
-    ?assertEqual(<<"https://ao.computer">>, hb_maps:get(node_host, Conf)),
-    % An atom, where the key contained a header-key `-' rather than a `_'.
-    ?assertEqual(false, hb_maps:get(await_inprogress, Conf)),
+    ?assertEqual(<<"https://ao.computer">>, hb_maps:get(<<"node-host">>, Conf)),
+    ?assertEqual(false, hb_maps:get(<<"await-inprogress">>, Conf)),
     % Ensure that a store with `ao-types' is loaded correctly.
     ?assertMatch(
         [#{ <<"store-module">> := hb_store_fs }|_],
-        hb_maps:get(store, Conf)
+        hb_maps:get(<<"store">>, Conf)
     ).
+
+default_message_canonical_test() ->
+    Default = default_message_with_env(),
+    ?assertEqual(undefined, maps:get(port, Default, undefined)),
+    ?assertEqual(undefined, maps:get(node_host, Default, undefined)),
+    ?assertEqual(undefined, maps:get(await_inprogress, Default, undefined)),
+    ?assert(is_integer(hb_maps:get(<<"port">>, Default))),
+    ?assert(is_list(hb_maps:get(<<"cache-control">>, Default))),
+    ?assertNotEqual(undefined, maps:get(<<"await-inprogress">>, Default, undefined)).
 
 as_identity_test() ->
     DefaultWallet = ar_wallet:new(),
@@ -1054,23 +1189,23 @@ as_identity_test() ->
     % The wallets for each of the names should be the same as the wallets we
     % provided. We also check that the settings are applied correctly.
     ?assertMatch(
-        {ok, #{ priv_wallet := DefaultWallet, test_key := 0 }},
+        {ok, #{ <<"priv-wallet">> := DefaultWallet, <<"test-key">> := 0 }},
         as(<<"default">>, Opts)
     ),
     ?assertMatch(
-        {ok, #{ priv_wallet := DefaultWallet, test_key := 0 }},
+        {ok, #{ <<"priv-wallet">> := DefaultWallet, <<"test-key">> := 0 }},
         as(hb_util:human_id(DefaultWallet), Opts)
     ),
     ?assertMatch(
-        {ok, #{ priv_wallet := TestWallet1, test_key := 1 }},
+        {ok, #{ <<"priv-wallet">> := TestWallet1, <<"test-key">> := 1 }},
         as(<<"testname-1">>, Opts)
     ),
     ?assertMatch(
-        {ok, #{ priv_wallet := TestWallet1, test_key := 1 }},
+        {ok, #{ <<"priv-wallet">> := TestWallet1, <<"test-key">> := 1 }},
         as(hb_util:human_id(TestWallet1), Opts)
     ),
     ?assertMatch(
-        {ok, #{ priv_wallet := TestWallet2, test_key := 2 }},
+        {ok, #{ <<"priv-wallet">> := TestWallet2, <<"test-key">> := 2 }},
         as(TestID2, Opts)
     ).
     
@@ -1094,7 +1229,7 @@ ensure_node_history_test() ->
             }, 
         <<"key2">> => <<"value2">>, 
         <<"extra">> => <<"value">>,
-        node_history => [
+        <<"node-history">> => [
             #{
                 <<"key1">> => 
                     #{
@@ -1124,7 +1259,7 @@ ensure_node_history_test() ->
                 <<"type">> => <<"string">>,
                 <<"value">> => <<"value1">>
             }, 
-        node_history => [
+        <<"node-history">> => [
             #{
                 <<"key1">> => 
                     #{
@@ -1147,7 +1282,7 @@ ensure_node_history_test() ->
                     <<"value">> => <<"value">>
                 }, 
             <<"key2">> => <<"value2">>,
-            node_history =>
+            <<"node-history">> =>
                 [
                     #{
                         <<"key1">> => 

--- a/src/hb_persistent.erl
+++ b/src/hb_persistent.erl
@@ -103,6 +103,8 @@ do_monitor(Group, Last, Opts) ->
 %% explicitly disabled (the common case for internal/recursive resolves) we
 %% skip the grouper dispatch entirely: the leader short-circuit below would
 %% discard the computed group name anyway.
+find_or_register(_Base, _Req, #{ <<"await-inprogress">> := false }) ->
+    {leader, ungrouped_exec};
 find_or_register(_Base, _Req, #{ await_inprogress := false }) ->
     {leader, ungrouped_exec};
 find_or_register(Base, Req, Opts) ->

--- a/src/hb_persistent.erl
+++ b/src/hb_persistent.erl
@@ -306,9 +306,9 @@ start_worker(GroupName, Msg, Opts) ->
                         GroupName,
                         Msg,
                         hb_maps:merge(Opts, #{
-                            is_worker => true,
-                            spawn_worker => false,
-                            allow_infinite => true
+                            <<"is-worker">> => true,
+                            <<"spawn-worker">> => false,
+                            <<"allow-infinite">> => true
                         },
 						Opts)
                     ]
@@ -505,9 +505,9 @@ spawn_after_execution_test() ->
             Base,
             Req,
             #{
-                spawn_worker => true,
-                static_worker => true,
-                hashpath => ignore
+                <<"spawn-worker">> => true,
+                <<"static-worker">> => true,
+                <<"hashpath">> => ignore
             }
         ),
     receive after 10 -> ok end,

--- a/src/hb_test_parallel.erl
+++ b/src/hb_test_parallel.erl
@@ -39,38 +39,20 @@
 %% what the generator will run, which is the primary debugging hook if a
 %% test unexpectedly does or does not appear in the parallel batch.
 all(Module) ->
-    Funs =
-        lists:sort(
-            [
-                F
-            ||
-                {F, 0} <- Module:module_info(exports),
-                    is_parallel_test_name(F)
-            ]
-        ),
     {inparallel,
         [
             {atom_to_list(F), fun Module:F/0}
         ||
-            F <- Funs
+            F <- parallel_test_funs(Module)
         ]
     }.
 
 all(Module, Timeout) ->
-    Funs =
-        lists:sort(
-            [
-                F
-            ||
-                {F, 0} <- Module:module_info(exports),
-                    is_parallel_test_name(F)
-            ]
-        ),
     {inparallel,
         [
             {atom_to_list(F), {timeout, Timeout, fun Module:F/0}}
         ||
-            F <- Funs
+            F <- parallel_test_funs(Module)
         ]
     }.
 
@@ -117,6 +99,18 @@ scan(Forms) ->
         end,
         {[], false},
         Forms
+    ).
+
+%% @doc Return the sorted list of 0-arity parallel test function names
+%% exported by `Module'.
+parallel_test_funs(Module) ->
+    lists:sort(
+        [
+            F
+        ||
+            {F, 0} <- Module:module_info(exports),
+                is_parallel_test_name(F)
+        ]
     ).
 
 %% @doc True when `Name' ends in `_test_parallel' or `_test_parallel_'.

--- a/src/hb_test_parallel.erl
+++ b/src/hb_test_parallel.erl
@@ -25,7 +25,7 @@
 %%% That is the whole contract. No manual exports, no hand-written
 %%% generator, and nothing renamed.
 -module(hb_test_parallel).
--export([parse_transform/2, all/1]).
+-export([parse_transform/2, all/1, all/2]).
 
 -define(SIMPLE_SUFFIX, "_test_parallel").
 -define(GENERATOR_SUFFIX, "_test_parallel_").
@@ -51,6 +51,24 @@ all(Module) ->
     {inparallel,
         [
             {atom_to_list(F), fun Module:F/0}
+        ||
+            F <- Funs
+        ]
+    }.
+
+all(Module, Timeout) ->
+    Funs =
+        lists:sort(
+            [
+                F
+            ||
+                {F, 0} <- Module:module_info(exports),
+                    is_parallel_test_name(F)
+            ]
+        ),
+    {inparallel,
+        [
+            {atom_to_list(F), {timeout, Timeout, fun Module:F/0}}
         ||
             F <- Funs
         ]

--- a/src/hb_test_parallel.erl
+++ b/src/hb_test_parallel.erl
@@ -25,7 +25,7 @@
 %%% That is the whole contract. No manual exports, no hand-written
 %%% generator, and nothing renamed.
 -module(hb_test_parallel).
--export([parse_transform/2, all/1, all/2]).
+-export([parse_transform/2, all/1]).
 
 -define(SIMPLE_SUFFIX, "_test_parallel").
 -define(GENERATOR_SUFFIX, "_test_parallel_").
@@ -39,20 +39,20 @@
 %% what the generator will run, which is the primary debugging hook if a
 %% test unexpectedly does or does not appear in the parallel batch.
 all(Module) ->
+    Funs =
+        lists:sort(
+            [
+                F
+            ||
+                {F, 0} <- Module:module_info(exports),
+                    is_parallel_test_name(F)
+            ]
+        ),
     {inparallel,
         [
             {atom_to_list(F), fun Module:F/0}
         ||
-            F <- parallel_test_funs(Module)
-        ]
-    }.
-
-all(Module, Timeout) ->
-    {inparallel,
-        [
-            {atom_to_list(F), {timeout, Timeout, fun Module:F/0}}
-        ||
-            F <- parallel_test_funs(Module)
+            F <- Funs
         ]
     }.
 
@@ -99,18 +99,6 @@ scan(Forms) ->
         end,
         {[], false},
         Forms
-    ).
-
-%% @doc Return the sorted list of 0-arity parallel test function names
-%% exported by `Module'.
-parallel_test_funs(Module) ->
-    lists:sort(
-        [
-            F
-        ||
-            {F, 0} <- Module:module_info(exports),
-                is_parallel_test_name(F)
-        ]
     ).
 
 %% @doc True when `Name' ends in `_test_parallel' or `_test_parallel_'.

--- a/src/include/hb.hrl
+++ b/src/include/hb.hrl
@@ -30,7 +30,7 @@
 %%% underlying function.
 -define(event(X), hb_event:log(global, X, ?MODULE, ?FUNCTION_NAME, ?LINE)).
 -define(event(Topic, X), hb_event:log(Topic, X, ?MODULE, ?FUNCTION_NAME, ?LINE)).
--define(event(Topic, X, Opts), hb_event:log(maps:get(topic, Opts, Topic), X, ?MODULE, ?FUNCTION_NAME, ?LINE, Opts)).
+-define(event(Topic, X, Opts), hb_event:log(maps:get(<<"topic">>, Opts, maps:get(topic, Opts, Topic)), X, ?MODULE, ?FUNCTION_NAME, ?LINE, Opts)).
 -define(debug_wait(T), hb:debug_wait(T, ?MODULE, ?FUNCTION_NAME, ?LINE)).
 -define(debug_print(X), hb_event:debug_print(X, ?MODULE, ?FUNCTION_NAME, ?LINE)).
 -define(no_prod(X), hb:no_prod(X, ?MODULE, ?LINE)).


### PR DESCRIPTION
## Summary

This PR canonicalizes HyperBEAM node opts to lower-case binary dash keys at the intended load/generation/persist boundaries, so the node message now behaves like a normal AO-Core message instead of a mixed atom/underscore structure.

The main changes are:

- Canonicalize node opts during generation of the default node message, config load, node start, HTTP server start, and `hb_http_server:set_opts`. We do not normalize during key lookup for the sake of speed. This means that ad-hoc keys added to the `Opts` outside of these venues must normalize their keys themselves.
- Preserve compatibility for `hb_opts:get(atom_key, Default, Opts)` without adding meaningful additional compute to the hot path.
- Keep passive test inputs in atom form where possible to limit PR size and auditability.
- 
## Why

We had a split model where node message fields were sometimes treated as atom
opts with underscores and sometimes as real message keys. This change makes the
stored/generated node message consistently use normal-form binary dash keys
while keeping existing atom-form reads working through `hb_opts:get/3`.

## Testing

- `HB_PORT=$((20000 + RANDOM % 40000)) rebar3 eunit`
- All `3056` tests passed
