### PR TITLE
impr: `device` forge testing flags

### DIFF
--- a/src/forge/plugin/src/hb_forge_args.erl
+++ b/src/forge/plugin/src/hb_forge_args.erl
@@ -14,6 +14,7 @@
 %%% {@link parse/2} to convert the parsed options into a normalised map.
 -module(hb_forge_args).
 -export([provider/6, opts/0, parse/2, scan_devices/1, package_opts/0]).
+-export([maybe_help/2]).
 -export([set_preloaded_env/1, restore_preloaded_env/1, with_preloaded_env/2]).
 -export([load_wallet/1, bootstrap_preloaded_dirs/0, bootstrap_preloaded_dirs/1]).
 -export([default_preloaded_dirs/1]).
@@ -49,10 +50,20 @@ opts() ->
             "Path to wallet keyfile used for signing."},
         {device_roots, $r, "device-roots", string,
             "Comma-separated list of dev_* roots to operate upon."},
+        {module, $m, "module", string,
+            "Comma-separated module names to run."},
+        {test, $t, "test", string,
+            "Comma-separated tests to run, optionally Module:Func1+Func2."},
+        {timeout, undefined, "timeout", string,
+            "Per-test timeout, in seconds."},
+        {timeout_multiplier, undefined, "timeout-multiplier", string,
+            "Multiplier for EUnit timeouts."},
         {with_core, undefined, "with-core", {boolean, false},
             "Also run core HyperBEAM EUnit modules."},
         {show_hash, undefined, "show-hash", {boolean, false},
-            "Show generated device module hashes in EUnit output."}
+            "Show generated device module hashes in EUnit output."},
+        {help, $h, "help", {boolean, false},
+            "Show command help."}
     ].
 
 %% @doc Convert parsed rebar command arguments into Forge's binary-keyed map.
@@ -62,6 +73,11 @@ parse(State, DefaultOutput) ->
     OutRaw = proplists:get_value(output_dir, Args, DefaultOutput),
     KeyRaw = proplists:get_value(key, Args, undefined),
     RootsRaw = proplists:get_value(device_roots, Args, undefined),
+    ModuleRaw = proplists:get_value(module, Args, undefined),
+    TestRaw = proplists:get_value(test, Args, undefined),
+    TimeoutRaw = proplists:get_value(timeout, Args, undefined),
+    TimeoutMultiplierRaw =
+        proplists:get_value(timeout_multiplier, Args, undefined),
     WithCore = proplists:get_value(with_core, Args, false),
     ShowHash = proplists:get_value(show_hash, Args, false),
     #{
@@ -70,12 +86,67 @@ parse(State, DefaultOutput) ->
         <<"key">> => maybe_bin(KeyRaw),
         <<"with-core">> => WithCore,
         <<"show-hash">> => ShowHash,
+        <<"module-names">> => parse_atom_list(ModuleRaw),
+        <<"test-specs">> => parse_test_specs(TestRaw),
+        <<"timeout">> => parse_number(TimeoutRaw),
+        <<"timeout-multiplier">> => parse_number(TimeoutMultiplierRaw),
         <<"device-roots">> =>
             case RootsRaw of
                 undefined -> all;
                 _ -> [to_bin(Root) || Root <- split_list(RootsRaw)]
             end
     }.
+
+%% @doc Print the current provider's generated help if `--help' was given.
+maybe_help(State, Module) ->
+    {Args, _Rest} = rebar_state:command_parsed_args(State),
+    case proplists:get_value(help, Args, false) of
+        true ->
+            Provider =
+                providers:get_provider_by_module(
+                    Module,
+                    rebar_state:providers(State)
+                ),
+            providers:help(Provider),
+            true;
+        false ->
+            false
+    end.
+
+%% @doc Parse a comma-separated provider option into atoms, or `all'.
+parse_atom_list(undefined) ->
+    all;
+parse_atom_list(Raw) ->
+    [binary_to_atom(Name, utf8) || Name <- split_list(Raw)].
+
+%% @doc Parse `--test' specs. Supports `Module:Fun1+Fun2' and bare funcs.
+parse_test_specs(undefined) ->
+    all;
+parse_test_specs(Raw) ->
+    lists:flatmap(fun parse_test_spec/1, split_list(Raw)).
+
+parse_test_spec(Spec) ->
+    case binary:split(Spec, <<":">>) of
+        [Funs] ->
+            [{all, parse_test_funs(Funs)}];
+        [Mod, Funs] ->
+            [{binary_to_atom(Mod, utf8), parse_test_funs(Funs)}]
+    end.
+
+parse_test_funs(Funs) ->
+    [binary_to_atom(Fun, utf8)
+        || Fun <- binary:split(Funs, <<"+">>, [global]),
+           Fun =/= <<>>].
+
+%% @doc Parse a numeric provider option, preserving `undefined'.
+parse_number(undefined) ->
+    undefined;
+parse_number(Raw) ->
+    Bin = to_bin(Raw),
+    try binary_to_integer(Bin)
+    catch
+        error:badarg -> binary_to_float(Bin)
+    end.
 
 %% @doc Split a comma-separated provider option into trimmed binary values.
 split_list(List) when is_list(List) ->

--- a/src/forge/plugin/src/hb_forge_local.erl
+++ b/src/forge/plugin/src/hb_forge_local.erl
@@ -21,6 +21,12 @@ init(State) ->
 
 %% @doc Build a preloaded-store and start a shell pointed at it.
 do(State) ->
+    case hb_forge_args:maybe_help(State, ?MODULE) of
+        true -> {ok, State};
+        false -> do_run(State)
+    end.
+
+do_run(State) ->
     Args = hb_forge_args:parse(State, <<"_build/device-local-store">>),
     case hb_forge_preload:run(Args, #{}) of
         {ok, Result} ->

--- a/src/forge/plugin/src/hb_forge_package.erl
+++ b/src/forge/plugin/src/hb_forge_package.erl
@@ -21,6 +21,12 @@ init(State) ->
 
 %% @doc Parse CLI args and emit generated package archives.
 do(State) ->
+    case hb_forge_args:maybe_help(State, ?MODULE) of
+        true -> {ok, State};
+        false -> do_run(State)
+    end.
+
+do_run(State) ->
     Args = hb_forge_args:parse(State, <<"_build/device-packages">>),
     case run_with_args(Args) of
         {ok, _Pkgs} -> {ok, State};

--- a/src/forge/plugin/src/hb_forge_preload.erl
+++ b/src/forge/plugin/src/hb_forge_preload.erl
@@ -29,6 +29,12 @@ init(State) ->
 
 %% @doc Parse CLI args and build a signed preloaded-store.
 do(State) ->
+    case hb_forge_args:maybe_help(State, ?MODULE) of
+        true -> {ok, State};
+        false -> do_run(State)
+    end.
+
+do_run(State) ->
     Args = hb_forge_args:parse(State, <<"_build/preloaded-store">>),
     case run(Args, default_node_opts()) of
         {ok, _Result} -> {ok, State};

--- a/src/forge/plugin/src/hb_forge_publish.erl
+++ b/src/forge/plugin/src/hb_forge_publish.erl
@@ -22,6 +22,12 @@ init(State) ->
 
 %% @doc Package, sign, and upload selected devices through the Arweave store.
 do(State) ->
+    case hb_forge_args:maybe_help(State, ?MODULE) of
+        true -> {ok, State};
+        false -> do_run(State)
+    end.
+
+do_run(State) ->
     Args = hb_forge_args:parse(State, <<"_build/device-publish-store">>),
     KeyPath = maps:get(<<"key">>, Args),
     Wallet = hb_forge_args:load_wallet(KeyPath),
@@ -35,7 +41,8 @@ do(State) ->
             <<"priv-wallet">> => Wallet,
             <<"preloaded-store">> => maps:get(store, Preload),
             <<"preloaded-devices-index">> => maps:get(index, Preload),
-            <<"bootstrap-device-src">> => hb_forge_args:bootstrap_preloaded_dirs(),
+            <<"bootstrap-device-src">> =>
+                hb_forge_args:bootstrap_preloaded_dirs(),
             <<"store">> =>
                 [#{ <<"store-module">> => hb_store_arweave }]
         },
@@ -61,7 +68,10 @@ do(State) ->
                 [maps:get(device_name, Pkg), SpecID, ImplID]
             )
         end,
-        hb_packager:package_all(hb_forge_args:scan_devices(Args), NodeOpts)
+        hb_packager:package_all(
+            hb_forge_args:scan_devices(Args),
+            NodeOpts
+        )
     ),
     {ok, State}.
 

--- a/src/forge/plugin/src/hb_forge_test.erl
+++ b/src/forge/plugin/src/hb_forge_test.erl
@@ -30,7 +30,6 @@ do(State) ->
 
 do_run(State) ->
     Args = hb_forge_args:parse(State, <<"_build/device-test-store">>),
-    CoreTests = maybe_compile_core_test_modules(Args),
     % Build a complete store from the configured source set so selected
     % device tests can resolve their dependencies.
     {ok, Result} =
@@ -54,6 +53,8 @@ do_run(State) ->
         ],
     Modules = lists:usort(lists:append([archive_modules(Pkg) || Pkg <- Pkgs])),
     ModuleLabels = device_module_labels(Pkgs),
+    SourceLabels = device_source_labels(Groups, Pkgs),
+    CoreTests = maybe_compile_core_test_modules(Args, ModuleLabels, SourceLabels),
     Names = [maps:get(device_name, Pkg) || Pkg <- Pkgs],
     case Names of
         [] ->
@@ -72,6 +73,7 @@ do_run(State) ->
                                 CoreModules,
                                 Modules ++ TestModules,
                                 ModuleLabels,
+                                SourceLabels,
                                 Args,
                                 Result
                             )
@@ -88,18 +90,46 @@ archive_modules(Pkg) ->
     [Mod || {Mod, _File, _Beam} <- Modules].
 
 %% @doc Run EUnit with the generated preloaded-store environment installed.
-test_modules(State, Names, CoreModules, DeviceModules, ModuleLabels, Args, Result) ->
+test_modules(
+    State,
+    Names,
+    CoreModules,
+    DeviceModules,
+    ModuleLabels,
+    SourceLabels,
+    Args,
+    Result
+) ->
     ShowHash = maps:get(<<"show-hash">>, Args, false),
+    ModuleNames = maps:get(<<"module-names">>, Args, all),
+    TestSpecs = maps:get(<<"test-specs">>, Args, all),
     Env = setup_device_tests(Names, Result),
     EUnitResult =
         try
-            Tests = test_order(
-                CoreModules,
-                device_tests(DeviceModules, ModuleLabels, ShowHash)
+            {SelectedCoreModules, SelectedDeviceModules} =
+                filter_modules(
+                    CoreModules,
+                    DeviceModules,
+                    ModuleLabels,
+                    SourceLabels,
+                    module_filter(ModuleNames, TestSpecs)
+                ),
+            Tests = selected_tests(
+                SelectedCoreModules,
+                SelectedDeviceModules,
+                ModuleLabels,
+                SourceLabels,
+                ShowHash,
+                ModuleNames,
+                TestSpecs
             ),
-            rebar_api:info(
-                "device test: running EUnit modules ~p",
-                [test_names(CoreModules, DeviceModules, ModuleLabels, ShowHash)]
+            log_run(
+                SelectedCoreModules,
+                SelectedDeviceModules,
+                ModuleLabels,
+                ShowHash,
+                ModuleNames,
+                TestSpecs
             ),
             eunit:test(Tests, [verbose, {scale_timeouts, 10}])
         after restore_test_env(Env)
@@ -109,6 +139,153 @@ test_modules(State, Names, CoreModules, DeviceModules, ModuleLabels, Args, Resul
         error -> {error, format_error(eunit_failed)};
         Other -> {error, format_error({eunit_failed, Other})}
     end.
+
+%% @doc Build the EUnit descriptor list, narrowed by `--module'/`--test'.
+selected_tests(
+    CoreModules,
+    DeviceModules,
+    ModuleLabels,
+    SourceLabels,
+    ShowHash,
+    ModuleNames,
+    TestSpecs
+) ->
+    case TestSpecs of
+        all ->
+            test_order(
+                CoreModules,
+                device_tests(DeviceModules, ModuleLabels, ShowHash)
+            );
+        _ ->
+            Descriptors =
+                [
+                    named_test_descriptor(Mod, Fun, Label, Type)
+                ||
+                    Mod <- CoreModules ++ DeviceModules,
+                    Fun0 <- matching_test_funs(
+                        Mod, ModuleLabels, SourceLabels, TestSpecs
+                    ),
+                    {Fun, Type} <- resolve_test_fun(Mod, Fun0),
+                    Label <- [test_label(Mod, ModuleLabels, ShowHash)]
+                ],
+            case Descriptors of
+                [] ->
+                    rebar_api:warn(
+                        "device test: no test matched --module ~p --test ~p",
+                        [ModuleNames, TestSpecs]
+                    );
+                _ ->
+                    ok
+            end,
+            Descriptors
+    end.
+
+%% @doc Apply `--module', or module-qualified `--test' when no module was given.
+module_filter(all, all) ->
+    all;
+module_filter(all, TestSpecs) ->
+    case [Mod || {Mod, _Funs} <- TestSpecs, Mod =/= all] of
+        [] -> all;
+        Mods -> lists:usort(Mods)
+    end;
+module_filter(ModuleNames, _TestSpecs) ->
+    ModuleNames.
+
+%% @doc Narrow core and device module lists using generated/source/label names.
+filter_modules(CoreModules, DeviceModules, _ModuleLabels, _SourceLabels, all) ->
+    {CoreModules, DeviceModules};
+filter_modules(CoreModules, DeviceModules, ModuleLabels, SourceLabels, Names) ->
+    Keep =
+        fun(Mod) ->
+            lists:any(
+                fun(Name) -> module_matches(Mod, Name, ModuleLabels, SourceLabels) end,
+                Names
+            )
+        end,
+    Filtered =
+        {
+            [Mod || Mod <- CoreModules, Keep(Mod)],
+            [Mod || Mod <- DeviceModules, Keep(Mod)]
+        },
+    case Filtered of
+        {[], []} ->
+            rebar_api:warn(
+                "device test: no module matched --module ~p", [Names]
+            );
+        _ ->
+            ok
+    end,
+    Filtered.
+
+matching_test_funs(Mod, ModuleLabels, SourceLabels, TestSpecs) ->
+    lists:usort(
+        lists:flatmap(
+            fun
+                ({all, Funs}) ->
+                    Funs;
+                ({Name, Funs}) ->
+                    case module_matches(Mod, Name, ModuleLabels, SourceLabels) of
+                        true -> Funs;
+                        false -> []
+                    end
+            end,
+            TestSpecs
+        )
+    ).
+
+module_matches(Mod, Name, ModuleLabels, SourceLabels) ->
+    Name =:= Mod orelse
+        Name =:= maps:get(Mod, ModuleLabels, undefined) orelse
+        Name =:= maps:get(Mod, SourceLabels, undefined).
+
+%% @doc EUnit descriptor for an explicitly named test or generator.
+named_test_descriptor(Mod, Fun, Label, generator) ->
+    {
+        generator,
+        fun() -> rewrite_test_term(apply(Mod, Fun, []), Mod, Label) end,
+        {Label, Fun, 0}
+    };
+named_test_descriptor(Mod, Fun, Label, test) ->
+    {{Label, Fun, 0}, {test, Mod, Fun}}.
+
+%% @doc Resolve a requested `-t' name, treating matching `_test_' as generator.
+resolve_test_fun(Mod, Fun) ->
+    code:ensure_loaded(Mod),
+    case erlang:function_exported(Mod, Fun, 0) of
+        true ->
+            [
+                {
+                    Fun,
+                    case lists:suffix("_test_", atom_to_list(Fun)) of
+                        true -> generator;
+                        false -> test
+                    end
+                }
+            ];
+        false ->
+            Gen = binary_to_atom(<<(atom_to_binary(Fun, utf8))/binary, "_">>, utf8),
+            case erlang:function_exported(Mod, Gen, 0) of
+                true -> [{Gen, generator}];
+                false -> []
+            end
+    end.
+
+test_label(Mod, _ModuleLabels, true) ->
+    Mod;
+test_label(Mod, ModuleLabels, false) ->
+    maps:get(Mod, ModuleLabels, Mod).
+
+%% @doc Log what this run will execute before EUnit starts.
+log_run(CoreModules, DeviceModules, ModuleLabels, ShowHash, all, all) ->
+    rebar_api:info(
+        "device test: running EUnit modules ~p",
+        [test_names(CoreModules, DeviceModules, ModuleLabels, ShowHash)]
+    );
+log_run(CoreModules, DeviceModules, ModuleLabels, ShowHash, _ModuleNames, TestSpecs) ->
+    rebar_api:info(
+        "device test: running modules ~p tests ~p",
+        [test_names(CoreModules, DeviceModules, ModuleLabels, ShowHash), TestSpecs]
+    ).
 
 %% @doc Run core tests first, but defer `hb_opts' until env vars are set.
 test_order(CoreModules, DeviceModules) ->
@@ -146,6 +323,49 @@ pkg_module_labels(Pkg) ->
     Root = maps:get(module_name, Pkg),
     Device = maps:get(device_name, Pkg),
     [{Mod, module_label(Device, Root, Mod)} || Mod <- archive_modules(Pkg)].
+
+%% @doc Map generated archive module atoms back to original source modules.
+device_source_labels(Groups, Pkgs) ->
+    maps:from_list(
+        lists:flatmap(fun(Group) -> group_source_labels(Group, Pkgs) end, Groups)
+    ).
+
+group_source_labels(Group, Pkgs) ->
+    Device = hb_packager:group_device_name(Group),
+    case [Pkg || Pkg <- Pkgs, maps:get(device_name, Pkg) =:= Device] of
+        [Pkg] ->
+            RootMod = maps:get(module_name, Pkg),
+            Root = maps:get(root, Group),
+            Entries =
+                [{Root, maps:get(root_file, Group)}] ++
+                maps:get(helpers, Group, []) ++
+                maps:get(libraries, Group, []),
+            [
+                {generated_module(RootMod, Root, Mod), Mod}
+             ||
+                {Mod, _Path} <- Entries
+            ];
+        [] ->
+            []
+    end.
+
+generated_module(RootMod, Root, Root) ->
+    RootMod;
+generated_module(RootMod, Root, Mod) ->
+    "dev_" ++ RootTail = atom_to_list(Root),
+    RootPrefix = "dev_" ++ RootTail ++ "_",
+    ModStr = atom_to_list(Mod),
+    Tail =
+        case {lists:prefix(RootPrefix, ModStr), lists:prefix("lib_", ModStr)} of
+            {true, _} -> lists:nthtail(length(RootPrefix), ModStr);
+            {_, true} -> lists:nthtail(length("lib_"), ModStr);
+            _ -> ModStr
+        end,
+    binary_to_atom(
+        <<(atom_to_binary(RootMod, utf8))/binary, "__",
+            (hb_device_name:sanitize(Tail))/binary>>,
+        utf8
+    ).
 
 module_label(Device, Root, Root) ->
     binary_to_atom(Device, utf8);
@@ -406,11 +626,37 @@ purge_test_module(Mod) ->
     code:delete(Mod),
     code:purge(Mod).
 
-%% @doc Compile core tests only when the caller opts into `--with-core'.
-maybe_compile_core_test_modules(#{ <<"with-core">> := true }) ->
+%% @doc Compile core tests when requested, or when filters name core modules.
+maybe_compile_core_test_modules(
+    #{ <<"with-core">> := true },
+    _ModuleLabels,
+    _SourceLabels
+) ->
     compile_core_test_modules();
-maybe_compile_core_test_modules(_Args) ->
-    none.
+maybe_compile_core_test_modules(Args, ModuleLabels, SourceLabels) ->
+    case filter_needs_core(Args, ModuleLabels, SourceLabels) of
+        true -> compile_core_test_modules();
+        false -> none
+    end.
+
+filter_needs_core(Args, ModuleLabels, SourceLabels) ->
+    ModuleNames = maps:get(<<"module-names">>, Args, all),
+    TestSpecs = maps:get(<<"test-specs">>, Args, all),
+    case module_filter(ModuleNames, TestSpecs) of
+        all ->
+            TestSpecs =/= all;
+        Names ->
+            lists:any(
+                fun(Name) -> not device_module_name(Name, ModuleLabels, SourceLabels) end,
+                Names
+            )
+    end.
+
+device_module_name(Name, ModuleLabels, SourceLabels) ->
+    lists:any(
+        fun(Mod) -> module_matches(Mod, Name, ModuleLabels, SourceLabels) end,
+        maps:keys(ModuleLabels) ++ maps:keys(SourceLabels)
+    ).
 
 %% @doc Run `Fun' with core test modules available when requested.
 with_core_test_modules(none, Fun) when is_function(Fun, 1) ->

--- a/src/forge/plugin/src/hb_forge_test.erl
+++ b/src/forge/plugin/src/hb_forge_test.erl
@@ -23,6 +23,12 @@ init(State) ->
 
 %% @doc Build a test preloaded-store and run selected package EUnit modules.
 do(State) ->
+    case hb_forge_args:maybe_help(State, ?MODULE) of
+        true -> {ok, State};
+        false -> do_run(State)
+    end.
+
+do_run(State) ->
     Args = hb_forge_args:parse(State, <<"_build/device-test-store">>),
     CoreTests = maybe_compile_core_test_modules(Args),
     % Build a complete store from the configured source set so selected

--- a/src/forge/plugin/src/hb_forge_test.erl
+++ b/src/forge/plugin/src/hb_forge_test.erl
@@ -131,7 +131,7 @@ test_modules(
                 ModuleNames,
                 TestSpecs
             ),
-            eunit:test(Tests, [verbose, {scale_timeouts, 10}])
+            eunit:test(timeout_tests(Tests, Args), eunit_opts(Args))
         after restore_test_env(Env)
         end,
     case EUnitResult of
@@ -286,6 +286,27 @@ log_run(CoreModules, DeviceModules, ModuleLabels, ShowHash, _ModuleNames, TestSp
         "device test: running modules ~p tests ~p",
         [test_names(CoreModules, DeviceModules, ModuleLabels, ShowHash), TestSpecs]
     ).
+
+%% @doc Apply a caller-supplied timeout to each top-level EUnit descriptor.
+timeout_tests(Tests, #{ <<"timeout">> := undefined }) ->
+    Tests;
+timeout_tests(Tests, #{ <<"timeout">> := Timeout })
+        when is_number(Timeout), Timeout >= 0 ->
+    [{timeout, Timeout, Test} || Test <- Tests];
+timeout_tests(_Tests, #{ <<"timeout">> := Timeout }) ->
+    error({invalid_timeout, Timeout}).
+
+%% @doc EUnit options, preserving the historical timeout multiplier by default.
+eunit_opts(#{ <<"timeout-multiplier">> := Multiplier })
+        when is_number(Multiplier), Multiplier >= 0 ->
+    [verbose, {scale_timeouts, Multiplier}];
+eunit_opts(#{ <<"timeout-multiplier">> := Multiplier })
+        when Multiplier =/= undefined ->
+    error({invalid_timeout_multiplier, Multiplier});
+eunit_opts(#{ <<"timeout">> := Timeout }) when Timeout =/= undefined ->
+    [verbose, {scale_timeouts, 1}];
+eunit_opts(_Args) ->
+    [verbose, {scale_timeouts, 10}].
 
 %% @doc Run core tests first, but defer `hb_opts' until env vars are set.
 test_order(CoreModules, DeviceModules) ->

--- a/src/forge/plugin/src/hb_forge_verify.erl
+++ b/src/forge/plugin/src/hb_forge_verify.erl
@@ -24,6 +24,12 @@ init(State) ->
 
 %% @doc Package selected devices and load each archive via the runtime loader.
 do(State) ->
+    case hb_forge_args:maybe_help(State, ?MODULE) of
+        true -> {ok, State};
+        false -> do_run(State)
+    end.
+
+do_run(State) ->
     Args = hb_forge_args:parse(State, <<"_build/device-packages">>),
     Failures =
         hb_forge_seed:with_forge_bootstrap(


### PR DESCRIPTION
This PR adds a series of small helpers to the device forge to improve DevX:

*   **Improved Test Filtering:** Adds `-m | --module` and `-t | --test` options, allowing developers to specify which EUnit modules to run. If `dev_` names are given, the packaged device ID is automatically chosen behind the scenes, but if a kernel module (`hb_`) is given it is left as-is. This makes the interface match `rebar3 eunit` without the developer having to be concerned with device name->ID translation.
*   **Test Timeouts:** Introduces `--timeout` to set per-test timeouts and `--timeout-multiplier` to scale existing EUnit timeouts, providing better control over test duration and preventing excessively long runs.
*   **Contextual Help:** Implements a `--help` option for all Forge providers, displaying relevant usage information specific to each command.
*   **Improved Core Test Inclusion:** Core HyperBEAM EUnit modules are now automatically included if named by filtering options, even if `--with-core` is not explicitly set.
*   **Source Module Mapping:** Adds logic to map generated device module names back to their original source files, enabling filtering based on more intuitive source names.