### PR TITLE
impr: pot math minted_between/6 fixed exponentiation patch 

### DIFF
--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -61,7 +61,6 @@
     <<"total-weighted-units">>,
     <<"undistributed-mint">>
 ]).
--define(MAX_WEIGHT_BPS, 10_000).
 
 %%% Pot Model Functions.
 
@@ -1265,7 +1264,7 @@ validate_match_config(_) ->
 
 %% @doc Set the weight of a specific resource in the pot, updating the pot state
 %% as necessary.
-register_resource(ResourceID, Weight, S, Opts) when is_integer(Weight), Weight >= 0, Weight =< ?MAX_WEIGHT_BPS ->
+register_resource(ResourceID, Weight, S, Opts) when is_integer(Weight), Weight >= 0 ->
     maybe
         true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
         % Run the global drip to ensure the state is up to date.
@@ -1301,9 +1300,7 @@ end;
 register_resource(_, Weight, _, _) when not is_integer(Weight) ->
     {error, <<"Invalid Weight type.">>};
 register_resource(_, Weight, _, _) when is_integer(Weight), Weight < 0 ->
-    {error, <<"Weight must be a non-negative integer.">>};
-register_resource(_, Weight, _, _) when is_integer(Weight), Weight > ?MAX_WEIGHT_BPS ->
-    {error, <<"Weight must be less than or equal to 10000.">>}.
+    {error, <<"Weight must be a non-negative integer.">>}.
 
 %% @doc Update the inverted index for a specific address in a specific resource.
 update_deposit_index(Addr, ResourceID, Quantity, S, Opts) ->

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -61,6 +61,7 @@
     <<"total-weighted-units">>,
     <<"undistributed-mint">>
 ]).
+-define(MAX_WEIGHT_BPS, 10_000).
 
 %%% Pot Model Functions.
 
@@ -1264,7 +1265,7 @@ validate_match_config(_) ->
 
 %% @doc Set the weight of a specific resource in the pot, updating the pot state
 %% as necessary.
-register_resource(ResourceID, Weight, S, Opts) when is_integer(Weight), Weight >= 0 ->
+register_resource(ResourceID, Weight, S, Opts) when is_integer(Weight), Weight >= 0, Weight =< ?MAX_WEIGHT_BPS ->
     maybe
         true ?= dev_token:validate_address(ResourceID, ?RESERVED_KEYS),
         % Run the global drip to ensure the state is up to date.
@@ -1300,7 +1301,9 @@ end;
 register_resource(_, Weight, _, _) when not is_integer(Weight) ->
     {error, <<"Invalid Weight type.">>};
 register_resource(_, Weight, _, _) when is_integer(Weight), Weight < 0 ->
-    {error, <<"Weight must be a non-negative integer.">>}.
+    {error, <<"Weight must be a non-negative integer.">>};
+register_resource(_, Weight, _, _) when is_integer(Weight), Weight > ?MAX_WEIGHT_BPS ->
+    {error, <<"Weight must be less than or equal to 10000.">>}.
 
 %% @doc Update the inverted index for a specific address in a specific resource.
 update_deposit_index(Addr, ResourceID, Quantity, S, Opts) ->

--- a/src/dev_pot.erl
+++ b/src/dev_pot.erl
@@ -118,9 +118,10 @@ drip_global(S = #{ <<"t">> := T, <<"last-drip">> := Last }, Opts)
     );
 drip_global(S = #{ <<"t">> := T, <<"last-drip">> := Last }, _) when T == Last -> S;
 drip_global(S, Opts) ->
-    T = hb_ao:get(<<"t">>, S, 0, Opts),
+    RawT = hb_ao:get(<<"t">>, S, 0, Opts),
     AlreadyMinted = hb_maps:get(<<"minted">>, S, 0, Opts),
     LastT = hb_maps:get(<<"last-drip">>, S, 0, Opts),
+    T = max(RawT, LastT),
     MintCap = hb_ao:get(<<"mint-cap">>, S, 0, Opts),
     TotalWeightedUnits = hb_maps:get(<<"total-weighted-units">>, S, 0, Opts),
     GlobalAcc = hb_maps:get(<<"accumulator">>, S, 0, Opts),

--- a/src/dev_pot_math.erl
+++ b/src/dev_pot_math.erl
@@ -38,6 +38,23 @@
 -export([drip_global/3, drip_resource/4, drip_user/3, drip_user/4]).
 -export([bignum_exp/2]).
 
+minted_between(Minted, Max, PropN, PropD, LastT, T)
+    when not is_integer(Minted) orelse not is_integer(Max)
+        orelse not is_integer(PropN) orelse not is_integer(PropD)
+        orelse not is_integer(LastT) orelse not is_integer(T) ->
+            throw({error, invalid_parameter});
+minted_between(Minted, Max, _, _, _, _)
+    when Minted < 0 orelse Max < 0 orelse Minted > Max ->
+        throw({error, invalid_minted_max_boundaries});
+minted_between(_, _, PropN, _, _, _)
+    when PropN < 0 ->
+        throw({error, invalid_negative_propn});
+minted_between(_, _, _, PropD, _, _)
+    when PropD =< 0 ->
+        throw({error, invalid_non_positive_propd});
+minted_between(_, _, PropN, PropD, _, _)
+    when PropD > PropN ->
+      throw({error, invalid_prop_division});
 minted_between(Minted, Max, PropN, PropD, LastT, T) ->
     Steps = max(T - LastT, 0),
     Remaining = Max - Minted,

--- a/src/dev_pot_math.erl
+++ b/src/dev_pot_math.erl
@@ -38,6 +38,9 @@
 -export([drip_global/3, drip_resource/4, drip_user/3, drip_user/4]).
 -export([bignum_exp/2]).
 
+-define(MAX_EXACT_POWER_DIGITS, 1000).
+-define(FIXED_SCALE_DIGITS, [40, 60, 80]).
+
 minted_between(Minted, Max, PropN, PropD, LastT, T)
     when not is_integer(Minted) orelse not is_integer(Max)
         orelse not is_integer(PropN) orelse not is_integer(PropD)
@@ -54,16 +57,102 @@ minted_between(_, _, _, PropD, _, _)
         throw({error, invalid_non_positive_propd});
 minted_between(_, _, PropN, PropD, _, _)
     when PropN > PropD ->
-      throw({error, invalid_prop_division});    
+        throw({error, invalid_prop_division});
 minted_between(Minted, Max, PropN, PropD, LastT, T) ->
     Steps = max(T - LastT, 0),
     Remaining = Max - Minted,
+    minted_between_validated(Remaining, PropN, PropD, Steps).
+
+minted_between_validated(_, _, _, 0) ->
+    0;
+minted_between_validated(0, _, _, _) ->
+    0;
+minted_between_validated(_, 0, _, _) ->
+    0;
+minted_between_validated(Remaining, PropD, PropD, _) ->
+    Remaining;
+minted_between_validated(Remaining, PropN, PropD, Steps) ->
+    case estimated_power_digits(PropD, Steps) =< ?MAX_EXACT_POWER_DIGITS of
+        true -> minted_between_exact(Remaining, PropN, PropD, Steps);
+        false -> minted_between_fixed_scale(Remaining, PropN, PropD, Steps)
+    end.
+
+minted_between_exact(Remaining, PropN, PropD, Steps) ->
     NComplementOverTime = bignum_exp(PropD - PropN, Steps),
     DOverTime = bignum_exp(PropD, Steps),
     case DOverTime of
         0 -> throw({error, division_with_zero_denominator});
         _ -> (Remaining * (DOverTime - NComplementOverTime)) div DOverTime
     end.
+
+minted_between_fixed_scale(Remaining, PropN, PropD, Steps) ->
+    case try_fixed_scales(Remaining, PropN, PropD, Steps, ?FIXED_SCALE_DIGITS) of
+        {ok, ToMint} -> ToMint;
+        unresolved -> throw({error, precision_not_resolved})
+    end.
+
+try_fixed_scales(_, _, _, _, []) ->
+    unresolved;
+try_fixed_scales(Remaining, PropN, PropD, Steps, [ScaleDigits | Rest]) ->
+    Scale = bignum_exp(10, ScaleDigits),
+    PowerBase = power_base_interval(PropN, PropD, Scale),
+    {PowLo, PowHi} = pow_fixed_scale(PowerBase, Steps, Scale),
+    case minted_from_power_interval(Remaining, PowLo, PowHi, Scale) of
+        {ok, ToMint} -> {ok, ToMint};
+        unresolved -> try_fixed_scales(Remaining, PropN, PropD, Steps, Rest)
+    end.
+
+power_base_interval(PropN, PropD, Scale) ->
+    BaseN = PropD - PropN,
+    {
+        (BaseN * Scale) div PropD,
+        ceil_div(BaseN * Scale, PropD)
+    }.
+
+minted_from_power_interval(Remaining, PowLo, PowHi, Scale) ->
+    MintLo = (Remaining * (Scale - PowHi)) div Scale,
+    MintHi = (Remaining * (Scale - PowLo)) div Scale,
+    case MintLo == MintHi of
+        true -> {ok, MintLo};
+        false -> minted_from_residual_interval(Remaining, PowLo, PowHi, Scale)
+    end.
+
+minted_from_residual_interval(Remaining, PowLo, PowHi, Scale) ->
+    ResidualLo = max(1, ceil_div(Remaining * PowLo, Scale)),
+    ResidualHi = ceil_div(Remaining * PowHi, Scale),
+    case ResidualLo == ResidualHi of
+        true -> {ok, Remaining - ResidualLo};
+        false -> unresolved
+    end.
+
+pow_fixed_scale(Base, Steps, Scale) ->
+    pow_fixed_scale(Base, Steps, {Scale, Scale}, Scale).
+
+pow_fixed_scale(_, 0, Acc, _) ->
+    Acc;
+pow_fixed_scale(Base, Steps, Acc, Scale) when Steps rem 2 =:= 1 ->
+    NewAcc = mul_interval(Acc, Base, Scale),
+    case Steps div 2 of
+        0 -> NewAcc;
+        NextSteps ->
+            pow_fixed_scale(mul_interval(Base, Base, Scale), NextSteps, NewAcc, Scale)
+    end;
+pow_fixed_scale(Base, Steps, Acc, Scale) ->
+    pow_fixed_scale(mul_interval(Base, Base, Scale), Steps div 2, Acc, Scale).
+
+mul_interval({Lo1, Hi1}, {Lo2, Hi2}, Scale) ->
+    {
+        (Lo1 * Lo2) div Scale,
+        ceil_div(Hi1 * Hi2, Scale)
+    }.
+
+ceil_div(N, D) ->
+    (N + D - 1) div D.
+
+estimated_power_digits(_, 0) ->
+    1;
+estimated_power_digits(N, Steps) ->
+    length(integer_to_list(N)) * Steps.
 
 bignum_exp(_, 0) -> 1;
 bignum_exp(X, Y) ->

--- a/src/dev_pot_math.erl
+++ b/src/dev_pot_math.erl
@@ -53,8 +53,8 @@ minted_between(_, _, _, PropD, _, _)
     when PropD =< 0 ->
         throw({error, invalid_non_positive_propd});
 minted_between(_, _, PropN, PropD, _, _)
-    when PropD > PropN ->
-      throw({error, invalid_prop_division});
+    when PropN > PropD ->
+      throw({error, invalid_prop_division});    
 minted_between(Minted, Max, PropN, PropD, LastT, T) ->
     Steps = max(T - LastT, 0),
     Remaining = Max - Minted,

--- a/src/dev_pot_math.erl
+++ b/src/dev_pot_math.erl
@@ -160,6 +160,8 @@ bignum_exp(X, Y) ->
 
 do_bignum_exp(_, 0, Acc) ->
     Acc;
+do_bignum_exp(X, 1, Acc) ->
+    Acc * X;
 do_bignum_exp(X, Y, Acc) when Y rem 2 =:= 1 ->
     do_bignum_exp(X * X, Y div 2, Acc * X);
 do_bignum_exp(X, Y, Acc) ->

--- a/src/dev_pot_props.erl
+++ b/src/dev_pot_props.erl
@@ -47,7 +47,7 @@ generate_initial_state(Opts) ->
     MintCap = 21_000_000,
     PropN = 1,
     PropD = 1000,
-    StartWeight = hb_invariant:int(1, 10_000),
+    StartWeight = hb_invariant:int(1, 100_000),
     StartQty = hb_invariant:int(1, 100_000),
     StartResource = hb_invariant:pick(hb_maps:get(resources, Opts)),
     UserAddrs = hb_maps:keys(hb_maps:get(identities, Opts)),
@@ -118,7 +118,7 @@ generate_initial_state(Opts) ->
         fun(Resource, State) ->
             ResourceState = dev_pot:register_resource(
                 Resource,
-                hb_invariant:int(1, 10_000),
+                hb_invariant:int(1, 100_000),
                 State,
                 Opts
             ),

--- a/src/dev_pot_props.erl
+++ b/src/dev_pot_props.erl
@@ -47,7 +47,7 @@ generate_initial_state(Opts) ->
     MintCap = 21_000_000,
     PropN = 1,
     PropD = 1000,
-    StartWeight = hb_invariant:int(1, 100_000),
+    StartWeight = hb_invariant:int(1, 10_000),
     StartQty = hb_invariant:int(1, 100_000),
     StartResource = hb_invariant:pick(hb_maps:get(resources, Opts)),
     UserAddrs = hb_maps:keys(hb_maps:get(identities, Opts)),
@@ -118,7 +118,7 @@ generate_initial_state(Opts) ->
         fun(Resource, State) ->
             ResourceState = dev_pot:register_resource(
                 Resource,
-                hb_invariant:int(1, 100_000),
+                hb_invariant:int(1, 10_000),
                 State,
                 Opts
             ),

--- a/src/dev_pot_test_vectors.erl
+++ b/src/dev_pot_test_vectors.erl
@@ -1257,6 +1257,29 @@ rapid_weight_changes_test() ->
     % Final TWU should be 1 * 10 = 10
     ?assertEqual(10, hb_maps:get(<<"total-weighted-units">>, S4, 0, Opts)).
 
+weight_at_bps_cap_is_accepted_test() ->
+    Alice = <<"alice">>,
+    ResourceOxygen = <<"oxygen">>,
+    Opts = #{},
+    S0 = pot_state(Alice, ResourceOxygen, 10),
+    S1 = dev_pot:register_resource(ResourceOxygen, 10_000, S0, Opts),
+    ?assert(is_map(S1)),
+    ?assertEqual(
+        10_000,
+        hb_ao:get(<<"/resources/oxygen/weight">>, S1, 0, Opts)
+    ),
+    ?assertEqual(100_000, hb_maps:get(<<"total-weighted-units">>, S1, 0, Opts)).
+
+weight_above_bps_cap_is_rejected_test() ->
+    Alice = <<"alice">>,
+    ResourceOxygen = <<"oxygen">>,
+    Opts = #{},
+    S0 = pot_state(Alice, ResourceOxygen, 10),
+    ?assertEqual(
+        {error, <<"Weight must be less than or equal to 10000.">>},
+        dev_pot:register_resource(ResourceOxygen, 10_001, S0, Opts)
+    ).
+
 %%% Time Handling Edge Cases
 
 drip_with_large_time_jump_test() ->

--- a/src/dev_pot_test_vectors.erl
+++ b/src/dev_pot_test_vectors.erl
@@ -146,6 +146,22 @@ hyperbeam_mint_current_ms_day_test() ->
     ),
     ?assertEqual(?AO_ONE_DAY_MS, hb_maps:get(<<"last-drip">>, S1, 0, Opts)).
 
+hyperbeam_mint_current_ms_256_year_inactive_gap_test() ->
+    Opts = #{},
+    InactiveT = 256 * 365 * ?AO_ONE_DAY_MS,
+    S0 =
+        (pot_state_empty(
+            [],
+            ?AO_TOTAL_SUPPLY,
+            ?AO_MS_STEP_NUMERATOR,
+            ?AO_MINT_PROP_DENOMINATOR
+        ))#{
+            <<"t-source">> => <<"timestamp">>
+        },
+    {ok, S1} = dev_pot:mint(S0, #{<<"timestamp">> => InactiveT}, Opts),
+    ?assertEqual(2, ?AO_TOTAL_SUPPLY - hb_maps:get(<<"minted">>, S1, 0, Opts)),
+    ?assertEqual(InactiveT, hb_maps:get(<<"last-drip">>, S1, 0, Opts)).
+
 hyperbeam_mint_current_ms_day_by_day_effective_cap_test() ->
     FinalMinted = simulate_hyperbeam_mint_days(?AO_CURRENT_MS_EFFECTIVE_CAP_DAYS),
     ?assertEqual(

--- a/src/dev_pot_test_vectors.erl
+++ b/src/dev_pot_test_vectors.erl
@@ -1257,29 +1257,6 @@ rapid_weight_changes_test() ->
     % Final TWU should be 1 * 10 = 10
     ?assertEqual(10, hb_maps:get(<<"total-weighted-units">>, S4, 0, Opts)).
 
-weight_at_bps_cap_is_accepted_test() ->
-    Alice = <<"alice">>,
-    ResourceOxygen = <<"oxygen">>,
-    Opts = #{},
-    S0 = pot_state(Alice, ResourceOxygen, 10),
-    S1 = dev_pot:register_resource(ResourceOxygen, 10_000, S0, Opts),
-    ?assert(is_map(S1)),
-    ?assertEqual(
-        10_000,
-        hb_ao:get(<<"/resources/oxygen/weight">>, S1, 0, Opts)
-    ),
-    ?assertEqual(100_000, hb_maps:get(<<"total-weighted-units">>, S1, 0, Opts)).
-
-weight_above_bps_cap_is_rejected_test() ->
-    Alice = <<"alice">>,
-    ResourceOxygen = <<"oxygen">>,
-    Opts = #{},
-    S0 = pot_state(Alice, ResourceOxygen, 10),
-    ?assertEqual(
-        {error, <<"Weight must be less than or equal to 10000.">>},
-        dev_pot:register_resource(ResourceOxygen, 10_001, S0, Opts)
-    ).
-
 %%% Time Handling Edge Cases
 
 drip_with_large_time_jump_test() ->

--- a/src/dev_pot_test_vectors.erl
+++ b/src/dev_pot_test_vectors.erl
@@ -3,6 +3,18 @@
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
 
+%% HyperBEAM AO mint checkpoints for the current millisecond-based pot curve.
+-define(AO_TOKEN_DENOMINATION, 1_000_000_000_000).
+-define(AO_TOTAL_SUPPLY, 21_000_000 * ?AO_TOKEN_DENOMINATION).
+-define(AO_MINT_PROP_DENOMINATOR, 1_000_000_000_000_000).
+-define(AO_ONE_DAY_MS, 86_400_000).
+-define(AO_MS_STEP_NUMERATOR, 5_492).
+-define(AO_CURRENT_MS_FIRST_DAY_MINTED, 9_962_321_008_608_663).
+%% Daily flooring means the lazy curve becomes unable to mint the final
+%% 2,107 raw units when evaluated once per day.
+-define(AO_CURRENT_MS_EFFECTIVE_CAP_DAYS, 93_762).
+-define(AO_CURRENT_MS_DAY_BY_DAY_FINAL_REMAINDER, 2_107).
+
 %%% Test Helper Functions
 
 %% @doc Create a pot state with one user
@@ -115,6 +127,63 @@ mint_quantity_test() ->
     Period1 = dev_pot_math:minted_between(0, 100, 1, 2, 0, 2),
     Period2 = dev_pot_math:minted_between(Period1, 100, 1, 2, 2, 3),
     ?assertEqual(87, Period1 + Period2).
+
+hyperbeam_mint_current_ms_day_test() ->
+    Opts = #{},
+    S0 =
+        (pot_state_empty(
+            [],
+            ?AO_TOTAL_SUPPLY,
+            ?AO_MS_STEP_NUMERATOR,
+            ?AO_MINT_PROP_DENOMINATOR
+        ))#{
+            <<"t-source">> => <<"timestamp">>
+        },
+    {ok, S1} = dev_pot:mint(S0, #{<<"timestamp">> => ?AO_ONE_DAY_MS}, Opts),
+    ?assertEqual(
+        ?AO_CURRENT_MS_FIRST_DAY_MINTED,
+        hb_maps:get(<<"minted">>, S1, 0, Opts)
+    ),
+    ?assertEqual(?AO_ONE_DAY_MS, hb_maps:get(<<"last-drip">>, S1, 0, Opts)).
+
+hyperbeam_mint_current_ms_day_by_day_effective_cap_test() ->
+    FinalMinted = simulate_hyperbeam_mint_days(?AO_CURRENT_MS_EFFECTIVE_CAP_DAYS),
+    ?assertEqual(
+        ?AO_CURRENT_MS_DAY_BY_DAY_FINAL_REMAINDER,
+        ?AO_TOTAL_SUPPLY - FinalMinted
+    ),
+    NextT = (?AO_CURRENT_MS_EFFECTIVE_CAP_DAYS + 1) * ?AO_ONE_DAY_MS,
+    LastT = ?AO_CURRENT_MS_EFFECTIVE_CAP_DAYS * ?AO_ONE_DAY_MS,
+    ?assertEqual(
+        0,
+        dev_pot_math:minted_between(
+            FinalMinted,
+            ?AO_TOTAL_SUPPLY,
+            ?AO_MS_STEP_NUMERATOR,
+            ?AO_MINT_PROP_DENOMINATOR,
+            LastT,
+            NextT
+        )
+    ).
+
+simulate_hyperbeam_mint_days(Days) ->
+    simulate_hyperbeam_mint_days(0, 1, Days).
+
+simulate_hyperbeam_mint_days(Minted, Day, Days) when Day > Days ->
+    Minted;
+simulate_hyperbeam_mint_days(Minted, Day, Days) ->
+    LastT = (Day - 1) * ?AO_ONE_DAY_MS,
+    T = Day * ?AO_ONE_DAY_MS,
+    ToMint =
+        dev_pot_math:minted_between(
+            Minted,
+            ?AO_TOTAL_SUPPLY,
+            ?AO_MS_STEP_NUMERATOR,
+            ?AO_MINT_PROP_DENOMINATOR,
+            LastT,
+            T
+        ),
+    simulate_hyperbeam_mint_days(Minted + ToMint, Day + 1, Days).
 
 %% @doc Demonstrate minting using the proportional model and a single resource.
 single_resource_test() ->

--- a/src/dev_pot_test_vectors.erl
+++ b/src/dev_pot_test_vectors.erl
@@ -128,7 +128,7 @@ mint_quantity_test() ->
     Period2 = dev_pot_math:minted_between(Period1, 100, 1, 2, 2, 3),
     ?assertEqual(87, Period1 + Period2).
 
-hyperbeam_mint_current_ms_day_test() ->
+mint3_current_ms_day_test() ->
     Opts = #{},
     S0 =
         (pot_state_empty(
@@ -146,7 +146,7 @@ hyperbeam_mint_current_ms_day_test() ->
     ),
     ?assertEqual(?AO_ONE_DAY_MS, hb_maps:get(<<"last-drip">>, S1, 0, Opts)).
 
-hyperbeam_mint_current_ms_256_year_inactive_gap_test() ->
+mint3_current_ms_256_year_inactive_gap_test() ->
     Opts = #{},
     InactiveT = 256 * 365 * ?AO_ONE_DAY_MS,
     S0 =
@@ -162,8 +162,8 @@ hyperbeam_mint_current_ms_256_year_inactive_gap_test() ->
     ?assertEqual(2, ?AO_TOTAL_SUPPLY - hb_maps:get(<<"minted">>, S1, 0, Opts)),
     ?assertEqual(InactiveT, hb_maps:get(<<"last-drip">>, S1, 0, Opts)).
 
-hyperbeam_mint_current_ms_day_by_day_effective_cap_test() ->
-    FinalMinted = simulate_hyperbeam_mint_days(?AO_CURRENT_MS_EFFECTIVE_CAP_DAYS),
+mint3_current_ms_day_by_day_effective_cap_test() ->
+    FinalMinted = simulate_mint3_days(?AO_CURRENT_MS_EFFECTIVE_CAP_DAYS),
     ?assertEqual(
         ?AO_CURRENT_MS_DAY_BY_DAY_FINAL_REMAINDER,
         ?AO_TOTAL_SUPPLY - FinalMinted
@@ -182,12 +182,12 @@ hyperbeam_mint_current_ms_day_by_day_effective_cap_test() ->
         )
     ).
 
-simulate_hyperbeam_mint_days(Days) ->
-    simulate_hyperbeam_mint_days(0, 1, Days).
+simulate_mint3_days(Days) ->
+    simulate_mint3_days(0, 1, Days).
 
-simulate_hyperbeam_mint_days(Minted, Day, Days) when Day > Days ->
+simulate_mint3_days(Minted, Day, Days) when Day > Days ->
     Minted;
-simulate_hyperbeam_mint_days(Minted, Day, Days) ->
+simulate_mint3_days(Minted, Day, Days) ->
     LastT = (Day - 1) * ?AO_ONE_DAY_MS,
     T = Day * ?AO_ONE_DAY_MS,
     ToMint =
@@ -199,7 +199,7 @@ simulate_hyperbeam_mint_days(Minted, Day, Days) ->
             LastT,
             T
         ),
-    simulate_hyperbeam_mint_days(Minted + ToMint, Day + 1, Days).
+    simulate_mint3_days(Minted + ToMint, Day + 1, Days).
 
 %% @doc Demonstrate minting using the proportional model and a single resource.
 single_resource_test() ->

--- a/src/dev_pot_test_vectors.erl
+++ b/src/dev_pot_test_vectors.erl
@@ -1286,6 +1286,17 @@ drip_same_timestamp_idempotent_test() ->
     % Should not mint additional tokens
     ?assertEqual(Minted1, Minted2).
 
+drip_backward_timestamp_does_not_remint_test() ->
+    ResourceOxygen = <<"oxygen">>,
+    Opts = #{},
+    S0 = pot_state_empty([ResourceOxygen], 100, 1, 2),
+    S1 = dev_pot:test_drip(S0, #{<<"t">> => 100}, Opts),
+    Minted1 = hb_maps:get(<<"minted">>, S1, 0, Opts),
+    {ok, S2} = dev_pot:mint(S1, #{<<"timestamp">> => 50}, Opts),
+    ?assertEqual(Minted1, hb_maps:get(<<"minted">>, S2, 0, Opts)),
+    ?assertEqual(100, hb_maps:get(<<"last-drip">>, S2, 0, Opts)),
+    ?assertEqual(50, hb_maps:get(<<"t">>, S2, 0, Opts)).
+
 %%% Accumulator Precision Tests
 
 accumulator_over_many_periods_test() ->

--- a/src/dev_token.erl
+++ b/src/dev_token.erl
@@ -39,7 +39,9 @@
         <<"info">>,
         <<"set_path">>,
         <<"reserved_keys">>,
-        <<"is_reserved_key">>
+        <<"is_reserved_key">>,
+        <<"dedup">>,
+        <<"dedupt-subject">>
     ]
 ).
 

--- a/src/dev_token.erl
+++ b/src/dev_token.erl
@@ -41,7 +41,7 @@
         <<"reserved_keys">>,
         <<"is_reserved_key">>,
         <<"dedup">>,
-        <<"dedupt-subject">>
+        <<"dedup-subject">>
     ]
 ).
 


### PR DESCRIPTION
  ## findings

1. LOW: `dev_pot_math:minted_between/6` lacked input validation for malformed mint parameters

invalues such as non-integers, negative supply bounds, non-positive denominators, or `PropN > PropD` could enter the mint math path and fail later with less explicit badarith.

2. MEDIUM: `dev_pot:drip_global/2` allowed non-monotonic `last-drip` advancement

`last-drip` was assigned directly from the scheduler-provided timestamp (`erlang:system_time(millisecond).`). iff that timestamp moved backward, for example due to wall-clock drift or an invalid assignment timestamp, the process could persist a lower `last-drip` than before. a later ts recovery could then re-cover an already minted time range, causing inconsistent mint accounting

3. HIGH: `dev_pot_math:minted_between/6` exact exponentiation explosion for `PropD^Steps` with prod values 

in minted_between Mint equation, the code did exact exponentiation for PropD and PropN (both ^Steps) - given 1ms = 1 Step, and real production values for PropN/D could be very large (e.g. 10^15 for PropD in AO's mint curve - derived from mint2 vals). the code path did hit `system_limit` with only 86.4s (86400 ms/steps) of `drip_global` inactivity, that's because the Mint eq was doing PropD^Steps -> (10^15)^86400 -> 1.29 million digits number; for 1 day of inactivity that's 1.29 billion digits number


## patches

1. added guards for `minted_between/6` to validate input params sanity
2. in drip_global/2 - assign the hb_set's T to the `max(RawT, LastT)` ensure a high water-marking T monotonic advancement regardless of scheduler's reported current timestamp
3. kept the same minting equation, but moved from exact exponentiation to fixed point exp representation - changes + math in details here: https://hackmd.io/@BlMUCyCuTQaaEkEmZl5i0g/dev-pot-math

### tests added
* `mint3_current_ms_day_test`
* `mint3_current_ms_256_year_inactive_gap_test`
* `mint3_current_ms_day_by_day_effective_cap_test`
