### PR TITLE
fix: honor `load-remote-devices` value in device loader

### DIFF
--- a/src/core/device/hb_device_load.erl
+++ b/src/core/device/hb_device_load.erl
@@ -170,7 +170,7 @@ preloaded(Opts) ->
 
 %% @doc Resolve the name through `name@1.0' (safe here -- the codecs are
 %% already loaded via the high-trust path), then load the first signed,
-%% compatible implementation. Local caches are always searched; gateway
+%% compatible implementation. Local caches are always searched -- gateway
 %% lookup is gated by `load-remote-devices'.
 from_low_trust(Ref, Opts) ->
     maybe

--- a/src/core/device/hb_device_load.erl
+++ b/src/core/device/hb_device_load.erl
@@ -169,32 +169,42 @@ preloaded(Opts) ->
 %%% --------------------------------------------------------------------
 
 %% @doc Resolve the name through `name@1.0' (safe here -- the codecs are
-%% already loaded via the high-trust path), then load the first
-%% implementation -- from the wider caches, then a gateway -- that is
-%% signed by a trusted signer and compatible with this machine.
+%% already loaded via the high-trust path), then load the first signed,
+%% compatible implementation. Local caches are always searched; gateway
+%% lookup is gated by `load-remote-devices'.
 from_low_trust(Ref, Opts) ->
     maybe
         {ok, SpecID} ?= resolve_spec(Ref, Opts),
-        lazy_first(
-            fun(ID) -> verify_and_load(SpecID, ID, Opts) end,
+        LocalIterators =
             [
                 fun() ->
                     hb_util:ok_or(
                         hb_cache:match(implementation_query(SpecID), Opts),
                         []
                     )
-                end,
-                fun() ->
-                    hb_util:ok_or(
-                        hb_client_gateway:device(
-                            SpecID,
-                            trusted_signers(Opts),
-                            Opts
-                        ),
-                        []
-                    )
                 end
-            ]
+            ],
+        RemoteIterators =
+            case hb_opts:get(<<"load-remote-devices">>, false, Opts) of
+                true ->
+                    [
+                        fun() ->
+                            hb_util:ok_or(
+                                hb_client_gateway:device(
+                                    SpecID,
+                                    trusted_signers(Opts),
+                                    Opts
+                                ),
+                                []
+                            )
+                        end
+                    ];
+                false ->
+                    []
+            end,
+        lazy_first(
+            fun(ID) -> verify_and_load(SpecID, ID, Opts) end,
+            LocalIterators ++ RemoteIterators
         )
     end.
 

--- a/src/core/test/hb_ao_test_vectors.erl
+++ b/src/core/test/hb_ao_test_vectors.erl
@@ -312,6 +312,29 @@ untrusted_load_device_test() ->
         exec_dummy_device(Opts)
     ).
 
+load_remote_devices_false_skips_gateway_test() ->
+    Wallet = ar_wallet:new(),
+    Opts = #{
+        <<"load-remote-devices">> => false,
+        <<"routes">> => invalid,
+        <<"store">> => Store = hb_test_utils:test_store(hb_store_fs),
+        <<"priv-wallet">> => Wallet
+    },
+    hb_store:reset(Store),
+    SpecMsg =
+        hb_message:commit(
+            #{
+                <<"data-protocol">> => <<"ao">>,
+                <<"name">> => <<"dummy@1.0">>
+            },
+            Opts
+        ),
+    SpecID = hb_message:id(SpecMsg, signed, Opts),
+    ?assertEqual(
+        {error, not_found},
+        hb_device_load:reference(SpecID, Opts)
+    ).
+
 %%% Test vector suite
 
 resolve_simple_test(Opts) ->


### PR DESCRIPTION
spec from docs:

> | `<<"load-remote-devices">>` | bool | Whether unmatched devices may be fetched via the Arweave gateway. |


before this patch, local cache miss would still fall through to gateway lookup in `hb_device_load:from_low_trust/2` -- with this PR now local cache is always checked, and gateway lookup only happens when `Opts#{<<"load-remote-devices">> => true}`

added a minimal `load_remote_devices_false_skips_gateway_test/0` test

all `hb_ao_test_vectors` module pass: 

```
  [done in 2.407 s]
=======================================================
  All 187 tests passed.
```