### PR TITLE
feat: deterministic derivation of L2 item's parent bundle id & block height

### DIFF
--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -5,7 +5,7 @@
 %%% `/arweave` route in the node's configuration message.
 -module(dev_arweave).
 -export([info/0]).
--export([tx/3, raw/3, chunk/3, block/3, current/3, status/3, price/3, tx_anchor/3]).
+-export([tx/3, raw/3, parent_of/3, chunk/3, block/3, current/3, status/3, price/3, tx_anchor/3]).
 -export([pending/3]).
 -export([post_tx_header/2, post_tx/3, post_tx/4, post_chunk/2]).
 %%% Helper functions
@@ -150,6 +150,13 @@ raw(Base, Request, Opts) ->
     case hb_maps:get(<<"method">>, Request, <<"GET">>, Opts) of
         <<"HEAD">> -> head_raw(Base, Request, Opts);
         <<"GET">> -> get_raw(Base, Request, Opts)
+    end.
+
+%% @doc Resolve the L1 transaction that contains an indexed L2 ANS-104 dataitem.
+parent_of(Base, Request, Opts) ->
+    case find_key(<<"parent-of">>, Base, Request, Opts) of
+        ID when ?IS_ID(ID) -> parent_of_id(ID, Opts);
+        _ -> {error, not_found}
     end.
 
 %% @doc Handle `HEAD /raw=ID` requests by reading the header chunk and
@@ -864,6 +871,66 @@ find_key(Key, Base, Request, Opts) ->
         hb_maps:get(Key, Base, not_found, Opts),
         Opts
     ).
+
+parent_of_id(ID, Opts) ->
+    StoreOpts = hb_store_arweave:store_from_opts(Opts),
+    maybe
+        {ok, #{
+            <<"codec-device">> := <<"ans104@1.0">>,
+            <<"start-offset">> := Offset
+        }} ?= hb_store_arweave:read_offset(StoreOpts, ID),
+        {ok, Block} ?= block_for_offset(Offset, Opts),
+        tx_at_offset(hb_maps:get(<<"txs">>, Block, [], Opts), Offset, StoreOpts)
+    else
+        _ -> {error, not_found}
+    end.
+
+block_for_offset(Offset, Opts) ->
+    case dev_arweave_block_cache:latest(Opts) of
+        {ok, Height} ->
+            case block_for_offset(Offset, 0, Height, Opts) of
+                {error, not_found} -> block_for_offset_current(Offset, Opts);
+                Res -> Res
+            end;
+        _ -> block_for_offset_current(Offset, Opts)
+    end.
+
+block_for_offset_current(Offset, Opts) ->
+    maybe
+        {ok, Block} ?= current(#{}, #{}, Opts),
+        Height = hb_util:int(hb_maps:get(<<"height">>, Block, 0, Opts)),
+        block_for_offset(Offset, 0, Height, Opts)
+    end.
+
+block_for_offset(_Offset, Low, High, _Opts) when Low > High ->
+    {error, not_found};
+block_for_offset(Offset, Low, High, Opts) ->
+    Height = (Low + High) div 2,
+    maybe
+        {ok, Block} ?= block({height, Height}, Opts),
+        End = hb_util:int(hb_maps:get(<<"weave_size">>, Block, 0, Opts)),
+        Size = hb_util:int(hb_maps:get(<<"block_size">>, Block, 0, Opts)),
+        Start = End - Size,
+        case {Offset < Start, Offset >= End} of
+            {true, _} -> block_for_offset(Offset, Low, Height - 1, Opts);
+            {_, true} -> block_for_offset(Offset, Height + 1, High, Opts);
+            _ -> {ok, Block}
+        end
+    end.
+
+tx_at_offset([], _Offset, _StoreOpts) ->
+    {error, not_found};
+tx_at_offset([TXID | Rest], Offset, StoreOpts) ->
+    case hb_store_arweave:read_offset(StoreOpts, TXID) of
+        {ok, #{
+            <<"codec-device">> := <<"tx@1.0">>,
+            <<"start-offset">> := TXOffset,
+            <<"length">> := Length
+        }} when TXOffset =< Offset, Offset < TXOffset + Length ->
+            {ok, TXID};
+        _ ->
+            tx_at_offset(Rest, Offset, StoreOpts)
+    end.
 
 %% @doc Make a request to the Arweave node and parse the response into an
 %% AO-Core message. Most Arweave API responses are in JSON format, but without

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -880,7 +880,17 @@ parent_of_id(ID, Opts) ->
             <<"start-offset">> := Offset
         }} ?= hb_store_arweave:read_offset(StoreOpts, ID),
         {ok, Block} ?= block_for_offset(Offset, Opts),
-        tx_at_offset(hb_maps:get(<<"txs">>, Block, [], Opts), Offset, StoreOpts)
+        {ok, ParentID, ParentOffset, ParentLength} ?=
+            tx_at_offset(hb_maps:get(<<"txs">>, Block, [], Opts), Offset, StoreOpts),
+        {ok, #{
+            <<"id">> => ParentID,
+            <<"offset">> => ParentOffset,
+            <<"length">> => ParentLength,
+            <<"child">> => ID,
+            <<"child-offset">> => Offset,
+            <<"block-height">> => hb_maps:get(<<"height">>, Block, null, Opts),
+            <<"block-hash">> => hb_maps:get(<<"indep_hash">>, Block, null, Opts)
+        }}
     else
         _ -> {error, not_found}
     end.
@@ -927,7 +937,7 @@ tx_at_offset([TXID | Rest], Offset, StoreOpts) ->
             <<"start-offset">> := TXOffset,
             <<"length">> := Length
         }} when TXOffset =< Offset, Offset < TXOffset + Length ->
-            {ok, TXID};
+            {ok, TXID, TXOffset, Length};
         _ ->
             tx_at_offset(Rest, Offset, StoreOpts)
     end.


### PR DESCRIPTION
 ## about
 
  this PR introduces `~arweave@2.9/parent-of=<L2_DATAITEM_ID>` to resolve an indexed ANS-104 dataitem to the L1 Arweave transaction that contains it (and the containing block)

e2e flow

- read DATAITEM_ID from the local copycat's arweave offset index
- use the child `start-offset` to find the arweave block containing that byte position
 - read that block’s L1 tx list
 - for each L1 tx in the block, read its indexed offset/length
 - teturn the tx with byte range contains the child offset

res shape
```erl
  #{
    <<"id">> => ParentTxID,
    <<"offset">> => ParentTxStartOffset,
    <<"length">> => ParentTxLength,
    <<"child">> => ChildDataItemID,
    <<"child-offset">> => ChildStartOffset,
    <<"block-height">> => BlockHeight,
    <<"block-hash">> => BlockIndepHash
  }
```

## block lookup & perf

block lookup uses binary search over arweave block heights. each block has:

```bash
end = weave_size
start = weave_size - block_size
```
so we determine thechild belonging to the block iff `start <= child_offset < end`


so each binary-search step fetch or read one block, compares the child offset to that block byte range, and search lower/higher heights -- ~ log2(height)

 ### performance tldr:

 - children items and parent tx offsets come from the local copycat/arweave offset index
 - block metadata read go through the existing `dev_arweave_block_cache`
 - a cold lookup would fetch midpoint block metadata remotely (chain nodes) while the binary search warms the cache (a few seconds, ~< 10s for a warmup)
  - after warmup, repeated lookups for the same block or nearby offsets are local and very fast ( thats because the midpoint blocks and final target block are cached)
 - GQL-less & deterministic

N.B. if a bundler retries settling the same L2 dataitem / bundle, it can exist multiple times in the weave. `arweave.net` strategy is reporting the latest indexed settlement retry for budndled in -- but `parent-of=` return the parent for the locally indexed occurrence in local-node copycat. so bundle-id/block-height can differ across indexers