### PR TITLE
fix: enforce ~dedup@1.0 at token compute/3 entrypoint

### DIFF
--- a/src/dev_token.erl
+++ b/src/dev_token.erl
@@ -79,24 +79,49 @@ normalize(Base, _Req, _Opts) ->
 snapshot(Base, _Req, _Opts) ->
     {ok, Base}.
 
-%% @doc Entrypoint for computations on token processes. Expects the `action'
-%% key to hold the `path' to execute after enforcing the token's security
-%% constraints. Always returns the base state unmodified in the event of 
-%% downstream device errors, such that invalid interactions do not result in
-%% invalid `~process@1.0' states.
+%% @doc Entrypoint for computations on token processes. Deduplicates by signed
+%% assignment body, then expects the `action' key to hold the `path' to execute
+%% after enforcing the token's security constraints. Always returns the base
+%% state unmodified in the event of downstream device errors, such that invalid
+%% interactions do not result in invalid `~process@1.0' states.
 compute(Base, Assignment, Opts) ->
     ?event({token_call, Assignment}),
-    maybe
-        {ok, SecureReq} ?= enforce_security(Base, Assignment, Opts),
-        {ok, Action} ?= hb_ao:resolve(Assignment, <<"body/action">>, Opts),
-        {ok, Res} ?= handle_action(Action, Base, SecureReq, Opts),
-        ?event(debug_token, {route_result, Res}, Opts),
-        {ok, Res}
-    else
+    case deduplicate(Base, Assignment, Opts) of
+        {skip, DedupedBase} ->
+            ?event(token_short, {skipping_duplicate_assignment, Assignment}, Opts),
+            {ok, DedupedBase};
+        {ok, DedupedBase} ->
+            maybe
+                {ok, SecureReq} ?= enforce_security(DedupedBase, Assignment, Opts),
+                {ok, Action} ?= hb_ao:resolve(Assignment, <<"body/action">>, Opts),
+                {ok, Res} ?= handle_action(Action, DedupedBase, SecureReq, Opts),
+                ?event(debug_token, {route_result, Res}, Opts),
+                {ok, Res}
+            else
+                {error, Reason} ->
+                    ?event(token_short, {error_during_token_call, Reason}, Opts),
+                    send_error(Base, Assignment, Reason, Opts)
+            end;
         {error, Reason} ->
-            ?event(token_short, {error_during_token_call, Reason}, Opts),
+            ?event(token_short, {error_during_token_dedup, Reason}, Opts),
             send_error(Base, Assignment, Reason, Opts)
     end.
+
+%% @doc Deduplicate token computations by the signed assignment body. Replayed
+%% assignments get fresh slots, so the assignment itself cannot be the subject.
+deduplicate(Base, Assignment, Opts) ->
+    BaseDevice = hb_maps:get(<<"device">>, Base, not_found, Opts),
+    case hb_ao:resolve(Base, {as, <<"dedup@1.0">>, Assignment}, Opts) of
+        {Status, DedupedBase} when Status =:= ok; Status =:= skip ->
+            {Status, restore_device(BaseDevice, DedupedBase, Opts)};
+        Error ->
+            Error
+    end.
+
+restore_device(not_found, Base, _Opts) ->
+    Base;
+restore_device(Device, Base, Opts) ->
+    hb_ao:set(Base, <<"device">>, Device, Opts).
 
 %% @doc Enforce the security constraints of the base state upon the request.
 enforce_security(Base, Req, Opts) ->

--- a/src/dev_token_pot_test_vectors.erl
+++ b/src/dev_token_pot_test_vectors.erl
@@ -196,6 +196,7 @@ generate_base_process_state(ExtraKeys, Opts) ->
             <<"device">> => <<"process@1.0">>,
             <<"type">> => <<"Process">>,
             <<"execution-device">> => <<"token@1.0">>,
+            <<"dedup-subject">> => <<"body">>,
             <<"scheduler-device">> => <<"scheduler@1.0">>,
             <<"push-device">> => <<"push@1.0">>,
             <<"scheduler">> => Addr,

--- a/src/dev_token_test_vectors.erl
+++ b/src/dev_token_test_vectors.erl
@@ -68,6 +68,7 @@ generate_process(Params, Opts) ->
             <<"device">> => <<"process@1.0">>,
             <<"type">> => <<"Process">>,
             <<"execution-device">> => <<"token@1.0">>,
+            <<"dedup-subject">> => <<"body">>,
             <<"scheduler-device">> => <<"scheduler@1.0">>,
             <<"push-device">> => <<"push@1.0">>,
             <<"scheduler">> => Addr,


### PR DESCRIPTION
## about

token device had a missing dedup feature at `dev_token:compute/3` entrypoint that allow replayed token messages to execute again

## fix

integrated ~dedup@1.0 device, where dedups happen at Assignment body level (not full Assignment given each assignment get assigned a unique slot), and dedups happen before the security enforcement / action handling path.

also updated `dev_token_test_vectors` + `dev_token_pot_test_vectors` adding `<<"dedup-subject">> => <<"body">>` at process base, all tests pass.

Base devices get restored after the dedup resolve as