### PR TITLE
#906 Docs updates around scheduler location and node operation

### DIFF
--- a/docs/run/running-a-hyperbeam-node.md
+++ b/docs/run/running-a-hyperbeam-node.md
@@ -147,9 +147,6 @@ The simplest way to start a HyperBEAM node for development or testing is using `
 rebar3 shell
 ```
 
->[!NOTE]
->For current process operations, start HyperBEAM with the <code>genesis_wasm</code> profile by running <code>rebar3 as genesis_wasm shell</code>.
-
 This command:
 
 1.  Starts the Erlang Virtual Machine (BEAM) with all HyperBEAM modules loaded.

--- a/docs/run/running-a-hyperbeam-node.md
+++ b/docs/run/running-a-hyperbeam-node.md
@@ -248,3 +248,4 @@ To stop the node running *within the `rebar3 shell`*, press `Ctrl+C` twice or us
 *   **Configure Your Node:** Deep dive into [configuration options](./configuring-your-machine.md).
 *   **TEE Nodes:** Learn about running nodes in [Trusted Execution Environments](./tee-nodes.md) for enhanced security.
 *   **Routers:** Understand how to configure and run a [router node](./joining-running-a-router.md).
+*   **Scheduler Device:** Learn how to [set up a Scheduler device](./setting-up-a-scheduler-device.md) to announce your node as an AO scheduler.

--- a/docs/run/running-a-hyperbeam-node.md
+++ b/docs/run/running-a-hyperbeam-node.md
@@ -147,6 +147,9 @@ The simplest way to start a HyperBEAM node for development or testing is using `
 rebar3 shell
 ```
 
+>[!NOTE]
+>For current process operations, start HyperBEAM with the <code>genesis_wasm</code> profile by running <code>rebar3 as genesis_wasm shell</code>.
+
 This command:
 
 1.  Starts the Erlang Virtual Machine (BEAM) with all HyperBEAM modules loaded.

--- a/docs/run/setting-up-a-scheduler-device.md
+++ b/docs/run/setting-up-a-scheduler-device.md
@@ -1,8 +1,7 @@
 # Setting Up a Scheduler Device
 
-> **Note:** When your node launches, it will normally post (announce) its scheduler location automatically. This guide is useful if you need to re-announce the location or manually update the published location data.
 
-This guide is for operators who are already running a production HyperBEAM node and want to register it as an AO scheduler.
+This guide is for operators who are already running a production HyperBEAM node and want to register it as an AO scheduler on the network publicly.
 
 ## Prerequisites
 

--- a/docs/run/setting-up-a-scheduler-device.md
+++ b/docs/run/setting-up-a-scheduler-device.md
@@ -1,0 +1,47 @@
+# Setting Up a Scheduler Device
+
+> **Note:** When your node launches, it will normally post (announce) its scheduler location automatically. This guide is useful if you need to re-announce the location or manually update the published location data.
+
+This guide is for operators who are already running a production HyperBEAM node and want to register it as an AO scheduler.
+
+## Prerequisites
+
+If you started your node using the default device list in [hb_opts.erl](../../src/hb_opts.erl), both `~location@1.0` and `~scheduler@1.0` are already onboarded — no additional configuration is required.
+
+You must set `host` in your `config.flat` so the `~location@1.0` device announces the correct public URL for your node.
+
+Example:
+
+```erlang
+host = "your-node-domain.example.com".
+```
+
+## Announcing Your Scheduler Location
+
+To register your node as a scheduler on the AO network, you need to call the `~location@1.0` device endpoint **from the node host itself** (i.e. run the command on the same machine running HyperBEAM).
+
+Run the following curl command on your node host (Linux/Mac):
+
+```bash
+curl -sS -v http://127.0.0.1:8734/~location@1.0/node
+```
+
+### What Success Looks Like
+
+A successful call returns an **HTTP 200 OK** response from `~location@1.0` in the node logs and will give you some details in your local console. This publishes a transaction to the network announcing your scheduler location.
+
+## Emitted Transaction Tags
+
+The published transaction should include tags similar to the following:
+
+```
+data-Protocol: ao
+variant: ao.N.1
+type: location
+url: https://your-node-domain.example.com
+nonce: <nonce-value>
+time-to-live:  TTL
+codec-device: Codec
+```
+
+> **Note:** The `url` field should point to your node's publicly accessible address (for example, `https://push.forward.computer`). The `nonce` value is generated automatically.


### PR DESCRIPTION
This pull request improves the documentation for running and configuring a HyperBEAM node, particularly focusing on how to set up and announce a Scheduler device. The updates clarify how to start the node for specific operations and provide a new guide for Scheduler setup.

**Documentation improvements:**

* Added a note to the `running-a-hyperbeam-node.md` guide explaining how to start HyperBEAM with the `genesis_wasm` profile for current process operations.
* Added a link in `running-a-hyperbeam-node.md` to a new guide on setting up a Scheduler device, helping users announce their node as an AO scheduler.

**New Scheduler device setup guide:**

* Introduced a new file, `setting-up-a-scheduler-device.md`, providing step-by-step instructions for registering a HyperBEAM node as an AO scheduler, including prerequisites, configuration, announcement procedure, and details about the emitted transaction tags.