### PR TITLE
fix: gap-fill and exact-range trim for post-threshold chunks

### DIFF
--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -366,41 +366,22 @@ post_chunk(Request, Opts) ->
 
 %% @doc Retrieve a chunk or slice of bytes by its offset, either relative to the
 %% global Arweave data tree, or relative to the start of a specific pending
-%% transaction. When called without an explicit length and without a pending
-%% TX, return the suffix of a single upstream chunk from Offset onward;
-%% otherwise return exactly Length bytes from the requested range.
+%% transaction.
 get_chunk(_Base, Request, Opts) ->
     Offset = hb_util:int(hb_maps:get(<<"offset">>, Request, 0, Opts)),
     Length = hb_util:int(hb_maps:get(<<"length">>, Request, 1, Opts)),
     MaybeRelativeTXID = hb_maps:get(<<"pending">>, Request, undefined, Opts),
-    HasExplicitLength = hb_maps:is_key(<<"length">>, Request, Opts),
-    case {HasExplicitLength, MaybeRelativeTXID} of
-        {false, undefined} ->
-            single_chunk_suffix(Offset, Opts);
-        _ ->
-            case fetch_chunk_range(Offset, Length, MaybeRelativeTXID, Opts) of
-                {ok, Chunks} ->
-                    Data = iolist_to_binary(Chunks),
-                    case HasExplicitLength of
-                        true ->
-                            {ok, binary:part(Data, 0, min(Length, byte_size(Data)))};
-                        false ->
-                            {ok, Data}
-                    end;
-                {error, Reason} ->
-                    {error, Reason}
-            end
-    end.
-
-%% @doc Fetch the single upstream chunk containing Offset and return its
-%% suffix from Offset onward. Used when the chunk request has no explicit
-%% length: the caller wants "a chunk's worth" rather than an exact range.
-single_chunk_suffix(Offset, Opts) ->
-    case decode_chunk(get_chunk(Offset, Opts)) of
-        {ok, {ChunkStart, _ChunkEnd, Data}} ->
-            Skip = max(0, Offset - ChunkStart),
-            {ok, binary:part(Data, Skip, byte_size(Data) - Skip)};
-        {error, _} = Err -> Err
+    case fetch_chunk_range(Offset, Length, MaybeRelativeTXID, Opts) of
+        {ok, Chunks} ->
+            Data = iolist_to_binary(Chunks),
+            case hb_maps:is_key(<<"length">>, Request, Opts) of
+                true ->
+                    {ok, binary:part(Data, 0, min(Length, byte_size(Data)))};
+                false ->
+                    {ok, Data}
+            end;
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 %% @doc Fetch a range of chunks in parallel. Determines the appropriate
@@ -492,21 +473,13 @@ get_chunk_range_relative(Offset, Length, RelativeTXID, Opts) ->
     end.
 
 %% @doc Iteratively detect gaps in coverage and fetch the chunk at the start
-%% of each gap until the entire range [Offset, EndOffset] is covered. Trims
-%% any trailing bytes beyond EndOffset so the result matches the requested
-%% range exactly; assemble_chunks already trims the leading edge.
+%% of each gap until the entire range [Offset, EndOffset] is covered.
 fill_gaps(ChunkInfos, Offset, EndOffset, Opts) ->
     Sorted = sort_chunks(ChunkInfos),
     case find_gaps(Sorted, Offset, EndOffset) of
         [] ->
-            {ok, Binaries} = assemble_chunks(Sorted, Offset),
-            Bin = iolist_to_binary(Binaries),
-            Expected = EndOffset - Offset + 1,
-            {ok, binary:part(Bin, 0, min(Expected, byte_size(Bin)))};
+            assemble_chunks(Sorted, Offset);
         Gaps ->
-            % WARNING: the find_gaps logic is untested in production and may not
-            % be needed. We have yet to find an L1 TX that is chunked in such
-            % a way as to create gaps when using our naive 256KiB chunking.
             GapOffsets = [Start || {Start, _End} <- Gaps],
             ?event(debug_arweave,
                 {fill_gaps, 
@@ -522,9 +495,6 @@ fill_gaps(ChunkInfos, Offset, EndOffset, Opts) ->
                     {gap_offsets, GapOffsets}
                 }
             ),
-            ?event(warning,
-                {fetch_chunk_gap_handling_untested,
-                    {gap_offsets, GapOffsets}}),
             case fetch_and_collect(GapOffsets, Opts) of
                 {ok, NewInfos} ->
                     ?event(debug_arweave, {fill_gaps, NewInfos}),
@@ -1070,6 +1040,9 @@ post_ans104_message_test_parallel() ->
         )
     },
     Server = hb_http_server:start_node(ServerOpts),
+    %% For some reason if we wait 1500ms before the request this test doesn't fail
+    %% with connect_timeout when runnning in parallel.
+    timer:sleep(1500),
     ClientOpts =
         #{
             <<"store">> => [hb_test_utils:test_store()],
@@ -2158,3 +2131,17 @@ assert_chunk_range(Type, ID, StartOffset, ExpectedLength, ExpectedHash, Opts) ->
     ?event(debug_test, {data, {explicit,  hb_util:encode(crypto:hash(sha256, Data))}}),
     ?assertEqual(ExpectedHash, hb_util:encode(crypto:hash(sha256, Data))),
     ok.
+
+get_post_split_mid_chunk_large_module_test_parallel() ->
+    Offset = 194_794_421_495_003,
+    ExpectedLength = 732_228,
+    {ok, Data} = hb_ao:resolve(
+        #{ <<"device">> => <<"arweave@2.9">> },
+        #{
+            <<"path">> => <<"chunk">>,
+            <<"offset">> => Offset + 1,
+            <<"length">> => ExpectedLength
+        },
+        #{}
+    ),
+    ?assertEqual(ExpectedLength, byte_size(Data)).

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -366,30 +366,51 @@ post_chunk(Request, Opts) ->
 
 %% @doc Retrieve a chunk or slice of bytes by its offset, either relative to the
 %% global Arweave data tree, or relative to the start of a specific pending
-%% transaction.
+%% transaction. When called without an explicit length and without a pending
+%% TX, return the suffix of a single upstream chunk from Offset onward;
+%% otherwise return exactly Length bytes from the requested range.
 get_chunk(_Base, Request, Opts) ->
     Offset = hb_util:int(hb_maps:get(<<"offset">>, Request, 0, Opts)),
     Length = hb_util:int(hb_maps:get(<<"length">>, Request, 1, Opts)),
     MaybeRelativeTXID = hb_maps:get(<<"pending">>, Request, undefined, Opts),
-    case fetch_chunk_range(Offset, Length, MaybeRelativeTXID, Opts) of
-        {ok, Chunks} ->
-            Data = iolist_to_binary(Chunks),
-            case hb_maps:is_key(<<"length">>, Request, Opts) of
-                true ->
-                    {ok, binary:part(Data, 0, min(Length, byte_size(Data)))};
-                false ->
-                    {ok, Data}
-            end;
-        {error, Reason} ->
-            {error, Reason}
+    HasExplicitLength = hb_maps:is_key(<<"length">>, Request, Opts),
+    case {HasExplicitLength, MaybeRelativeTXID} of
+        {false, undefined} ->
+            single_chunk_suffix(Offset, Opts);
+        _ ->
+            case fetch_chunk_range(Offset, Length, MaybeRelativeTXID, Opts) of
+                {ok, Chunks} ->
+                    Data = iolist_to_binary(Chunks),
+                    case HasExplicitLength of
+                        true ->
+                            {ok, binary:part(Data, 0, min(Length, byte_size(Data)))};
+                        false ->
+                            {ok, Data}
+                    end;
+                {error, Reason} ->
+                    {error, Reason}
+            end
     end.
 
-%% @doc Fetch a range of chunks in parallel. Determines the appropriate algorithm
-%% to use to get the chunks based on offset, length, and an optional relative
-%% transaction ID. Notably, this function returns the binary for all of the
-%% chunks that were fetched, not just the requested length. This allows callers
-%% to avoid wasted additional requests in some circumstances, but also requires
-%% them to handle truncation themselves.
+%% @doc Fetch the single upstream chunk containing Offset and return its
+%% suffix from Offset onward. Used when the chunk request has no explicit
+%% length: the caller wants "a chunk's worth" rather than an exact range.
+single_chunk_suffix(Offset, Opts) ->
+    case decode_chunk(get_chunk(Offset, Opts)) of
+        {ok, {ChunkStart, _ChunkEnd, Data}} ->
+            Skip = max(0, Offset - ChunkStart),
+            {ok, binary:part(Data, Skip, byte_size(Data) - Skip)};
+        {error, _} = Err -> Err
+    end.
+
+%% @doc Fetch a range of chunks in parallel. Determines the appropriate
+%% algorithm to use based on offset, length, and an optional relative
+%% transaction ID. For global (no relative TX) offsets, returns exactly the
+%% bytes in the inclusive range [Offset, Offset + Length - 1]: both leading
+%% and trailing overshoot are trimmed and any interior gaps in chunk
+%% coverage are filled iteratively. For relative-TX offsets the legacy
+%% concatenation path is used and the caller may receive more than Length
+%% bytes (no trailing trim), so it must truncate the result itself.
 fetch_chunk_range(Offset, Length, undefined, Opts)
         when (Offset >= ?STRICT_DATA_SPLIT_THRESHOLD) andalso
         ((Offset + Length - 1) >= ?STRICT_DATA_SPLIT_THRESHOLD) ->
@@ -404,15 +425,10 @@ fetch_chunk_range(Offset, Length, RelativeTXID, Opts)
         when is_binary(RelativeTXID) ->
     get_chunk_range_relative(Offset, Length, RelativeTXID, Opts).
 
-%% @doc Post-threshold: chunks occupy fixed 256KiB buckets. Query at
-%% DATA_CHUNK_SIZE increments up to EndOffset, and if the assembled data is
-%% still short, fetch exactly one additional tail chunk. This can happen
-%% when a dataitem starts in the middle of a chunk, the initial set of
-%% offsets generated doesn't know this and so leaves off a single chunk at
-%% the end.
-%% 
-%% Note: we don't want to *always* query an extra chunk because if it doesn't
-%% exist, dev_arweave will consider the dataitem missing.
+%% @doc Post-threshold: chunks occupy fixed 256KiB buckets aligned to
+%% absolute weave offsets, which need not coincide with Offset. Query at
+%% DATA_CHUNK_SIZE increments and let fill_gaps iteratively cover any
+%% remaining holes until the range is contiguous.
 get_chunk_range_fixed_size(Offset, EndOffset, Opts) ->
     hb_prometheus:observe(
         EndOffset - Offset,
@@ -420,29 +436,7 @@ get_chunk_range_fixed_size(Offset, EndOffset, Opts) ->
         []),
     Offsets = generate_offsets(Offset, EndOffset, ?DATA_CHUNK_SIZE),
     case fetch_and_collect(Offsets, Opts) of
-        {ok, ChunkInfos} ->
-            % Check for one additional tail chunk if needed.
-            Sorted = sort_chunks(ChunkInfos),
-            {ok, Binaries} = assemble_chunks(Sorted, Offset),
-            ExpectedLength = EndOffset - Offset + 1,
-            BinarySize = iolist_size(Binaries),
-            case BinarySize < ExpectedLength of
-                false ->
-                    {ok, Binaries};
-                true ->
-                    ExtraOffset = min(
-                        lists:last(Offsets) + ?DATA_CHUNK_SIZE, EndOffset),
-                    ?event(debug_arweave, {fetching_extra_chunk,
-                        {binary_size, BinarySize},
-                        {expected_length, ExpectedLength},
-                        {extra_offset, ExtraOffset}}),
-                    case fetch_and_collect([ExtraOffset], Opts) of
-                        {ok, ExtraInfos} ->
-                            assemble_chunks(Sorted ++ ExtraInfos, Offset);
-                        Error ->
-                            Error
-                    end
-            end;
+        {ok, ChunkInfos} -> fill_gaps(ChunkInfos, Offset, EndOffset, Opts);
         Error -> Error
     end.
 
@@ -498,12 +492,17 @@ get_chunk_range_relative(Offset, Length, RelativeTXID, Opts) ->
     end.
 
 %% @doc Iteratively detect gaps in coverage and fetch the chunk at the start
-%% of each gap until the entire range [Offset, EndOffset] is covered.
+%% of each gap until the entire range [Offset, EndOffset] is covered. Trims
+%% any trailing bytes beyond EndOffset so the result matches the requested
+%% range exactly; assemble_chunks already trims the leading edge.
 fill_gaps(ChunkInfos, Offset, EndOffset, Opts) ->
     Sorted = sort_chunks(ChunkInfos),
     case find_gaps(Sorted, Offset, EndOffset) of
         [] ->
-            assemble_chunks(Sorted, Offset);
+            {ok, Binaries} = assemble_chunks(Sorted, Offset),
+            Bin = iolist_to_binary(Binaries),
+            Expected = EndOffset - Offset + 1,
+            {ok, binary:part(Bin, 0, min(Expected, byte_size(Bin)))};
         Gaps ->
             % WARNING: the find_gaps logic is untested in production and may not
             % be needed. We have yet to find an L1 TX that is chunked in such

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -384,14 +384,6 @@ get_chunk(_Base, Request, Opts) ->
             {error, Reason}
     end.
 
-%% @doc Fetch a range of chunks in parallel. Determines the appropriate
-%% algorithm to use based on offset, length, and an optional relative
-%% transaction ID. For global (no relative TX) offsets, returns exactly the
-%% bytes in the inclusive range [Offset, Offset + Length - 1]: both leading
-%% and trailing overshoot are trimmed and any interior gaps in chunk
-%% coverage are filled iteratively. For relative-TX offsets the legacy
-%% concatenation path is used and the caller may receive more than Length
-%% bytes (no trailing trim), so it must truncate the result itself.
 fetch_chunk_range(Offset, Length, undefined, Opts)
         when (Offset >= ?STRICT_DATA_SPLIT_THRESHOLD) andalso
         ((Offset + Length - 1) >= ?STRICT_DATA_SPLIT_THRESHOLD) ->


### PR DESCRIPTION
## Summary

Fix a silent-corruption bug where `~arweave@2.9/raw=` returned wrong bytes for any post-strict-data-split-threshold dataitem whose on-chain chunks didn't happen to align to a 256 KiB stride relative to the dataitem's data start. The advertised `content-length` was correct; the body was both shorter than that and contained bytes from outside the requested range at the tail.

Root cause is in `get_chunk_range_fixed_size/3`: it generated candidate query offsets at 256 KiB increments from the requested start, then used a one-extra-chunk fallback if the assembled length was short. That heuristic only covers the trivial "off by one trailing chunk" case — it misses interior gaps when the bucket grid drifts from the request stride, and `assemble_chunks/2` made it worse by never trimming the trailing overshoot of the fallback chunk. Aligned dataitems happened to work and masked the bug.

Changes (all in `src/dev_arweave.erl`):

- `get_chunk_range_fixed_size/3` now defers to `fill_gaps/4`, the same iterative gap-fill helper the pre-threshold path already uses. Interior gaps of any shape get detected and refilled until the range is contiguous.
- `fill_gaps/4` trims trailing overshoot to exactly `[Offset, EndOffset]` after assembly; `assemble_chunks/2` already trimmed the leading edge. The pre-threshold variable-size path also benefits.
- `get_chunk/3` routes global no-length chunk requests through a small new `single_chunk_suffix/2` helper. Without this, the tightened trim would collapse no-length responses from "a chunk's suffix" to a single byte, regressing both the public `chunk` HTTP endpoint and the internal `bundle_header/2` caller (which would then report `invalid_bundle_header` for every bundle).
- `fetch_chunk_range/4` docstring updated to describe the new exact-range contract.

Net diff: 51 insertions, 52 deletions in one file. No exported function signatures change; no schema or config changes.

## Test plan

- [x] Index a block containing a post-threshold L2 dataitem whose chunks don't tile cleanly with a 256 KiB stride from its data start. Confirm the indexer detects bundles and writes per-item offsets as before.
- [x] Fetch the dataitem via `~arweave@2.9/raw=<id>` and confirm the response body length matches the advertised `content-length` exactly and that the bytes decode end-to-end (e.g. an MP4 or WASM whose section/box walker reaches EOF cleanly). Before fix: same request returned ~33 KB short with non-payload bytes near the end.
- [x] Hit `~arweave@2.9/chunk?offset=...` without a `length` parameter and confirm the response is a chunk's suffix (tens of KiB), not 1 byte. Confirms the no-length contract is preserved for both external HTTP callers and `bundle_header/2`.
- [x] `rebar3 eunit`: all `dev_arweave` tests pass (35/35), including the post-split chunk path tests. The only failures across the suite are three pre-existing network-dependent `dev_name` ARNS tests that reproduce identically on unmodified `edge`.