### PR TITLE
impr: Make start, stop and scope common to all store policies

### DIFF
--- a/src/hb_store.erl
+++ b/src/hb_store.erl
@@ -88,12 +88,13 @@ behavior_info(callbacks) ->
 
 -define(DEFAULT_SCOPE, local).
 -define(DEFAULT_RETRIES, 1).
+-define(COMMON_POLICIES, [start, stop, scope]).
 
 %% @doc Store access policies to function names.
 -define(STORE_ACCESS_POLICIES, #{
-    <<"read">> => [read, resolve, list, type, match, scope],
-    <<"write">> => [write, link, group, reset, scope],
-    <<"admin">> => [start, stop, reset, scope]
+    <<"read">> => [read, resolve, list, type, match] ++ ?COMMON_POLICIES,
+    <<"write">> => [write, link, group, reset] ++ ?COMMON_POLICIES,
+    <<"admin">> => [reset] ++ ?COMMON_POLICIES
 }).
 
 %%% Store named terms registry functions.

--- a/src/hb_store_gateway.erl
+++ b/src/hb_store_gateway.erl
@@ -1,9 +1,13 @@
 %%% @doc A store module that reads data from the nodes Arweave gateway and 
 %%% GraphQL routes, additionally including additional store-specific routes.
 -module(hb_store_gateway).
--export([scope/1, type/3, read/3, resolve/3, list/3]).
+-export([scope/1, type/3, read/3, resolve/3, list/3, start/1, stop/1]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
+
+start(_) -> ok.
+
+stop(_) -> ok.
 
 %% @doc The scope of a GraphQL store is always remote, due to performance.
 scope(_) -> remote.


### PR DESCRIPTION
start, stop, and scope should be transversal to all the policies (read, write, and admin).