### PR TITLE
fix: list legacy LMDB cache children

### DIFF
--- a/src/core/resolver/hb_cache.erl
+++ b/src/core/resolver/hb_cache.erl
@@ -191,7 +191,8 @@ list(Path, Opts) when is_map(Opts) and not is_map_key(<<"store-module">>, Opts) 
 list(Path, Store) ->
     list(Path, Store, #{}).
 list(Path, Store, Opts) ->
-    case hb_store:read(Store, Path, Opts) of
+    case hb_store:list(Store, Path, Opts) of
+        {ok, Names} -> Names;
         {composite, Names} -> Names;
         _ -> []
     end.
@@ -1274,6 +1275,18 @@ write_with_only_read_only_store_test() ->
     Opts = #{ <<"store">> => [ReadOnlyStore] },
     ?assertMatch({ok, _}, write(<<"some-binary-payload">>, Opts)),
     ?assertMatch({ok, _}, write(#{ <<"hello">> => <<"world">> }, Opts)).
+
+list_lmdb_children_without_group_marker_test() ->
+    Store = hb_test_utils:test_store(hb_store_lmdb, <<"legacy-list">>),
+    Opts = #{ <<"store">> => Store },
+    try
+        hb_store:reset(Store),
+        ok = hb_store:write(Store, #{ <<"legacy/1">> => <<"one">> }, Opts),
+        ok = hb_store:write(Store, #{ <<"legacy/2">> => <<"two">> }, Opts),
+        ?assertEqual([<<"1">>, <<"2">>], lists:sort(list(<<"legacy">>, Opts)))
+    after
+        hb_store:reset(Store)
+    end.
 
 %% @doc Run a specific test with a given store module.
 run_test() ->

--- a/src/core/store/hb_store_lmdb.erl
+++ b/src/core/store/hb_store_lmdb.erl
@@ -377,13 +377,14 @@ scope(_) -> scope().
 %% @param Path Binary prefix to search for
 %% @returns {ok, [Key]} list of matching keys, {error, Reason} on failure
 list(Opts, #{ <<"list">> := Path }, _NodeOpts) ->
-    case read_resolved(Opts, hb_path:to_binary(Path)) of
+    PathBin = hb_path:to_binary(Path),
+    case read_resolved(Opts, PathBin) of
         {ok, ResolvedPath, <<"group">>} ->
             list_children(Opts, ResolvedPath);
         {ok, _ResolvedPath, _Value} ->
             {error, not_found};
         not_found ->
-            {error, not_found}
+            list_children(Opts, PathBin)
     end.
 
 list_children(Opts, ResolvedPath) ->


### PR DESCRIPTION
## Summary

Fix legacy LMDB child listing so bundler recovery can discover cached recovery state written without explicit group markers.

Older bundler cache entries write leaf pseudopaths directly, for example:

- `~bundler@1.0/tx/<txid>/status`
- `~bundler@1.0/item/<itemid>/bundle`

but they do not necessarily write a `<<"group">>` marker at the parent path. Current `hb_cache:list/2` goes through `hb_store:read/3`, so listing a parent like `~bundler@1.0/tx` returns `[]` when the parent marker is missing, even though child keys exist underneath it.

That causes startup recovery to miss old in-progress bundle states.

## What changed

- `hb_cache:list/3` now delegates to `hb_store:list/3` instead of using `hb_store:read/3`.
- `hb_store_lmdb:list/3` now falls back to listing child keys for a missing parent path, while still rejecting direct listing of simple leaf values.
- Added a regression test for LMDB children that exist without a group marker.

## Why

Bundler recovery depends on prefix listing:

- `dev_bundler_cache:load_bundle_states/1` lists `~bundler@1.0/tx`
- `dev_bundler_cache:load_items/2` lists `~bundler@1.0/item`

Without this fix, legacy LMDBs with child pseudopaths but no parent group marker look empty to recovery.

## Tests

- [x] `rebar3 eunit --module=hb_cache`
- [x] `rebar3 eunit --module=hb_store_lmdb`
