### PR TITLE
fix: dep overrides to dev template

### DIFF
--- a/src/forge/plugin/priv/_rebar.config
+++ b/src/forge/plugin/priv/_rebar.config
@@ -4,6 +4,11 @@
     {hb, {{hb_dep}}}
 ]}.
 
+{overrides, [
+    {override, cowboy, [{deps, [cowlib, ranch]}]},
+    {override, gun, [{deps, [cowlib]}]}
+]}.
+
 {plugins, [
     {plugin, {{hb_plugin}}},
     {rebar3_eunit_start,


### PR DESCRIPTION
## about 

testing `rebar3 new device name=testdev` from latest edge results in the error below because Forge device template dont inherit the root hyperbeam dependency overrides. so running  `rebar3 compile` in `/testdev`:
```
      Dep cowlib has invalid version >= 2.16.0 and < 3.0.0

```
## patch
added the same dep overrides to the generated device `rebar.config` so external dev repositories compile from a clean template

 ## repro

  - `rebar3 new device name=testdev` from `edge` fails with the cowlib error above ^
  - `install-template --local "$PWD"` from this PR branch generate a project that compile fine
  - `install-template --branch fix/plugin-rebar-config --repo https://github.com/permaweb/HyperBEAM.git` generates a project that compile as well
  