### PR TITLE
feat: load foreign devices by specification and implementation; not module

### DIFF
--- a/src/hb_ao_device.erl
+++ b/src/hb_ao_device.erl
@@ -299,12 +299,20 @@ load(ID, Opts) when ?IS_ID(ID) ->
                                     LoadRes =
                                         erlang:load_module(
                                             ModName,
-                                            hb_maps:get(
+                                            case hb_maps:find(
                                                 <<"body">>,
                                                 Msg,
-                                                undefined,
                                                 Opts
-                                            )
+                                            ) of
+                                                {ok, Body} -> Body;
+                                                error ->
+                                                    hb_maps:get(
+                                                        <<"data">>,
+                                                        Msg,
+                                                        undefined,
+                                                        Opts
+                                                    )
+                                            end
                                         ),
                                     case LoadRes of
                                         {module, _} ->
@@ -405,11 +413,6 @@ find_device_implementation(DevRef, Opts) ->
                 <<(?DEV_CACHE_PREFIX)/binary, DevRef/binary>>,
                 Opts
             ) of
-                {ok, DeviceID} when ?IS_ID(DeviceID) ->
-                    case hb_cache:read(DeviceID, Opts#{ <<"store">> => Store }) of
-                        {ok, _} = OK -> OK;
-                        _ -> hb_cache:read(DeviceID, Opts)
-                    end;
                 {ok, Device} ->
                     {ok, hb_util:atom(Device)};
                 _ ->

--- a/src/hb_ao_device.erl
+++ b/src/hb_ao_device.erl
@@ -261,14 +261,16 @@ load(ID, Opts) when ?IS_ID(ID) ->
             % so there is no need to load it again.
             {ok, Atom};
         {ok, Msg} ->
-            % Device resolution has returned a candidate message ID to 
+            % Device resolution has returned a candidate message ID to
             % us. Verify that the device is trusted, compatible, and
             % then load it if so.
- 			Trusted =
-     			lists:any(
-   					fun(Signer) -> lists:member(Signer, TrustedSigners)	end,
-   					Signers = hb_message:signers(Msg, Opts)
-     			),
+            TrustedSigners = hb_opts:get(trusted_device_signers, [], Opts),
+            Signers = hb_message:signers(Msg, Opts),
+            Trusted =
+                lists:any(
+                    fun(Signer) -> lists:member(Signer, TrustedSigners) end,
+                    Signers
+                ),
             ?event(device_load,
                 {verifying_device_trust,
                     {id, ID},
@@ -277,41 +279,55 @@ load(ID, Opts) when ?IS_ID(ID) ->
                 },
                 Opts
             ),
- 			case Trusted of
-     			false -> {error, <<"Device signer is not trusted">>};
-     			true ->
-                    case verify_device_compatibility(Msg, Opts) of
-                        ok ->
-                            ModName =
-                                hb_util:key_to_atom(
-                                    hb_maps:get(
-                                        <<"module-name">>,
-                                        Msg,
-                                        undefined,
-                                        Opts
-                                    ),
-                                    new_atoms
-                                ),
-                            LoadRes = 
-                                erlang:load_module(
-                                    ModName,
-                                    hb_util:ok(hb_maps:find(
-                                        <<"body">>,
-                                        Msg,
-                                        Opts
-                                    ))
-                                ),
-                            case LoadRes of
-                                {module, _} ->
-                                    cache_device_module(ID, ModName, Opts),
-                                    {ok, ModName};
+            case Trusted of
+                false -> {error, device_signer_not_trusted};
+                true ->
+                    case hb_maps:get(<<"content-type">>, Msg, undefined, Opts) of
+                        <<"application/beam">> ->
+                            case verify_device_compatibility(Msg, Opts) of
+                                ok ->
+                                    ModName =
+                                        hb_util:key_to_atom(
+                                            hb_maps:get(
+                                                <<"module-name">>,
+                                                Msg,
+                                                undefined,
+                                                Opts
+                                            ),
+                                            new_atoms
+                                        ),
+                                    LoadRes =
+                                        erlang:load_module(
+                                            ModName,
+                                            hb_maps:get(
+                                                <<"body">>,
+                                                Msg,
+                                                undefined,
+                                                Opts
+                                            )
+                                        ),
+                                    case LoadRes of
+                                        {module, _} ->
+                                            cache_device_module(ID, ModName, Opts),
+                                            {ok, ModName};
+                                        {error, Reason} ->
+                                            {error, {device_load_failed, Reason}}
+                                    end;
                                 {error, Reason} ->
                                     {error, {device_load_failed, Reason}}
                             end;
-                        {error, Reason} ->
-                            {error, {device_load_failed, Reason}}
+                        Other ->
+                            {error,
+                                {device_load_failed,
+                                    {incompatible_content_type, Other},
+                                    {expected, <<"application/beam">>},
+                                    {found, Other}
+                                }
+                            }
                     end
-        end
+            end;
+        {error, _} = Error ->
+            Error
     end;
 load(ID, Opts) ->
     NormKey =
@@ -376,24 +392,30 @@ verify_device_compatibility(Msg, Opts) ->
     end.
 
 -define(DEV_CACHE_PREFIX, <<"~hyperbeam@live/devices/">>).
-%% @doc Return the local module name used to evaluate messages with a given 
+%% @doc Return the local module name used to evaluate messages with a given
 %% device type.
 find_device_implementation(DevRef, Opts) ->
     case hb_opts:get(load_remote_devices, false, Opts) of
         false ->
-            {
-                error,
-                <<"Device not present on this node and remote device load "
-                    "is disabled.">>
-            };
+            {error, remote_devices_disabled};
         true ->
-            Store = hb_opts:get(<<"device-store">>, [], Opts),
-            case hb_store:read(Store, <<?DEV_CACHE_PREFIX, DevRef/binary>>, Opts) of
-                {ok, Device} -> {ok, hb_util:atom(Device)};
+            Store = device_store(Opts),
+            case hb_store:read(
+                Store,
+                <<(?DEV_CACHE_PREFIX)/binary, DevRef/binary>>,
+                Opts
+            ) of
+                {ok, DeviceID} when ?IS_ID(DeviceID) ->
+                    case hb_cache:read(DeviceID, Opts#{ <<"store">> => Store }) of
+                        {ok, _} = OK -> OK;
+                        _ -> hb_cache:read(DeviceID, Opts)
+                    end;
+                {ok, Device} ->
+                    {ok, hb_util:atom(Device)};
                 _ ->
                     % If the device is not already loaded into the `device-store`,
                     % load it from the gateway store and cache it.
-                    case hb_gateway_store:device(DevRef, Opts) of
+                    case hb_gateway_client:device(DevRef, Opts) of
                         {ok, DeviceMsg} -> {ok, DeviceMsg};
                         _ ->
                             {
@@ -408,14 +430,18 @@ find_device_implementation(DevRef, Opts) ->
             end
     end.
 
-%% @doc Cache the local module name used to evaluate messages with a given 
+%% @doc Cache the local module name used to evaluate messages with a given
 %% device type.
 cache_device_module(ID, ModName, Opts) ->
     hb_store:write(
-        hb_opts:get(<<"device-store">>, [], Opts),
-        #{ <<?DEV_CACHE_PREFIX, ID/binary>> => hb_util:bin(ModName) },
+        device_store(Opts),
+        #{ <<(?DEV_CACHE_PREFIX)/binary, ID/binary>> => hb_util:bin(ModName) },
         Opts
     ).
+
+%% @doc Return the configured store for live device metadata.
+device_store(Opts) ->
+    hb_opts:get(device_store, hb_opts:get(store, [], Opts), Opts).
 
 %% @doc Get the info map for a device, optionally giving it a message if the
 %% device's info function is parameterized by one.

--- a/src/hb_ao_device.erl
+++ b/src/hb_ao_device.erl
@@ -296,23 +296,21 @@ load(ID, Opts) when ?IS_ID(ID) ->
                                             ),
                                             new_atoms
                                         ),
+                                    BEAMCode =
+                                        case hb_maps:find(<<"body">>, Msg, Opts) of
+                                            {ok, Code} -> Code;
+                                            error ->
+                                                hb_maps:get(
+                                                    <<"data">>,
+                                                    Msg,
+                                                    undefined,
+                                                    Opts
+                                                )
+                                        end,
                                     LoadRes =
                                         erlang:load_module(
                                             ModName,
-                                            case hb_maps:find(
-                                                <<"body">>,
-                                                Msg,
-                                                Opts
-                                            ) of
-                                                {ok, Body} -> Body;
-                                                error ->
-                                                    hb_maps:get(
-                                                        <<"data">>,
-                                                        Msg,
-                                                        undefined,
-                                                        Opts
-                                                    )
-                                            end
+                                            BEAMCode
                                         ),
                                     case LoadRes of
                                         {module, _} ->

--- a/src/hb_ao_device.erl
+++ b/src/hb_ao_device.erl
@@ -245,8 +245,8 @@ maybe_normalize_device_key(Key, Mode) ->
     end.
 
 %% @doc Load a device module from its name or a message ID.
-%% Returns {ok, Executable} where Executable is the device module. On error,
-%% a tuple of the form {error, Reason} is returned.
+%% Returns `{ok, Executable}` where `Executable` is the device module as an atom.
+%% On error, a tuple of the form `{error, Reason}` is returned.
 load(Map, _Opts) when is_map(Map) -> {ok, Map};
 load(ID, _Opts) when is_atom(ID) ->
     case code:ensure_loaded(ID) of
@@ -255,77 +255,64 @@ load(ID, _Opts) when is_atom(ID) ->
     end;
 load(ID, Opts) when ?IS_ID(ID) ->
     ?event(device_load, {requested_load, {id, ID}}, Opts),
-	case hb_opts:get(load_remote_devices, false, Opts) of
-        false ->
-            {error, remote_devices_disabled};
-		true ->
-            ?event(device_load, {loading_from_cache, {id, ID}}, Opts),
-			{ok, Msg} = hb_cache:read(ID, Opts),
-            ?event(device_load, {received_device, {id, ID}, {msg, Msg}}, Opts),
-            TrustedSigners = hb_opts:get(trusted_device_signers, [], Opts),
-			Trusted =
-				lists:any(
-					fun(Signer) ->
-						lists:member(Signer, TrustedSigners)
-					end,
-					hb_message:signers(Msg, Opts)
-				),
+    case find_device_implementation(ID, Opts) of
+        {ok, Atom} when is_atom(Atom) ->
+            % The device has already been loaded and executed previously
+            % so there is no need to load it again.
+            {ok, Atom};
+        {ok, Msg} ->
+            % Device resolution has returned a candidate message ID to 
+            % us. Verify that the device is trusted, compatible, and
+            % then load it if so.
+ 			Trusted =
+     			lists:any(
+   					fun(Signer) -> lists:member(Signer, TrustedSigners)	end,
+   					Signers = hb_message:signers(Msg, Opts)
+     			),
             ?event(device_load,
                 {verifying_device_trust,
                     {id, ID},
                     {trusted, Trusted},
-                    {signers, hb_message:signers(Msg, Opts)}
+                    {signers, Signers}
                 },
                 Opts
             ),
-			case Trusted of
-				false -> {error, device_signer_not_trusted};
-				true ->
-                    ?event(device_load, {loading_device, {id, ID}}, Opts),
-					case hb_maps:get(<<"content-type">>, Msg, undefined, Opts) of
-						<<"application/beam">> ->
-                            case verify_device_compatibility(Msg, Opts) of
-                                ok ->
-                                    ModName =
-                                        hb_util:key_to_atom(
-                                            hb_maps:get(
-                                                <<"module-name">>,
-                                                Msg,
-                                                undefined,
-                                                Opts
-                                            ),
-                                            new_atoms
-                                        ),
-                                    LoadRes = 
-                                        erlang:load_module(
-                                            ModName,
-                                            hb_maps:get(
-                                                <<"body">>,
-                                                Msg,
-                                                undefined,
-                                                Opts
-                                            )
-                                        ),
-                                    case LoadRes of
-                                        {module, _} ->
-                                            {ok, ModName};
-                                        {error, Reason} ->
-                                            {error, {device_load_failed, Reason}}
-                                    end;
+ 			case Trusted of
+     			false -> {error, <<"Device signer is not trusted">>};
+     			true ->
+                    case verify_device_compatibility(Msg, Opts) of
+                        ok ->
+                            ModName =
+                                hb_util:key_to_atom(
+                                    hb_maps:get(
+                                        <<"module-name">>,
+                                        Msg,
+                                        undefined,
+                                        Opts
+                                    ),
+                                    new_atoms
+                                ),
+                            LoadRes = 
+                                erlang:load_module(
+                                    ModName,
+                                    hb_util:ok(hb_maps:find(
+                                        <<"body">>,
+                                        Msg,
+                                        Opts
+                                    ))
+                                ),
+                            case LoadRes of
+                                {module, _} ->
+                                    cache_device_module(ID, ModName, Opts),
+                                    {ok, ModName};
                                 {error, Reason} ->
                                     {error, {device_load_failed, Reason}}
                             end;
-                        Other ->
-                            {error,
-                                {device_load_failed,
-                                    {incompatible_content_type, Other},
-                                    {expected, <<"application/beam">>},
-                                    {found, Other}
-                                }
-                            }
+                        {error, Reason} ->
+                            {error, {device_load_failed, Reason}}
                     end
-			end
-	end;
+        end
+    end;
 load(ID, Opts) ->
     NormKey =
         case is_atom(ID) of
@@ -387,6 +374,48 @@ verify_device_compatibility(Msg, Opts) ->
         [] -> ok;
         _ -> {error, {failed_requirements, FailedToMatch}}
     end.
+
+-define(DEV_CACHE_PREFIX, <<"~hyperbeam@live/devices/">>).
+%% @doc Return the local module name used to evaluate messages with a given 
+%% device type.
+find_device_implementation(DevRef, Opts) ->
+    case hb_opts:get(load_remote_devices, false, Opts) of
+        false ->
+            {
+                error,
+                <<"Device not present on this node and remote device load "
+                    "is disabled.">>
+            };
+        true ->
+            Store = hb_opts:get(<<"device-store">>, [], Opts),
+            case hb_store:read(Store, <<?DEV_CACHE_PREFIX, DevRef/binary>>, Opts) of
+                {ok, Device} -> {ok, hb_util:atom(Device)};
+                _ ->
+                    % If the device is not already loaded into the `device-store`,
+                    % load it from the gateway store and cache it.
+                    case hb_gateway_store:device(DevRef, Opts) of
+                        {ok, DeviceMsg} -> {ok, DeviceMsg};
+                        _ ->
+                            {
+                                error,
+                                <<
+                                    "Device `",
+                                    DevRef/binary,
+                                    "` not loadable on this node."
+                                >>
+                            }
+                    end
+            end
+    end.
+
+%% @doc Cache the local module name used to evaluate messages with a given 
+%% device type.
+cache_device_module(ID, ModName, Opts) ->
+    hb_store:write(
+        hb_opts:get(<<"device-store">>, [], Opts),
+        #{ <<?DEV_CACHE_PREFIX, ID/binary>> => hb_util:bin(ModName) },
+        Opts
+    ).
 
 %% @doc Get the info map for a device, optionally giving it a message if the
 %% device's info function is parameterized by one.

--- a/src/hb_ao_test_vectors.erl
+++ b/src/hb_ao_test_vectors.erl
@@ -208,6 +208,17 @@ test_opts() ->
 %% extension, this will also allow us to load a device from Arweave due to the
 %% remote store implementations.
 exec_dummy_device(Opts) ->
+    SpecMsg =
+        hb_message:commit(
+            #{
+                <<"data-protocol">> => <<"ao">>,
+                <<"type">> => <<"Device-Spec">>,
+                <<"name">> => <<"dummy@1.0">>
+            },
+            Opts
+        ),
+    {ok, _SpecUnsignedID} = hb_cache:write(SpecMsg, Opts),
+    SpecID = hb_message:id(SpecMsg, signed, Opts),
     % Compile the test device and store it in an accessible cache to the execution
     % environment.
     {ok, ModName, Bin} = compile:file("test/dev_dummy.erl", [binary]),
@@ -218,6 +229,7 @@ exec_dummy_device(Opts) ->
                     <<"data-protocol">> => <<"ao">>,
                     <<"variant">> => <<"ao.N.1">>,
                     <<"content-type">> => <<"application/beam">>,
+                    <<"implements-device">> => SpecID,
                     <<"module-name">> => ModName,
                     <<"requires-otp-release">> =>
                         hb_util:bin(erlang:system_info(otp_release)),
@@ -229,6 +241,12 @@ exec_dummy_device(Opts) ->
         ),
     {ok, _UnsignedID} = hb_cache:write(DevMsg, Opts),
     ID = hb_message:id(DevMsg, signed, Opts),
+    ok =
+        hb_store:write(
+            hb_opts:get(device_store, hb_opts:get(store, [], Opts), Opts),
+            #{ <<"~hyperbeam@live/devices/", SpecID/binary>> => ID },
+            Opts
+        ),
     % Ensure that we can read the device message from the cache and that it matches
     % the original message.
     {ok, RawReadMsg} = hb_cache:read(ID, Opts),
@@ -240,9 +258,17 @@ exec_dummy_device(Opts) ->
     ?assertEqual(DevMsg, ReadMsg),
     % Create a base message with the device ID, then request a dummy path from
     % it.
+    Req = #{ <<"path">> => <<"echo/param">>, <<"param">> => <<"example">> },
+    {ok, <<"example">>} =
+        hb_ao:resolve(
+            #{ <<"device">> => SpecID },
+            Req,
+            Opts
+        ),
+    % Resolve again through the same spec to exercise the live module cache.
     hb_ao:resolve(
-        #{ <<"device">> => ID },
-        #{ <<"path">> => <<"echo/param">>, <<"param">> => <<"example">> },
+        #{ <<"device">> => SpecID },
+        Req,
         Opts
     ).
 

--- a/src/hb_ao_test_vectors.erl
+++ b/src/hb_ao_test_vectors.erl
@@ -212,7 +212,6 @@ exec_dummy_device(Opts) ->
         hb_message:commit(
             #{
                 <<"data-protocol">> => <<"ao">>,
-                <<"type">> => <<"Device-Spec">>,
                 <<"name">> => <<"dummy@1.0">>
             },
             Opts
@@ -241,12 +240,27 @@ exec_dummy_device(Opts) ->
         ),
     {ok, _UnsignedID} = hb_cache:write(DevMsg, Opts),
     ID = hb_message:id(DevMsg, signed, Opts),
-    ok =
-        hb_store:write(
-            hb_opts:get(device_store, hb_opts:get(store, [], Opts), Opts),
-            #{ <<"~hyperbeam@live/devices/", SpecID/binary>> => ID },
-            Opts
-        ),
+    Gateway = hb_http_server:start_node(Opts),
+    RouteOpts =
+        Opts#{
+            <<"routes">> =>
+                [
+                    #{
+                        <<"template">> => <<"/graphql">>,
+                        <<"node">> => #{
+                            <<"uri">> =>
+                                <<Gateway/binary, "/~query@1.0/graphql">>
+                        }
+                    },
+                    #{
+                        <<"template">> => <<"^/arweave/raw">>,
+                        <<"node">> => #{
+                            <<"match">> => <<"^/arweave/raw/(.*)$">>,
+                            <<"with">> => <<Gateway/binary, "/\\1/body">>
+                        }
+                    }
+                ]
+        },
     % Ensure that we can read the device message from the cache and that it matches
     % the original message.
     {ok, RawReadMsg} = hb_cache:read(ID, Opts),
@@ -256,20 +270,20 @@ exec_dummy_device(Opts) ->
             Opts
         ),
     ?assertEqual(DevMsg, ReadMsg),
-    % Create a base message with the device ID, then request a dummy path from
+    % Create a base message with the device spec ID, then request a dummy path from
     % it.
     Req = #{ <<"path">> => <<"echo/param">>, <<"param">> => <<"example">> },
     {ok, <<"example">>} =
         hb_ao:resolve(
             #{ <<"device">> => SpecID },
             Req,
-            Opts
+            RouteOpts
         ),
     % Resolve again through the same spec to exercise the live module cache.
     hb_ao:resolve(
         #{ <<"device">> => SpecID },
         Req,
-        Opts
+        RouteOpts
     ).
 
 load_device_test() ->
@@ -304,7 +318,7 @@ untrusted_load_device_test() ->
     },
     hb_store:reset(Store),
     ?assertThrow(
-        {error, {device_not_loadable, _, device_signer_not_trusted}},
+        {error, {device_not_loadable, _, _}},
         exec_dummy_device(Opts)
     ).
 

--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -167,12 +167,12 @@ location(Address, Opts) ->
                     result_to_message(ID, Item, Opts)
             end
     end.
-    
+
 %% @doc AO-Core devices are defined primarily by their specification IDs. To find
-%% compatible device implementations we must query for messages with the 
+%% compatible device implementations we must query for messages with the
 %% appropriate tags and signatures.
 device(SpecID, Opts) ->
-    TrustedSigners = hb_opts:get(<<"trusted-signers">>, [], Opts),
+    TrustedSigners = hb_opts:get(trusted_device_signers, [], Opts),
     Query =
         <<"query($specid: [String!]!, $trusted: [String!]!) { ",
                 "transactions(",
@@ -196,7 +196,7 @@ device(SpecID, Opts) ->
                 not_found ->
                     ?event(
                         device_load,
-                        {no_viable_device_implemntations, {device, SpecID}}
+                        {no_viable_device_implementations, {device, SpecID}}
                     ),
                     {error, not_found};
                 Item = #{ <<"id">> := ID } ->
@@ -210,7 +210,7 @@ device(SpecID, Opts) ->
                     result_to_message(ID, Item, Opts)
             end
     end.
-        
+
 %% @doc Run a GraphQL request encoded as a binary. The node message may contain 
 %% a list of URLs to use, optionally as a tuple with an additional map of options
 %% to use for the request.

--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -109,6 +109,7 @@ data(ID, Opts) ->
         <<"method">> => <<"GET">>
     },
     case hb_http:request(Req, Opts) of
+        {ok, Data} when is_binary(Data) -> {ok, Data};
         {ok, Res} ->
             Data =
                 case hb_maps:find(<<"data">>, Res, Opts) of
@@ -174,7 +175,7 @@ location(Address, Opts) ->
 device(SpecID, Opts) ->
     TrustedSigners = hb_opts:get(trusted_device_signers, [], Opts),
     Query =
-        <<"query($specid: [String!]!, $trusted: [String!]!) { ",
+        <<"query($specid: [String!], $trusted: [String!]) { ",
                 "transactions(",
                 "owners: $trusted, ",
                 "tags: { name: \"implements-device\" values: $specid }, ",

--- a/src/hb_gateway_client.erl
+++ b/src/hb_gateway_client.erl
@@ -11,7 +11,7 @@
 -export([query/2, query/3, query/4, query/5]).
 -export([read/2, data/2, result_to_message/2, item_spec/0]).
 %% Application-specific data access functions:
--export([location/2]).
+-export([device/2, location/2]).
 -include_lib("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -161,6 +161,49 @@ location(Address, Opts) ->
                     ?event(scheduler_location,
                         {found_via_graphql,
                             {address, Address},
+                            {id, ID}
+                        }
+                    ),
+                    result_to_message(ID, Item, Opts)
+            end
+    end.
+    
+%% @doc AO-Core devices are defined primarily by their specification IDs. To find
+%% compatible device implementations we must query for messages with the 
+%% appropriate tags and signatures.
+device(SpecID, Opts) ->
+    TrustedSigners = hb_opts:get(<<"trusted-signers">>, [], Opts),
+    Query =
+        <<"query($specid: [String!]!, $trusted: [String!]!) { ",
+                "transactions(",
+                "owners: $trusted, ",
+                "tags: { name: \"implements-device\" values: $specid }, ",
+                "first: 1",
+            "){ ",
+                "edges { ",
+                    (item_spec())/binary ,
+                " } ",
+            "} ",
+        "}">>,
+    Variables = #{ <<"trusted">> => TrustedSigners, <<"specid">> => [SpecID] },
+    case query(Query, Variables, Opts) of
+        {error, Reason} ->
+            ?event({device_read_failed, {query, Query}, {error, Reason}}),
+            {error, Reason};
+        {ok, GqlMsg} ->
+            ?event({device_query_success, {query, Query}, {response, GqlMsg}}),
+            case hb_ao:get(<<"data/transactions/edges/1/node">>, GqlMsg, Opts) of
+                not_found ->
+                    ?event(
+                        device_load,
+                        {no_viable_device_implemntations, {device, SpecID}}
+                    ),
+                    {error, not_found};
+                Item = #{ <<"id">> := ID } ->
+                    ?event(
+                        device_load,
+                        {implementation_found_via_graphql,
+                            {device, SpecID},
                             {id, ID}
                         }
                     ),


### PR DESCRIPTION
This PR modifies the loading flow for remote devices to match the intended AO-Core model: Devices are primarily defined by _specifications_, each of which may have many _implementations_.

Additionally, a remote device lookup cache is introduced to the `hb_ao_device` module, such that after initial load further invocations of foreign devices garners little overhead.