### PR TITLE
feat(push): opt-in `parallel-outbox` for fan-out parallelism

### DIFF
--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -36,6 +36,14 @@
 %%                       `N > 0' - recurse, with the inner `/push'
 %%                                 inheriting `max-depth = N - 1'.
 %%                                 Unwinds at most `N' levels deep.
+%% `/parallel-outbox': Boolean (default `false'). When `true', each
+%%                    outbox entry's `schedule + recurse' chain runs in
+%%                    its own spawned process so a slow downstream chain
+%%                    on one entry does not block its siblings (e.g. a
+%%                    multi-target broadcast where target 1 is LLM-bound
+%%                    must not starve targets 2..N). The `hb_maps:map'
+%%                    callback returns a `<<"scheduled">>' stub for each
+%%                    spawned entry instead of the full chain result.
 push(Base, Req, Opts) ->
     Process = dev_process_lib:as_process(Base, Opts),
     ?event(push, {push_base, {base, Process}, {req, Req}}, Opts),
@@ -180,6 +188,7 @@ do_push(PrimaryProcess, Assignment, Opts) ->
             {ok, AdditionalRes#{ <<"slot">> => Slot, <<"process">> => ID }};
         {ok, Outbox} ->
             ?event(push, {push_found_outbox, {outbox, Outbox}}),
+            Parallel = parallel_outbox(Assignment, Opts),
             Downstream =
                 hb_maps:map(
                     fun(Key, RawMsgToPush = #{ <<"target">> := Target }) ->
@@ -198,9 +207,7 @@ do_push(PrimaryProcess, Assignment, Opts) ->
                             end,
                         case hb_cache:read(Target, Opts) of
                             {ok, DownstreamProcess} ->
-                                push_result_message(
-                                    DownstreamProcess,
-                                    MsgToPush,
+                                Origin =
                                     #{
                                         <<"process">> => ID,
                                         <<"slot">> => Slot,
@@ -222,6 +229,14 @@ do_push(PrimaryProcess, Assignment, Opts) ->
                                                 Opts
                                             )
                                     },
+                                push_outbox_entry(
+                                    Parallel,
+                                    DownstreamProcess,
+                                    MsgToPush,
+                                    Origin,
+                                    Target,
+                                    Key,
+                                    Slot,
                                     Opts
                                 );
                             {error, not_found} ->
@@ -259,6 +274,42 @@ target_process_not_found(Target) ->
         <<"target">> => Target,
         <<"reason">> => <<"Could not access target process!">>
     }.
+
+%% @doc Resolve the optional `parallel-outbox' boolean off the request.
+%% Default `false' preserves the legacy synchronous fan-out: each outbox
+%% entry's `schedule + recurse' chain runs inline so the caller observes
+%% the full result map. Pass `true' to spawn each entry's chain in its
+%% own process -- a slow downstream chain on one entry then no longer
+%% blocks its siblings.
+parallel_outbox(Assignment, Opts) ->
+    hb_util:bin(
+        hb_maps:get(<<"parallel-outbox">>, Assignment, false, Opts)
+    ) =:= <<"true">>.
+
+%% @doc Schedule + recurse one outbox entry. With `parallel-outbox = true'
+%% the chain runs in a fresh spawn and we return a `<<"scheduled">>' stub
+%% so sibling outbox entries are not blocked by this entry's downstream
+%% latency. Otherwise the chain runs inline and the caller observes the
+%% full nested result map (the legacy contract).
+push_outbox_entry(true, DownstreamProcess, MsgToPush, Origin, Target, Key, Slot, Opts) ->
+    ?event(push,
+        {spawning_chain,
+            {outbox_key, Key},
+            {target, Target},
+            {from_slot, Slot}
+        },
+        Opts
+    ),
+    spawn(fun() ->
+        push_result_message(DownstreamProcess, MsgToPush, Origin, Opts)
+    end),
+    #{
+        <<"response">> => <<"scheduled">>,
+        <<"target">> => Target,
+        <<"outbox-key">> => Key
+    };
+push_outbox_entry(false, DownstreamProcess, MsgToPush, Origin, _Target, _Key, _Slot, Opts) ->
+    push_result_message(DownstreamProcess, MsgToPush, Origin, Opts).
 
 
 %% @doc If the outbox message has a path we interpret it as a request to perform
@@ -857,6 +908,7 @@ max_depth_test_cases() ->
         {timeout, 30, fun test_max_depth_zero_schedules_only/0},
         {timeout, 30, fun test_max_depth_one_walks_one_hop/0},
         {timeout, 30, fun test_compute_push_hook_idempotent/0},
+        {timeout, 30, fun test_parallel_outbox_returns_scheduled_stubs/0},
         fun test_parse_max_depth/0
     ].
 
@@ -1450,6 +1502,32 @@ test_compute_push_hook_idempotent() ->
         hb_ao:resolve(Receiver, #{ <<"path">> => <<"slot/current">> }, Opts),
     ?assertEqual(ReceiverSlot1, ReceiverSlot2).
 
+%% @doc `parallel-outbox = true' makes each outbox entry's chain run in
+%% its own spawn. The synchronous response degenerates to a `<<"scheduled">>'
+%% stub per entry; the actual schedule lands asynchronously on the target.
+%% We assert both: the response carries the stub, and the receiver's
+%% scheduler eventually advances.
+test_parallel_outbox_returns_scheduled_stubs() ->
+    {Sender, Receiver, MsgSlot, Opts} = setup_two_process_message(),
+    {ok, ReceiverSlotBefore} =
+        hb_ao:resolve(Receiver, #{ <<"path">> => <<"slot/current">> }, Opts),
+    {ok, PushResult} =
+        hb_ao:resolve(
+            Sender,
+            #{
+                <<"path">> => <<"push">>,
+                <<"slot">> => MsgSlot,
+                <<"parallel-outbox">> => true,
+                <<"max-depth">> => 0
+            },
+            Opts
+        ),
+    ?assertMatch(
+        #{ <<"1">> := #{ <<"response">> := <<"scheduled">> }},
+        PushResult
+    ),
+    ?assert(wait_for_slot_above(Receiver, ReceiverSlotBefore, 10000, Opts)).
+
 %% @doc Spin up two AOS processes -- a Sender and a Receiver with a `Reply'
 %% handler for `Action = "Ping"' -- and schedule (without pushing) a single
 %% Ping message on the Sender that targets the Receiver. Returns
@@ -1512,6 +1590,20 @@ wait_until_loop(Pred, Deadline) ->
                     wait_until_loop(Pred, Deadline)
             end
     end.
+
+%% @doc Wait until `Process'/`slot/current' is strictly greater than
+%% `Floor', or `TimeoutMs' elapses. Used to await an async push landing
+%% a fresh assignment on the target's scheduler queue.
+wait_for_slot_above(Process, Floor, TimeoutMs, Opts) ->
+    wait_until(
+        fun() ->
+            case hb_ao:resolve(Process, #{<<"path">> => <<"slot/current">>}, Opts) of
+                {ok, S} when S > Floor -> true;
+                _ -> false
+            end
+        end,
+        TimeoutMs
+    ).
 
 -ifdef(ENABLE_GENESIS_WASM).
 %% @doc Test that a message that generates another message which resides on an


### PR DESCRIPTION
## Summary

Adds an opt-in `parallel-outbox` boolean key to `~push@1.0/push`. When `true`, each outbox entry's `schedule + recurse` chain runs in its own spawned process so a slow downstream chain on one entry no longer blocks its siblings. Default `false` preserves the existing synchronous, fully-observable contract.

## Motivation

A multi-target broadcast where target 1's downstream is LLM-bound (10–30s) currently starves targets 2..N: the recursive sync `push_result_message` on outbox key `1` blocks the `hb_maps:map` iterator over the rest of the outbox, so targets 2..N never receive their messages. Diagnosed via `?event(push, ...)` traces showing only key=1 firing.

`parallel-outbox = true` lets each entry's chain run concurrently — the iterator returns a `<<"scheduled">>` stub per entry immediately. Off-by-default keeps existing callers untouched (e.g. `dev_lua_test_ledgers` asserts a balance immediately after a transfer chain — the legacy contract holds).

## Implementation

- `parallel_outbox/2` resolves the boolean off the request, mirroring `is_async/3`'s `hb_util:bin(...) =:= <<"true">>` pattern.
- `push_outbox_entry/8` dispatches: `true` spawns the chain and returns the stub; `false` calls `push_result_message` inline (legacy).
- `?event(push, {spawning_chain, {outbox_key, Key}, {target, Target}, {from_slot, Slot}}, Opts)` fires before each spawn so an operator can correlate parent stubs against spawned chains in the BEAM log.
- The post-compute hook in `dev_process:dispatch_push` deliberately does not inject `parallel-outbox` — hook-fired pushes stay on the inline path so back-pressure to the cron tick is preserved.

## Test plan

- [x] `rebar3 eunit --module=dev_push` — **11/11** green, suite wall ~32 s
  - New: `test_parallel_outbox_returns_scheduled_stubs` asserts `<<"response">> := <<"scheduled">>` on the outbox-key entry, then polls Receiver's `slot/current` via the new `wait_for_slot_above/4` helper.
  - Sibling `test_max_depth_zero_schedules_only` (no flag) still asserts the legacy `<<"resulted-in">> := <<"skipped">>` shape on the same outbox key — different keys, different binaries, mutually-exclusive paths.
- [x] `rebar3 eunit --module=dev_lua_test_ledgers` — **8/8** green (these tests assert balance immediately after transfer chains; default-off preserves their synchronous contract).
- [x] `rebar3 eunit` (full suite) — **3061/3061** green, **208 s wall** matches edge baseline (208 s).

## Independent peer review

A senior contributor ran the verifications independently and **approved**. Two non-blocking follow-ups noted for future work:

1. Wide outboxes (~100+ entries) with `parallel-outbox = true` spawn one child per entry — `max-depth` caps depth but not breadth. A `parallel-outbox-limit` integer (or `hb_util:pmap`-style throttling) would bound fan-out under load.
2. The `{spawning_chain, ...}` event currently logs at the parent. Adding `process` and parent-slot to the event payload would let operators correlate orphan-child events back to their parent without grepping by `target` + `from-slot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)