### PR TITLE
fix: dev_name tests, because previous ARNS transaction list was blacklisted

### DIFF
--- a/src/dev_name.erl
+++ b/src/dev_name.erl
@@ -293,7 +293,7 @@ load_and_execute_test_parallel() ->
 %% @doc Return an `Opts` for an environment with the default ARNS name export
 %% and a temporary store for the test.
 test_arns_opts() ->
-    JSONNames = <<"G_gb7SAgogHMtmqycwaHaC6uC-CZ3akACdFv5PUaEE8">>,
+    JSONNames = <<"fG_Tr0H7xI64xTXVq9-O9YvUefht-gW30gtOHGRMhb8">>,
     Path = <<JSONNames/binary, "~json@1.0/deserialize&target=data">>,
     TempStore = hb_test_utils:test_store(),
     #{

--- a/src/hb_opts.erl
+++ b/src/hb_opts.erl
@@ -46,7 +46,7 @@
         #{ <<"device">> => <<"arweave@2.9">> },
         #{ <<"device">> => <<"b32-name@1.0">> },
         <<
-            "G_gb7SAgogHMtmqycwaHaC6uC-CZ3akACdFv5PUaEE8",
+            "fG_Tr0H7xI64xTXVq9-O9YvUefht-gW30gtOHGRMhb8",
                 "~json@1.0/deserialize&target=data"
         >>
     ]


### PR DESCRIPTION
```
=======================================================
  All 3072 tests passed.
```