### PR TITLE
fix: default trusted signer at gateway discovery lvl

### DIFF
--- a/docs/build/device-packaging.md
+++ b/docs/build/device-packaging.md
@@ -125,7 +125,7 @@ variables. Returns each device's spec and impl IDs on stdout.
 | `<<"preloaded-store">>` | store map | LMDB preloaded device store. |
 | `<<"preloaded-devices-index">>` | binary | Committed ID of the flat preloaded resolver message. Embedded into `hb_opts` from `_build/hb_preloaded_index.hrl` during compilation. |
 | `<<"device-store">>` | store map | Volatile cache of name/spec-ID → loaded module atom. |
-| `<<"trusted-device-signers">>` | `[Address]` or `all` | Acceptable signer addresses for impl messages. Defaults to the node wallet. |
+| `<<"trusted-device-signers">>` | `[Address]` | Acceptable signer addresses for impl messages. Empty/default uses the node wallet. |
 | `<<"trusted-devices">>` | `[ImplID]` | Implementation message IDs trusted directly, bypassing signer matching for those IDs only. |
 | `<<"load-remote-devices">>` | bool | Whether unmatched devices may be fetched via the Arweave gateway. |
 | `<<"admissible-devices">>` | `all` or `[Name]` | Per-execution allowlist (used by the Lua sandbox). |

--- a/src/kernel/hb_ao_device.erl
+++ b/src/kernel/hb_ao_device.erl
@@ -4,7 +4,7 @@
 -module(hb_ao_device).
 -export([truncate_args/2, message_to_fun/3, message_to_device/2, load/2]).
 -export([implementation_dir/1]).
--export([is_direct_key_access/3, is_direct_key_access/4]).
+-export([is_direct_key_access/3, is_direct_key_access/4, trusted_signers/1]).
 -export([find_exported_function/5, is_exported/4, info/2, info/3, default/0]).
 -include("include/hb.hrl").
 

--- a/src/kernel/hb_ao_device.erl
+++ b/src/kernel/hb_ao_device.erl
@@ -1083,7 +1083,8 @@ trusted_devices(Opts) ->
 trusted_signers(Opts) ->
     case hb_opts:get(trusted_device_signers, [], Opts) of
         [] -> default_trusted_signers(Opts);
-        Configured -> Configured
+        Signers when is_list(Signers) -> [hb_util:bin(Signer) || Signer <- Signers];
+        _ -> []
     end.
 
 %% @doc The production default is the node wallet address.
@@ -1108,17 +1109,11 @@ is_trusted_device(ID, Opts) ->
 %% @doc Determine whether an implementation signer is trusted.
 is_signer_trusted([], _TrustedSigners) ->
     false;
-is_signer_trusted(_Signers, all) ->
-    true;
 is_signer_trusted(Signers, List) when is_list(List) ->
-    case lists:member(all, List) of
-        true -> true;
-        false ->
-            lists:any(
-                fun(Signer) -> lists:member(Signer, List) end,
-                Signers
-            )
-    end;
+    lists:any(
+        fun(Signer) -> lists:member(Signer, List) end,
+        Signers
+    );
 is_signer_trusted(_Signers, _TrustedSigners) ->
     false.
 

--- a/src/kernel/hb_gateway_client.erl
+++ b/src/kernel/hb_gateway_client.erl
@@ -173,7 +173,7 @@ location(Address, Opts) ->
 %% compatible device implementations we must query for messages with the
 %% appropriate tags and signatures.
 device(SpecID, Opts) ->
-    TrustedSigners = hb_opts:get(trusted_device_signers, [], Opts),
+    TrustedSigners = hb_ao_device:trusted_signers(Opts),
     Query =
         <<"query($specid: [String!], $trusted: [String!]) { ",
                 "transactions(",


### PR DESCRIPTION
## changes 

### 1- `trusted-device-signers` default mismatch 
docs state `trusted-device-signers` default to the node wallet, and `hb_ao_device:trusted_signers/1` already applies that default during trust checks -- but for remote discovery, that same default fallback isnt aligned: 

`hb_gateway_client:device/2` query GQL with `[]` when no trusted signers were configured.

tldr, this PR update gateway discovery to use the same trusted signer resolution as device loading

### 2- wildcard `all`  trusted signer

dropped the `all` atom (wildcard, any) trusted signer in `hb_ao_device:is_signer_trusted/2`