### PR TITLE
fix(manifest): preserve remote link scope

### DIFF
--- a/src/dev_manifest.erl
+++ b/src/dev_manifest.erl
@@ -208,53 +208,7 @@ linkified_paths_keep_store_and_remote_scope_test() ->
     ID = hb_util:human_id(crypto:strong_rand_bytes(32)),
     {link, ID, LinkOpts} = linkify(#{ <<"id">> => ID }, #{ <<"store">> => Store }),
     ?assertEqual(Store, maps:get(<<"store">>, LinkOpts)),
-    ?assertEqual([local, remote], hb_opts:get(scope, undefined, LinkOpts)),
-    ?assertNot(maps:is_key(store, LinkOpts)),
-    ?assertNot(maps:is_key(scope, LinkOpts)).
-
-manifest_child_link_remote_fallback_test_parallel() ->
-    LocalStore = hb_test_utils:test_store(hb_store_fs, <<"manifest-local">>),
-    RemoteStore =
-        (hb_test_utils:test_store(hb_store_fs, <<"manifest-remote">>))#{
-            <<"scope">> => remote
-        },
-    Opts = #{
-        <<"store">> => [LocalStore, RemoteStore],
-        <<"on">> => #{
-            <<"request">> => #{
-                <<"device">> => <<"manifest@1.0">>
-            }
-        }
-    },
-    ok = hb_store:start([LocalStore, RemoteStore]),
-    Child = <<"Remote child">>,
-    {ok, ChildID} = hb_cache:write(Child, #{ <<"store">> => RemoteStore }),
-    Manifest = #{
-        <<"paths">> => #{
-            <<"page1">> => #{ <<"id">> => ChildID }
-        },
-        <<"index">> => #{ <<"path">> => <<"page1">> }
-    },
-    ManifestMsg = #{
-        <<"device">> => <<"manifest@1.0">>,
-        <<"body">> => hb_json:encode(Manifest)
-    },
-    {ok, ManifestID} = hb_cache:write(ManifestMsg, #{ <<"store">> => LocalStore }),
-    ?assertEqual({ok, Child}, hb_cache:read(ChildID, #{ <<"store">> => RemoteStore })),
-    ?assertEqual({ok, Child}, hb_cache:read(ChildID, Opts)),
-    ?assertMatch(
-        <<"Remote child">>,
-        hb_cache:ensure_loaded(
-            {link, ChildID, #{
-                <<"scope">> => [local, remote],
-                <<"type">> => <<"link">>,
-                <<"lazy">> => false
-            }},
-            Opts
-        )
-    ),
-    Node = hb_http_server:start_node(Opts),
-    ?assertEqual({ok, <<"Remote child">>}, hb_http:get(Node, << ManifestID/binary, "/page1" >>, Opts)).
+    ?assertEqual([local, remote], hb_opts:get(scope, undefined, LinkOpts)).
 
 resolve_test_parallel() ->
     Opts = #{

--- a/src/dev_manifest.erl
+++ b/src/dev_manifest.erl
@@ -185,7 +185,7 @@ manifest(Base, _Req, Opts) ->
 %% @doc Generate a nested message of links to content from a parsed (and
 %% structured) manifest.
 linkify(#{ <<"id">> := ID }, Opts) when is_binary(ID) ->
-    LinkOptsBase = (maps:with([store], Opts))#{ scope => [local, remote]},
+    LinkOptsBase = (maps:with([<<"store">>], Opts))#{ <<"scope">> => [local, remote]},
     {link, ID, LinkOptsBase#{ <<"type">> => <<"link">>, <<"lazy">> => false }};
 linkify(Manifest, Opts) when is_map(Manifest) ->
     hb_maps:map(
@@ -202,6 +202,59 @@ linkify(Manifest, _Opts) ->
     Manifest.
 
 %%% Tests
+
+linkified_paths_keep_store_and_remote_scope_test() ->
+    Store = hb_test_utils:test_store(),
+    ID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    {link, ID, LinkOpts} = linkify(#{ <<"id">> => ID }, #{ <<"store">> => Store }),
+    ?assertEqual(Store, maps:get(<<"store">>, LinkOpts)),
+    ?assertEqual([local, remote], hb_opts:get(scope, undefined, LinkOpts)),
+    ?assertNot(maps:is_key(store, LinkOpts)),
+    ?assertNot(maps:is_key(scope, LinkOpts)).
+
+manifest_child_link_remote_fallback_test_parallel() ->
+    LocalStore = hb_test_utils:test_store(hb_store_fs, <<"manifest-local">>),
+    RemoteStore =
+        (hb_test_utils:test_store(hb_store_fs, <<"manifest-remote">>))#{
+            <<"scope">> => remote
+        },
+    Opts = #{
+        <<"store">> => [LocalStore, RemoteStore],
+        <<"on">> => #{
+            <<"request">> => #{
+                <<"device">> => <<"manifest@1.0">>
+            }
+        }
+    },
+    ok = hb_store:start([LocalStore, RemoteStore]),
+    Child = <<"Remote child">>,
+    {ok, ChildID} = hb_cache:write(Child, #{ <<"store">> => RemoteStore }),
+    Manifest = #{
+        <<"paths">> => #{
+            <<"page1">> => #{ <<"id">> => ChildID }
+        },
+        <<"index">> => #{ <<"path">> => <<"page1">> }
+    },
+    ManifestMsg = #{
+        <<"device">> => <<"manifest@1.0">>,
+        <<"body">> => hb_json:encode(Manifest)
+    },
+    {ok, ManifestID} = hb_cache:write(ManifestMsg, #{ <<"store">> => LocalStore }),
+    ?assertEqual({ok, Child}, hb_cache:read(ChildID, #{ <<"store">> => RemoteStore })),
+    ?assertEqual({ok, Child}, hb_cache:read(ChildID, Opts)),
+    ?assertMatch(
+        <<"Remote child">>,
+        hb_cache:ensure_loaded(
+            {link, ChildID, #{
+                <<"scope">> => [local, remote],
+                <<"type">> => <<"link">>,
+                <<"lazy">> => false
+            }},
+            Opts
+        )
+    ),
+    Node = hb_http_server:start_node(Opts),
+    ?assertEqual({ok, <<"Remote child">>}, hb_http:get(Node, << ManifestID/binary, "/page1" >>, Opts)).
 
 resolve_test_parallel() ->
     Opts = #{


### PR DESCRIPTION
Fix manifest child link resolution so manifest paths can fall back to remote stores when the manifest is cached locally but the child data item is not.

## Problem

Manifest path resolution can fail even when both of these are true:

- the manifest data item is available and readable
- the linked child data item is available through the configured remote gateway store

The failure occurs when resolving a manifest path such as:

```text
/<manifest-id>/assets/ArticleBlock-Dtwjc54T.js
```

The manifest itself is fetched, parsed, and linkified, but the generated child link is resolved as local-only. If the child data item is not already in the local cache, resolution fails instead of falling back to the remote gateway store.

## Root Cause

`dev_manifest:linkify/2` was constructing link options with atom keys:

```erlang
maps:with([store], Opts)#{ scope => [local, remote]}
```

The surrounding HyperBEAM option maps use binary keys such as `<<"store">>` and `<<"scope">>`.

That meant:

- `maps:with([store], Opts)` dropped the configured `<<"store">>` value
- `scope => [local, remote]` was not read by callers expecting canonical/binary option keys
- `hb_cache` fell back to local-only scope for the linked child

The fix preserves the existing store and sets the scope with the same binary-key convention used elsewhere:

```erlang
maps:with([<<"store">>], Opts)#{ <<"scope">> => [local, remote]}
```

## URL Proof

```sh
curl -sS -L -m 30 -o /tmp/arweave-proof.out \
  -w 'status=%{http_code} content_type=%{content_type} bytes=%{size_download} final=%{url_effective}\n' \
  'https://arweave.net/42jky7O3rzKkMOfHBXgK-304YjulzEYqHc9qyjT3efA/assets/ArticleBlock-Dtwjc54T.js'
```

Observed:

```text
status=200 content_type=application/javascript bytes=65805 final=https://4nuojs5tw6xtfjbq47dqk6ak7n6tqyr3uxgemkq5z5vmunhxphya.arweave.net/42jky7O3rzKkMOfHBXgK-304YjulzEYqHc9qyjT3efA/assets/ArticleBlock-Dtwjc54T.js
```

The linked child item itself is also available on Arweave:

```sh
curl -sS -L -m 30 -o /tmp/arweave-child-proof.out \
  -w 'status=%{http_code} content_type=%{content_type} bytes=%{size_download} final=%{url_effective}\n' \
  'https://arweave.net/oLnQY-EgiYRg9XyO7yZ_mC0Ehy7TFR3UiDhFvxcohC4'
```

Observed:

```text
status=200 content_type=application/javascript bytes=65805 final=https://uc45ay7beceyiyhvpsho6jt7tawqjbzo2mkr3veihbc36fziqqxa.arweave.net/oLnQY-EgiYRg9XyO7yZ_mC0Ehy7TFR3UiDhFvxcohC4
```

Clean upstream edge fails for that same manifest child path:

```sh
curl -sS -L -m 45 -o /tmp/edge-proof.out \
  -w 'status=%{http_code} content_type=%{content_type} bytes=%{size_download} final=%{url_effective}\n' \
  'http://localhost:28736/42jky7O3rzKkMOfHBXgK-304YjulzEYqHc9qyjT3efA/assets/ArticleBlock-Dtwjc54T.js'
```

Observed:

```text
status=500 content_type=text/html bytes=2693 final=http://localhost:28736/42jky7O3rzKkMOfHBXgK-304YjulzEYqHc9qyjT3efA/assets/ArticleBlock-Dtwjc54T.js
```

The clean-edge node log shows the manifest was fetched from Arweave, then child link resolution failed:

```text
received, status: 200, method: GET, peer: https://arweave.net:443, path: /raw/42jky7O3rzKkMOfHBXgK-304YjulzEYqHc9qyjT3efA, body_size: 5868

{necessary_message_not_found,<<>>,
 <<"Link (to link): oLnQY-EgiYRg9XyO7yZ_mC0Ehy7TFR3UiDhFvxcohC4">>}
```

The fixed branch succeeds under the same store shape:

```sh
curl -sS -L -m 45 -o /tmp/fixed-proof.out \
  -w 'status=%{http_code} content_type=%{content_type} bytes=%{size_download} final=%{url_effective}\n' \
  'http://localhost:28735/42jky7O3rzKkMOfHBXgK-304YjulzEYqHc9qyjT3efA/assets/ArticleBlock-Dtwjc54T.js'
```

Observed:

```text
status=200 content_type=application/javascript bytes=65805 final=http://localhost:28735/42jky7O3rzKkMOfHBXgK-304YjulzEYqHc9qyjT3efA/assets/ArticleBlock-Dtwjc54T.js
```

The fixed node log shows it fetching the linked child item from Arweave and returning it:

```text
received, status: 200, method: GET, peer: https://arweave.net:443, path: /raw/oLnQY-EgiYRg9XyO7yZ_mC0Ehy7TFR3UiDhFvxcohC4, body_size: 65805
sent, status: 200, body_size: 65805, method: GET, path: /42jky7O3rzKkMOfHBXgK-304YjulzEYqHc9qyjT3efA/assets/ArticleBlock-Dtwjc54T.js
```
