### PR TITLE
fix(forge): move template installer to repo root

### DIFF
--- a/docs/build/device-packaging.md
+++ b/docs/build/device-packaging.md
@@ -182,13 +182,13 @@ authors. Install it into the user-level rebar3 template directory from
 a HyperBEAM checkout:
 
 ```bash
-./src/forge/plugin/install-template --branch edge
+./install-template --branch edge
 ```
 
 Development checkouts can be used directly:
 
 ```bash
-./src/forge/plugin/install-template --local /path/to/hyperbeam
+./install-template --local /path/to/hyperbeam
 ```
 
 For reproducible scaffolding, use `--commit COMMIT_SHA`; for a

--- a/docs/build/external-device-repository.md
+++ b/docs/build/external-device-repository.md
@@ -37,13 +37,13 @@ From a HyperBEAM checkout, install the Forge template into your user
 rebar3 template directory:
 
 ```bash
-./src/forge/plugin/install-template --branch edge
+./install-template --branch edge
 ```
 
 Use a local checkout while developing HyperBEAM itself:
 
 ```bash
-./src/forge/plugin/install-template --local /path/to/hyperbeam
+./install-template --local /path/to/hyperbeam
 ```
 
 `--local` pins the checkout's committed `HEAD`. Commit or switch to the
@@ -53,7 +53,7 @@ template to move.
 Pin to an exact commit for reproducible local scaffolding:
 
 ```bash
-./src/forge/plugin/install-template --commit COMMIT_SHA
+./install-template --commit COMMIT_SHA
 ```
 
 The script writes only template files under

--- a/install-template
+++ b/install-template
@@ -107,7 +107,7 @@ install_template() {
     template_dir="$1"
     hb_dep="$2"
     hb_plugin="$3"
-    src="$(script_dir)/priv"
+    src="$(script_dir)/src/forge/plugin/priv"
     support="$template_dir/hyperbeam-device"
     tmp="$support.tmp.$$"
     template="$template_dir/device.template"


### PR DESCRIPTION
Expose the Forge template installer at `./install-template` so setup is easy to find from a HyperBEAM checkout. Update the script's `priv` path after the move and refresh the docs to use the root-level command.