### PR TITLE
feat: `~metering@1.0` device offering multi-resource a pricing interface; bundling hooks

### DIFF
--- a/src/dev_bundler.erl
+++ b/src/dev_bundler.erl
@@ -47,11 +47,10 @@ item(_Base, Req, Opts) ->
             error -> Req
         end,
     case verify_message(ItemToProcess, Opts) of
-        {ok, Item} ->
+        {ok, Item, BundledItem, BundledSize} ->
             ItemID = hb_message:id(Item, signed, Opts),
             case cache_item(Item, Opts) of
                 ok ->
-                    BundledSize = bundled_item_size(Item, Opts),
                     dev_metering:consume(
                         <<"arweave-bytes">>,
                         BundledSize,
@@ -59,7 +58,7 @@ item(_Base, Req, Opts) ->
                     ),
                     % Queue the item for bundling
                     % (fire-and-forget, ignore errors)
-                    ServerPID ! {enqueue_item, Item, BundledSize},
+                    ServerPID ! {enqueue_item, Item, BundledSize, BundledItem},
                     {ok, #{
                         <<"id">> => ItemID,
                         <<"timestamp">> => erlang:system_time(millisecond)
@@ -87,20 +86,27 @@ item(_Base, Req, Opts) ->
     end.
 
 %% @doc Verify the subject by extracting committed fields and checking signatures.
-%% Returns {ok, Item} or {error, Reason}.
+%% Returns {ok, Item, BundledItem, BundledSize} or {error, Reason}.
 verify_message(Req, Opts) ->
     case hb_message:with_only_committed(Req, Opts) of
         {ok, Item} ->
-            case hb_message:signers(Item, Opts) of
-                [] ->
+            TX =
+                hb_message:convert(
+                    Item,
+                    <<"ans104@1.0">>,
+                    <<"structured@1.0">>,
+                    Opts
+                ),
+            case TX#tx.signature of
+                ?DEFAULT_SIG ->
                     ?event(
                         bundler_short,
                         {verify_failed, {reason, unsigned_item}}
                     ),
                     {error, unsigned_item};
                 _ ->
-                    case hb_message:verify(Item, all, Opts) of
-                        true -> {ok, Item};
+                    case ar_bundles:verify_item(TX) of
+                        true -> {ok, Item, TX, bundled_item_size(TX)};
                         false ->
                             ?event(
                                 bundler_short,
@@ -218,16 +224,18 @@ init(Opts) ->
 server(State = #state{max_idle_time = MaxIdleTime}, Opts) ->
     receive
         {enqueue_item, Item} ->
+            BundledItem = bundled_item(Item, Opts),
             State1 =
                 add_to_queue(
                     Item,
-                    bundled_item_size(Item, Opts),
+                    bundled_item_size(BundledItem),
+                    BundledItem,
                     State,
                     Opts
                 ),
             server(assign_tasks(maybe_dispatch(State1)), Opts);
-        {enqueue_item, Item, BundledSize} ->
-            State1 = add_to_queue(Item, BundledSize, State, Opts),
+        {enqueue_item, Item, BundledSize, BundledItem} ->
+            State1 = add_to_queue(Item, BundledSize, BundledItem, State, Opts),
             server(assign_tasks(maybe_dispatch(State1)), Opts);
         {dispatch_queue, Timestamp} ->
             ?event(bundler_short, {dispatched_queue_start, calendar:now_to_universal_time(Timestamp)}),
@@ -260,12 +268,12 @@ server(State = #state{max_idle_time = MaxIdleTime}, Opts) ->
 %% @doc Add an item to the queue. Update the state with the queue's total
 %% bundled byte size.
 %% Note: Item has already been verified and cached before reaching here.
-add_to_queue(Item, BundledSize, State = #state{
+add_to_queue(Item, BundledSize, BundledItem, State = #state{
         queue = Queue,
         bytes = Bytes,
         dispatch_ref = DispatchRef
     }, Opts) ->
-    NewQueue = [{Item, BundledSize} | Queue],
+    NewQueue = [{Item, BundledSize, BundledItem} | Queue],
     NewBytes = Bytes + BundledSize,
     ?event(bundler_short, {queueing_item, 
         {id, {explicit, hb_message:id(Item, signed, Opts)}},
@@ -323,7 +331,7 @@ dispatchable(_State) ->
 %% @doc Return the total size of a queue of items.
 queue_bytes(Items) ->
     lists:foldl(
-        fun({_Item, BundledSize}, Acc) -> Acc + BundledSize end,
+        fun({_Item, BundledSize, _BundledItem}, Acc) -> Acc + BundledSize end,
         0,
         Items
     ).
@@ -342,7 +350,7 @@ dispatch_queue(State = #state{queue = Queue, dispatch_ref = DispatchRef}) ->
 create_bundle([], State) ->
     State;
 create_bundle(QueuedItems, State = #state{bundles = Bundles, opts = Opts}) ->
-    {Items, ItemSizes} = lists:unzip(QueuedItems),
+    {Items, ItemSizes, BundledItems} = lists:unzip3(QueuedItems),
     BundleID = make_ref(),
     Bundle = #bundle{
         id = BundleID,
@@ -367,7 +375,7 @@ create_bundle(QueuedItems, State = #state{bundles = Bundles, opts = Opts}) ->
     Task = #task{
         bundle_id = BundleID,
         type = post_tx,
-        data = Items,
+        data = {Items, BundledItems},
         opts = Opts
     },
     enqueue_task(Task, State1).
@@ -567,14 +575,30 @@ run_completion_hooks(Bundle, Opts) ->
 
 %% @doc Calculate the exact byte size of an item inside its bundle.
 bundled_item_size(Item, Opts) ->
-    TX =
-        hb_message:convert(
-            Item,
-            #{ <<"device">> => <<"ans104@1.0">>, <<"bundle">> => true },
-            <<"structured@1.0">>,
-            Opts
-        ),
-    byte_size(ar_bundles:serialize(TX)).
+    bundled_item_size(bundled_item(Item, Opts)).
+
+%% @doc Convert an item to its ANS-104 item form.
+bundled_item(Item, Opts) ->
+    hb_message:convert(
+        Item,
+        <<"ans104@1.0">>,
+        <<"structured@1.0">>,
+        Opts
+    ).
+
+bundled_item_size(TX = #tx{}) ->
+    EncodedTags = ar_bundles:encode_tags(TX#tx.tags),
+    2
+        + byte_size(TX#tx.signature)
+        + byte_size(TX#tx.owner)
+        + optional_field_size(TX#tx.target)
+        + optional_field_size(TX#tx.anchor)
+        + 16
+        + byte_size(EncodedTags)
+        + byte_size(TX#tx.data).
+
+optional_field_size(<<>>) -> 1;
+optional_field_size(Field) -> 1 + byte_size(Field).
 
 %% @doc Calculate the byte size of the completed bundle payload.
 bundle_size(CommittedTX, Opts) ->

--- a/src/dev_bundler.erl
+++ b/src/dev_bundler.erl
@@ -51,11 +51,16 @@ item(_Base, Req, Opts) ->
             ItemID = hb_message:id(Item, signed, Opts),
             case cache_item(Item, Opts) of
                 ok ->
-                    dev_metering:meter(
-                        <<"arweave-bytes">>,
-                        bundled_item_size(Item, Opts),
-                        Opts
-                    ),
+                    case dev_metering:active() of
+                        true ->
+                            dev_metering:meter(
+                                <<"arweave-bytes">>,
+                                bundled_item_size(Item, Opts),
+                                Opts
+                            );
+                        false ->
+                            ok
+                    end,
                     % Queue the item for bundling
                     % (fire-and-forget, ignore errors)
                     ServerPID ! {enqueue_item, Item},

--- a/src/dev_bundler.erl
+++ b/src/dev_bundler.erl
@@ -51,6 +51,11 @@ item(_Base, Req, Opts) ->
             ItemID = hb_message:id(Item, signed, Opts),
             case cache_item(Item, Opts) of
                 ok ->
+                    dev_metering:meter(
+                        <<"arweave-bytes">>,
+                        bundled_item_size(Item, Opts),
+                        Opts
+                    ),
                     % Queue the item for bundling
                     % (fire-and-forget, ignore errors)
                     ServerPID ! {enqueue_item, Item},
@@ -515,7 +520,104 @@ bundle_complete(Bundle, State = #state{opts = Opts}) ->
             {elapsed_time_s, ElapsedTime}
         }
     ),
+    run_completion_hooks(Bundle, Opts),
     State#state{bundles = maps:remove(Bundle#bundle.id, State#state.bundles)}.
+
+%% @doc Execute hooks for each completed bundled item and the full bundle.
+run_completion_hooks(Bundle, Opts) ->
+    lists:foreach(
+        fun(Item) ->
+            run_hook(
+                <<"bundled-message-complete">>,
+                fun(HookOpts) ->
+                    #{
+                        <<"body">> => Item,
+                        <<"bundled-size">> => bundled_item_size(Item, HookOpts)
+                    }
+                end,
+                Opts
+            )
+        end,
+        lists:reverse(Bundle#bundle.items)
+    ),
+    run_hook(
+        <<"bundle-complete">>,
+        fun(HookOpts) ->
+            #{
+                <<"body">> => Bundle#bundle.tx,
+                <<"bundled-size">> => bundle_size(Bundle#bundle.tx, HookOpts)
+            }
+        end,
+        Opts
+    ).
+
+%% @doc Execute a single completion hook without failing the bundler server.
+run_hook(HookName, ReqFun, Opts) ->
+    try
+        HookOpts = latest_opts(Opts),
+        case dev_hook:on(HookName, ReqFun(HookOpts), HookOpts) of
+            {ok, _} ->
+                ok;
+            {Status, _Res} ->
+                ?event(
+                    hook_error,
+                    {bundler_completion_hook_failed,
+                        {hook, HookName},
+                        {status, Status}
+                    }
+                )
+        end
+    catch
+        Class:Reason:Stack ->
+            ?event(
+                hook_error,
+                {bundler_completion_hook_exception,
+                    {hook, HookName},
+                    {class, Class},
+                    {reason, Reason},
+                    {stacktrace, {trace, Stack}}
+                }
+            )
+    end.
+
+%% @doc Calculate the exact byte size of an item inside its bundle.
+bundled_item_size(Item, Opts) ->
+    TX =
+        hb_message:convert(
+            Item,
+            #{ <<"device">> => <<"ans104@1.0">>, <<"bundle">> => true },
+            <<"structured@1.0">>,
+            Opts
+        ),
+    byte_size(ar_bundles:serialize(TX)).
+
+%% @doc Calculate the byte size of the completed bundle payload.
+bundle_size(CommittedTX, Opts) ->
+    TX =
+        hb_message:convert(
+            CommittedTX,
+            <<"tx@1.0">>,
+            <<"structured@1.0">>,
+            Opts
+        ),
+    case TX#tx.data_size of
+        Size when is_integer(Size) -> Size;
+        _ -> byte_size(TX#tx.data)
+    end.
+
+%% @doc Refresh options before running hooks that may depend on live state.
+latest_opts(Opts) ->
+    case hb_opts:get(http_server, no_server_ref, Opts) of
+        no_server_ref ->
+            Opts;
+        _ ->
+            try hb_http_server:get_opts(Opts) of
+                no_node_msg -> Opts;
+                CurrentOpts -> CurrentOpts
+            catch
+                _:_ -> Opts
+            end
+    end.
 
 %% @doc Recover a single bundle and enqueue any follow-up work.
 recover_bundle(CommittedTX, Items, State = #state{opts = Opts}) ->

--- a/src/dev_bundler.erl
+++ b/src/dev_bundler.erl
@@ -257,20 +257,19 @@ server(State = #state{max_idle_time = MaxIdleTime}, Opts) ->
         server(assign_tasks(dispatch_queue(State)), Opts)
     end.
 
-%% @doc Add an item to the queue. Update the state with the new queue and
-%% approximate total byte size of the queue.
+%% @doc Add an item to the queue. Update the state with the queue's total
+%% bundled byte size.
 %% Note: Item has already been verified and cached before reaching here.
 add_to_queue(Item, BundledSize, State = #state{
         queue = Queue,
         bytes = Bytes,
         dispatch_ref = DispatchRef
     }, Opts) ->
-    QueueSize = erlang:external_size(Item),
     NewQueue = [{Item, BundledSize} | Queue],
-    NewBytes = Bytes + QueueSize,
+    NewBytes = Bytes + BundledSize,
     ?event(bundler_short, {queueing_item, 
         {id, {explicit, hb_message:id(Item, signed, Opts)}},
-        {size, QueueSize},
+        {size, BundledSize},
         {queue_size, length(NewQueue)},
         {queue_bytes, NewBytes}
     }),
@@ -324,7 +323,7 @@ dispatchable(_State) ->
 %% @doc Return the total size of a queue of items.
 queue_bytes(Items) ->
     lists:foldl(
-        fun({Item, _BundledSize}, Acc) -> Acc + erlang:external_size(Item) end,
+        fun({_Item, BundledSize}, Acc) -> Acc + BundledSize end,
         0,
         Items
     ).

--- a/src/dev_bundler.erl
+++ b/src/dev_bundler.erl
@@ -51,14 +51,15 @@ item(_Base, Req, Opts) ->
             ItemID = hb_message:id(Item, signed, Opts),
             case cache_item(Item, Opts) of
                 ok ->
+                    BundledSize = bundled_item_size(Item, Opts),
                     dev_metering:consume(
                         <<"arweave-bytes">>,
-                        bundled_item_size(Item, Opts),
+                        BundledSize,
                         Opts
                     ),
                     % Queue the item for bundling
                     % (fire-and-forget, ignore errors)
-                    ServerPID ! {enqueue_item, Item},
+                    ServerPID ! {enqueue_item, Item, BundledSize},
                     {ok, #{
                         <<"id">> => ItemID,
                         <<"timestamp">> => erlang:system_time(millisecond)
@@ -217,7 +218,16 @@ init(Opts) ->
 server(State = #state{max_idle_time = MaxIdleTime}, Opts) ->
     receive
         {enqueue_item, Item} ->
-            State1 = add_to_queue(Item, State, Opts),
+            State1 =
+                add_to_queue(
+                    Item,
+                    bundled_item_size(Item, Opts),
+                    State,
+                    Opts
+                ),
+            server(assign_tasks(maybe_dispatch(State1)), Opts);
+        {enqueue_item, Item, BundledSize} ->
+            State1 = add_to_queue(Item, BundledSize, State, Opts),
             server(assign_tasks(maybe_dispatch(State1)), Opts);
         {dispatch_queue, Timestamp} ->
             ?event(bundler_short, {dispatched_queue_start, calendar:now_to_universal_time(Timestamp)}),
@@ -247,16 +257,20 @@ server(State = #state{max_idle_time = MaxIdleTime}, Opts) ->
         server(assign_tasks(dispatch_queue(State)), Opts)
     end.
 
-%% @doc Add an enqueue_item to the queue. Update the state with the new queue
-%% and approximate total byte size of the queue.
+%% @doc Add an item to the queue. Update the state with the new queue and
+%% approximate total byte size of the queue.
 %% Note: Item has already been verified and cached before reaching here.
-add_to_queue(Item, State = #state{queue = Queue, bytes = Bytes, dispatch_ref =  DispatchRef}, Opts) ->
-    ItemSize = erlang:external_size(Item),
-    NewQueue = [Item | Queue],
-    NewBytes = Bytes + ItemSize,
+add_to_queue(Item, BundledSize, State = #state{
+        queue = Queue,
+        bytes = Bytes,
+        dispatch_ref = DispatchRef
+    }, Opts) ->
+    QueueSize = erlang:external_size(Item),
+    NewQueue = [{Item, BundledSize} | Queue],
+    NewBytes = Bytes + QueueSize,
     ?event(bundler_short, {queueing_item, 
         {id, {explicit, hb_message:id(Item, signed, Opts)}},
-        {size, erlang:external_size(Item)},
+        {size, QueueSize},
         {queue_size, length(NewQueue)},
         {queue_bytes, NewBytes}
     }),
@@ -310,7 +324,7 @@ dispatchable(_State) ->
 %% @doc Return the total size of a queue of items.
 queue_bytes(Items) ->
     lists:foldl(
-        fun(Item, Acc) -> Acc + erlang:external_size(Item) end,
+        fun({Item, _BundledSize}, Acc) -> Acc + erlang:external_size(Item) end,
         0,
         Items
     ).
@@ -328,11 +342,13 @@ dispatch_queue(State = #state{queue = Queue, dispatch_ref = DispatchRef}) ->
 %% @doc Create a bundle and enqueue its initial post task.
 create_bundle([], State) ->
     State;
-create_bundle(Items, State = #state{bundles = Bundles, opts = Opts}) ->
+create_bundle(QueuedItems, State = #state{bundles = Bundles, opts = Opts}) ->
+    {Items, ItemSizes} = lists:unzip(QueuedItems),
     BundleID = make_ref(),
     Bundle = #bundle{
         id = BundleID,
         items = Items,
+        item_sizes = ItemSizes,
         status = initializing,
         tx = undefined,
         proofs = #{},
@@ -526,17 +542,20 @@ bundle_complete(Bundle, State = #state{opts = Opts}) ->
 %% @doc Execute hooks for each completed bundled item and the full bundle.
 run_completion_hooks(Bundle, Opts) ->
     lists:foreach(
-        fun(Item) ->
+        fun({Item, Size}) ->
             dev_hook:on(
                 <<"bundled-message-complete">>,
                 #{
                     <<"body">> => Item,
-                    <<"bundled-size">> => bundled_item_size(Item, Opts)
+                    <<"bundled-size">> => Size
                 },
                 Opts
             )
         end,
-        lists:reverse(Bundle#bundle.items)
+        lists:zip(
+            lists:reverse(Bundle#bundle.items),
+            lists:reverse(Bundle#bundle.item_sizes)
+        )
     ),
     dev_hook:on(
         <<"bundle-complete">>,
@@ -578,6 +597,7 @@ recover_bundle(CommittedTX, Items, State = #state{opts = Opts}) ->
     Bundle = #bundle{
         id = BundleID,
         items = Items,
+        item_sizes = [bundled_item_size(Item, Opts) || Item <- Items],
         status = tx_posted,
         tx = CommittedTX,
         proofs = #{},

--- a/src/dev_bundler.erl
+++ b/src/dev_bundler.erl
@@ -533,7 +533,7 @@ run_completion_hooks(Bundle, Opts) ->
                     <<"body">> => Item,
                     <<"bundled-size">> => bundled_item_size(Item, Opts)
                 },
-                latest_opts(Opts)
+                Opts
             )
         end,
         lists:reverse(Bundle#bundle.items)
@@ -544,7 +544,7 @@ run_completion_hooks(Bundle, Opts) ->
             <<"body">> => Bundle#bundle.tx,
             <<"bundled-size">> => bundle_size(Bundle#bundle.tx, Opts)
         },
-        latest_opts(Opts)
+        Opts
     ).
 
 %% @doc Calculate the exact byte size of an item inside its bundle.
@@ -570,20 +570,6 @@ bundle_size(CommittedTX, Opts) ->
     case TX#tx.data_size of
         Size when is_integer(Size) -> Size;
         _ -> byte_size(TX#tx.data)
-    end.
-
-%% @doc Refresh options before running hooks that may depend on live state.
-latest_opts(Opts) ->
-    case hb_opts:get(http_server, no_server_ref, Opts) of
-        no_server_ref ->
-            Opts;
-        _ ->
-            try hb_http_server:get_opts(Opts) of
-                no_node_msg -> Opts;
-                CurrentOpts -> CurrentOpts
-            catch
-                _:_ -> Opts
-            end
     end.
 
 %% @doc Recover a single bundle and enqueue any follow-up work.

--- a/src/dev_bundler.erl
+++ b/src/dev_bundler.erl
@@ -51,7 +51,7 @@ item(_Base, Req, Opts) ->
             ItemID = hb_message:id(Item, signed, Opts),
             case cache_item(Item, Opts) of
                 ok ->
-                    dev_metering:meter(
+                    dev_metering:consume(
                         <<"arweave-bytes">>,
                         bundled_item_size(Item, Opts),
                         Opts

--- a/src/dev_bundler.erl
+++ b/src/dev_bundler.erl
@@ -527,35 +527,25 @@ bundle_complete(Bundle, State = #state{opts = Opts}) ->
 run_completion_hooks(Bundle, Opts) ->
     lists:foreach(
         fun(Item) ->
-            run_hook(
+            dev_hook:on(
                 <<"bundled-message-complete">>,
-                fun(HookOpts) ->
-                    #{
-                        <<"body">> => Item,
-                        <<"bundled-size">> => bundled_item_size(Item, HookOpts)
-                    }
-                end,
-                Opts
+                #{
+                    <<"body">> => Item,
+                    <<"bundled-size">> => bundled_item_size(Item, Opts)
+                },
+                latest_opts(Opts)
             )
         end,
         lists:reverse(Bundle#bundle.items)
     ),
-    run_hook(
+    dev_hook:on(
         <<"bundle-complete">>,
-        fun(HookOpts) ->
-            #{
-                <<"body">> => Bundle#bundle.tx,
-                <<"bundled-size">> => bundle_size(Bundle#bundle.tx, HookOpts)
-            }
-        end,
-        Opts
+        #{
+            <<"body">> => Bundle#bundle.tx,
+            <<"bundled-size">> => bundle_size(Bundle#bundle.tx, Opts)
+        },
+        latest_opts(Opts)
     ).
-
-%% @doc Execute a single completion hook.
-run_hook(HookName, ReqFun, Opts) ->
-    HookOpts = latest_opts(Opts),
-    _ = dev_hook:on(HookName, ReqFun(HookOpts), HookOpts),
-    ok.
 
 %% @doc Calculate the exact byte size of an item inside its bundle.
 bundled_item_size(Item, Opts) ->

--- a/src/dev_bundler.erl
+++ b/src/dev_bundler.erl
@@ -51,16 +51,11 @@ item(_Base, Req, Opts) ->
             ItemID = hb_message:id(Item, signed, Opts),
             case cache_item(Item, Opts) of
                 ok ->
-                    case dev_metering:active() of
-                        true ->
-                            dev_metering:meter(
-                                <<"arweave-bytes">>,
-                                bundled_item_size(Item, Opts),
-                                Opts
-                            );
-                        false ->
-                            ok
-                    end,
+                    dev_metering:meter(
+                        <<"arweave-bytes">>,
+                        bundled_item_size(Item, Opts),
+                        Opts
+                    ),
                     % Queue the item for bundling
                     % (fire-and-forget, ignore errors)
                     ServerPID ! {enqueue_item, Item},

--- a/src/dev_bundler.erl
+++ b/src/dev_bundler.erl
@@ -551,34 +551,11 @@ run_completion_hooks(Bundle, Opts) ->
         Opts
     ).
 
-%% @doc Execute a single completion hook without failing the bundler server.
+%% @doc Execute a single completion hook.
 run_hook(HookName, ReqFun, Opts) ->
-    try
-        HookOpts = latest_opts(Opts),
-        case dev_hook:on(HookName, ReqFun(HookOpts), HookOpts) of
-            {ok, _} ->
-                ok;
-            {Status, _Res} ->
-                ?event(
-                    hook_error,
-                    {bundler_completion_hook_failed,
-                        {hook, HookName},
-                        {status, Status}
-                    }
-                )
-        end
-    catch
-        Class:Reason:Stack ->
-            ?event(
-                hook_error,
-                {bundler_completion_hook_exception,
-                    {hook, HookName},
-                    {class, Class},
-                    {reason, Reason},
-                    {stacktrace, {trace, Stack}}
-                }
-            )
-    end.
+    HookOpts = latest_opts(Opts),
+    _ = dev_hook:on(HookName, ReqFun(HookOpts), HookOpts),
+    ok.
 
 %% @doc Calculate the exact byte size of an item inside its bundle.
 bundled_item_size(Item, Opts) ->

--- a/src/dev_bundler.erl
+++ b/src/dev_bundler.erl
@@ -47,10 +47,11 @@ item(_Base, Req, Opts) ->
             error -> Req
         end,
     case verify_message(ItemToProcess, Opts) of
-        {ok, Item, BundledItem, BundledSize} ->
+        {ok, Item} ->
             ItemID = hb_message:id(Item, signed, Opts),
             case cache_item(Item, Opts) of
                 ok ->
+                    BundledSize = bundled_item_size(Item, Opts),
                     dev_metering:consume(
                         <<"arweave-bytes">>,
                         BundledSize,
@@ -58,7 +59,7 @@ item(_Base, Req, Opts) ->
                     ),
                     % Queue the item for bundling
                     % (fire-and-forget, ignore errors)
-                    ServerPID ! {enqueue_item, Item, BundledSize, BundledItem},
+                    ServerPID ! {enqueue_item, Item, BundledSize},
                     {ok, #{
                         <<"id">> => ItemID,
                         <<"timestamp">> => erlang:system_time(millisecond)
@@ -86,27 +87,20 @@ item(_Base, Req, Opts) ->
     end.
 
 %% @doc Verify the subject by extracting committed fields and checking signatures.
-%% Returns {ok, Item, BundledItem, BundledSize} or {error, Reason}.
+%% Returns {ok, Item} or {error, Reason}.
 verify_message(Req, Opts) ->
     case hb_message:with_only_committed(Req, Opts) of
         {ok, Item} ->
-            TX =
-                hb_message:convert(
-                    Item,
-                    <<"ans104@1.0">>,
-                    <<"structured@1.0">>,
-                    Opts
-                ),
-            case TX#tx.signature of
-                ?DEFAULT_SIG ->
+            case hb_message:signers(Item, Opts) of
+                [] ->
                     ?event(
                         bundler_short,
                         {verify_failed, {reason, unsigned_item}}
                     ),
                     {error, unsigned_item};
                 _ ->
-                    case ar_bundles:verify_item(TX) of
-                        true -> {ok, Item, TX, bundled_item_size(TX)};
+                    case hb_message:verify(Item, all, Opts) of
+                        true -> {ok, Item};
                         false ->
                             ?event(
                                 bundler_short,
@@ -224,18 +218,16 @@ init(Opts) ->
 server(State = #state{max_idle_time = MaxIdleTime}, Opts) ->
     receive
         {enqueue_item, Item} ->
-            BundledItem = bundled_item(Item, Opts),
             State1 =
                 add_to_queue(
                     Item,
-                    bundled_item_size(BundledItem),
-                    BundledItem,
+                    bundled_item_size(Item, Opts),
                     State,
                     Opts
                 ),
             server(assign_tasks(maybe_dispatch(State1)), Opts);
-        {enqueue_item, Item, BundledSize, BundledItem} ->
-            State1 = add_to_queue(Item, BundledSize, BundledItem, State, Opts),
+        {enqueue_item, Item, BundledSize} ->
+            State1 = add_to_queue(Item, BundledSize, State, Opts),
             server(assign_tasks(maybe_dispatch(State1)), Opts);
         {dispatch_queue, Timestamp} ->
             ?event(bundler_short, {dispatched_queue_start, calendar:now_to_universal_time(Timestamp)}),
@@ -268,12 +260,12 @@ server(State = #state{max_idle_time = MaxIdleTime}, Opts) ->
 %% @doc Add an item to the queue. Update the state with the queue's total
 %% bundled byte size.
 %% Note: Item has already been verified and cached before reaching here.
-add_to_queue(Item, BundledSize, BundledItem, State = #state{
+add_to_queue(Item, BundledSize, State = #state{
         queue = Queue,
         bytes = Bytes,
         dispatch_ref = DispatchRef
     }, Opts) ->
-    NewQueue = [{Item, BundledSize, BundledItem} | Queue],
+    NewQueue = [{Item, BundledSize} | Queue],
     NewBytes = Bytes + BundledSize,
     ?event(bundler_short, {queueing_item, 
         {id, {explicit, hb_message:id(Item, signed, Opts)}},
@@ -331,7 +323,7 @@ dispatchable(_State) ->
 %% @doc Return the total size of a queue of items.
 queue_bytes(Items) ->
     lists:foldl(
-        fun({_Item, BundledSize, _BundledItem}, Acc) -> Acc + BundledSize end,
+        fun({_Item, BundledSize}, Acc) -> Acc + BundledSize end,
         0,
         Items
     ).
@@ -350,7 +342,7 @@ dispatch_queue(State = #state{queue = Queue, dispatch_ref = DispatchRef}) ->
 create_bundle([], State) ->
     State;
 create_bundle(QueuedItems, State = #state{bundles = Bundles, opts = Opts}) ->
-    {Items, ItemSizes, BundledItems} = lists:unzip3(QueuedItems),
+    {Items, ItemSizes} = lists:unzip(QueuedItems),
     BundleID = make_ref(),
     Bundle = #bundle{
         id = BundleID,
@@ -375,7 +367,7 @@ create_bundle(QueuedItems, State = #state{bundles = Bundles, opts = Opts}) ->
     Task = #task{
         bundle_id = BundleID,
         type = post_tx,
-        data = {Items, BundledItems},
+        data = Items,
         opts = Opts
     },
     enqueue_task(Task, State1).
@@ -575,30 +567,14 @@ run_completion_hooks(Bundle, Opts) ->
 
 %% @doc Calculate the exact byte size of an item inside its bundle.
 bundled_item_size(Item, Opts) ->
-    bundled_item_size(bundled_item(Item, Opts)).
-
-%% @doc Convert an item to its ANS-104 item form.
-bundled_item(Item, Opts) ->
-    hb_message:convert(
-        Item,
-        <<"ans104@1.0">>,
-        <<"structured@1.0">>,
-        Opts
-    ).
-
-bundled_item_size(TX = #tx{}) ->
-    EncodedTags = ar_bundles:encode_tags(TX#tx.tags),
-    2
-        + byte_size(TX#tx.signature)
-        + byte_size(TX#tx.owner)
-        + optional_field_size(TX#tx.target)
-        + optional_field_size(TX#tx.anchor)
-        + 16
-        + byte_size(EncodedTags)
-        + byte_size(TX#tx.data).
-
-optional_field_size(<<>>) -> 1;
-optional_field_size(Field) -> 1 + byte_size(Field).
+    TX =
+        hb_message:convert(
+            Item,
+            #{ <<"device">> => <<"ans104@1.0">>, <<"bundle">> => true },
+            <<"structured@1.0">>,
+            Opts
+        ),
+    byte_size(ar_bundles:serialize(TX)).
 
 %% @doc Calculate the byte size of the completed bundle payload.
 bundle_size(CommittedTX, Opts) ->

--- a/src/dev_bundler_task.erl
+++ b/src/dev_bundler_task.erl
@@ -27,17 +27,10 @@ worker_loop() ->
     end.
 
 %% @doc Execute a specific task.
-execute_task(#task{type = post_tx, data = DataItems, opts = Opts} = Task) ->
-    {Items, TXItems, ItemMode} =
-        case DataItems of
-            {QueuedItems, BundledItems} ->
-                {QueuedItems, BundledItems, preconverted};
-            _ ->
-                {DataItems, DataItems, convert}
-        end,
+execute_task(#task{type = post_tx, data = Items, opts = Opts} = Task) ->
     try
         ?event(debug_bundler, log_task(executing_task, Task, [])),
-        case build_signed_tx(TXItems, Opts, ItemMode) of
+        case build_signed_tx(Items, Opts) of
             {ok, SignedTX} ->
                 Committed = hb_message:convert(
                     SignedTX,
@@ -158,16 +151,7 @@ execute_task(#task{type = post_proof, data = Proof, opts = Opts} = Task) ->
 
 %% @doc Build and sign a bundle TX without posting it.
 build_signed_tx(Items, Opts) ->
-    build_signed_tx(Items, Opts, convert).
-
-build_signed_tx(Items, Opts, convert) ->
     TX = data_items_to_tx(Items, Opts),
-    sign_tx(TX, Opts);
-build_signed_tx(Items, Opts, preconverted) ->
-    TX = data_items_to_tx(Items),
-    sign_tx(TX, Opts).
-
-sign_tx(TX, Opts) ->
     DataSize = TX#tx.data_size,
     PriceResult = get_price(DataSize, Opts),
     AnchorResult = get_anchor(Opts),
@@ -202,12 +186,6 @@ data_items_to_tx(Items, Opts) ->
         data = List
     }).
 
-data_items_to_tx(Items) ->
-    dev_arweave_common:normalize(#tx{
-        format = 2,
-        data = lists:reverse(Items)
-    }).
-
 get_price(DataSize, Opts) ->
     hb_ao:resolve(
         #{ <<"device">> => <<"arweave@2.9">> },
@@ -231,17 +209,6 @@ log_task(Event, Task, ExtraLogs) ->
     erlang:list_to_tuple([Event | format_task(Task) ++ ExtraLogs]).
 
 %% @doc Format a task for logging.
-format_task(#task{
-        bundle_id = BundleID,
-        type = post_tx,
-        data = {DataItems, _BundledItems}
-    }) ->
-    [
-        {task_type, post_tx},
-        {timestamp, format_timestamp()},
-        {bundle, BundleID},
-        {num_items, length(DataItems)}
-    ];
 format_task(#task{bundle_id = BundleID, type = post_tx, data = DataItems}) ->
     [
         {task_type, post_tx},

--- a/src/dev_bundler_task.erl
+++ b/src/dev_bundler_task.erl
@@ -27,10 +27,17 @@ worker_loop() ->
     end.
 
 %% @doc Execute a specific task.
-execute_task(#task{type = post_tx, data = Items, opts = Opts} = Task) ->
+execute_task(#task{type = post_tx, data = DataItems, opts = Opts} = Task) ->
+    {Items, TXItems, ItemMode} =
+        case DataItems of
+            {QueuedItems, BundledItems} ->
+                {QueuedItems, BundledItems, preconverted};
+            _ ->
+                {DataItems, DataItems, convert}
+        end,
     try
         ?event(debug_bundler, log_task(executing_task, Task, [])),
-        case build_signed_tx(Items, Opts) of
+        case build_signed_tx(TXItems, Opts, ItemMode) of
             {ok, SignedTX} ->
                 Committed = hb_message:convert(
                     SignedTX,
@@ -151,7 +158,16 @@ execute_task(#task{type = post_proof, data = Proof, opts = Opts} = Task) ->
 
 %% @doc Build and sign a bundle TX without posting it.
 build_signed_tx(Items, Opts) ->
+    build_signed_tx(Items, Opts, convert).
+
+build_signed_tx(Items, Opts, convert) ->
     TX = data_items_to_tx(Items, Opts),
+    sign_tx(TX, Opts);
+build_signed_tx(Items, Opts, preconverted) ->
+    TX = data_items_to_tx(Items),
+    sign_tx(TX, Opts).
+
+sign_tx(TX, Opts) ->
     DataSize = TX#tx.data_size,
     PriceResult = get_price(DataSize, Opts),
     AnchorResult = get_anchor(Opts),
@@ -186,6 +202,12 @@ data_items_to_tx(Items, Opts) ->
         data = List
     }).
 
+data_items_to_tx(Items) ->
+    dev_arweave_common:normalize(#tx{
+        format = 2,
+        data = lists:reverse(Items)
+    }).
+
 get_price(DataSize, Opts) ->
     hb_ao:resolve(
         #{ <<"device">> => <<"arweave@2.9">> },
@@ -209,6 +231,17 @@ log_task(Event, Task, ExtraLogs) ->
     erlang:list_to_tuple([Event | format_task(Task) ++ ExtraLogs]).
 
 %% @doc Format a task for logging.
+format_task(#task{
+        bundle_id = BundleID,
+        type = post_tx,
+        data = {DataItems, _BundledItems}
+    }) ->
+    [
+        {task_type, post_tx},
+        {timestamp, format_timestamp()},
+        {bundle, BundleID},
+        {num_items, length(DataItems)}
+    ];
 format_task(#task{bundle_id = BundleID, type = post_tx, data = DataItems}) ->
     [
         {task_type, post_tx},

--- a/src/dev_metering.erl
+++ b/src/dev_metering.erl
@@ -5,18 +5,17 @@
 %%% device:
 %%%
 %%%     `estimate/3' opens a process-local metering session.
-%%%     `meter/[3,4]' increments resource usage during that session.
+%%%     `meter/3' increments resource usage during that session.
 %%%     `price/3' closes the session and returns the integer charge.
 %%%
-%%% Calls to `meter/[3,4]' outside an active session are no-ops, so callers do
+%%% Calls to `meter/3' outside an active session are no-ops, so callers do
 %%% not need to check whether metering is enabled. Resource names are normalized
 %%% keys, such as `arweave-bytes' and `beam-reductions'. The operator sets
 %%% `metering-rates' in the node message as a map of resource name to AO token
 %%% units per resource unit.
 -module(dev_metering).
--export([info/1, estimate/3, price/3, is_active/0, meter/3, meter/4]).
+-export([info/1, estimate/3, price/3, is_active/0, meter/3]).
 
--include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 -define(METERING_KEY, {dev_metering, state}).
@@ -34,13 +33,11 @@ info(_) ->
     }.
 
 %% @doc Start a metering session for the request.
-estimate(_Base, EstimateReq, Opts) ->
-    Request = hb_maps:get(<<"request">>, EstimateReq, #{}, Opts),
+estimate(_Base, _EstimateReq, _Opts) ->
     {reductions, Reductions} = erlang:process_info(self(), reductions),
     erlang:put(
         ?METERING_KEY,
         #{
-            default_payer => payer(Request, Opts),
             start_reductions => Reductions,
             meters => #{}
         }
@@ -48,23 +45,21 @@ estimate(_Base, EstimateReq, Opts) ->
     {ok, 0}.
 
 %% @doc Close the metering session and calculate the final AO token price.
-price(_Base, PriceReq, Opts) ->
-    Request = hb_maps:get(<<"request">>, PriceReq, #{}, Opts),
-    State0 = metering_state(Request, Opts),
-    State = meter_reductions(State0),
-    Meters = maps:get(meters, State, #{}),
+price(_Base, _PriceReq, Opts) ->
     Rates = hb_opts:get(<<"metering-rates">>, #{}, Opts),
     Price =
-        case hb_maps:find(<<"party">>, PriceReq, Opts) of
-            {ok, Party} ->
-                price_for(
-                    maps:get(normalize_party(Party, State, Opts), Meters, #{}),
-                    Rates,
-                    Opts
-                );
-            error ->
-                price_for_all(Meters, Rates, Opts)
-        end,
+        maps:fold(
+            fun(Resource, Amount, Acc) ->
+                Rate = hb_util:int(hb_maps:get(Resource, Rates, 0, Opts)),
+                Acc + (Amount * Rate)
+            end,
+            0,
+            maps:get(
+                meters,
+                meter_reductions(erlang:get(?METERING_KEY)),
+                #{}
+            )
+        ),
     erlang:erase(?METERING_KEY),
     {ok, Price}.
 
@@ -74,7 +69,6 @@ is_active() ->
 
 %% @doc Device API for incrementing a resource counter.
 meter(Base, Req, Opts) when is_map(Base), is_map(Req) ->
-    Party = hb_maps:get(<<"party">>, Req, default, Opts),
     Resource =
         hb_maps:get(
             <<"resource">>,
@@ -83,128 +77,52 @@ meter(Base, Req, Opts) when is_map(Base), is_map(Req) ->
             Opts
         ),
     Amount = hb_maps:get(<<"amount">>, Req, 1, Opts),
-    ok = meter(Party, Resource, Amount, Opts),
+    ok = meter(Resource, Amount, Opts),
     {ok, true};
-%% @doc Helper API for other devices. Increments the default payer.
-meter(Resource, Amount, Opts) ->
-    meter(default, Resource, Amount, Opts).
 
-%% @doc Helper API for other devices. Increments a specific payer.
-meter(Party, Resource, Amount, Opts) ->
+%% @doc Helper API for other devices.
+meter(Resource, Amount, _Opts) ->
     case erlang:get(?METERING_KEY) of
         undefined ->
             ok;
         State ->
-            Payer = normalize_party(Party, State, Opts),
-            ResourceKey = normalize_resource(Resource),
-            AmountInt = non_negative_int(Amount),
-            erlang:put(
-                ?METERING_KEY,
-                add_meter(Payer, ResourceKey, AmountInt, State)
-            ),
-            ok
-    end.
-
-%% @doc Return the active metering state, creating one if needed.
-metering_state(Request, Opts) ->
-    case erlang:get(?METERING_KEY) of
-        undefined ->
-            {reductions, Reductions} = erlang:process_info(self(), reductions),
-            #{
-                default_payer => payer(Request, Opts),
-                start_reductions => Reductions,
-                meters => #{}
-            };
-        State ->
-            State
+            AmountInt = hb_util:int(Amount),
+            case AmountInt >= 0 of
+                true ->
+                    erlang:put(
+                        ?METERING_KEY,
+                        add_meter(
+                            hb_ao:normalize_key(Resource),
+                            AmountInt,
+                            State
+                        )
+                    ),
+                    ok;
+                false ->
+                    error({invalid_meter_amount, Amount})
+            end
     end.
 
 %% @doc Add the process reductions delta to the active metering state.
+meter_reductions(undefined) ->
+    #{ meters => #{} };
 meter_reductions(State = #{ start_reductions := Start }) ->
     {reductions, Current} = erlang:process_info(self(), reductions),
-    Delta = max(0, Current - Start),
     add_meter(
-        maps:get(default_payer, State),
         ?BEAM_REDUCTIONS,
-        Delta,
+        max(0, Current - Start),
         State
     ).
 
-%% @doc Add a resource amount to a party's meters.
-add_meter(_Payer, _Resource, 0, State) ->
-    State;
-add_meter(Payer, Resource, Amount, State) ->
+%% @doc Add a resource amount to the meter state.
+add_meter(Resource, Amount, State) ->
     Meters = maps:get(meters, State, #{}),
-    PayerMeters = maps:get(Payer, Meters, #{}),
-    Current = maps:get(Resource, PayerMeters, 0),
     State#{
         meters =>
             Meters#{
-                Payer =>
-                    PayerMeters#{ Resource => Current + Amount }
+                Resource => maps:get(Resource, Meters, 0) + Amount
             }
     }.
-
-%% @doc Calculate a token price across all metered parties.
-price_for_all(Meters, Rates, Opts) ->
-    maps:fold(
-        fun(_Payer, PayerMeters, Acc) ->
-            Acc + price_for(PayerMeters, Rates, Opts)
-        end,
-        0,
-        Meters
-    ).
-
-%% @doc Calculate a token price from resource meters and operator rates.
-price_for(Meters, Rates, Opts) ->
-    maps:fold(
-        fun(Resource, Amount, Acc) ->
-            Acc + (Amount * rate(Resource, Rates, Opts))
-        end,
-        0,
-        Meters
-    ).
-
-%% @doc Return the operator-configured token rate for a resource.
-rate(Resource, Rates, Opts) ->
-    case hb_maps:get(Resource, Rates, 0, Opts) of
-        Rate when is_integer(Rate) -> Rate;
-        Rate -> hb_util:int(Rate)
-    end.
-
-%% @doc Determine the default payer for a request.
-payer(Request, Opts) ->
-    case hb_message:signers(Request, Opts) of
-        [Signer] -> normalize_party(Signer, #{}, Opts);
-        [] -> <<"unknown">>;
-        Multiple ->
-            hb_util:bin(
-                lists:join(
-                    <<",">>,
-                    lists:map(fun hb_util:bin/1, Multiple)
-                )
-            )
-    end.
-
-%% @doc Normalize a payer identifier for storage in the meter map.
-normalize_party(default, State, _Opts) ->
-    maps:get(default_payer, State, <<"unknown">>);
-normalize_party(Payer, _State, _Opts) when ?IS_ID(Payer) ->
-    hb_util:human_id(Payer);
-normalize_party(Payer, _State, _Opts) ->
-    hb_util:bin(Payer).
-
-%% @doc Normalize a resource name for storage in the meter map.
-normalize_resource(Resource) ->
-    hb_ao:normalize_key(Resource).
-
-%% @doc Convert an amount to a non-negative integer.
-non_negative_int(Amount) ->
-    Int = hb_util:int(Amount),
-    case Int >= 0 of
-        true -> Int;
-        false -> error({invalid_meter_amount, Amount})
-    end.
 
 %%% Tests
 
@@ -216,67 +134,26 @@ inactive_meter_noop_test() ->
 
 %% @doc The helper API meters resources and prices them via configured rates.
 helper_price_test() ->
-    Wallet = ar_wallet:new(),
-    Request =
-        hb_message:commit(
-            #{ <<"path">> => <<"/metered">> },
-            #{ <<"priv-wallet">> => Wallet }
-        ),
     Opts = #{
         <<"metering-rates">> => #{
             <<"arweave-bytes">> => 3,
             ?BEAM_REDUCTIONS => 0
         }
     },
-    {ok, 0} = estimate(#{}, #{ <<"request">> => Request }, Opts),
+    {ok, 0} = estimate(#{}, #{}, Opts),
     ok = meter(<<"arweave-bytes">>, 5, Opts),
-    {ok, 15} = price(#{}, #{ <<"request">> => Request }, Opts).
+    {ok, 15} = price(#{}, #{}, Opts).
 
 %% @doc BEAM reductions are metered between estimate and price.
 beam_reductions_price_test() ->
-    Wallet = ar_wallet:new(),
-    Request =
-        hb_message:commit(
-            #{ <<"path">> => <<"/metered">> },
-            #{ <<"priv-wallet">> => Wallet }
-        ),
     Opts = #{ <<"metering-rates">> => #{ ?BEAM_REDUCTIONS => 1 } },
-    {ok, 0} = estimate(#{}, #{ <<"request">> => Request }, Opts),
+    {ok, 0} = estimate(#{}, #{}, Opts),
     lists:foreach(
         fun(_) -> erlang:phash2(rand:bytes(16)) end,
         lists:seq(1, 10)
     ),
-    {ok, Price} = price(#{}, #{ <<"request">> => Request }, Opts),
+    {ok, Price} = price(#{}, #{}, Opts),
     ?assert(Price > 0).
-
-%% @doc Pricing without a party includes all explicitly metered parties.
-explicit_party_price_test() ->
-    Wallet = ar_wallet:new(),
-    Request =
-        hb_message:commit(
-            #{ <<"path">> => <<"/metered">> },
-            #{ <<"priv-wallet">> => Wallet }
-        ),
-    Other = hb_util:human_id(ar_wallet:to_address(ar_wallet:new())),
-    Opts = #{
-        <<"metering-rates">> => #{
-            <<"arweave-bytes">> => 2,
-            ?BEAM_REDUCTIONS => 0
-        }
-    },
-    {ok, 0} = estimate(#{}, #{ <<"request">> => Request }, Opts),
-    ok = meter(<<"arweave-bytes">>, 3, Opts),
-    ok = meter(Other, <<"arweave-bytes">>, 5, Opts),
-    {ok, 10} =
-        price(
-            #{},
-            #{ <<"request">> => Request, <<"party">> => Other },
-            Opts
-        ),
-    {ok, 0} = estimate(#{}, #{ <<"request">> => Request }, Opts),
-    ok = meter(<<"arweave-bytes">>, 3, Opts),
-    ok = meter(Other, <<"arweave-bytes">>, 5, Opts),
-    {ok, 16} = price(#{}, #{ <<"request">> => Request }, Opts).
 
 %% @doc P4 charges a dynamic metering price during response processing.
 p4_response_charge_test() ->

--- a/src/dev_metering.erl
+++ b/src/dev_metering.erl
@@ -176,8 +176,7 @@ p4_response_charge_test() ->
                 <<"data">> => <<"metered-bundler-item">>,
                 <<"test">> => <<"p4-response-metering">>
             },
-            #{ <<"priv-wallet">> => ar_wallet:new() },
-            <<"ans104@1.0">>
+            #{ <<"priv-wallet">> => ar_wallet:new() }
         ),
     {ServerHandle, GatewayOpts} =
         dev_bundler:start_mock_gateway(

--- a/src/dev_metering.erl
+++ b/src/dev_metering.erl
@@ -1,0 +1,289 @@
+%%% @doc Dynamic pricing device for P4.
+%%%
+%%% `metering@1.0' records resource usage in the current process during a P4
+%%% request/response lifecycle. `estimate/3' starts the metering session and
+%%% captures the initial BEAM reductions count. Other devices can then call
+%%% `meter/3' or `increase/3' to add resource usage. Finally, `price/3' adds the
+%%% reductions delta, applies the operator's `metering-rates' table, and returns
+%%% the total integer token charge to P4.
+-module(dev_metering).
+-export([info/1, estimate/3, price/3, meter/3, meter/4]).
+-export([increase/3, increase/4, totals/3]).
+
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(METERING_KEY, {dev_metering, state}).
+-define(BEAM_REDUCTIONS, <<"beam-reductions">>).
+
+%% @doc Device API information.
+info(_) ->
+    #{
+        exports =>
+            [
+                <<"estimate">>,
+                <<"price">>,
+                <<"meter">>,
+                <<"increase">>,
+                <<"totals">>
+            ]
+    }.
+
+%% @doc Start a metering session for the request.
+estimate(_Base, EstimateReq, Opts) ->
+    Request = hb_maps:get(<<"request">>, EstimateReq, #{}, Opts),
+    {reductions, Reductions} = erlang:process_info(self(), reductions),
+    erlang:put(
+        ?METERING_KEY,
+        #{
+            default_payer => payer(Request, Opts),
+            start_reductions => Reductions,
+            meters => #{}
+        }
+    ),
+    {ok, hb_util:int(hb_opts:get(metering_minimum_price, 0, Opts))}.
+
+%% @doc Close the metering session and calculate the final AO token price.
+price(_Base, PriceReq, Opts) ->
+    Request = hb_maps:get(<<"request">>, PriceReq, #{}, Opts),
+    State0 = metering_state(Request, Opts),
+    State = meter_reductions(State0),
+    ChargePayer =
+        normalize_party(
+            hb_maps:get(
+                <<"party">>,
+                PriceReq,
+                maps:get(default_payer, State),
+                Opts
+            ),
+            State,
+            Opts
+        ),
+    Price =
+        price_for(
+            maps:get(ChargePayer, maps:get(meters, State, #{}), #{}),
+            hb_opts:get(<<"metering-rates">>, #{}, Opts),
+            Opts
+        ),
+    erlang:erase(?METERING_KEY),
+    {ok, Price}.
+
+%% @doc Device API for incrementing a resource counter.
+meter(Base, Req, Opts) when is_map(Base), is_map(Req) ->
+    Party = hb_maps:get(<<"party">>, Req, default, Opts),
+    Resource =
+        hb_maps:get(
+            <<"resource">>,
+            Req,
+            hb_maps:get(<<"resource">>, Base, undefined, Opts),
+            Opts
+        ),
+    Amount = hb_maps:get(<<"amount">>, Req, 1, Opts),
+    ok = meter(Party, Resource, Amount, Opts),
+    {ok, current_totals()};
+%% @doc Helper API for other devices. Increments the default payer.
+meter(Resource, Amount, Opts) ->
+    meter(default, Resource, Amount, Opts).
+
+%% @doc Helper API for other devices. Increments a specific payer.
+meter(Party, Resource, Amount, Opts) ->
+    case erlang:get(?METERING_KEY) of
+        undefined ->
+            ok;
+        State ->
+            Payer = normalize_party(Party, State, Opts),
+            ResourceKey = normalize_resource(Resource),
+            AmountInt = non_negative_int(Amount),
+            erlang:put(
+                ?METERING_KEY,
+                add_meter(Payer, ResourceKey, AmountInt, State)
+            ),
+            ok
+    end.
+
+%% @doc Alias for `meter/3' in helper and device contexts.
+increase(Base, Req, Opts) when is_map(Base), is_map(Req) ->
+    meter(Base, Req, Opts);
+increase(Resource, Amount, Opts) ->
+    meter(Resource, Amount, Opts).
+
+%% @doc Alias for `meter/4'.
+increase(Party, Resource, Amount, Opts) ->
+    meter(Party, Resource, Amount, Opts).
+
+%% @doc Return the current process's metering totals.
+totals(_Base, _Req, _Opts) ->
+    {ok, current_totals()}.
+
+%% @doc Return the active metering state, creating one if needed.
+metering_state(Request, Opts) ->
+    case erlang:get(?METERING_KEY) of
+        undefined ->
+            {reductions, Reductions} = erlang:process_info(self(), reductions),
+            #{
+                default_payer => payer(Request, Opts),
+                start_reductions => Reductions,
+                meters => #{}
+            };
+        State ->
+        State
+    end.
+
+%% @doc Add the process reductions delta to the active metering state.
+meter_reductions(State = #{ start_reductions := Start }) ->
+    {reductions, Current} = erlang:process_info(self(), reductions),
+    Delta = max(0, Current - Start),
+    add_meter(
+        maps:get(default_payer, State),
+        ?BEAM_REDUCTIONS,
+        Delta,
+        State
+    ).
+
+%% @doc Add a resource amount to a party's meters.
+add_meter(_Payer, _Resource, 0, State) ->
+    State;
+add_meter(Payer, Resource, Amount, State) ->
+    Meters = maps:get(meters, State, #{}),
+    PayerMeters = maps:get(Payer, Meters, #{}),
+    Current = maps:get(Resource, PayerMeters, 0),
+    State#{
+        meters =>
+            Meters#{
+                Payer =>
+                    PayerMeters#{ Resource => Current + Amount }
+            }
+    }.
+
+%% @doc Calculate a token price from resource meters and operator rates.
+price_for(Meters, Rates, Opts) ->
+    maps:fold(
+        fun(Resource, Amount, Acc) ->
+            Acc + (Amount * rate(Resource, Rates, Opts))
+        end,
+        0,
+        Meters
+    ).
+
+%% @doc Return the operator-configured token rate for a resource.
+rate(Resource, Rates, Opts) ->
+    case hb_maps:get(Resource, Rates, 0, Opts) of
+        Rate when is_integer(Rate) -> Rate;
+        Rate -> hb_util:int(Rate)
+    end.
+
+%% @doc Determine the default payer for a request.
+payer(Request, Opts) ->
+    case hb_message:signers(Request, Opts) of
+        [Signer] -> normalize_party(Signer, #{}, Opts);
+        [] -> <<"unknown">>;
+        Multiple ->
+            hb_util:bin(lists:join(<<",">>, lists:map(fun hb_util:bin/1, Multiple)))
+    end.
+
+%% @doc Normalize a payer identifier for storage in the meter map.
+normalize_party(default, State, _Opts) ->
+    maps:get(default_payer, State, <<"unknown">>);
+normalize_party(Payer, _State, _Opts) when ?IS_ID(Payer) ->
+    hb_util:human_id(Payer);
+normalize_party(Payer, _State, _Opts) ->
+    hb_util:bin(Payer).
+
+%% @doc Normalize a resource name for storage in the meter map.
+normalize_resource(Resource) ->
+    hb_ao:normalize_key(Resource).
+
+%% @doc Convert an amount to a non-negative integer.
+non_negative_int(Amount) ->
+    Int = hb_util:int(Amount),
+    case Int >= 0 of
+        true -> Int;
+        false -> error({invalid_meter_amount, Amount})
+    end.
+
+%% @doc Return the current process's raw metering map.
+current_totals() ->
+    case erlang:get(?METERING_KEY) of
+        undefined -> #{};
+        State -> maps:get(meters, State, #{})
+    end.
+
+%%% Tests
+
+%% @doc The helper API meters resources and prices them via configured rates.
+helper_price_test() ->
+    Wallet = ar_wallet:new(),
+    Request =
+        hb_message:commit(
+            #{ <<"path">> => <<"/metered">> },
+            #{ <<"priv-wallet">> => Wallet }
+        ),
+    Opts = #{
+        <<"metering-rates">> => #{
+            <<"arweave-bytes">> => 3,
+            ?BEAM_REDUCTIONS => 0
+        }
+    },
+    {ok, 0} = estimate(#{}, #{ <<"request">> => Request }, Opts),
+    ok = meter(<<"arweave-bytes">>, 5, Opts),
+    {ok, 15} = price(#{}, #{ <<"request">> => Request }, Opts).
+
+%% @doc BEAM reductions are metered between estimate and price.
+beam_reductions_price_test() ->
+    Wallet = ar_wallet:new(),
+    Request =
+        hb_message:commit(
+            #{ <<"path">> => <<"/metered">> },
+            #{ <<"priv-wallet">> => Wallet }
+        ),
+    Opts = #{ <<"metering-rates">> => #{ ?BEAM_REDUCTIONS => 1 } },
+    {ok, 0} = estimate(#{}, #{ <<"request">> => Request }, Opts),
+    lists:foreach(fun(_) -> erlang:phash2(rand:bytes(16)) end, lists:seq(1, 10)),
+    {ok, Price} = price(#{}, #{ <<"request">> => Request }, Opts),
+    ?assert(Price > 0).
+
+%% @doc P4 charges a dynamic metering price during response processing.
+p4_response_charge_test() ->
+    Wallet = ar_wallet:new(),
+    Address = hb_util:human_id(ar_wallet:to_address(Wallet)),
+    Processor =
+        #{
+            <<"device">> => <<"p4@1.0">>,
+            <<"ledger-device">> => <<"simple-pay@1.0">>,
+            <<"pricing-device">> => <<"metering@1.0">>
+        },
+    Node =
+        hb_http_server:start_node(
+            #{
+                <<"simple-pay-ledger">> => #{ Address => 100 },
+                <<"metering-rates">> => #{
+                    <<"arweave-bytes">> => 2,
+                    ?BEAM_REDUCTIONS => 0
+                },
+                <<"operator">> => hb:address(),
+                <<"on">> => #{
+                    <<"request">> => Processor,
+                    <<"response">> => Processor
+                }
+            }
+        ),
+    MeterReq =
+        hb_message:commit(
+            #{
+                <<"path">> => <<"/~metering@1.0/meter">>,
+                <<"resource">> => <<"arweave-bytes">>,
+                <<"amount">> => 5
+            },
+            #{ <<"priv-wallet">> => Wallet }
+        ),
+    ?assertMatch({ok, _}, hb_http:post(Node, MeterReq, #{})),
+    {ok, Balance} =
+        hb_http:get(
+            Node,
+            hb_message:commit(
+                #{ <<"path">> => <<"/~p4@1.0/balance">> },
+                #{ <<"priv-wallet">> => Wallet }
+            ),
+            #{}
+        ),
+    ?assertEqual(90, Balance).

--- a/src/dev_metering.erl
+++ b/src/dev_metering.erl
@@ -16,8 +16,6 @@
 -module(dev_metering).
 -export([info/1, estimate/3, price/3, is_active/0, consume/3]).
 
--include("include/hb.hrl").
-
 -include_lib("eunit/include/eunit.hrl").
 
 -define(METERING_KEY, {dev_metering, state}).
@@ -173,14 +171,13 @@ p4_response_charge_test() ->
     Address = hb_util:human_id(ar_wallet:to_address(Wallet)),
     Rate = 2,
     Item =
-        ar_bundles:sign_item(
-            #tx{
-                data = <<"metered-bundler-item">>,
-                tags = [{<<"test">>, <<"p4-response-metering">>}]
+        hb_message:commit(
+            #{
+                <<"data">> => <<"metered-bundler-item">>,
+                <<"test">> => <<"p4-response-metering">>
             },
-            ar_wallet:new()
+            #{ <<"priv-wallet">> => ar_wallet:new() }
         ),
-    ItemSize = byte_size(ar_bundles:serialize(Item)),
     {ServerHandle, GatewayOpts} =
         dev_bundler:start_mock_gateway(
             #{
@@ -194,12 +191,11 @@ p4_response_charge_test() ->
             <<"ledger-device">> => <<"simple-pay@1.0">>,
             <<"pricing-device">> => <<"metering@1.0">>
         },
-    Opts =
+    BaseOpts =
         GatewayOpts#{
             <<"priv-wallet">> => HostWallet,
             <<"store">> => hb_test_utils:test_store(),
             <<"bundler-max-items">> => 1,
-            <<"simple-pay-ledger">> => #{ Address => (ItemSize * Rate) + 50 },
             <<"metering-rates">> => #{
                 <<"arweave-bytes">> => Rate,
                 ?BEAM_REDUCTIONS => 0
@@ -210,21 +206,32 @@ p4_response_charge_test() ->
                 <<"response">> => Processor
             }
         },
+    ItemSize =
+        byte_size(
+            ar_bundles:serialize(
+                hb_message:convert(
+                    Item,
+                    #{
+                        <<"device">> => <<"ans104@1.0">>,
+                        <<"bundle">> => true
+                    },
+                    <<"structured@1.0">>,
+                    BaseOpts
+                )
+            )
+        ),
+    Opts =
+        BaseOpts#{
+            <<"simple-pay-ledger">> => #{ Address => (ItemSize * Rate) + 50 }
+        },
     try
         Node = hb_http_server:start_node(Opts),
-        StructuredItem =
-            hb_message:convert(
-                Item,
-                <<"structured@1.0">>,
-                <<"ans104@1.0">>,
-                Opts
-            ),
         UploadReq =
             hb_message:commit(
                 #{
                     <<"path">> => <<"/~bundler@1.0/tx">>,
                     <<"bundler-subject">> => <<"body">>,
-                    <<"body">> => StructuredItem
+                    <<"body">> => Item
                 },
                 Opts#{ <<"priv-wallet">> => Wallet }
             ),

--- a/src/dev_metering.erl
+++ b/src/dev_metering.erl
@@ -7,7 +7,7 @@
 %%% reductions delta, applies the operator's `metering-rates' table, and returns
 %%% the total integer token charge to P4.
 -module(dev_metering).
--export([info/1, estimate/3, price/3, active/0, meter/3, meter/4]).
+-export([info/1, estimate/3, price/3, is_active/0, meter/3, meter/4]).
 -export([increase/3, increase/4, totals/3]).
 
 -include("include/hb.hrl").
@@ -65,7 +65,7 @@ price(_Base, PriceReq, Opts) ->
     {ok, Price}.
 
 %% @doc Return whether the current process has an active metering session.
-active() ->
+is_active() ->
     erlang:get(?METERING_KEY) =/= undefined.
 
 %% @doc Device API for incrementing a resource counter.

--- a/src/dev_metering.erl
+++ b/src/dev_metering.erl
@@ -176,7 +176,8 @@ p4_response_charge_test() ->
                 <<"data">> => <<"metered-bundler-item">>,
                 <<"test">> => <<"p4-response-metering">>
             },
-            #{ <<"priv-wallet">> => ar_wallet:new() }
+            #{ <<"priv-wallet">> => ar_wallet:new() },
+            <<"ans104@1.0">>
         ),
     {ServerHandle, GatewayOpts} =
         dev_bundler:start_mock_gateway(

--- a/src/dev_metering.erl
+++ b/src/dev_metering.erl
@@ -45,7 +45,7 @@ estimate(_Base, EstimateReq, Opts) ->
             meters => #{}
         }
     ),
-    {ok, hb_util:int(hb_opts:get(metering_minimum_price, 0, Opts))}.
+    {ok, 0}.
 
 %% @doc Close the metering session and calculate the final AO token price.
 price(_Base, PriceReq, Opts) ->
@@ -84,7 +84,7 @@ meter(Base, Req, Opts) when is_map(Base), is_map(Req) ->
         ),
     Amount = hb_maps:get(<<"amount">>, Req, 1, Opts),
     ok = meter(Party, Resource, Amount, Opts),
-    {ok, current_totals()};
+    {ok, true};
 %% @doc Helper API for other devices. Increments the default payer.
 meter(Resource, Amount, Opts) ->
     meter(default, Resource, Amount, Opts).
@@ -204,13 +204,6 @@ non_negative_int(Amount) ->
     case Int >= 0 of
         true -> Int;
         false -> error({invalid_meter_amount, Amount})
-    end.
-
-%% @doc Return the current process's raw metering map.
-current_totals() ->
-    case erlang:get(?METERING_KEY) of
-        undefined -> #{};
-        State -> maps:get(meters, State, #{})
     end.
 
 %%% Tests

--- a/src/dev_metering.erl
+++ b/src/dev_metering.erl
@@ -5,16 +5,18 @@
 %%% device:
 %%%
 %%%     `estimate/3' opens a process-local metering session.
-%%%     `meter/3' increments resource usage during that session.
+%%%     `consume/3' increments resource usage during that session.
 %%%     `price/3' closes the session and returns the integer charge.
 %%%
-%%% Calls to `meter/3' outside an active session are no-ops, so callers do
+%%% Calls to `consume/3' outside an active session are no-ops, so callers do
 %%% not need to check whether metering is enabled. Resource names are normalized
 %%% keys, such as `arweave-bytes' and `beam-reductions'. The operator sets
 %%% `metering-rates' in the node message as a map of resource name to AO token
 %%% units per resource unit.
 -module(dev_metering).
--export([info/1, estimate/3, price/3, is_active/0, meter/3]).
+-export([info/1, estimate/3, price/3, is_active/0, consume/3]).
+
+-include("include/hb.hrl").
 
 -include_lib("eunit/include/eunit.hrl").
 
@@ -27,8 +29,7 @@ info(_) ->
         exports =>
             [
                 <<"estimate">>,
-                <<"price">>,
-                <<"meter">>
+                <<"price">>
             ]
     }.
 
@@ -67,21 +68,8 @@ price(_Base, _PriceReq, Opts) ->
 is_active() ->
     erlang:get(?METERING_KEY) =/= undefined.
 
-%% @doc Device API for incrementing a resource counter.
-meter(Base, Req, Opts) when is_map(Base), is_map(Req) ->
-    Resource =
-        hb_maps:get(
-            <<"resource">>,
-            Req,
-            hb_maps:get(<<"resource">>, Base, undefined, Opts),
-            Opts
-        ),
-    Amount = hb_maps:get(<<"amount">>, Req, 1, Opts),
-    ok = meter(Resource, Amount, Opts),
-    {ok, true};
-
 %% @doc Helper API for other devices.
-meter(Resource, Amount, _Opts) ->
+consume(Resource, Amount, _Opts) ->
     case erlang:get(?METERING_KEY) of
         undefined ->
             ok;
@@ -129,74 +117,130 @@ add_meter(Resource, Amount, State) ->
 %% @doc Metering outside an active session is a no-op.
 inactive_meter_noop_test() ->
     erlang:erase(?METERING_KEY),
-    ok = meter(<<"arweave-bytes">>, 5, #{}),
+    ok = consume(<<"arweave-bytes">>, 5, #{}),
     ?assertEqual(false, is_active()).
 
 %% @doc The helper API meters resources and prices them via configured rates.
-helper_price_test() ->
+consume_price_test() ->
     Opts = #{
+        <<"store">> => hb_test_utils:test_store(),
         <<"metering-rates">> => #{
             <<"arweave-bytes">> => 3,
             ?BEAM_REDUCTIONS => 0
         }
     },
-    {ok, 0} = estimate(#{}, #{}, Opts),
-    ok = meter(<<"arweave-bytes">>, 5, Opts),
-    {ok, 15} = price(#{}, #{}, Opts).
+    Metering = #{ <<"device">> => <<"metering@1.0">> },
+    {ok, 0} = hb_ao:resolve(Metering, #{ <<"path">> => <<"estimate">> }, Opts),
+    ok = consume(<<"arweave-bytes">>, 5, Opts),
+    {ok, 15} = hb_ao:resolve(Metering, #{ <<"path">> => <<"price">> }, Opts).
+
+%% @doc Resource consumption is not exposed as an AO-Core key.
+consume_is_not_device_key_test() ->
+    Opts = #{ <<"store">> => hb_test_utils:test_store() },
+    Metering = #{ <<"device">> => <<"metering@1.0">> },
+    ?assertMatch(
+        {error, _},
+        hb_ao:resolve(
+            Metering,
+            #{
+                <<"path">> => <<"consume">>,
+                <<"resource">> => <<"arweave-bytes">>,
+                <<"amount">> => 5
+            },
+            Opts
+        )
+    ).
 
 %% @doc BEAM reductions are metered between estimate and price.
 beam_reductions_price_test() ->
-    Opts = #{ <<"metering-rates">> => #{ ?BEAM_REDUCTIONS => 1 } },
-    {ok, 0} = estimate(#{}, #{}, Opts),
+    Opts = #{
+        <<"store">> => hb_test_utils:test_store(),
+        <<"metering-rates">> => #{ ?BEAM_REDUCTIONS => 1 }
+    },
+    Metering = #{ <<"device">> => <<"metering@1.0">> },
+    {ok, 0} = hb_ao:resolve(Metering, #{ <<"path">> => <<"estimate">> }, Opts),
     lists:foreach(
         fun(_) -> erlang:phash2(rand:bytes(16)) end,
         lists:seq(1, 10)
     ),
-    {ok, Price} = price(#{}, #{}, Opts),
+    {ok, Price} = hb_ao:resolve(Metering, #{ <<"path">> => <<"price">> }, Opts),
     ?assert(Price > 0).
 
 %% @doc P4 charges a dynamic metering price during response processing.
 p4_response_charge_test() ->
+    HostWallet = ar_wallet:new(),
     Wallet = ar_wallet:new(),
     Address = hb_util:human_id(ar_wallet:to_address(Wallet)),
+    Rate = 2,
+    Item =
+        ar_bundles:sign_item(
+            #tx{
+                data = <<"metered-bundler-item">>,
+                tags = [{<<"test">>, <<"p4-response-metering">>}]
+            },
+            ar_wallet:new()
+        ),
+    ItemSize = byte_size(ar_bundles:serialize(Item)),
+    {ServerHandle, GatewayOpts} =
+        dev_bundler:start_mock_gateway(
+            #{
+                price => {200, <<"12345">>},
+                tx_anchor => {200, hb_util:encode(rand:bytes(32))}
+            }
+        ),
     Processor =
         #{
             <<"device">> => <<"p4@1.0">>,
             <<"ledger-device">> => <<"simple-pay@1.0">>,
             <<"pricing-device">> => <<"metering@1.0">>
         },
-    Node =
-        hb_http_server:start_node(
-            #{
-                <<"simple-pay-ledger">> => #{ Address => 100 },
-                <<"metering-rates">> => #{
-                    <<"arweave-bytes">> => 2,
-                    ?BEAM_REDUCTIONS => 0
-                },
-                <<"operator">> => hb:address(),
-                <<"on">> => #{
-                    <<"request">> => Processor,
-                    <<"response">> => Processor
-                }
-            }
-        ),
-    MeterReq =
-        hb_message:commit(
-            #{
-                <<"path">> => <<"/~metering@1.0/meter">>,
-                <<"resource">> => <<"arweave-bytes">>,
-                <<"amount">> => 5
+    Opts =
+        GatewayOpts#{
+            <<"priv-wallet">> => HostWallet,
+            <<"store">> => hb_test_utils:test_store(),
+            <<"bundler-max-items">> => 1,
+            <<"simple-pay-ledger">> => #{ Address => (ItemSize * Rate) + 50 },
+            <<"metering-rates">> => #{
+                <<"arweave-bytes">> => Rate,
+                ?BEAM_REDUCTIONS => 0
             },
-            #{ <<"priv-wallet">> => Wallet }
-        ),
-    ?assertMatch({ok, _}, hb_http:post(Node, MeterReq, #{})),
-    {ok, Balance} =
-        hb_http:get(
-            Node,
-            hb_message:commit(
-                #{ <<"path">> => <<"/~p4@1.0/balance">> },
-                #{ <<"priv-wallet">> => Wallet }
+            <<"operator">> => ar_wallet:to_address(HostWallet),
+            <<"on">> => #{
+                <<"request">> => Processor,
+                <<"response">> => Processor
+            }
+        },
+    try
+        Node = hb_http_server:start_node(Opts),
+        StructuredItem =
+            hb_message:convert(
+                Item,
+                <<"structured@1.0">>,
+                <<"ans104@1.0">>,
+                Opts
             ),
-            #{}
-        ),
-    ?assertEqual(90, Balance).
+        UploadReq =
+            hb_message:commit(
+                #{
+                    <<"path">> => <<"/~bundler@1.0/tx">>,
+                    <<"bundler-subject">> => <<"body">>,
+                    <<"body">> => StructuredItem
+                },
+                Opts#{ <<"priv-wallet">> => Wallet }
+            ),
+        ?assertMatch({ok, _}, hb_http:post(Node, UploadReq, Opts)),
+        [_] = hb_mock_server:get_requests(tx, 1, ServerHandle),
+        {ok, Balance} =
+            hb_http:get(
+                Node,
+                hb_message:commit(
+                    #{ <<"path">> => <<"/~p4@1.0/balance">> },
+                    Opts#{ <<"priv-wallet">> => Wallet }
+                ),
+                Opts
+            ),
+        ?assertEqual(50, Balance)
+    after
+        hb_mock_server:stop(ServerHandle),
+        dev_bundler:stop_server(Opts)
+    end.

--- a/src/dev_metering.erl
+++ b/src/dev_metering.erl
@@ -48,23 +48,19 @@ price(_Base, PriceReq, Opts) ->
     Request = hb_maps:get(<<"request">>, PriceReq, #{}, Opts),
     State0 = metering_state(Request, Opts),
     State = meter_reductions(State0),
-    ChargePayer =
-        normalize_party(
-            hb_maps:get(
-                <<"party">>,
-                PriceReq,
-                maps:get(default_payer, State),
-                Opts
-            ),
-            State,
-            Opts
-        ),
+    Meters = maps:get(meters, State, #{}),
+    Rates = hb_opts:get(<<"metering-rates">>, #{}, Opts),
     Price =
-        price_for(
-            maps:get(ChargePayer, maps:get(meters, State, #{}), #{}),
-            hb_opts:get(<<"metering-rates">>, #{}, Opts),
-            Opts
-        ),
+        case hb_maps:find(<<"party">>, PriceReq, Opts) of
+            {ok, Party} ->
+                price_for(
+                    maps:get(normalize_party(Party, State, Opts), Meters, #{}),
+                    Rates,
+                    Opts
+                );
+            error ->
+                price_for_all(Meters, Rates, Opts)
+        end,
     erlang:erase(?METERING_KEY),
     {ok, Price}.
 
@@ -155,6 +151,16 @@ add_meter(Payer, Resource, Amount, State) ->
             }
     }.
 
+%% @doc Calculate a token price across all metered parties.
+price_for_all(Meters, Rates, Opts) ->
+    maps:fold(
+        fun(_Payer, PayerMeters, Acc) ->
+            Acc + price_for(PayerMeters, Rates, Opts)
+        end,
+        0,
+        Meters
+    ).
+
 %% @doc Calculate a token price from resource meters and operator rates.
 price_for(Meters, Rates, Opts) ->
     maps:fold(
@@ -241,6 +247,35 @@ beam_reductions_price_test() ->
     lists:foreach(fun(_) -> erlang:phash2(rand:bytes(16)) end, lists:seq(1, 10)),
     {ok, Price} = price(#{}, #{ <<"request">> => Request }, Opts),
     ?assert(Price > 0).
+
+%% @doc Pricing without a party includes all explicitly metered parties.
+explicit_party_price_test() ->
+    Wallet = ar_wallet:new(),
+    Request =
+        hb_message:commit(
+            #{ <<"path">> => <<"/metered">> },
+            #{ <<"priv-wallet">> => Wallet }
+        ),
+    Other = hb_util:human_id(ar_wallet:to_address(ar_wallet:new())),
+    Opts = #{
+        <<"metering-rates">> => #{
+            <<"arweave-bytes">> => 2,
+            ?BEAM_REDUCTIONS => 0
+        }
+    },
+    {ok, 0} = estimate(#{}, #{ <<"request">> => Request }, Opts),
+    ok = meter(<<"arweave-bytes">>, 3, Opts),
+    ok = meter(Other, <<"arweave-bytes">>, 5, Opts),
+    {ok, 10} =
+        price(
+            #{},
+            #{ <<"request">> => Request, <<"party">> => Other },
+            Opts
+        ),
+    {ok, 0} = estimate(#{}, #{ <<"request">> => Request }, Opts),
+    ok = meter(<<"arweave-bytes">>, 3, Opts),
+    ok = meter(Other, <<"arweave-bytes">>, 5, Opts),
+    {ok, 16} = price(#{}, #{ <<"request">> => Request }, Opts).
 
 %% @doc P4 charges a dynamic metering price during response processing.
 p4_response_charge_test() ->

--- a/src/dev_metering.erl
+++ b/src/dev_metering.erl
@@ -7,7 +7,7 @@
 %%% reductions delta, applies the operator's `metering-rates' table, and returns
 %%% the total integer token charge to P4.
 -module(dev_metering).
--export([info/1, estimate/3, price/3, meter/3, meter/4]).
+-export([info/1, estimate/3, price/3, active/0, meter/3, meter/4]).
 -export([increase/3, increase/4, totals/3]).
 
 -include("include/hb.hrl").
@@ -63,6 +63,10 @@ price(_Base, PriceReq, Opts) ->
         end,
     erlang:erase(?METERING_KEY),
     {ok, Price}.
+
+%% @doc Return whether the current process has an active metering session.
+active() ->
+    erlang:get(?METERING_KEY) =/= undefined.
 
 %% @doc Device API for incrementing a resource counter.
 meter(Base, Req, Opts) when is_map(Base), is_map(Req) ->

--- a/src/dev_metering.erl
+++ b/src/dev_metering.erl
@@ -1,14 +1,20 @@
 %%% @doc Dynamic pricing device for P4.
 %%%
 %%% `metering@1.0' records resource usage in the current process during a P4
-%%% request/response lifecycle. `estimate/3' starts the metering session and
-%%% captures the initial BEAM reductions count. Other devices can then call
-%%% `meter/3' or `increase/3' to add resource usage. Finally, `price/3' adds the
-%%% reductions delta, applies the operator's `metering-rates' table, and returns
-%%% the total integer token charge to P4.
+%%% request/response lifecycle. It is intended to be used as a P4 pricing
+%%% device:
+%%%
+%%%     `estimate/3' opens a process-local metering session.
+%%%     `meter/[3,4]' increments resource usage during that session.
+%%%     `price/3' closes the session and returns the integer charge.
+%%%
+%%% Calls to `meter/[3,4]' outside an active session are no-ops, so callers do
+%%% not need to check whether metering is enabled. Resource names are normalized
+%%% keys, such as `arweave-bytes' and `beam-reductions'. The operator sets
+%%% `metering-rates' in the node message as a map of resource name to AO token
+%%% units per resource unit.
 -module(dev_metering).
 -export([info/1, estimate/3, price/3, is_active/0, meter/3, meter/4]).
--export([increase/3, increase/4, totals/3]).
 
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -23,9 +29,7 @@ info(_) ->
             [
                 <<"estimate">>,
                 <<"price">>,
-                <<"meter">>,
-                <<"increase">>,
-                <<"totals">>
+                <<"meter">>
             ]
     }.
 
@@ -101,20 +105,6 @@ meter(Party, Resource, Amount, Opts) ->
             ok
     end.
 
-%% @doc Alias for `meter/3' in helper and device contexts.
-increase(Base, Req, Opts) when is_map(Base), is_map(Req) ->
-    meter(Base, Req, Opts);
-increase(Resource, Amount, Opts) ->
-    meter(Resource, Amount, Opts).
-
-%% @doc Alias for `meter/4'.
-increase(Party, Resource, Amount, Opts) ->
-    meter(Party, Resource, Amount, Opts).
-
-%% @doc Return the current process's metering totals.
-totals(_Base, _Req, _Opts) ->
-    {ok, current_totals()}.
-
 %% @doc Return the active metering state, creating one if needed.
 metering_state(Request, Opts) ->
     case erlang:get(?METERING_KEY) of
@@ -126,7 +116,7 @@ metering_state(Request, Opts) ->
                 meters => #{}
             };
         State ->
-        State
+            State
     end.
 
 %% @doc Add the process reductions delta to the active metering state.
@@ -188,7 +178,12 @@ payer(Request, Opts) ->
         [Signer] -> normalize_party(Signer, #{}, Opts);
         [] -> <<"unknown">>;
         Multiple ->
-            hb_util:bin(lists:join(<<",">>, lists:map(fun hb_util:bin/1, Multiple)))
+            hb_util:bin(
+                lists:join(
+                    <<",">>,
+                    lists:map(fun hb_util:bin/1, Multiple)
+                )
+            )
     end.
 
 %% @doc Normalize a payer identifier for storage in the meter map.
@@ -220,6 +215,12 @@ current_totals() ->
 
 %%% Tests
 
+%% @doc Metering outside an active session is a no-op.
+inactive_meter_noop_test() ->
+    erlang:erase(?METERING_KEY),
+    ok = meter(<<"arweave-bytes">>, 5, #{}),
+    ?assertEqual(false, is_active()).
+
 %% @doc The helper API meters resources and prices them via configured rates.
 helper_price_test() ->
     Wallet = ar_wallet:new(),
@@ -248,7 +249,10 @@ beam_reductions_price_test() ->
         ),
     Opts = #{ <<"metering-rates">> => #{ ?BEAM_REDUCTIONS => 1 } },
     {ok, 0} = estimate(#{}, #{ <<"request">> => Request }, Opts),
-    lists:foreach(fun(_) -> erlang:phash2(rand:bytes(16)) end, lists:seq(1, 10)),
+    lists:foreach(
+        fun(_) -> erlang:phash2(rand:bytes(16)) end,
+        lists:seq(1, 10)
+    ),
     {ok, Price} = price(#{}, #{ <<"request">> => Request }, Opts),
     ?assert(Price > 0).
 

--- a/src/dev_simple_pay.erl
+++ b/src/dev_simple_pay.erl
@@ -208,8 +208,9 @@ balance(_, RawReq, NodeMsg) ->
 
 %% @doc Adjust a user's balance, normalizing their wallet ID first.
 set_balance(Signer, Amount, NodeMsg) ->
+    LiveNodeMsg = latest_node_msg(NodeMsg),
     NormSigner = hb_util:human_id(Signer),
-    Ledger = hb_opts:get(simple_pay_ledger, #{}, NodeMsg),
+    Ledger = hb_opts:get(simple_pay_ledger, #{}, LiveNodeMsg),
     ?event(payment,
         {modifying_balance,
             {user, NormSigner},
@@ -219,17 +220,31 @@ set_balance(Signer, Amount, NodeMsg) ->
     ),
     hb_http_server:set_opts(
         #{},
-        NewMsg = NodeMsg#{
+        NewMsg = LiveNodeMsg#{
             <<"simple-pay-ledger">> =>
                 hb_ao:set(
                     Ledger,
                     NormSigner,
                     Amount,
-                    NodeMsg
+                    LiveNodeMsg
                 )
         }
     ),
     {ok, NewMsg}.
+
+%% @doc Refresh the node message before mutating the ledger.
+latest_node_msg(NodeMsg) ->
+    case hb_opts:get(http_server, no_server_ref, NodeMsg) of
+        no_server_ref ->
+            NodeMsg;
+        _ ->
+            try hb_http_server:get_opts(NodeMsg) of
+                no_node_msg -> NodeMsg;
+                CurrentNodeMsg -> CurrentNodeMsg
+            catch
+                _:_ -> NodeMsg
+            end
+    end.
 
 %% @doc Get the balance of a user in the ledger.
 get_balance(Signer, NodeMsg) ->

--- a/src/hb_examples.erl
+++ b/src/hb_examples.erl
@@ -126,6 +126,315 @@ paid_wasm() ->
     {ok, Res2} = hb_http:get(HostNode, ClientRequest, Opts),
     ?assertMatch(60, Res2).
 
+%% @doc Charge an uploader for bundled item bytes through dynamic metering.
+bundler_dynamic_metering_test_() ->
+    {timeout, 30, fun bundler_dynamic_metering/0}.
+bundler_dynamic_metering() ->
+    HostWallet = ar_wallet:new(),
+    UploaderWallet = ar_wallet:new(),
+    UploaderAddress = hb_util:human_id(ar_wallet:to_address(UploaderWallet)),
+    Item = bundle_payment_item(),
+    ItemSize = byte_size(ar_bundles:serialize(Item)),
+    Rate = 2,
+    InitialBalance = (ItemSize * Rate) + 50,
+    Anchor = rand:bytes(32),
+    NetworkPrice = 12345,
+    {ServerHandle, GatewayOpts} =
+        dev_bundler:start_mock_gateway(
+            #{
+                price => {200, integer_to_binary(NetworkPrice)},
+                tx_anchor => {200, hb_util:encode(Anchor)}
+            }
+        ),
+    ProcessorMsg =
+        #{
+            <<"device">> => <<"p4@1.0">>,
+            <<"ledger-device">> => <<"simple-pay@1.0">>,
+            <<"pricing-device">> => <<"metering@1.0">>
+        },
+    Opts =
+        GatewayOpts#{
+            <<"priv-wallet">> => HostWallet,
+            <<"store">> => hb_test_utils:test_store(),
+            <<"bundler-max-items">> => 1,
+            <<"simple-pay-ledger">> => #{ UploaderAddress => InitialBalance },
+            <<"metering-rates">> => #{
+                <<"arweave-bytes">> => Rate,
+                <<"beam-reductions">> => 0
+            },
+            <<"operator">> => ar_wallet:to_address(HostWallet),
+            <<"on">> => #{
+                <<"request">> => ProcessorMsg,
+                <<"response">> => ProcessorMsg
+            }
+        },
+    try
+        Node = hb_http_server:start_node(Opts),
+        StructuredItem =
+            hb_message:convert(
+                Item,
+                <<"structured@1.0">>,
+                <<"ans104@1.0">>,
+                Opts
+            ),
+        UploadReq =
+            hb_message:commit(
+                #{
+                    <<"path">> => <<"/~bundler@1.0/tx">>,
+                    <<"bundler-subject">> => <<"body">>,
+                    <<"body">> => StructuredItem
+                },
+                #{ <<"priv-wallet">> => UploaderWallet }
+            ),
+        ?assertMatch({ok, _}, hb_http:post(Node, UploadReq, #{})),
+        ?assertEqual(50, bundle_payment_balance(Node, UploaderWallet))
+    after
+        hb_mock_server:stop(ServerHandle),
+        dev_bundler:stop_server(Opts)
+    end.
+
+%% @doc Release a paid bundling fee to an operator-specified address only after
+%% the bundle has been posted and seeded successfully.
+bundler_completion_payment_hook_test_() ->
+    {timeout, 30, fun bundler_completion_payment_hook/0}.
+bundler_completion_payment_hook() ->
+    HostWallet = ar_wallet:new(),
+    UploaderWallet = ar_wallet:new(),
+    MessageReleaseWallet = ar_wallet:new(),
+    BundleReleaseWallet = ar_wallet:new(),
+    UploaderAddress = hb_util:human_id(ar_wallet:to_address(UploaderWallet)),
+    MessageReleaseAddress =
+        hb_util:human_id(ar_wallet:to_address(MessageReleaseWallet)),
+    BundleReleaseAddress =
+        hb_util:human_id(ar_wallet:to_address(BundleReleaseWallet)),
+    InitialBalance = 100,
+    UploadFee = 10,
+    MessageReleaseAmount = 3,
+    BundleReleaseAmount = 7,
+    Item = bundle_payment_item(),
+    ExpectedItemID = hb_util:encode(ar_bundles:id(Item, signed)),
+    ExpectedItemSize = byte_size(ar_bundles:serialize(Item)),
+    Anchor = rand:bytes(32),
+    NetworkPrice = 12345,
+    {ServerHandle, GatewayOpts} =
+        dev_bundler:start_mock_gateway(
+            #{
+                price => {200, integer_to_binary(NetworkPrice)},
+                tx_anchor => {200, hb_util:encode(Anchor)}
+            }
+        ),
+    ProcessorMsg =
+        #{
+            <<"device">> => <<"p4@1.0">>,
+            <<"ledger-device">> => <<"simple-pay@1.0">>,
+            <<"pricing-device">> => <<"simple-pay@1.0">>
+        },
+    Opts =
+        GatewayOpts#{
+            <<"priv-wallet">> => HostWallet,
+            <<"store">> => hb_test_utils:test_store(),
+            <<"bundler-max-items">> => 1,
+            <<"simple-pay-price">> => 0,
+            <<"simple-pay-ledger">> => #{ UploaderAddress => InitialBalance },
+            <<"operator">> => ar_wallet:to_address(HostWallet),
+            <<"router-opts">> => #{
+                <<"offered">> => [
+                    #{
+                        <<"template">> => <<"/~bundler@1.0/tx">>,
+                        <<"price">> => UploadFee
+                    }
+                ]
+            },
+            <<"on">> => #{
+                <<"request">> => ProcessorMsg,
+                <<"response">> => ProcessorMsg,
+                <<"bundled-message-complete">> =>
+                    bundle_payment_message_hook(
+                        ExpectedItemID,
+                        ExpectedItemSize,
+                        MessageReleaseAmount,
+                        MessageReleaseAddress
+                    ),
+                <<"bundle-complete">> =>
+                    bundle_payment_release_hook(
+                        BundleReleaseAmount,
+                        BundleReleaseAddress
+                    )
+            }
+        },
+    try
+        Node = hb_http_server:start_node(Opts),
+        StructuredItem =
+            hb_message:convert(
+                Item,
+                <<"structured@1.0">>,
+                <<"ans104@1.0">>,
+                Opts
+            ),
+        UploadReq =
+            hb_message:commit(
+                #{
+                    <<"path">> => <<"/~bundler@1.0/tx">>,
+                    <<"bundler-subject">> => <<"body">>,
+                    <<"body">> => StructuredItem
+                },
+                #{ <<"priv-wallet">> => UploaderWallet }
+            ),
+        ?assertMatch({ok, _}, hb_http:post(Node, UploadReq, #{})),
+        ?assert(
+            hb_util:wait_until(
+                fun() ->
+                    bundle_payment_balance(Node, BundleReleaseWallet)
+                        =:= BundleReleaseAmount
+                end,
+                5000
+            )
+        ),
+        ?assertEqual(
+            InitialBalance - UploadFee,
+            bundle_payment_balance(Node, UploaderWallet)
+        ),
+        ?assertEqual(
+            MessageReleaseAmount,
+            bundle_payment_balance(Node, MessageReleaseWallet)
+        ),
+        ?assertEqual(
+            BundleReleaseAmount,
+            bundle_payment_balance(Node, BundleReleaseWallet)
+        )
+    after
+        hb_mock_server:stop(ServerHandle),
+        dev_bundler:stop_server(Opts)
+    end.
+
+%% @doc Build a per-message hook that validates the item payload and releases pay.
+bundle_payment_message_hook(
+        ExpectedItemID,
+        ExpectedItemSize,
+        ReleaseAmount,
+        ReleaseAddress
+    ) ->
+    #{
+        <<"expected-item-id">> => ExpectedItemID,
+        <<"expected-item-size">> => ExpectedItemSize,
+        <<"release-amount">> => ReleaseAmount,
+        <<"release-recipient">> => ReleaseAddress,
+        <<"device">> => #{
+            bundled_message_complete =>
+                fun(Base, Req, Opts) ->
+                    Body = hb_maps:get(<<"body">>, Req, not_found, Opts),
+                    Size = hb_maps:get(<<"bundled-size">>, Req, not_found, Opts),
+                    ExpectedID =
+                        hb_maps:get(
+                            <<"expected-item-id">>,
+                            Base,
+                            undefined,
+                            Opts
+                        ),
+                    ExpectedSize =
+                        hb_maps:get(
+                            <<"expected-item-size">>,
+                            Base,
+                            undefined,
+                            Opts
+                        ),
+                    case {hb_message:id(Body, signed, Opts), Size} of
+                        {ExpectedID, ExpectedSize} ->
+                            bundle_payment_release(Base, Req, Opts);
+                        _ ->
+                            {error, invalid_bundled_message_hook_payload}
+                    end
+                end
+        },
+        <<"hook">> => #{ <<"result">> => <<"ignore">> }
+    }.
+
+%% @doc Build a bundle hook that validates the bundle payload and releases pay.
+bundle_payment_release_hook(ReleaseAmount, ReleaseAddress) ->
+    #{
+        <<"release-amount">> => ReleaseAmount,
+        <<"release-recipient">> => ReleaseAddress,
+        <<"device">> => #{
+            bundle_complete =>
+                fun(Base, Req, Opts) ->
+                    Body = hb_maps:get(<<"body">>, Req, not_found, Opts),
+                    Size = hb_maps:get(<<"bundled-size">>, Req, not_found, Opts),
+                    case
+                        is_map(Body) andalso
+                        is_integer(Size) andalso
+                        (Size =:= bundle_payment_bundle_size(Body, Opts))
+                    of
+                        true ->
+                            bundle_payment_release(Base, Req, Opts);
+                        false -> {error, invalid_bundle_hook_payload}
+                    end
+                end
+        },
+        <<"hook">> => #{ <<"result">> => <<"ignore">> }
+    }.
+
+%% @doc Release a configured amount to a configured recipient via simple-pay.
+bundle_payment_release(Base, Req, Opts) ->
+    Amount = hb_maps:get(<<"release-amount">>, Base, 0, Opts),
+    Recipient = hb_maps:get(<<"release-recipient">>, Base, undefined, Opts),
+    TopupReq =
+        hb_message:commit(
+            #{
+                <<"path">> => <<"topup">>,
+                <<"amount">> => Amount,
+                <<"recipient">> => Recipient,
+                <<"request">> => Req
+            },
+            Opts
+        ),
+    case
+        hb_ao:resolve(
+            #{ <<"device">> => <<"simple-pay@1.0">> },
+            TopupReq,
+            Opts
+        )
+    of
+        {ok, _Balance} -> {ok, Req};
+        Error -> Error
+    end.
+
+%% @doc Calculate the byte size of a completed bundle transaction.
+bundle_payment_bundle_size(Bundle, Opts) ->
+    TX =
+        hb_message:convert(
+            Bundle,
+            <<"tx@1.0">>,
+            <<"structured@1.0">>,
+            Opts
+        ),
+    case TX#tx.data_size of
+        Size when is_integer(Size) -> Size;
+        _ -> byte_size(TX#tx.data)
+    end.
+
+%% @doc Build a signed data item used by the bundler payment examples.
+bundle_payment_item() ->
+    ar_bundles:sign_item(
+        #tx{
+            data = <<"bundled-payment-hook">>,
+            tags = [{<<"example">>, <<"bundler-completion-payment">>}]
+        },
+        ar_wallet:new()
+    ).
+
+%% @doc Read a wallet's balance through the P4/simple-pay HTTP surface.
+bundle_payment_balance(Node, Wallet) ->
+    {ok, Balance} =
+        hb_http:get(
+            Node,
+            hb_message:commit(
+                #{ <<"path">> => <<"/~p4@1.0/balance">> },
+                #{ <<"priv-wallet">> => Wallet }
+            ),
+            #{}
+        ),
+    Balance.
+
 create_schedule_aos2_test_disabled() ->
     % The legacy process format, according to the ao.tn.1 spec:
     % Data-Protocol	The name of the Data-Protocol for this data-item	1-1	ao

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -242,6 +242,7 @@ raw_default_message() ->
             #{<<"name">> => <<"lua@5.3a">>, <<"module">> => dev_lua},
             #{<<"name">> => <<"manifest@1.0">>, <<"module">> => dev_manifest},
             #{<<"name">> => <<"message@1.0">>, <<"module">> => dev_message},
+            #{<<"name">> => <<"metering@1.0">>, <<"module">> => dev_metering},
             #{<<"name">> => <<"meta@1.0">>, <<"module">> => dev_meta},
             #{<<"name">> => <<"monitor@1.0">>, <<"module">> => dev_monitor},
             #{<<"name">> => <<"multipass@1.0">>, <<"module">> => dev_multipass},

--- a/src/include/dev_bundler.hrl
+++ b/src/include/dev_bundler.hrl
@@ -29,6 +29,7 @@
 -record(bundle, {
     id,
     items,
+    item_sizes,
     status,
     tx,
     proofs,


### PR DESCRIPTION
Introduces a new `~p4@1.0`-compatible `pricing-device` that offers a generic way for other devices to tally charges that should be made during the execution of a user's request. The device provides an interface that lets callers specify a resource type and quantity to increment. During the terminating `on/response` phase of the `~p4@1.0` flow the device then multiplies the quantity for each given resource by the node-operator provided `rate` and returns the summation as the recommended charge amount.

The PR includes examples of both BEAM reduction-count based (approximate) raw computation charges, as well as charges for per bundled Arweave byte of data stored.

**Key Changes:**

*   **New `metering@1.0` device**: Provides a generic mechanism for tracking and pricing resource usage (e.g., "arweave-bytes", "beam-reductions") within a request's lifecycle.
*   **Bundler integration**: The bundler now accurately calculates the exact size of items as they are prepared for bundling and records this usage via the metering device. Optimizes byte metering by skipping when inactive and reusing calculated item sizes.
*   **Bundler completion hooks**: Introduces `bundled-message-complete` and `bundle-complete` hooks, allowing operators to define custom actions (such as releasing payments) once items or entire bundles are successfully processed and seeded.
*   **`simple-pay` ledger updates**: Ensures the simple payment ledger always uses the latest node configuration when adjusting balances, preventing issues with stale options.

This update enables more granular, dynamic pricing models for bundler services and automates post-bundling workflows through customizable event hooks.