### PR TITLE
perf(process): bypass worker queue for cached compute reads

### DIFF
--- a/src/dev_lua.erl
+++ b/src/dev_lua.erl
@@ -814,7 +814,6 @@ aos_process_benchmark_test_() ->
     {timeout, 30, fun() ->
         BenchMsgs = 6,
         Opts = #{
-            <<"process-async-cache">> => true,
             <<"hashpath">> => ignore,
             <<"process-snapshot-slots">> => 50
         },

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -376,13 +376,6 @@ compute_slot(ProcID, State, RawInputMsg, InitReq, TargetSlot, Opts) ->
                     #{ <<"device">> => <<"process@1.0">>, <<"at-slot">> => Slot },
                     Opts
                 ),
-            % Notify any waiters that the result for a slot is now available.
-            dev_process_worker:notify_compute(
-                ProcID,
-                Slot,
-                {ok, NewProcStateMsgWithSlot},
-                Opts
-            ),
             {StoreTimeMicroSecs, ProcStateWithSnapshot} =
                 timer:tc(
                     fun() ->
@@ -414,6 +407,15 @@ compute_slot(ProcID, State, RawInputMsg, InitReq, TargetSlot, Opts) ->
                         )
                     }
                 }
+            ),
+            % Notify waiters only after the slot is readable from the process
+            % cache. Waiters may immediately re-enter via `/compute' or `/push',
+            % and those paths treat the cache as the completion boundary.
+            dev_process_worker:notify_compute(
+                ProcID,
+                Slot,
+                {ok, ProcStateWithSnapshot},
+                Opts
             ),
             % Optionally fire an async `/push' for the slot we just cached.
             % Only fresh computes reach this branch; cache hits in `compute/3'
@@ -526,7 +528,8 @@ dispatch_push(Process, Slot, MaxDepth, Req, Opts) ->
     ok.
 
 %% @doc Store the resulting state in the cache, potentially with the snapshot
-%% key.
+%% key. The write is synchronous: callers may notify waiters or run push hooks
+%% as soon as this returns, so the slot must already be cache-visible.
 store_result(ForceSnapshot, ProcID, Slot, Res, Req, Opts) ->
     % Cache the `Snapshot' key as frequently as the node is configured to.
     ResMaybeWithSnapshot =
@@ -575,20 +578,10 @@ store_result(ForceSnapshot, ProcID, Slot, Res, Req, Opts) ->
                     }
                 ),
                 WithLastSnapshot
-        end,
-    ?event(compute, {caching_result, {proc_id, ProcID}, {slot, Slot}}, Opts),
-    Writer = 
-        fun() ->
-            dev_process_cache:write(ProcID, Slot, ResMaybeWithSnapshot, Opts)
-        end,
-    case hb_opts:get(process_async_cache, true, Opts) of
-        true ->
-            spawn(Writer),
-            ?event(compute, {caching_delegated, {proc_id, ProcID}, {slot, Slot}}, Opts);
-        false ->
-            Writer(),
-            ?event(compute, {caching_completed, {proc_id, ProcID}, {slot, Slot}}, Opts)
     end,
+    ?event(compute, {caching_result, {proc_id, ProcID}, {slot, Slot}}, Opts),
+    dev_process_cache:write(ProcID, Slot, ResMaybeWithSnapshot, Opts),
+    ?event(compute, {caching_completed, {proc_id, ProcID}, {slot, Slot}}, Opts),
     hb_maps:without([<<"snapshot">>], ResMaybeWithSnapshot, Opts).
 
 %% @doc Should we snapshot a new full state result? First, we check if the 

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -408,7 +408,9 @@ compute_slot(ProcID, State, RawInputMsg, InitReq, TargetSlot, Opts) ->
                     }
                 }
             ),
-            % Notify only once the slot is readable from the process cache.
+            % Notify waiters only after the slot is readable from the process
+            % cache. Waiters may immediately re-enter via `/compute' or `/push',
+            % and those paths treat the cache as the completion boundary.
             dev_process_worker:notify_compute(
                 ProcID,
                 Slot,
@@ -526,7 +528,8 @@ dispatch_push(Process, Slot, MaxDepth, Req, Opts) ->
     ok.
 
 %% @doc Store the resulting state in the cache, potentially with the snapshot
-%% key.
+%% key. The write is synchronous: callers may notify waiters or run push hooks
+%% as soon as this returns, so the slot must already be cache-visible.
 store_result(ForceSnapshot, ProcID, Slot, Res, Req, Opts) ->
     % Cache the `Snapshot' key as frequently as the node is configured to.
     ResMaybeWithSnapshot =

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -408,9 +408,7 @@ compute_slot(ProcID, State, RawInputMsg, InitReq, TargetSlot, Opts) ->
                     }
                 }
             ),
-            % Notify waiters only after the slot is readable from the process
-            % cache. Waiters may immediately re-enter via `/compute' or `/push',
-            % and those paths treat the cache as the completion boundary.
+            % Notify only once the slot is readable from the process cache.
             dev_process_worker:notify_compute(
                 ProcID,
                 Slot,
@@ -528,8 +526,7 @@ dispatch_push(Process, Slot, MaxDepth, Req, Opts) ->
     ok.
 
 %% @doc Store the resulting state in the cache, potentially with the snapshot
-%% key. The write is synchronous: callers may notify waiters or run push hooks
-%% as soon as this returns, so the slot must already be cache-visible.
+%% key.
 store_result(ForceSnapshot, ProcID, Slot, Res, Req, Opts) ->
     % Cache the `Snapshot' key as frequently as the node is configured to.
     ResMaybeWithSnapshot =

--- a/src/dev_process.erl
+++ b/src/dev_process.erl
@@ -48,6 +48,7 @@
 -module(dev_process).
 %%% Public API
 -export([info/1, as/3, compute/3, schedule/3, slot/3, now/3, push/3, snapshot/3]).
+-export([target_slot/2]).
 -export([default_device/3]).
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("include/hb.hrl").
@@ -204,14 +205,7 @@ init(Base, Req, Opts) ->
 compute(Base, Req, Opts) ->
     ProcBase = dev_process_lib:ensure_process_key(Base, Opts),
     ProcID = dev_process_lib:process_id(ProcBase, #{}, Opts),
-    TargetSlot =
-        hb_ao:get_first(
-            [
-                {{as, <<"message@1.0">>, Req}, <<"compute">>},
-                {{as, <<"message@1.0">>, Req}, <<"slot">>}
-            ],
-            Opts
-        ),
+    TargetSlot = target_slot(Req, Opts),
     case TargetSlot of
         not_found ->
             % The slot is not set, so we need to serve the latest known state
@@ -252,6 +246,16 @@ compute(Base, Req, Opts) ->
                     )
             end
     end.
+
+%% @doc Return the slot requested by a `compute' request, or `not_found'.
+target_slot(Req, Opts) ->
+    hb_ao:get_first(
+        [
+            {{as, <<"message@1.0">>, Req}, <<"compute">>},
+            {{as, <<"message@1.0">>, Req}, <<"slot">>}
+        ],
+        Opts
+    ).
 
 %% @doc Continually get and apply the next assignment from the scheduler until
 %% we reach the target slot that the user has requested.

--- a/src/dev_process_cache.erl
+++ b/src/dev_process_cache.erl
@@ -3,7 +3,7 @@
 %%% convenient interface for reading the result of a process at a given slot or
 %%% message ID.
 -module(dev_process_cache).
--export([latest/2, latest/3, latest/4, read/2, read/3, write/4]).
+-export([latest/2, latest/3, latest/4, latest_slot/2, read/2, read/3, write/4]).
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
 
@@ -57,6 +57,28 @@ path(ProcID, Ref, PathSuffix, Opts) ->
             _ -> [Ref]
         end ++ PathSuffix
     ).
+
+%% @doc Return the highest slot number that has been written into the
+%% local cache for a process, without reading the slot's contents.
+%% Returns `not_found' when the cache holds no slots for the process.
+%%
+%% Cheaper than `latest/2,3,4' when the caller only needs to know
+%% whether a particular slot is already computed (for example, the
+%% `~process@1.0' worker grouper deciding whether to bypass the worker
+%% queue for a cache-resolvable read).
+latest_slot(ProcID, Opts) ->
+    Scope = hb_opts:get(process_cache_scope, local, Opts),
+    UnscopedStore =
+        case hb_opts:get(store, no_viable_store, Opts) of
+            StoreMsg when is_map(StoreMsg) -> [StoreMsg];
+            Other -> Other
+        end,
+    ScopedOpts = Opts#{ store => hb_store:scope(UnscopedStore, Scope) },
+    Path = path(ProcID, slot_root, ScopedOpts),
+    case hb_cache:list_numbered(Path, ScopedOpts) of
+        [] -> not_found;
+        Slots -> {ok, lists:max(Slots)}
+    end.
 
 %% @doc Retrieve the latest slot for a given process. Optionally state a limit
 %% on the slot number to search for, as well as a required path that the slot

--- a/src/dev_process_cache.erl
+++ b/src/dev_process_cache.erl
@@ -44,7 +44,7 @@ write(ProcID, Slot, Msg, Opts) ->
 %% @doc Calculate the path of a result, given a process ID and a slot.
 path(ProcID, Ref, Opts) ->
     path(ProcID, Ref, [], Opts).
-path(ProcID, Ref, PathSuffix, Opts) ->
+path(ProcID, Ref, PathSuffix, _Opts) ->
     hb_path:to_binary(
         [
             <<"computed">>,

--- a/src/dev_process_cache.erl
+++ b/src/dev_process_cache.erl
@@ -44,7 +44,7 @@ write(ProcID, Slot, Msg, Opts) ->
 %% @doc Calculate the path of a result, given a process ID and a slot.
 path(ProcID, Ref, Opts) ->
     path(ProcID, Ref, [], Opts).
-path(ProcID, Ref, PathSuffix, _Opts) ->
+path(ProcID, Ref, PathSuffix, Opts) ->
     hb_path:to_binary(
         [
             <<"computed">>,

--- a/src/dev_process_cache.erl
+++ b/src/dev_process_cache.erl
@@ -73,7 +73,7 @@ latest_slot(ProcID, Opts) ->
             StoreMsg when is_map(StoreMsg) -> [StoreMsg];
             Other -> Other
         end,
-    ScopedOpts = Opts#{ store => hb_store:scope(UnscopedStore, Scope) },
+    ScopedOpts = Opts#{ <<"store">> => hb_store:scope(UnscopedStore, Scope) },
     Path = path(ProcID, slot_root, ScopedOpts),
     case hb_cache:list_numbered(Path, ScopedOpts) of
         [] -> not_found;

--- a/src/dev_process_cache.erl
+++ b/src/dev_process_cache.erl
@@ -3,7 +3,7 @@
 %%% convenient interface for reading the result of a process at a given slot or
 %%% message ID.
 -module(dev_process_cache).
--export([latest/2, latest/3, latest/4, latest_slot/2, read/2, read/3, write/4]).
+-export([latest/2, latest/3, latest/4, read/2, read/3, write/4]).
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
 
@@ -44,7 +44,7 @@ write(ProcID, Slot, Msg, Opts) ->
 %% @doc Calculate the path of a result, given a process ID and a slot.
 path(ProcID, Ref, Opts) ->
     path(ProcID, Ref, [], Opts).
-path(ProcID, Ref, PathSuffix, Opts) ->
+path(ProcID, Ref, PathSuffix, _Opts) ->
     hb_path:to_binary(
         [
             <<"computed">>,
@@ -57,28 +57,6 @@ path(ProcID, Ref, PathSuffix, Opts) ->
             _ -> [Ref]
         end ++ PathSuffix
     ).
-
-%% @doc Return the highest slot number that has been written into the
-%% local cache for a process, without reading the slot's contents.
-%% Returns `not_found' when the cache holds no slots for the process.
-%%
-%% Cheaper than `latest/2,3,4' when the caller only needs to know
-%% whether a particular slot is already computed (for example, the
-%% `~process@1.0' worker grouper deciding whether to bypass the worker
-%% queue for a cache-resolvable read).
-latest_slot(ProcID, Opts) ->
-    Scope = hb_opts:get(process_cache_scope, local, Opts),
-    UnscopedStore =
-        case hb_opts:get(store, no_viable_store, Opts) of
-            StoreMsg when is_map(StoreMsg) -> [StoreMsg];
-            Other -> Other
-        end,
-    ScopedOpts = Opts#{ <<"store">> => hb_store:scope(UnscopedStore, Scope) },
-    Path = path(ProcID, slot_root, ScopedOpts),
-    case hb_cache:list_numbered(Path, ScopedOpts) of
-        [] -> not_found;
-        Slots -> {ok, lists:max(Slots)}
-    end.
 
 %% @doc Retrieve the latest slot for a given process. Optionally state a limit
 %% on the slot number to search for, as well as a required path that the slot

--- a/src/dev_process_test_vectors.erl
+++ b/src/dev_process_test_vectors.erl
@@ -526,12 +526,12 @@ now_results_test_parallel_() ->
     end}.
 
 prior_results_accessible_test_parallel_() ->
-    {timeout, 30, fun() ->
-        Opts = test_opts(),
-        Base = aos_process(Opts),
-        schedule_aos_call(Base, <<"return 1+1">>, Opts),
-        schedule_aos_call(Base, <<"return 2+2">>, Opts),
-        ?assertEqual(
+	{timeout, 30, fun() ->
+		Opts = test_opts(),
+		Base = aos_process(Opts),
+		schedule_aos_call(Base, <<"return 1+1">>, Opts),
+		schedule_aos_call(Base, <<"return 2+2">>, Opts),
+		?assertEqual(
             {ok, <<"4">>},
             hb_ao:resolve(Base, <<"now/results/data">>, Opts)
         ),
@@ -541,11 +541,11 @@ prior_results_accessible_test_parallel_() ->
                 #{ <<"path">> => <<"compute">>, <<"slot">> => 1 },
                 Opts
             ),
-        ?assertMatch(
+		?assertMatch(
             #{ <<"results">> := #{ <<"data">> := <<"4">> } },
             hb_cache:ensure_all_loaded(Results, Opts)
-        )
-    end}.
+		)
+	end}.
 
 persistent_process_test_parallel() ->
     {timeout, 30, fun() ->

--- a/src/dev_process_test_vectors.erl
+++ b/src/dev_process_test_vectors.erl
@@ -302,7 +302,6 @@ http_wasm_process_by_id_test_parallel() ->
         <<"port">> => 10000 + rand:uniform(10000),
         <<"priv-wallet">> => SchedWallet,
         <<"cache-control">> => <<"always">>,
-        <<"process-async-cache">> => false,
         <<"store">> => #{
             <<"store-module">> => hb_store_fs,
             <<"name">> => <<"cache-mainnet">>
@@ -495,8 +494,7 @@ do_test_restore() ->
     % 2. Return the variable.
     % Execute the first computation, then the second as a disconnected process.
     Opts = test_opts(#{
-        <<"process-cache-frequency">> => 1,
-        <<"process-async-cache">> => false
+        <<"process-cache-frequency">> => 1
     }),
     Base = aos_process(Opts),
     schedule_aos_call(Base, <<"X = 42">>, Opts),
@@ -528,12 +526,12 @@ now_results_test_parallel_() ->
     end}.
 
 prior_results_accessible_test_parallel_() ->
-	{timeout, 30, fun() ->
-		Opts = test_opts(#{ <<"process-async-cache">> => false }),
-		Base = aos_process(Opts),
-		schedule_aos_call(Base, <<"return 1+1">>, Opts),
-		schedule_aos_call(Base, <<"return 2+2">>, Opts),
-		?assertEqual(
+    {timeout, 30, fun() ->
+        Opts = test_opts(),
+        Base = aos_process(Opts),
+        schedule_aos_call(Base, <<"return 1+1">>, Opts),
+        schedule_aos_call(Base, <<"return 2+2">>, Opts),
+        ?assertEqual(
             {ok, <<"4">>},
             hb_ao:resolve(Base, <<"now/results/data">>, Opts)
         ),
@@ -543,11 +541,11 @@ prior_results_accessible_test_parallel_() ->
                 #{ <<"path">> => <<"compute">>, <<"slot">> => 1 },
                 Opts
             ),
-		?assertMatch(
+        ?assertMatch(
             #{ <<"results">> := #{ <<"data">> := <<"4">> } },
             hb_cache:ensure_all_loaded(Results, Opts)
-		)
-	end}.
+        )
+    end}.
 
 persistent_process_test_parallel() ->
     {timeout, 30, fun() ->

--- a/src/dev_process_test_vectors.erl
+++ b/src/dev_process_test_vectors.erl
@@ -526,12 +526,12 @@ now_results_test_parallel_() ->
     end}.
 
 prior_results_accessible_test_parallel_() ->
-	{timeout, 30, fun() ->
-		Opts = test_opts(),
-		Base = aos_process(Opts),
-		schedule_aos_call(Base, <<"return 1+1">>, Opts),
-		schedule_aos_call(Base, <<"return 2+2">>, Opts),
-		?assertEqual(
+    {timeout, 30, fun() ->
+        Opts = test_opts(),
+        Base = aos_process(Opts),
+        schedule_aos_call(Base, <<"return 1+1">>, Opts),
+        schedule_aos_call(Base, <<"return 2+2">>, Opts),
+        ?assertEqual(
             {ok, <<"4">>},
             hb_ao:resolve(Base, <<"now/results/data">>, Opts)
         ),
@@ -541,11 +541,11 @@ prior_results_accessible_test_parallel_() ->
                 #{ <<"path">> => <<"compute">>, <<"slot">> => 1 },
                 Opts
             ),
-		?assertMatch(
+        ?assertMatch(
             #{ <<"results">> := #{ <<"data">> := <<"4">> } },
             hb_cache:ensure_all_loaded(Results, Opts)
-		)
-	end}.
+        )
+    end}.
 
 persistent_process_test_parallel() ->
     {timeout, 30, fun() ->

--- a/src/dev_process_worker.erl
+++ b/src/dev_process_worker.erl
@@ -275,11 +275,11 @@ grouper_skips_when_slot_cached_test() ->
     test_init(),
     Opts =
         #{
-            store => hb_test_utils:test_store(hb_store_lmdb),
-            priv_wallet => ar_wallet:new()
+            <<"store">> => hb_test_utils:test_store(hb_store_lmdb),
+            <<"priv-wallet">> => ar_wallet:new()
         },
     M1 = dev_process_test_vectors:aos_process(Opts),
-    POpts = Opts#{ process_workers => true },
+    POpts = Opts#{ <<"process-workers">> => true },
     %% With the cache empty, every compute request must group by
     %% process so that the worker can do the actual work.
     Uncached = #{ <<"path">> => <<"compute">>, <<"slot">> => 5 },

--- a/src/dev_process_worker.erl
+++ b/src/dev_process_worker.erl
@@ -7,36 +7,23 @@
 -include_lib("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-%% @doc Return a group name for a request. Cached compute reads run
-%% ungrouped; uncached compute work groups by process ID; everything
-%% else uses the default grouper.
+%% @doc Return a group name for a request.
 group(Base, undefined, Opts) ->
     hb_persistent:default_grouper(Base, undefined, Opts);
 group(Base, Req, Opts) ->
-    ProcessWorkers = hb_opts:get(process_workers, false, Opts),
-    IsCompute = hb_path:matches(<<"compute">>, hb_path:hd(Req, Opts)),
-    case ProcessWorkers andalso IsCompute of
+    case hb_opts:get(process_workers, false, Opts)
+            andalso hb_path:matches(<<"compute">>, hb_path:hd(Req, Opts)) of
         true ->
             compute_group(Base, Req, Opts);
         false ->
             hb_persistent:default_grouper(Base, Req, Opts)
     end.
 
-%% @doc Decide which group to enrol a `compute' request into. Cache-hit
-%% reads bypass the per-process queue via `ungrouped_exec'; everything
-%% else is serialised through the worker keyed on the process ID.
+%% @doc Group uncached compute work by process; let cached reads run ungrouped.
 compute_group(Base, Req, Opts) ->
     ProcID = process_to_group_name(Base, Opts),
     case compute_cached(ProcID, dev_process:target_slot(Req, Opts), Opts) of
-        true ->
-            ?event(worker,
-                {compute_cache_hit_bypassing_queue,
-                    {proc_id, ProcID},
-                    {req, Req}
-                },
-                Opts
-            ),
-            ungrouped_exec;
+        true -> ungrouped_exec;
         false ->
             ProcID
     end.
@@ -44,12 +31,12 @@ compute_group(Base, Req, Opts) ->
 %% @doc Return `true' if the requested compute result is already cached.
 compute_cached(ProcID, not_found, Opts) ->
     case dev_process_cache:latest(ProcID, Opts) of
-        {ok, _Slot, _Msg} -> true;
+        {ok, _, _} -> true;
         _ -> false
     end;
 compute_cached(ProcID, RawSlot, Opts) ->
     case dev_process_cache:read(ProcID, hb_util:int(RawSlot), Opts) of
-        {ok, _Msg} -> true;
+        {ok, _} -> true;
         _ -> false
     end.
 
@@ -211,12 +198,7 @@ grouper_test() ->
     ?assertEqual(G1, G2),
     ?assertNotEqual(G1, G3).
 
-%% @doc `compute' requests whose result is already in the local cache
-%% should bypass the per-process worker queue (returning the
-%% `ungrouped_exec' sentinel that `hb_persistent:find_or_register/3'
-%% short-circuits). Requests that still need work, and requests for a
-%% slot beyond what is cached, must continue to serialise through the
-%% process group.
+%% @doc Cached compute results bypass process-worker grouping.
 grouper_skips_when_slot_cached_test() ->
     test_init(),
     Opts =
@@ -226,13 +208,11 @@ grouper_skips_when_slot_cached_test() ->
         },
     M1 = dev_process_test_vectors:aos_process(Opts),
     POpts = Opts#{ <<"process-workers">> => true },
-    % With the cache empty, every compute request must group by
-    % process so that the worker can do the actual work.
-    Uncached = #{ <<"path">> => <<"compute">>, <<"slot">> => 5 },
-    ProcessGroup = hb_persistent:group(M1, Uncached, POpts),
+    Group = fun(Req) -> hb_persistent:group(M1, Req, POpts) end,
+    Compute = fun(Slot) -> #{ <<"path">> => <<"compute">>, <<"slot">> => Slot } end,
+    Uncached = Compute(5),
+    ProcessGroup = Group(Uncached),
     ?assertNotEqual(ungrouped_exec, ProcessGroup),
-    % Write slot 5 into the cache. The same request now has a result
-    % available and the grouper should step out of the queue.
     {ok, _} =
         dev_process_cache:write(
             ProcessGroup,
@@ -240,23 +220,7 @@ grouper_skips_when_slot_cached_test() ->
             #{ <<"hello">> => <<"cached">> },
             Opts
         ),
-    ?assertEqual(
-        ungrouped_exec,
-        hb_persistent:group(M1, Uncached, POpts)
-    ),
-    % Cache slots are not assumed to be gap-free. A lower slot that
-    % has not actually been written must still go through the worker.
-    MissingLower = #{ <<"path">> => <<"compute">>, <<"slot">> => 4 },
-    ?assertEqual(ProcessGroup, hb_persistent:group(M1, MissingLower, POpts)),
-    % A request for a slot beyond what we cached must still be
-    % serialised through the worker.
-    Beyond = #{ <<"path">> => <<"compute">>, <<"slot">> => 999 },
-    ?assertEqual(ProcessGroup, hb_persistent:group(M1, Beyond, POpts)),
-    % A `compute' request without a slot resolves via the cache-only
-    % branch of `now/3' once any slot exists, so it also bypasses the
-    % queue.
-    NoSlot = #{ <<"path">> => <<"compute">> },
-    ?assertEqual(
-        ungrouped_exec,
-        hb_persistent:group(M1, NoSlot, POpts)
-    ).
+    ?assertEqual(ungrouped_exec, Group(Uncached)),
+    ?assertEqual(ProcessGroup, Group(Compute(4))),
+    ?assertEqual(ProcessGroup, Group(Compute(999))),
+    ?assertEqual(ungrouped_exec, Group(#{ <<"path">> => <<"compute">> })).

--- a/src/dev_process_worker.erl
+++ b/src/dev_process_worker.erl
@@ -36,9 +36,9 @@ group(Base, Req, Opts) ->
             end
     end.
 
-%% @doc Decide which group to enrol a `compute' request into. Cache-hit
+%% @doc Decide which group to enroll a `compute' request into. Cache-hit
 %% reads bypass the per-process queue via `ungrouped_exec'; everything
-%% else is serialised through the worker keyed on the process ID.
+%% else is serialized through the worker keyed on the process ID.
 compute_group(Base, Req, Opts) ->
     ProcID = process_to_group_name(Base, Opts),
     case requested_compute_already_cached(ProcID, Req, Opts) of
@@ -63,24 +63,26 @@ compute_group(Base, Req, Opts) ->
 %%     is already written.
 %%   * No slot -- the device falls into the cache-only branch of
 %%     `now/3', so cached iff at least one slot exists for the process.
+%%   * Invalid slot -- not cached.
 %%
 %% Any error on the cache lookup falls back to `false', so the caller
-%% defaults to the existing per-process group and behaviour is, at
+%% defaults to the existing per-process group and behavior is, at
 %% worst, unchanged.
 requested_compute_already_cached(ProcID, Req, Opts) ->
     try
-        case dev_process_cache:latest_slot(ProcID, Opts) of
-            {ok, _LatestCached} ->
-                case requested_slot(Req, Opts) of
-                    undefined -> true;
-                    Slot ->
-                        case dev_process_cache:read(ProcID, Slot, Opts) of
-                            {ok, _} -> true;
-                            _ -> false
-                        end
+        case requested_slot(Req, Opts) of
+            undefined ->
+                case dev_process_cache:latest_slot(ProcID, Opts) of
+                    {ok, _LatestCached} -> true;
+                    _ -> false
                 end;
-            _ ->
-                false
+            invalid ->
+                false;
+            Slot ->
+                case dev_process_cache:read(ProcID, Slot, Opts) of
+                    {ok, _} -> true;
+                    _ -> false
+                end
         end
     catch
         _:_ -> false
@@ -89,8 +91,8 @@ requested_compute_already_cached(ProcID, Req, Opts) ->
 %% @doc Extract the requested slot number from a `compute' request, if
 %% any. Mirrors `dev_process:compute/3''s lookup order: an explicit
 %% `compute' key first, then `slot'. Returns `undefined' when neither
-%% is present, or when the value cannot be parsed as a non-negative
-%% integer.
+%% is present, or `invalid' when the explicit value cannot be parsed as
+%% a non-negative integer.
 requested_slot(Req, Opts) ->
     Raw =
         hb_ao:get_first(
@@ -105,9 +107,9 @@ requested_slot(Req, Opts) ->
         _ ->
             try hb_util:int(Raw) of
                 Int when is_integer(Int), Int >= 0 -> Int;
-                _ -> undefined
+                _ -> invalid
             catch
-                _:_ -> undefined
+                _:_ -> invalid
             end
     end.
 
@@ -273,7 +275,7 @@ grouper_test() ->
 %% should bypass the per-process worker queue (returning the
 %% `ungrouped_exec' sentinel that `hb_persistent:find_or_register/3'
 %% short-circuits). Requests that still need work, and requests for a
-%% slot beyond what is cached, must continue to serialise through the
+%% slot beyond what is cached, must continue to serialize through the
 %% process group.
 grouper_skips_when_slot_cached_test() ->
     test_init(),
@@ -306,8 +308,11 @@ grouper_skips_when_slot_cached_test() ->
     %% has not actually been written must still go through the worker.
     MissingLower = #{ <<"path">> => <<"compute">>, <<"slot">> => 4 },
     ?assertEqual(ProcessGroup, hb_persistent:group(M1, MissingLower, POpts)),
+    %% Invalid slot values are explicit requests, not slotless reads.
+    Invalid = #{ <<"path">> => <<"compute">>, <<"slot">> => <<"bad">> },
+    ?assertEqual(ProcessGroup, hb_persistent:group(M1, Invalid, POpts)),
     %% A request for a slot beyond what we cached must still be
-    %% serialised through the worker.
+    %% serialized through the worker.
     Beyond = #{ <<"path">> => <<"compute">>, <<"slot">> => 999 },
     ?assertEqual(ProcessGroup, hb_persistent:group(M1, Beyond, POpts)),
     %% A `compute' request without a slot resolves via the cache-only

--- a/src/dev_process_worker.erl
+++ b/src/dev_process_worker.erl
@@ -7,33 +7,19 @@
 -include_lib("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-%% @doc Returns a group name for a request. The worker is responsible for all
-%% computation work on the same process on a single node, so we use the
-%% process ID as the group name -- but only when the request is one that
-%% actually needs the worker to compute. `compute' requests whose result
-%% is already available in the local cache return `ungrouped_exec' so
-%% that `hb_persistent:find_or_register/3' short-circuits the wait and
-%% the device's `compute/3' can serve the cached message immediately.
-%% This keeps the dedup invariants for genuine compute work while
-%% letting concurrent cache-hit reads run in parallel.
+%% @doc Return a group name for a request. Cached compute reads run
+%% ungrouped; uncached compute work groups by process ID; everything
+%% else uses the default grouper.
 group(Base, undefined, Opts) ->
     hb_persistent:default_grouper(Base, undefined, Opts);
 group(Base, Req, Opts) ->
-    case hb_opts:get(process_workers, false, Opts) of
-        false ->
-            hb_persistent:default_grouper(Base, Req, Opts);
+    ProcessWorkers = hb_opts:get(process_workers, false, Opts),
+    IsCompute = hb_path:matches(<<"compute">>, hb_path:hd(Req, Opts)),
+    case ProcessWorkers andalso IsCompute of
         true ->
-            case Req of
-                undefined ->
-                    hb_persistent:default_grouper(Base, undefined, Opts);
-                _ ->
-                    case hb_path:matches(<<"compute">>, hb_path:hd(Req, Opts)) of
-                        true ->
-                            compute_group(Base, Req, Opts);
-                        _ ->
-                            hb_persistent:default_grouper(Base, Req, Opts)
-                    end
-            end
+            compute_group(Base, Req, Opts);
+        false ->
+            hb_persistent:default_grouper(Base, Req, Opts)
     end.
 
 %% @doc Decide which group to enrol a `compute' request into. Cache-hit
@@ -41,7 +27,7 @@ group(Base, Req, Opts) ->
 %% else is serialised through the worker keyed on the process ID.
 compute_group(Base, Req, Opts) ->
     ProcID = process_to_group_name(Base, Opts),
-    case requested_compute_already_cached(ProcID, Req, Opts) of
+    case compute_cached(ProcID, dev_process:target_slot(Req, Opts), Opts) of
         true ->
             ?event(worker,
                 {compute_cache_hit_bypassing_queue,
@@ -55,60 +41,16 @@ compute_group(Base, Req, Opts) ->
             ProcID
     end.
 
-%% @doc Returns `true' iff `dev_process:compute/3' will resolve the
-%% request from the local cache without spawning or awaiting work.
-%% Mirrors the lookup rules in `dev_process:compute/3':
-%%
-%%   * Explicit `compute' or `slot' key -- cached iff that slot number
-%%     is already written.
-%%   * No slot -- the device falls into the cache-only branch of
-%%     `now/3', so cached iff at least one slot exists for the process.
-%%
-%% Any error on the cache lookup falls back to `false', so the caller
-%% defaults to the existing per-process group and behaviour is, at
-%% worst, unchanged.
-requested_compute_already_cached(ProcID, Req, Opts) ->
-    try
-        case dev_process_cache:latest_slot(ProcID, Opts) of
-            {ok, _LatestCached} ->
-                case requested_slot(Req, Opts) of
-                    undefined -> true;
-                    Slot ->
-                        case dev_process_cache:read(ProcID, Slot, Opts) of
-                            {ok, _} -> true;
-                            _ -> false
-                        end
-                end;
-            _ ->
-                false
-        end
-    catch
-        _:_ -> false
-    end.
-
-%% @doc Extract the requested slot number from a `compute' request, if
-%% any. Mirrors `dev_process:compute/3''s lookup order: an explicit
-%% `compute' key first, then `slot'. Returns `undefined' when neither
-%% is present, or when the value cannot be parsed as a non-negative
-%% integer.
-requested_slot(Req, Opts) ->
-    Raw =
-        hb_ao:get_first(
-            [
-                {{as, <<"message@1.0">>, Req}, <<"compute">>},
-                {{as, <<"message@1.0">>, Req}, <<"slot">>}
-            ],
-            Opts
-        ),
-    case Raw of
-        not_found -> undefined;
-        _ ->
-            try hb_util:int(Raw) of
-                Int when is_integer(Int), Int >= 0 -> Int;
-                _ -> undefined
-            catch
-                _:_ -> undefined
-            end
+%% @doc Return `true' if the requested compute result is already cached.
+compute_cached(ProcID, not_found, Opts) ->
+    case dev_process_cache:latest(ProcID, Opts) of
+        {ok, _Slot, _Msg} -> true;
+        _ -> false
+    end;
+compute_cached(ProcID, RawSlot, Opts) ->
+    case dev_process_cache:read(ProcID, hb_util:int(RawSlot), Opts) of
+        {ok, _Msg} -> true;
+        _ -> false
     end.
 
 process_to_group_name(Base, Opts) ->

--- a/src/dev_process_worker.erl
+++ b/src/dev_process_worker.erl
@@ -7,23 +7,36 @@
 -include_lib("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-%% @doc Return a group name for a request.
+%% @doc Return a group name for a request. Cached compute reads run
+%% ungrouped; uncached compute work groups by process ID; everything
+%% else uses the default grouper.
 group(Base, undefined, Opts) ->
     hb_persistent:default_grouper(Base, undefined, Opts);
 group(Base, Req, Opts) ->
-    case hb_opts:get(process_workers, false, Opts)
-            andalso hb_path:matches(<<"compute">>, hb_path:hd(Req, Opts)) of
+    ProcessWorkers = hb_opts:get(process_workers, false, Opts),
+    IsCompute = hb_path:matches(<<"compute">>, hb_path:hd(Req, Opts)),
+    case ProcessWorkers andalso IsCompute of
         true ->
             compute_group(Base, Req, Opts);
         false ->
             hb_persistent:default_grouper(Base, Req, Opts)
     end.
 
-%% @doc Group uncached compute work by process; let cached reads run ungrouped.
+%% @doc Decide which group to enrol a `compute' request into. Cache-hit
+%% reads bypass the per-process queue via `ungrouped_exec'; everything
+%% else is serialised through the worker keyed on the process ID.
 compute_group(Base, Req, Opts) ->
     ProcID = process_to_group_name(Base, Opts),
     case compute_cached(ProcID, dev_process:target_slot(Req, Opts), Opts) of
-        true -> ungrouped_exec;
+        true ->
+            ?event(worker,
+                {compute_cache_hit_bypassing_queue,
+                    {proc_id, ProcID},
+                    {req, Req}
+                },
+                Opts
+            ),
+            ungrouped_exec;
         false ->
             ProcID
     end.
@@ -31,12 +44,12 @@ compute_group(Base, Req, Opts) ->
 %% @doc Return `true' if the requested compute result is already cached.
 compute_cached(ProcID, not_found, Opts) ->
     case dev_process_cache:latest(ProcID, Opts) of
-        {ok, _, _} -> true;
+        {ok, _Slot, _Msg} -> true;
         _ -> false
     end;
 compute_cached(ProcID, RawSlot, Opts) ->
     case dev_process_cache:read(ProcID, hb_util:int(RawSlot), Opts) of
-        {ok, _} -> true;
+        {ok, _Msg} -> true;
         _ -> false
     end.
 
@@ -198,7 +211,12 @@ grouper_test() ->
     ?assertEqual(G1, G2),
     ?assertNotEqual(G1, G3).
 
-%% @doc Cached compute results bypass process-worker grouping.
+%% @doc `compute' requests whose result is already in the local cache
+%% should bypass the per-process worker queue (returning the
+%% `ungrouped_exec' sentinel that `hb_persistent:find_or_register/3'
+%% short-circuits). Requests that still need work, and requests for a
+%% slot beyond what is cached, must continue to serialise through the
+%% process group.
 grouper_skips_when_slot_cached_test() ->
     test_init(),
     Opts =
@@ -208,11 +226,13 @@ grouper_skips_when_slot_cached_test() ->
         },
     M1 = dev_process_test_vectors:aos_process(Opts),
     POpts = Opts#{ <<"process-workers">> => true },
-    Group = fun(Req) -> hb_persistent:group(M1, Req, POpts) end,
-    Compute = fun(Slot) -> #{ <<"path">> => <<"compute">>, <<"slot">> => Slot } end,
-    Uncached = Compute(5),
-    ProcessGroup = Group(Uncached),
+    % With the cache empty, every compute request must group by
+    % process so that the worker can do the actual work.
+    Uncached = #{ <<"path">> => <<"compute">>, <<"slot">> => 5 },
+    ProcessGroup = hb_persistent:group(M1, Uncached, POpts),
     ?assertNotEqual(ungrouped_exec, ProcessGroup),
+    % Write slot 5 into the cache. The same request now has a result
+    % available and the grouper should step out of the queue.
     {ok, _} =
         dev_process_cache:write(
             ProcessGroup,
@@ -220,7 +240,23 @@ grouper_skips_when_slot_cached_test() ->
             #{ <<"hello">> => <<"cached">> },
             Opts
         ),
-    ?assertEqual(ungrouped_exec, Group(Uncached)),
-    ?assertEqual(ProcessGroup, Group(Compute(4))),
-    ?assertEqual(ProcessGroup, Group(Compute(999))),
-    ?assertEqual(ungrouped_exec, Group(#{ <<"path">> => <<"compute">> })).
+    ?assertEqual(
+        ungrouped_exec,
+        hb_persistent:group(M1, Uncached, POpts)
+    ),
+    % Cache slots are not assumed to be gap-free. A lower slot that
+    % has not actually been written must still go through the worker.
+    MissingLower = #{ <<"path">> => <<"compute">>, <<"slot">> => 4 },
+    ?assertEqual(ProcessGroup, hb_persistent:group(M1, MissingLower, POpts)),
+    % A request for a slot beyond what we cached must still be
+    % serialised through the worker.
+    Beyond = #{ <<"path">> => <<"compute">>, <<"slot">> => 999 },
+    ?assertEqual(ProcessGroup, hb_persistent:group(M1, Beyond, POpts)),
+    % A `compute' request without a slot resolves via the cache-only
+    % branch of `now/3' once any slot exists, so it also bypasses the
+    % queue.
+    NoSlot = #{ <<"path">> => <<"compute">> },
+    ?assertEqual(
+        ungrouped_exec,
+        hb_persistent:group(M1, NoSlot, POpts)
+    ).

--- a/src/dev_process_worker.erl
+++ b/src/dev_process_worker.erl
@@ -36,9 +36,9 @@ group(Base, Req, Opts) ->
             end
     end.
 
-%% @doc Decide which group to enroll a `compute' request into. Cache-hit
+%% @doc Decide which group to enrol a `compute' request into. Cache-hit
 %% reads bypass the per-process queue via `ungrouped_exec'; everything
-%% else is serialized through the worker keyed on the process ID.
+%% else is serialised through the worker keyed on the process ID.
 compute_group(Base, Req, Opts) ->
     ProcID = process_to_group_name(Base, Opts),
     case requested_compute_already_cached(ProcID, Req, Opts) of
@@ -63,26 +63,24 @@ compute_group(Base, Req, Opts) ->
 %%     is already written.
 %%   * No slot -- the device falls into the cache-only branch of
 %%     `now/3', so cached iff at least one slot exists for the process.
-%%   * Invalid slot -- not cached.
 %%
 %% Any error on the cache lookup falls back to `false', so the caller
-%% defaults to the existing per-process group and behavior is, at
+%% defaults to the existing per-process group and behaviour is, at
 %% worst, unchanged.
 requested_compute_already_cached(ProcID, Req, Opts) ->
     try
-        case requested_slot(Req, Opts) of
-            undefined ->
-                case dev_process_cache:latest_slot(ProcID, Opts) of
-                    {ok, _LatestCached} -> true;
-                    _ -> false
+        case dev_process_cache:latest_slot(ProcID, Opts) of
+            {ok, _LatestCached} ->
+                case requested_slot(Req, Opts) of
+                    undefined -> true;
+                    Slot ->
+                        case dev_process_cache:read(ProcID, Slot, Opts) of
+                            {ok, _} -> true;
+                            _ -> false
+                        end
                 end;
-            invalid ->
-                false;
-            Slot ->
-                case dev_process_cache:read(ProcID, Slot, Opts) of
-                    {ok, _} -> true;
-                    _ -> false
-                end
+            _ ->
+                false
         end
     catch
         _:_ -> false
@@ -91,8 +89,8 @@ requested_compute_already_cached(ProcID, Req, Opts) ->
 %% @doc Extract the requested slot number from a `compute' request, if
 %% any. Mirrors `dev_process:compute/3''s lookup order: an explicit
 %% `compute' key first, then `slot'. Returns `undefined' when neither
-%% is present, or `invalid' when the explicit value cannot be parsed as
-%% a non-negative integer.
+%% is present, or when the value cannot be parsed as a non-negative
+%% integer.
 requested_slot(Req, Opts) ->
     Raw =
         hb_ao:get_first(
@@ -107,9 +105,9 @@ requested_slot(Req, Opts) ->
         _ ->
             try hb_util:int(Raw) of
                 Int when is_integer(Int), Int >= 0 -> Int;
-                _ -> invalid
+                _ -> undefined
             catch
-                _:_ -> invalid
+                _:_ -> undefined
             end
     end.
 
@@ -275,7 +273,7 @@ grouper_test() ->
 %% should bypass the per-process worker queue (returning the
 %% `ungrouped_exec' sentinel that `hb_persistent:find_or_register/3'
 %% short-circuits). Requests that still need work, and requests for a
-%% slot beyond what is cached, must continue to serialize through the
+%% slot beyond what is cached, must continue to serialise through the
 %% process group.
 grouper_skips_when_slot_cached_test() ->
     test_init(),
@@ -308,11 +306,8 @@ grouper_skips_when_slot_cached_test() ->
     %% has not actually been written must still go through the worker.
     MissingLower = #{ <<"path">> => <<"compute">>, <<"slot">> => 4 },
     ?assertEqual(ProcessGroup, hb_persistent:group(M1, MissingLower, POpts)),
-    %% Invalid slot values are explicit requests, not slotless reads.
-    Invalid = #{ <<"path">> => <<"compute">>, <<"slot">> => <<"bad">> },
-    ?assertEqual(ProcessGroup, hb_persistent:group(M1, Invalid, POpts)),
     %% A request for a slot beyond what we cached must still be
-    %% serialized through the worker.
+    %% serialised through the worker.
     Beyond = #{ <<"path">> => <<"compute">>, <<"slot">> => 999 },
     ?assertEqual(ProcessGroup, hb_persistent:group(M1, Beyond, POpts)),
     %% A `compute' request without a slot resolves via the cache-only

--- a/src/dev_process_worker.erl
+++ b/src/dev_process_worker.erl
@@ -70,10 +70,14 @@ compute_group(Base, Req, Opts) ->
 requested_compute_already_cached(ProcID, Req, Opts) ->
     try
         case dev_process_cache:latest_slot(ProcID, Opts) of
-            {ok, LatestCached} ->
+            {ok, _LatestCached} ->
                 case requested_slot(Req, Opts) of
                     undefined -> true;
-                    Slot -> Slot =< LatestCached
+                    Slot ->
+                        case dev_process_cache:read(ProcID, Slot, Opts) of
+                            {ok, _} -> true;
+                            _ -> false
+                        end
                 end;
             _ ->
                 false
@@ -298,6 +302,10 @@ grouper_skips_when_slot_cached_test() ->
         ungrouped_exec,
         hb_persistent:group(M1, Uncached, POpts)
     ),
+    %% Cache slots are not assumed to be gap-free. A lower slot that
+    %% has not actually been written must still go through the worker.
+    MissingLower = #{ <<"path">> => <<"compute">>, <<"slot">> => 4 },
+    ?assertEqual(ProcessGroup, hb_persistent:group(M1, MissingLower, POpts)),
     %% A request for a slot beyond what we cached must still be
     %% serialised through the worker.
     Beyond = #{ <<"path">> => <<"compute">>, <<"slot">> => 999 },

--- a/src/dev_process_worker.erl
+++ b/src/dev_process_worker.erl
@@ -9,7 +9,13 @@
 
 %% @doc Returns a group name for a request. The worker is responsible for all
 %% computation work on the same process on a single node, so we use the
-%% process ID as the group name.
+%% process ID as the group name -- but only when the request is one that
+%% actually needs the worker to compute. `compute' requests whose result
+%% is already available in the local cache return `ungrouped_exec' so
+%% that `hb_persistent:find_or_register/3' short-circuits the wait and
+%% the device's `compute/3' can serve the cached message immediately.
+%% This keeps the dedup invariants for genuine compute work while
+%% letting concurrent cache-hit reads run in parallel.
 group(Base, undefined, Opts) ->
     hb_persistent:default_grouper(Base, undefined, Opts);
 group(Base, Req, Opts) ->
@@ -23,10 +29,81 @@ group(Base, Req, Opts) ->
                 _ ->
                     case hb_path:matches(<<"compute">>, hb_path:hd(Req, Opts)) of
                         true ->
-                            process_to_group_name(Base, Opts);
+                            compute_group(Base, Req, Opts);
                         _ ->
                             hb_persistent:default_grouper(Base, Req, Opts)
                     end
+            end
+    end.
+
+%% @doc Decide which group to enrol a `compute' request into. Cache-hit
+%% reads bypass the per-process queue via `ungrouped_exec'; everything
+%% else is serialised through the worker keyed on the process ID.
+compute_group(Base, Req, Opts) ->
+    ProcID = process_to_group_name(Base, Opts),
+    case requested_compute_already_cached(ProcID, Req, Opts) of
+        true ->
+            ?event(worker,
+                {compute_cache_hit_bypassing_queue,
+                    {proc_id, ProcID},
+                    {req, Req}
+                },
+                Opts
+            ),
+            ungrouped_exec;
+        false ->
+            ProcID
+    end.
+
+%% @doc Returns `true' iff `dev_process:compute/3' will resolve the
+%% request from the local cache without spawning or awaiting work.
+%% Mirrors the lookup rules in `dev_process:compute/3':
+%%
+%%   * Explicit `compute' or `slot' key -- cached iff that slot number
+%%     is already written.
+%%   * No slot -- the device falls into the cache-only branch of
+%%     `now/3', so cached iff at least one slot exists for the process.
+%%
+%% Any error on the cache lookup falls back to `false', so the caller
+%% defaults to the existing per-process group and behaviour is, at
+%% worst, unchanged.
+requested_compute_already_cached(ProcID, Req, Opts) ->
+    try
+        case dev_process_cache:latest_slot(ProcID, Opts) of
+            {ok, LatestCached} ->
+                case requested_slot(Req, Opts) of
+                    undefined -> true;
+                    Slot -> Slot =< LatestCached
+                end;
+            _ ->
+                false
+        end
+    catch
+        _:_ -> false
+    end.
+
+%% @doc Extract the requested slot number from a `compute' request, if
+%% any. Mirrors `dev_process:compute/3''s lookup order: an explicit
+%% `compute' key first, then `slot'. Returns `undefined' when neither
+%% is present, or when the value cannot be parsed as a non-negative
+%% integer.
+requested_slot(Req, Opts) ->
+    Raw =
+        hb_ao:get_first(
+            [
+                {{as, <<"message@1.0">>, Req}, <<"compute">>},
+                {{as, <<"message@1.0">>, Req}, <<"slot">>}
+            ],
+            Opts
+        ),
+    case Raw of
+        not_found -> undefined;
+        _ ->
+            try hb_util:int(Raw) of
+                Int when is_integer(Int), Int >= 0 -> Int;
+                _ -> undefined
+            catch
+                _:_ -> undefined
             end
     end.
 
@@ -187,3 +264,49 @@ grouper_test() ->
     ?event({group_samples, {g1, G1}, {g2, G2}, {g3, G3}}),
     ?assertEqual(G1, G2),
     ?assertNotEqual(G1, G3).
+
+%% @doc `compute' requests whose result is already in the local cache
+%% should bypass the per-process worker queue (returning the
+%% `ungrouped_exec' sentinel that `hb_persistent:find_or_register/3'
+%% short-circuits). Requests that still need work, and requests for a
+%% slot beyond what is cached, must continue to serialise through the
+%% process group.
+grouper_skips_when_slot_cached_test() ->
+    test_init(),
+    Opts =
+        #{
+            store => hb_test_utils:test_store(hb_store_lmdb),
+            priv_wallet => ar_wallet:new()
+        },
+    M1 = dev_process_test_vectors:aos_process(Opts),
+    POpts = Opts#{ process_workers => true },
+    %% With the cache empty, every compute request must group by
+    %% process so that the worker can do the actual work.
+    Uncached = #{ <<"path">> => <<"compute">>, <<"slot">> => 5 },
+    ProcessGroup = hb_persistent:group(M1, Uncached, POpts),
+    ?assertNotEqual(ungrouped_exec, ProcessGroup),
+    %% Write slot 5 into the cache. The same request now has a result
+    %% available and the grouper should step out of the queue.
+    {ok, _} =
+        dev_process_cache:write(
+            ProcessGroup,
+            5,
+            #{ <<"hello">> => <<"cached">> },
+            Opts
+        ),
+    ?assertEqual(
+        ungrouped_exec,
+        hb_persistent:group(M1, Uncached, POpts)
+    ),
+    %% A request for a slot beyond what we cached must still be
+    %% serialised through the worker.
+    Beyond = #{ <<"path">> => <<"compute">>, <<"slot">> => 999 },
+    ?assertEqual(ProcessGroup, hb_persistent:group(M1, Beyond, POpts)),
+    %% A `compute' request without a slot resolves via the cache-only
+    %% branch of `now/3' once any slot exists, so it also bypasses the
+    %% queue.
+    NoSlot = #{ <<"path">> => <<"compute">> },
+    ?assertEqual(
+        ungrouped_exec,
+        hb_persistent:group(M1, NoSlot, POpts)
+    ).

--- a/src/dev_process_worker.erl
+++ b/src/dev_process_worker.erl
@@ -284,13 +284,13 @@ grouper_skips_when_slot_cached_test() ->
         },
     M1 = dev_process_test_vectors:aos_process(Opts),
     POpts = Opts#{ <<"process-workers">> => true },
-    %% With the cache empty, every compute request must group by
-    %% process so that the worker can do the actual work.
+    % With the cache empty, every compute request must group by
+    % process so that the worker can do the actual work.
     Uncached = #{ <<"path">> => <<"compute">>, <<"slot">> => 5 },
     ProcessGroup = hb_persistent:group(M1, Uncached, POpts),
     ?assertNotEqual(ungrouped_exec, ProcessGroup),
-    %% Write slot 5 into the cache. The same request now has a result
-    %% available and the grouper should step out of the queue.
+    % Write slot 5 into the cache. The same request now has a result
+    % available and the grouper should step out of the queue.
     {ok, _} =
         dev_process_cache:write(
             ProcessGroup,
@@ -302,17 +302,17 @@ grouper_skips_when_slot_cached_test() ->
         ungrouped_exec,
         hb_persistent:group(M1, Uncached, POpts)
     ),
-    %% Cache slots are not assumed to be gap-free. A lower slot that
-    %% has not actually been written must still go through the worker.
+    % Cache slots are not assumed to be gap-free. A lower slot that
+    % has not actually been written must still go through the worker.
     MissingLower = #{ <<"path">> => <<"compute">>, <<"slot">> => 4 },
     ?assertEqual(ProcessGroup, hb_persistent:group(M1, MissingLower, POpts)),
-    %% A request for a slot beyond what we cached must still be
-    %% serialised through the worker.
+    % A request for a slot beyond what we cached must still be
+    % serialised through the worker.
     Beyond = #{ <<"path">> => <<"compute">>, <<"slot">> => 999 },
     ?assertEqual(ProcessGroup, hb_persistent:group(M1, Beyond, POpts)),
-    %% A `compute' request without a slot resolves via the cache-only
-    %% branch of `now/3' once any slot exists, so it also bypasses the
-    %% queue.
+    % A `compute' request without a slot resolves via the cache-only
+    % branch of `now/3' once any slot exists, so it also bypasses the
+    % queue.
     NoSlot = #{ <<"path">> => <<"compute">> },
     ?assertEqual(
         ungrouped_exec,

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -1459,7 +1459,7 @@ test_compute_push_hook_idempotent() ->
 setup_two_process_message() ->
     dev_process_test_vectors:init(),
     Opts = #{
-        <<"priv-wallet">> => hb:wallet(),
+        <<"priv-wallet">> => ar_wallet:new(),
         <<"cache-control">> => <<"always">>,
         <<"store">> => [hb_test_utils:test_store(hb_store_lmdb)]
     },

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -949,7 +949,7 @@ test_push_as_identity() ->
     ?event({test_setup, {base, Base}, {sched_init, SchedInit}}),
     Script = ping_pong_script(2),
     ?event({script, Script}),
-    {ok, Req} = dev_process_test_vectors:schedule_aos_call(Base, Script),
+    {ok, Req} = dev_process_test_vectors:schedule_aos_call(Base, Script, Opts),
     ?event(push, {msg_sched_result, Req}),
     {ok, StartingMsgSlot} =
         hb_ao:resolve(Req, #{ <<"path">> => <<"slot">> }, Opts),
@@ -1000,7 +1000,8 @@ test_multi_process_push() ->
                 "       print(\"GOT PONG\")\n"
                 "   end\n"
                 ")"
-            >>
+            >>,
+            Opts
         ),
     {ok, PushResult} =
         hb_ao:resolve(
@@ -1459,8 +1460,9 @@ test_compute_push_hook_idempotent() ->
 setup_two_process_message() ->
     dev_process_test_vectors:init(),
     Opts = #{
-        <<"priv-wallet">> => hb:wallet(),
+        <<"priv-wallet">> => ar_wallet:new(),
         <<"cache-control">> => <<"always">>,
+        <<"process-async-cache">> => false,
         <<"store">> => [hb_test_utils:test_store(hb_store_lmdb)]
     },
     Sender = dev_process_test_vectors:aos_process(Opts),
@@ -1489,7 +1491,8 @@ setup_two_process_message() ->
             <<
                 "Send({ Target = \"", (ReceiverID)/binary,
                 "\", Action = \"Ping\" })\n"
-            >>
+            >>,
+            Opts
         ),
     {ok, MsgSlot} =
         hb_ao:resolve(MsgSched, #{ <<"path">> => <<"slot">> }, Opts),
@@ -1538,7 +1541,7 @@ test_nested_push_prompts_encoding_change() ->
     ?event({test_setup, {base, Base}, {sched_init, SchedInit}}),
     Script = message_to_legacynet_scheduler_script(),
     ?event({script, Script}),
-    {ok, Req} = dev_process_test_vectors:schedule_aos_call(Base, Script),
+    {ok, Req} = dev_process_test_vectors:schedule_aos_call(Base, Script, Opts),
     ?event(push, {msg_sched_result, Req}),
     {ok, StartingMsgSlot} =
         hb_ao:resolve(Req, #{ <<"path">> => <<"slot">> }, Opts),

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -1459,7 +1459,7 @@ test_compute_push_hook_idempotent() ->
 setup_two_process_message() ->
     dev_process_test_vectors:init(),
     Opts = #{
-        <<"priv-wallet">> => ar_wallet:new(),
+        <<"priv-wallet">> => hb:wallet(),
         <<"cache-control">> => <<"always">>,
         <<"store">> => [hb_test_utils:test_store(hb_store_lmdb)]
     },

--- a/src/dev_push.erl
+++ b/src/dev_push.erl
@@ -869,7 +869,6 @@ genesis_wasm_tests() -> [].
 test_full_push() ->
     dev_process_test_vectors:init(),
     Opts = #{
-        <<"process-async-cache">> => false,
         <<"priv-wallet">> => hb:wallet(),
         <<"cache-control">> => <<"always">>,
         <<"store">> => [hb_test_utils:test_store(hb_store_lmdb)]
@@ -1462,7 +1461,6 @@ setup_two_process_message() ->
     Opts = #{
         <<"priv-wallet">> => ar_wallet:new(),
         <<"cache-control">> => <<"always">>,
-        <<"process-async-cache">> => false,
         <<"store">> => [hb_test_utils:test_store(hb_store_lmdb)]
     },
     Sender = dev_process_test_vectors:aos_process(Opts),

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -1009,10 +1009,6 @@ global_preference_test() ->
         ?MODULE:get(mode, undefined, Global#{ <<"mode">> => incorrect })),
     ?assertNotEqual(undefined, ?MODULE:get(mode, undefined, Global)).
 
-process_workers_default_test() ->
-    ?assertEqual(named, ?MODULE:get(await_inprogress)),
-    ?assertEqual(true, ?MODULE:get(process_workers)).
-
 load_flat_test() ->
     % File contents:
     % port: 1234

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -516,7 +516,7 @@ raw_default_message() ->
         % Should the node store all signed messages?
         <<"store-all-signed">> => true,
         % Should the node use persistent processes?
-        <<"process-workers">> => false,
+        <<"process-workers">> => true,
         % Options for the router device
         <<"router-opts">> => #{
             <<"routes">> => []
@@ -1008,6 +1008,10 @@ global_preference_test() ->
     ?assertNotEqual(incorrect,
         ?MODULE:get(mode, undefined, Global#{ <<"mode">> => incorrect })),
     ?assertNotEqual(undefined, ?MODULE:get(mode, undefined, Global)).
+
+process_workers_default_test() ->
+    ?assertEqual(named, ?MODULE:get(await_inprogress)),
+    ?assertEqual(true, ?MODULE:get(process_workers)).
 
 load_flat_test() ->
     % File contents:


### PR DESCRIPTION
## Summary

- Enables persistent workers for processes by default. This deduplicates live executions if many users are asking for the same result simultaneously. This feature was first introduced in Dec 23/early Jan 24, but left disabled due to the lack of...
- ...bypassing the persistent process worker queue for `compute` requests that can be resolved from the process cache.
- Disable async process cache by default. This removes a class of causes of re-execution bugs, but also means that writes are forced to conclude before before execution moves to the next slot. This is a mixed bag for performance: Not perceptible in most cases, but slightly slower if you happen to have an extremely large _in-memory_ (not lazy linked) process state that must be written, and very fast slot resolution. The benefit we gain is felt in correctness (avoidance of bugs) and stability. 