### PR TITLE
fix: ignore hyperbeam rt dirs in forge template

### DIFF
--- a/src/forge/plugin/priv/_.gitignore
+++ b/src/forge/plugin/priv/_.gitignore
@@ -2,6 +2,8 @@ _build/
 _checkouts/
 ebin/
 .eunit/
+logs/
+cache-*/
 *.beam
 *.crashdump
 erl_crash.dump


### PR DESCRIPTION
template-generated device repos currently dont ignore some hyperbeam runtime output

repro:

  ```bash
  ./install-template --branch edge --repo https://github.com/permaweb/HyperBEAM.git
  rebar3 new device name=testdev1
  cd testdev1
  rebar3 device test
  git init
  git status --short
  ```
  
  N.B - package's `rebar3 compile` will fail on edge unless you run template with `feat/config-script` branch (more info #922)