### PR TITLE
perf: remote device byte cap before loading

### DIFF
--- a/src/hb_ao_device.erl
+++ b/src/hb_ao_device.erl
@@ -20,7 +20,8 @@
     <<"committers">>,
     <<"committed">>
 ]).
-
+%% Default max size for remote BEAM device artifacts. default can be 
+%% overwritten with `remote_device_byte_cap` in Opts.
 -define(DEFAULT_REMOTE_DEVICE_BYTE_CAP, 1024 * 1024).
 
 %% @doc Truncate the arguments of a function to the number of arguments it

--- a/src/hb_ao_device.erl
+++ b/src/hb_ao_device.erl
@@ -21,6 +21,8 @@
     <<"committed">>
 ]).
 
+-define(DEFAULT_REMOTE_DEVICE_BYTE_CAP, 1024 * 1024).
+
 %% @doc Truncate the arguments of a function to the number of arguments it
 %% actually takes.
 truncate_args(Fun, Args) ->
@@ -307,18 +309,36 @@ load(ID, Opts) when ?IS_ID(ID) ->
                                                     Opts
                                                 )
                                         end,
-                                    LoadRes =
-                                        erlang:load_module(
-                                            ModName,
-                                            BEAMCode
-                                        ),
-                                    case LoadRes of
-                                        {module, _} ->
-                                            cache_device_module(ID, ModName, Opts),
-                                            {ok, ModName};
-                                        {error, Reason} ->
-                                            {error, {device_load_failed, Reason}}
-                                    end;
+                                    MaxDeviceBytes = hb_util:int(
+                                        hb_opts:get(
+                                            remote_device_byte_cap,
+                                            ?DEFAULT_REMOTE_DEVICE_BYTE_CAP,
+                                            Opts
+                                        )
+                                    ),
+                                    case is_binary(BEAMCode) andalso byte_size(BEAMCode) > MaxDeviceBytes of
+                                        true ->
+                                            BEAMCodeSize = byte_size(BEAMCode),
+                                            {error,
+                                                {device_load_failed,
+                                                    {remote_device_byte_size_exceeds_limit, BEAMCodeSize},
+                                                    {byte_size_cap, MaxDeviceBytes}
+                                                }
+                                            };
+                                        false ->
+                                            LoadRes =
+                                                erlang:load_module(
+                                                    ModName,
+                                                    BEAMCode
+                                                ),
+                                            case LoadRes of
+                                                {module, _} ->
+                                                    cache_device_module(ID, ModName, Opts),
+                                                    {ok, ModName};
+                                                {error, Reason} ->
+                                                    {error, {device_load_failed, Reason}}
+                                            end
+                                        end;
                                 {error, Reason} ->
                                     {error, {device_load_failed, Reason}}
                             end;

--- a/src/hb_ao_test_vectors.erl
+++ b/src/hb_ao_test_vectors.erl
@@ -302,6 +302,33 @@ load_device_test() ->
     hb_store:reset(Store),
     ?assertEqual({ok, <<"example">>}, exec_dummy_device(Opts)).
 
+oversized_load_device_test() ->
+    Wallet = ar_wallet:new(),
+    Opts = #{
+        <<"load-remote-devices">> => true,
+        <<"remote-device-byte-cap">> => 1,
+        <<"trusted-device-signers">> =>
+            [hb_util:human_id(ar_wallet:to_address(Wallet))],
+        <<"store">> => Store = #{
+            <<"store-module">> => hb_store_fs,
+            <<"name">> => <<"cache-TEST/fs">>
+        },
+        <<"priv-wallet">> => Wallet
+    },
+    hb_store:reset(Store),
+    ?assertThrow(
+        {error,
+            {device_not_loadable,
+                _,
+                {device_load_failed,
+                    {remote_device_byte_size_exceeds_limit, _},
+                    {byte_size_cap, 1}
+                }
+            }
+        },
+        exec_dummy_device(Opts)
+    ).
+
 untrusted_load_device_test() ->
     % Establish an execution environment which does not trust the device author.
     UntrustedWallet = ar_wallet:new(),


### PR DESCRIPTION
## about
a surgical resources-aware patch as a followup to #898 - sets the default remote BEAM dev artifacts size cap to 1MB (`DEFAULT_REMOTE_DEVICE_BYTE_CAP`) and configureability in Opts under `remote_device_byte_cap` key

added `oversized_load_device_test`