### PR TITLE
fix: enforce strict tag-section boundary in ANS-104

### DIFF
--- a/src/ar_bundles.erl
+++ b/src/ar_bundles.erl
@@ -574,12 +574,18 @@ decode_signature(Other) ->
 %% @doc Decode tags from a binary format using Apache Avro.
 decode_tags(<<0:64/little-integer, 0:64/little-integer, Rest/binary>>) ->
     {[], Rest};
-decode_tags(<<_TagCount:64/little-integer, _TagSize:64/little-integer, Binary/binary>>) ->
-    {Count, BlocksBinary} = decode_zigzag(Binary),
-    {Tags, Rest} = decode_avro_tags(BlocksBinary, Count),
-    %% Pull out the terminating zero
-    {0, Rest2} = decode_zigzag(Rest),
-    {Tags, Rest2}.
+decode_tags(<<TagCount:64/little-integer, TagSize:64/little-integer, Binary/binary>>)
+        when byte_size(Binary) >= TagSize ->
+    <<TagsBinary:TagSize/binary, Rest/binary>> = Binary,
+    Tags = decode_avro_tag_section(TagsBinary),
+    case length(Tags) of
+        TagCount -> {Tags, Rest};
+        _ -> throw({invalid_ans104_tags, tag_count_mismatch})
+    end;
+decode_tags(<<_TagCount:64/little-integer, _TagSize:64/little-integer, _/binary>>) ->
+    throw({invalid_ans104_tags, truncated_tag_section});
+decode_tags(_) ->
+    throw({invalid_ans104_tags, truncated_tag_header}).
 
 decode_optional_field(<<0, Rest/binary>>) ->
     {<<>>, Rest};
@@ -587,16 +593,54 @@ decode_optional_field(<<1:8/little-integer, Field:32/binary, Rest/binary>>) ->
     {Field, Rest}.
 
 %% @doc Decode Avro blocks (for tags) from binary.
-decode_avro_tags(<<>>, _) ->
-    {[], <<>>};
+decode_avro_tag_section(TagsBinary) ->
+    case decode_avro_tag_array(TagsBinary, []) of
+        {Tags, <<>>} -> Tags;
+        {_Tags, _Residue} -> throw({invalid_ans104_tags, residue_in_tag_section})
+    end.
+
+decode_avro_tag_array(<<>>, _Acc) ->
+    throw({invalid_ans104_tags, missing_avro_array_terminator});
+decode_avro_tag_array(Binary, Acc) ->
+    {Count, Rest} = decode_zigzag(Binary),
+    decode_avro_tag_array_block(Count, Rest, Acc).
+
+decode_avro_tag_array_block(0, Rest, Acc) ->
+    {lists:reverse(Acc), Rest};
+decode_avro_tag_array_block(Count, Rest, Acc) when Count > 0 ->
+    {Tags, Rest2} = decode_avro_tags(Rest, Count),
+    decode_avro_tag_array(Rest2, lists:reverse(Tags, Acc));
+decode_avro_tag_array_block(Count, Rest, Acc) when Count < 0 ->
+    {BlockSize, BlockRest} = decode_zigzag(Rest),
+    case BlockSize >= 0 andalso byte_size(BlockRest) >= BlockSize of
+        true ->
+            <<Block:BlockSize/binary, Rest2/binary>> = BlockRest,
+            Tags = decode_avro_tag_block(Block, -Count),
+            decode_avro_tag_array(Rest2, lists:reverse(Tags, Acc));
+        false ->
+            throw({invalid_ans104_tags, invalid_avro_block_size})
+    end.
+
+decode_avro_tag_block(Block, Count) ->
+    case decode_avro_tags(Block, Count) of
+        {Tags, <<>>} -> Tags;
+        {_Tags, _Residue} -> throw({invalid_ans104_tags, residue_in_avro_block})
+    end.
+
 decode_avro_tags(Binary, Count) when Count =:= 0 ->
     {[], Binary};
+decode_avro_tags(<<>>, _Count) ->
+    throw({invalid_ans104_tags, truncated_avro_tag_item});
 decode_avro_tags(Binary, Count) ->
     {NameSize, Rest} = decode_zigzag(Binary),
     decode_avro_name(NameSize, Rest, Count).
 
 decode_avro_name(0, Rest, _) ->
     {[], Rest};
+decode_avro_name(NameSize, _Rest, _Count) when NameSize < 0 ->
+    throw({invalid_ans104_tags, invalid_avro_name_size});
+decode_avro_name(NameSize, Rest, _Count) when byte_size(Rest) < NameSize ->
+    throw({invalid_ans104_tags, truncated_avro_name});
 decode_avro_name(NameSize, Rest, Count) ->
     <<Name:NameSize/binary, Rest2/binary>> = Rest,
     {ValueSize, Rest3} = decode_zigzag(Rest2),
@@ -605,6 +649,10 @@ decode_avro_name(NameSize, Rest, Count) ->
 decode_avro_value(0, Name, Rest, Count) ->
     {DecodedTags, NonAvroRest} = decode_avro_tags(Rest, Count - 1),
     {[{Name, <<>>} | DecodedTags], NonAvroRest};
+decode_avro_value(ValueSize, _Name, _Rest, _Count) when ValueSize < 0 ->
+    throw({invalid_ans104_tags, invalid_avro_value_size});
+decode_avro_value(ValueSize, _Name, Rest, _Count) when byte_size(Rest) < ValueSize ->
+    throw({invalid_ans104_tags, truncated_avro_value});
 decode_avro_value(ValueSize, Name, Rest, Count) ->
     <<Value:ValueSize/binary, Rest2/binary>> = Rest,
     {DecodedTags, NonAvroRest} = decode_avro_tags(Rest2, Count - 1),
@@ -666,6 +714,59 @@ encode_tags_test() ->
     ?assertEqual(<<>>, EncodedEmpty),
     WrappedEmpty = <<0:64/little, 0:64/little>>,
     {[], <<>>} = decode_tags(WrappedEmpty).
+
+tag_size_boundary_test() ->
+    Tags = [{<<"Content-Type">>, <<"application/json">>}],
+    Body = <<"{\"ok\":true}">>,
+    EncodedTags = encode_tags(Tags),
+    Wrapped =
+        <<
+            (length(Tags)):64/little,
+            (byte_size(EncodedTags)):64/little,
+            EncodedTags/binary,
+            Body/binary
+        >>,
+    ?assertEqual({Tags, Body}, decode_tags(Wrapped)).
+
+missing_avro_tag_terminator_test() ->
+    Tags = [{<<"Content-Type">>, <<"application/json">>}],
+    EncodedTags = encode_tags(Tags),
+    TagsWithoutTerminator = binary:part(EncodedTags, 0, byte_size(EncodedTags) - 1),
+    Body = <<"{\"$schema\":\"https://example.invalid/schema\"}">>,
+    Wrapped =
+        <<
+            (length(Tags)):64/little,
+            (byte_size(TagsWithoutTerminator)):64/little,
+            TagsWithoutTerminator/binary,
+            Body/binary
+        >>,
+    ?assertThrow(
+        {invalid_ans104_tags, missing_avro_array_terminator},
+        decode_tags(Wrapped)
+    ).
+
+tag_count_mismatch_test() ->
+    Tags = [{<<"Content-Type">>, <<"application/json">>}],
+    EncodedTags = encode_tags(Tags),
+    Wrapped =
+        <<
+            (length(Tags) + 1):64/little,
+            (byte_size(EncodedTags)):64/little,
+            EncodedTags/binary
+        >>,
+    ?assertThrow({invalid_ans104_tags, tag_count_mismatch}, decode_tags(Wrapped)).
+
+residue_in_tag_section_test() ->
+    Tags = [{<<"Content-Type">>, <<"application/json">>}],
+    EncodedTags = encode_tags(Tags),
+    Wrapped =
+        <<
+            (length(Tags)):64/little,
+            (byte_size(EncodedTags) + 1):64/little,
+            EncodedTags/binary,
+            0
+        >>,
+    ?assertThrow({invalid_ans104_tags, residue_in_tag_section}, decode_tags(Wrapped)).
 
 no_tags_test() ->
     {Priv, Pub} = ar_wallet:new(),

--- a/src/dev_arweave.erl
+++ b/src/dev_arweave.erl
@@ -235,24 +235,40 @@ head_raw_ans104(TXID, ArweaveOffset, Length, Opts) ->
         {error, Error} -> {error, Error}
     end.
 do_head_raw_ans104(TXID, ArweaveOffset, Length, Data, _Opts) ->
-    {ok, HeaderSize, HeaderTX} = ar_bundles:deserialize_header(Data),
-    ContentType =
-        list_find(
-            <<"content-type">>,
-            HeaderTX#tx.tags,
-            <<"application/octet-stream">>
-        ),
-    {ok,
-        #{
-            <<"raw-id">> => TXID,
-            <<"offset">> => ArweaveOffset,
-            <<"data-offset">> => ArweaveOffset + HeaderSize,
-            <<"content-type">> => ContentType,
-            <<"header-length">> => HeaderSize,
-            <<"content-length">> => Length - HeaderSize,
-            <<"accept-ranges">> => <<"bytes">>
-        }
-    }.
+    case deserialize_ans104_header(Data) of
+        {ok, HeaderSize, HeaderTX} ->
+            ContentType =
+                list_find(
+                    <<"content-type">>,
+                    HeaderTX#tx.tags,
+                    <<"application/octet-stream">>
+                ),
+            {ok,
+                #{
+                    <<"raw-id">> => TXID,
+                    <<"offset">> => ArweaveOffset,
+                    <<"data-offset">> => ArweaveOffset + HeaderSize,
+                    <<"content-type">> => ContentType,
+                    <<"header-length">> => HeaderSize,
+                    <<"content-length">> => Length - HeaderSize,
+                    <<"accept-ranges">> => <<"bytes">>
+                }
+            };
+        Error ->
+            Error
+    end.
+
+deserialize_ans104_header(Data) ->
+    try ar_bundles:deserialize_header(Data)
+    catch
+        throw:{invalid_ans104_tags, _Reason} ->
+            {error,
+                #{
+                    <<"status">> => 400,
+                    <<"body">> => <<"Invalid ANS-104 tag encoding.">>
+                }
+            }
+    end.
 
 %% @doc Get raw transaction *data* and `content-type` of an Arweave message.
 %% Does not deserialize the message, nor return signature information. Included
@@ -1510,6 +1526,28 @@ head_raw_ans104_test_parallel() ->
     ?assertEqual(
         {ok, 575},
         hb_maps:find(<<"content-length">>, Result, Opts)
+    ).
+
+head_raw_ans104_invalid_tags_test() ->
+    Tags = [{<<"Content-Type">>, <<"application/json">>}],
+    EncodedTags = ar_bundles:encode_tags(Tags),
+    TagsWithoutTerminator = binary:part(EncodedTags, 0, byte_size(EncodedTags) - 1),
+    Body = <<"{\"$schema\":\"https://example.invalid/schema\"}">>,
+    DataItem =
+        <<
+            1, 0,
+            0:4096,
+            0:4096,
+            0,
+            0,
+            (length(Tags)):64/little,
+            (byte_size(TagsWithoutTerminator)):64/little,
+            TagsWithoutTerminator/binary,
+            Body/binary
+        >>,
+    ?assertMatch(
+        {error, #{ <<"status">> := 400 }},
+        do_head_raw_ans104(<<0:256>>, 0, byte_size(DataItem), DataItem, #{})
     ).
 
 get_raw_range_tx_test_parallel() ->


### PR DESCRIPTION
## Summary

A correctness bug in the ANS-104 tag decoder in `ar_bundles.erl` causes `~arweave@2.9/raw=<id>` requests to crash with HTTP 500 on certain bundled data items in production. The decoder ignores both `TagCount` and `TagSize` from the tag-section prefix, letting the Avro parser run past the declared tag bytes into the body — depending on what bytes follow, it crashes with `{badmatch, {<negative_int>, <body_bytes>}}`.

## Real failure observed on prod

Production currently returns HTTP 500 for these indexed bundled items:

- `XxAUuYu1XkWtSqHEwt9vfcifTEYC6e7qbi74BUi96-s`
- `2QypU0DzlTb7SrlJleMrLiMcv0YETtA9huGPC_oUmdc`
- `NXzB_T3jKk84xKw64SHojE6HCaFShGdlfYNhCbFwQ8s`
- `odnUUsNzKX7M3R-oY_ltEd04mNx5Okweb9-WPgX3VrE`

Reproduction:

```bash
curl -i '<prod>/~arweave@2.9/raw=XxAUuYu1XkWtSqHEwt9vfcifTEYC6e7qbi74BUi96-s'
```

Two parent bundles are involved:

- Block 1910204 (2026-05-03T10:35:43Z) — parent `IJ4Xtm7922re0L90WvdyYaGMWJA606E1HOlaPfFB7gg`, child items `XxAU…`, `2Qyp…`
- Block 1898177 (2026-04-15T16:41:43Z) — parent `rOW6VWvHqrvk6Z22CCOyxJx4wZYD2cPIVgHeFcKGQ5g`, child items `NXzB…`, `odnU…`

The badmatch values vary with item content (e.g. `{-62, ...}` for JSON-shaped items, `{-101709376, ...}` for image-shaped items), which is consistent with the decoder reading body bytes and interpreting them as zigzag-encoded length prefixes.

## What changes

- **Strict slice.** `decode_tags/1` requires the declared `TagSize` to fit within the remaining binary, slices exactly that many bytes for tag decoding, and verifies `length(Tags) == TagCount`.
- **Multi-block Avro arrays.** The tag-section decoder is reorganised around the Avro array protocol: one or more blocks (positive count = N items, negative count = explicit block size then |N| items, count = 0 terminates). The previous code only handled a single positive-count block.
- **Typed errors.** Recognized tag-decoding failure modes now raise `throw({invalid_ans104_tags, Reason})` with a specific reason atom (`tag_count_mismatch`, `residue_in_tag_section`, `missing_avro_array_terminator`, `truncated_avro_name`, `invalid_avro_value_size`, and so on). Top-level residue and per-block residue use distinct reasons to keep debugging unambiguous.
- **API boundary.** `dev_arweave.erl:head_raw_ans104` catches the typed throw and returns `{error, #{<<"status">> => 400, <<"body">> => <<"Invalid ANS-104 tag encoding.">>}}` instead of letting the crash escape as a 500.

## Verification on the failing items

After indexing the two affected blocks locally on this branch through copycat:

- Block 1910204: HTTP 200, 393 items indexed, 6 bundle TXs, 0 skipped
- Block 1898177: HTTP 200, 75 items indexed, 5 bundle TXs, 0 skipped

The same `~arweave@2.9/raw=<id>` requests that 500 on prod now return HTTP 400 on this branch with body `Invalid ANS-104 tag encoding.` — controlled rejection instead of a crash, on the actual failing items.

## Behavioral change

Items whose tag section is malformed under strict ANS-104 reading now return HTTP 400. Previously they could either silently mis-decode (returning a tag list with body bytes spliced into tag values) or surface as a 500 from an uncaught `badmatch`. If you know of legitimate items in the wild whose tag bytes lie outside the spec, please flag — they will now fail fast.

## Tests

- `ar_bundles:tag_size_boundary_test` — happy path with proper `TagCount`/`TagSize` prefix; verifies body bytes are not consumed by the tag decoder.
- `ar_bundles:missing_avro_tag_terminator_test` — strip the array terminator; expects `missing_avro_array_terminator`.
- `ar_bundles:tag_count_mismatch_test` — declare `TagCount + 1`; expects `tag_count_mismatch`.
- `ar_bundles:residue_in_tag_section_test` — declare `TagSize + 1` with a trailing byte; expects `residue_in_tag_section`.
- `dev_arweave:head_raw_ans104_invalid_tags_test` — synthesises an ANS-104 data item with a tag section missing its array terminator and asserts the 400 response shape.
