### PR TITLE
fix: run parallel generator tests

### DIFF
--- a/src/core/test/hb_test_parallel.erl
+++ b/src/core/test/hb_test_parallel.erl
@@ -5,7 +5,9 @@
 %%% `_test_parallel_' is treated as a parallel test: the transform
 %%% auto-exports it and -- when the module does not already define one --
 %%% injects an `all_parallel_test_/0' generator that runs all such
-%%% functions in a single `{inparallel, ...}' EUnit batch.
+%%% functions in a single `{inparallel, ...}' EUnit batch. A generator
+%%% may return `{serial, Test}' to run after that batch when it uses
+%%% shared global state that would make the benchmark/test meaningless.
 %%%
 %%% Because the `_test_parallel' suffix does not match EUnit's own
 %%% `_test'/`_test_' auto-discovery, the original function names are not
@@ -48,13 +50,34 @@ all(Module) ->
                     is_parallel_test_name(F)
             ]
         ),
-    {inparallel,
-        [
-            {atom_to_list(F), fun Module:F/0}
-        ||
-            F <- Funs
-        ]
-    }.
+    {Parallel, Serial} =
+        lists:foldr(
+            fun(F, {ParallelAcc, SerialAcc}) ->
+                Name = atom_to_list(F),
+                case parallel_test(Module, F, Name) of
+                    {serial, Test} -> {ParallelAcc, [Test | SerialAcc]};
+                    Test -> {[Test | ParallelAcc], SerialAcc}
+                end
+            end,
+            {[], []},
+            Funs
+        ),
+    case {Parallel, Serial} of
+        {_, []} -> {inparallel, Parallel};
+        {[], _} -> {inorder, Serial};
+        _ -> {inorder, [{inparallel, Parallel} | Serial]}
+    end.
+
+parallel_test(Module, F, Name) ->
+    case lists:suffix(?GENERATOR_SUFFIX, Name) of
+        true ->
+            case Module:F() of
+                {serial, Test} -> {serial, {Name, Test}};
+                Test -> {Name, Test}
+            end;
+        false ->
+            {Name, fun Module:F/0}
+    end.
 
 %%% Compiler entry point.
 

--- a/src/core/test/hb_test_utils.erl
+++ b/src/core/test/hb_test_utils.erl
@@ -39,10 +39,11 @@ test_store(Mod, Tag) ->
 %% Each element may also contain a `skip' key with a list of test names to skip.
 %% They can also contain a `desc' key with a description of the options.
 suite_with_opts(Suite, OptsList) ->
-    {inparallel,
+    Tests =
         lists:filtermap(
             fun(OptSpec = #{ name := _Name, opts := Opts, desc := ODesc}) ->
                 Skip = hb_maps:get(skip, OptSpec, [], Opts),
+                Timeout = hb_maps:get(timeout, OptSpec, no_timeout, Opts),
                 case satisfies_requirements(OptSpec) of
                     true ->
                         Tests =
@@ -78,12 +79,15 @@ suite_with_opts(Suite, OptsList) ->
                                 end,
                                 [
                                     fun(FreshOpts) ->
-                                        {
+                                        Desc =
                                             hb_util:list(ODesc)
                                                 ++ ": "
                                                 ++ hb_util:list(TestDesc),
-                                            fun() -> Test(FreshOpts) end
-                                        }
+                                        TestFun = fun() -> Test(FreshOpts) end,
+                                        case Timeout of
+                                            no_timeout -> {Desc, TestFun};
+                                            _ -> {Desc, {timeout, Timeout, TestFun}}
+                                        end
                                     end
                                 ||
                                     {TestDesc, Test} <- Tests
@@ -97,8 +101,16 @@ suite_with_opts(Suite, OptsList) ->
                 end
             end,
             OptsList
-        )
-    }.
+        ),
+    Serial =
+        lists:any(
+            fun(OptSpec) -> maps:get(parallel, OptSpec, true) == false end,
+            OptsList
+        ),
+    case Serial of
+        true -> Tests;
+        false -> {inparallel, Tests}
+    end.
 
 %% @doc Derive a fresh store for a single test based on the options' store
 %% template. For `hb_store_volatile' stores (the default test store), each
@@ -233,7 +245,6 @@ benchmark_iterations(Fun, N) ->
 %% @doc Run multiple instances of a function in parallel for a given amount of time.
 benchmark(Fun, TLen, Procs) ->
     Parent = self(),
-    receive _ -> worker_synchronized end,
     StartWorker =
         fun(_) ->
             Ref = make_ref(),

--- a/src/preloaded/node/dev_router.erl
+++ b/src/preloaded/node/dev_router.erl
@@ -838,7 +838,9 @@ preprocess(Base, RawReq, Opts) ->
 
 %%% Tests
 
-test_provider_test_parallel() ->
+test_provider_test_parallel_() ->
+    {timeout, 30, fun test_provider/0}.
+test_provider() ->
     Node =
         hb_http_server:start_node(Opts =
             #{
@@ -863,7 +865,9 @@ test_provider_test_parallel() ->
         hb_http:get(Node, <<"/~router@1.0/routes/1/node">>, Opts)
     ).
 
-dynamic_provider_test_parallel() ->
+dynamic_provider_test_parallel_() ->
+    {timeout, 30, fun dynamic_provider/0}.
+dynamic_provider() ->
     {ok, Script} = file:read_file("test/test.lua"),
     Node = hb_http_server:start_node(#{
         <<"store">> => hb_test_utils:test_store(),
@@ -1008,7 +1012,7 @@ local_dynamic_router() ->
     ),
     % Force computation of the current state. This should be done with a 
     % background worker (ex: a `~cron@1.0/every' task).
-    hb_http:get(Node, <<"/router~node-process@1.0/now">>, #{}),
+    hb_http:get(Node, <<"/router1~node-process@1.0/now">>, #{}),
     {ok, Routes} = hb_http:get(Node, RouteProvider, Opts),
     ?event(debug_dynrouter, {got_routes, Routes}),
     % Query the route 10 times with the same path. This should yield 2 different
@@ -1066,9 +1070,21 @@ dynamic_router_pricing() ->
     {ok, ClientScript} = file:read_file("scripts/hyper-token-p4-client.lua"),
     {ok, TokenScript} = file:read_file("scripts/hyper-token.lua"),
     {ok, ProcessScript} = file:read_file("scripts/hyper-token-p4.lua"),
-    ExecWallet = hb:wallet(<<"test/admissible-report-wallet.json">>),
+    ExecWallet = ar_wallet:new(),
     ProxyWallet = ar_wallet:new(),
     ExecNodeAddr = hb_util:human_id(ar_wallet:to_address(ExecWallet)),
+    RouterHook =
+        #{
+            <<"request">> => #{
+                <<"device">> => <<"router@1.0">>,
+                <<"path">> => <<"preprocess">>,
+                <<"commit-request">> => true
+            }
+        },
+    RouteProvider = #{
+        <<"path">> =>
+            <<"/router2~node-process@1.0/compute/routes~message@1.0">>
+    },
     Processor =
         #{
             <<"device">> => <<"p4@1.0">>,
@@ -1143,19 +1159,7 @@ dynamic_router_pricing() ->
         <<"port">> => 10010,
         <<"store">> => hb_test_utils:test_store(),
         <<"priv-wallet">> => ProxyWallet,
-        <<"on">> => 
-            #{
-                <<"request">> => #{
-                    <<"device">> => <<"router@1.0">>,
-                    <<"path">> => <<"preprocess">>,
-                    <<"commit-request">> => true
-                }
-            },
         <<"router-opts">> => #{
-            <<"provider">> => #{
-                <<"path">> =>
-                    <<"/router2~node-process@1.0/compute/routes~message@1.0">>
-            },
             <<"registrar">> => #{
                 <<"path">> => <<"/router2~node-process@1.0">>
             },
@@ -1196,6 +1200,16 @@ dynamic_router_pricing() ->
             <<"/~router@1.0/register">>,
             #{}
         ),
+    RouterServerID = hb_util:human_id(ar_wallet:to_address(ProxyWallet)),
+    LiveRouterOpts0 =
+        hb_http_server:get_opts(#{ <<"http-server">> => RouterServerID }),
+    RouterOpts0 = hb_opts:get(router_opts, #{}, LiveRouterOpts0),
+    ok =
+        hb_http_server:set_opts(
+            LiveRouterOpts0#{
+                <<"router-opts">> => RouterOpts0#{ <<"provider">> => RouteProvider }
+            }
+        ),
     % Force computation of the current state.
     {Status, _NodeRoutes} =
         hb_http:get(
@@ -1204,6 +1218,8 @@ dynamic_router_pricing() ->
             #{}
         ),
     ?assertEqual(ok, Status),
+    LiveRouterOpts = hb_http_server:get_opts(#{ <<"http-server">> => RouterServerID }),
+    ok = hb_http_server:set_opts(LiveRouterOpts#{ <<"on">> => RouterHook }),
     % Check that path /c is free
     {ok, CRes} = hb_http:get(RouterNode, <<"/c?c+list=1">>, #{}),
     ?event(debug_dynrouter, {res_msg, CRes}),
@@ -1224,6 +1240,13 @@ dynamic_router() ->
     {ok, Module} = file:read_file(<<"scripts/dynamic-router.lua">>),
     ExecWallet = hb:wallet(<<"test/admissible-report-wallet.json">>),
     ProxyWallet = ar_wallet:new(),
+    RouterHook =
+        #{
+            <<"request">> => #{
+                <<"device">> => <<"router@1.0">>,
+                <<"path">> => <<"preprocess">>
+            }
+        },
     ExecNode =
         hb_http_server:start_node(
             ExecOpts = #{ <<"priv-wallet">> => ExecWallet, <<"store">> => hb_test_utils:test_store() }
@@ -1247,13 +1270,6 @@ dynamic_router() ->
         ],
         <<"store">> => hb_test_utils:test_store(),
         <<"priv-wallet">> => ProxyWallet,
-        <<"on">> => 
-            #{
-                <<"request">> => #{
-                    <<"device">> => <<"router@1.0">>,
-                    <<"path">> => <<"preprocess">>
-                }
-            },
         <<"router-opts">> => #{
             <<"provider">> => #{
                 <<"path">> => <<"/router~node-process@1.0/compute/routes~message@1.0">>
@@ -1287,7 +1303,7 @@ dynamic_router() ->
     % Register workers with the dynamic router with varied prices.
     {ok, [Req]} = file:consult(<<"test/admissible-report.eterm">>),
     lists:foreach(fun(X) ->
-        {ok, Res} = 
+        {ok, Res} =
             hb_http:post(
                 Node,
                 #{
@@ -1317,6 +1333,9 @@ dynamic_router() ->
     {Status, NodeRoutes} = hb_http:get(Node, <<"/router~node-process@1.0/now/at-slot">>, #{}),
     ?event(debug_dynrouter, {got_node_routes, NodeRoutes}),
     ?assertEqual(ok, Status),
+    ProxyServerID = hb_util:human_id(ar_wallet:to_address(ProxyWallet)),
+    LiveProxyOpts = hb_http_server:get_opts(#{ <<"http-server">> => ProxyServerID }),
+    ok = hb_http_server:set_opts(LiveProxyOpts#{ <<"on">> => RouterHook }),
     ProxyWalletAddr = hb_util:human_id(ar_wallet:to_address(ProxyWallet)),
     ExecNodeAddr = hb_util:human_id(ar_wallet:to_address(ExecWallet)),
     % Ensure that the `~meta@1.0/info/address' response is produced by the
@@ -1461,7 +1480,15 @@ dynamic_routing_by_performance() ->
         end,
         lists:seq(1, BenchRoutes)
     ),
-    timer:sleep(150),
+    ?assert(hb_util:wait_until(
+        fun() ->
+            case hb_http:get(Node, <<"/perf-router~node-process@1.0/slot/current">>, Opts) of
+                {ok, Slot} when Slot >= TestNodes + BenchRoutes -> true;
+                _ -> false
+            end
+        end,
+        5000
+    )),
     % Call `recalculate' on the router process and get the resulting weight
     % table.
     hb_http:post(
@@ -1777,7 +1804,9 @@ device_call_from_singleton_test_parallel() ->
     ).
     
 
-get_routes_test_parallel() ->
+get_routes_test_parallel_() ->
+    {timeout, 30, fun get_routes/0}.
+get_routes() ->
     Node = hb_http_server:start_node(
         #{
             <<"force-signed">> => false,
@@ -1795,7 +1824,9 @@ get_routes_test_parallel() ->
     {ok, Recvd} = Res,
     ?assertMatch(<<"our_node">>, Recvd).
 
-add_route_test_parallel() ->
+add_route_test_parallel_() ->
+    {timeout, 30, fun add_route/0}.
+add_route() ->
     Owner = ar_wallet:new(),
     Node = hb_http_server:start_node(
         #{
@@ -1833,7 +1864,9 @@ add_route_test_parallel() ->
 
 %% @doc Test that the `preprocess/3' function re-routes a request to remote
 %% peers via `~relay@1.0', according to the node's routing table.
-request_hook_reroute_to_nearest_test_parallel() ->
+request_hook_reroute_to_nearest_test_parallel_() ->
+    {timeout, 30, fun request_hook_reroute_to_nearest/0}.
+request_hook_reroute_to_nearest() ->
     Peer1 = hb_http_server:start_node(#{ <<"priv-wallet">> => W1 = ar_wallet:new() }),
     Peer2 = hb_http_server:start_node(#{ <<"priv-wallet">> => W2 = ar_wallet:new() }),
     Address1 = hb_util:human_id(ar_wallet:to_address(W1)),
@@ -1961,7 +1994,7 @@ route_nearest_integer_preserves_opts_test_parallel() ->
 route_multirequest_parallel_limit_test_parallel_() ->
     {timeout, 30, fun route_multirequest_parallel_limit/0}.
 route_multirequest_parallel_limit() ->
-    DelayMs = 300,
+    DelayMs = 1000,
     WorkerNodes =
         lists:map(
             fun(N) ->
@@ -2025,17 +2058,19 @@ route_multirequest_parallel_limit() ->
             ]
         ),
     ?assertEqual([1, 2, 3], WorkerBodies),
-    % With 3 peers of 300ms each: `parallel = 2` should complete in about two
-    % waves (~600ms), not one (~300ms) or fully serial (~900ms).
+    % With 3 peers and `parallel = 2`, this should complete in two waves,
+    % not one wave or fully serial.
     ?event({duration, Duration}),
-    ?assert(Duration >= 600),
-    ?assert(Duration < 900).
+    ?assert(Duration >= DelayMs * 2),
+    ?assert(Duration < DelayMs * 3).
 
 %% @doc Test that a full production-style route configuration (matching a
 %% typical config.json) resolves every request type correctly: single-node
 %% prefix routes, multi-node All-strategy routes, Nearest-Integer chunk
 %% routes, match/with regex routes, and fallback routes.
-full_route_config_test_parallel() ->
+full_route_config_test_parallel_() ->
+    {timeout, 60, fun full_route_config/0}.
+full_route_config() ->
     Routes =
         [
             #{

--- a/src/preloaded/process/dev_scheduler.erl
+++ b/src/preloaded/process/dev_scheduler.erl
@@ -1875,14 +1875,20 @@ http_get_json_schedule_test_parallel_() ->
 
 single_resolution(Opts) ->
     start(),
-    BenchTime = 0.25,
     Wallet = hb_opts:get(priv_wallet, hb:wallet(), Opts),
-    Base = test_process(Opts#{ <<"priv-wallet">> => Wallet }),
+    SignedOpts = Opts#{ <<"priv-wallet">> => Wallet },
+    BenchTime =
+        case hb_opts:get(scheduling_mode, local_confirmation, SignedOpts) of
+            aggressive -> 1.0;
+            _ -> 2.0
+        end,
+    Base = hb_message:commit(test_process(SignedOpts), SignedOpts),
     ?event({benchmark_start, ?MODULE}),
     MsgToSchedule = hb_message:commit(#{
         <<"type">> => <<"Message">>,
         <<"test-key">> => <<"test-val">>
-    }, Opts),
+    }, SignedOpts),
+    {ok, _} = hb_cache:write(MsgToSchedule, SignedOpts),
     Iterations = hb_test_utils:benchmark(
         fun(_) ->
             MsgX = #{
@@ -1890,7 +1896,11 @@ single_resolution(Opts) ->
                 <<"method">> => <<"POST">>,
                 <<"body">> => MsgToSchedule
             },
-            ?assertMatch({ok, _}, hb_ao:resolve(Base, MsgX, Opts))
+            ?assertMatch({ok, _}, hb_ao:resolve(Base, MsgX, SignedOpts)),
+            case hb_opts:get(scheduling_mode, local_confirmation, SignedOpts) of
+                aggressive -> timer:sleep(50);
+                _ -> ok
+            end
         end,
         BenchTime
     ),
@@ -1898,11 +1908,11 @@ single_resolution(Opts) ->
     Res = #{
         <<"path">> => <<"slot">>,
         <<"method">> => <<"GET">>,
-        <<"process">> => hb_util:human_id(hb_message:id(Base, all, Opts))
+        <<"process">> => hb_util:human_id(hb_message:id(Base, all, SignedOpts))
     },
     ?assertMatch({ok, #{ <<"current">> := CurrentSlot }}
             when CurrentSlot == Iterations - 1,
-        hb_ao:resolve(Base, Res, Opts)),
+        hb_ao:resolve(Base, Res, SignedOpts)),
     ?event(bench, {res, Iterations - 1}),
     hb_test_utils:benchmark_print(
         <<"Scheduled through AO-Core:">>,
@@ -1915,18 +1925,18 @@ single_resolution(Opts) ->
 many_clients(Opts) ->
     BenchTime = 0.25,
     Processes = hb_opts:get(workers, 25, Opts),
-    {Node, Opts} = http_init(Opts),
-    PMsg = hb_message:commit(test_process(Opts), Opts),
+    {Node, HTTPOpts} = http_init(Opts),
+    PMsg = hb_message:commit(test_process(HTTPOpts), HTTPOpts),
     Base = hb_message:commit(#{
         <<"path">> => <<"/~scheduler@1.0/schedule">>,
         <<"method">> => <<"POST">>,
         <<"process">> => PMsg,
-        <<"body">> => hb_message:commit(#{ <<"inner">> => <<"test">> }, Opts)
-    }, Opts),
-    {ok, _} = hb_http:post(Node, Base, Opts),
-	    Iterations = hb_test_utils:benchmark(
+        <<"body">> => hb_message:commit(#{ <<"inner">> => <<"test">> }, HTTPOpts)
+    }, HTTPOpts),
+    {ok, _} = hb_http:post(Node, Base, HTTPOpts),
+    Iterations = hb_test_utils:benchmark(
         fun(X) ->
-            {ok, _} = hb_http:post(Node, Base, Opts),
+            {ok, _} = hb_http:post(Node, Base, HTTPOpts),
             ?event(bench, {iteration, X, self()})
         end,
         BenchTime,
@@ -1942,19 +1952,19 @@ many_clients(Opts) ->
     ?assert(Iterations > 10).
 
 benchmark_suite_test_parallel_() ->
-    {timeout, 10, fun() ->
-        Bench = [
-            {benchmark, "benchmark", fun single_resolution/1},
-            {multihttp_benchmark, "multihttp_benchmark", fun many_clients/1}
-        ],
-        hb_test_utils:suite_with_opts(Bench, benchmark_suite())
-    end}.
+    Bench = [
+        {benchmark, "benchmark", fun single_resolution/1},
+        {multihttp_benchmark, "multihttp_benchmark", fun many_clients/1}
+    ],
+    {serial, hb_test_utils:suite_with_opts(Bench, benchmark_suite())}.
 
 benchmark_suite() ->
     [
         #{
             name => fs,
             requires => [hb_store_fs],
+            parallel => false,
+            timeout => 30,
             opts => #{
                 <<"store">> => hb_test_utils:test_store(hb_store_fs),
                 <<"scheduling-mode">> => local_confirmation,
@@ -1965,9 +1975,12 @@ benchmark_suite() ->
         #{
             name => fs_aggressive,
             requires => [hb_store_fs],
+            parallel => false,
+            timeout => 30,
             opts => #{
                 <<"store">> => hb_test_utils:test_store(hb_store_fs),
                 <<"scheduling-mode">> => aggressive,
+                <<"scheduler-default-commitment-spec">> => <<"httpsig@1.0">>,
                 <<"port">> => 0
             },
             desc => <<"FS store, aggressive conf.">>
@@ -1975,6 +1988,8 @@ benchmark_suite() ->
         #{
             name => rocksdb,
             requires => [hb_store_rocksdb],
+            parallel => false,
+            timeout => 30,
             opts => #{
                 <<"store">> => hb_test_utils:test_store(hb_store_rocksdb),
                 <<"scheduling-mode">> => local_confirmation,
@@ -1985,9 +2000,12 @@ benchmark_suite() ->
         #{
             name => rocksdb_aggressive,
             requires => [hb_store_rocksdb],
+            parallel => false,
+            timeout => 30,
             opts => #{
                 <<"store">> => hb_test_utils:test_store(hb_store_rocksdb),
                 <<"scheduling-mode">> => aggressive,
+                <<"scheduler-default-commitment-spec">> => <<"httpsig@1.0">>,
                 <<"port">> => 0
             },
             desc => <<"RocksDB store, aggressive conf.">>
@@ -1995,9 +2013,12 @@ benchmark_suite() ->
         #{
             name => rocksdb_extreme_aggressive_h3,
             requires => [http3],
+            parallel => false,
+            timeout => 30,
             opts => #{
                 <<"store">> => hb_test_utils:test_store(hb_store_rocksdb),
                 <<"scheduling-mode">> => aggressive,
+                <<"scheduler-default-commitment-spec">> => <<"httpsig@1.0">>,
                 <<"protocol">> => http3,
                 <<"workers">> => 100
             },

--- a/src/preloaded/process/dev_scheduler_cache.erl
+++ b/src/preloaded/process/dev_scheduler_cache.erl
@@ -306,7 +306,9 @@ concurrent_read_write_test() ->
 
 %% @doc Test writing a large volume of assignments to stress memory. Helps
 %% identify memory leaks and also, checks performance issues.
-large_assignment_volume_test() ->
+large_assignment_volume_test_() ->
+    {timeout, 30, fun large_assignment_volume/0}.
+large_assignment_volume() ->
     VolStore = hb_test_utils:test_store(hb_store_fs, <<"volume-vol">>),
     NonVolStore = hb_test_utils:test_store(hb_store_fs, <<"volume-nonvol">>),
     Opts = #{

--- a/src/preloaded/process/dev_scheduler_server.erl
+++ b/src/preloaded/process/dev_scheduler_server.erl
@@ -370,36 +370,38 @@ new_proc_test() ->
     ).
     
 
-% benchmark_test() ->
-%     BenchTime = 1,
-%     Wallet = ar_wallet:new(),
-%     SignedItem = hb_message:commit(
-%         #{ <<"data">> => <<"test">>, <<"random-key">> => rand:uniform(10000) },
-%         Wallet
-%     ),
-%     dev_scheduler_registry:find(ID = hb_ao:get(id, SignedItem), true),
-%     ?event({benchmark_start, ?MODULE}),
-%     Iterations = hb_test_utils:benchmark(
-%         fun(X) ->
-%             MsgX = #{
-%                 path => <<"Schedule">>,
-%                 <<"method">> => <<"POST">>,
-%                 <<"body">> =>
-%                     #{
-%                         <<"type">> => <<"Message">>,
-%                         <<"test-val">> => X
-%                     }
-%             },
-%             schedule(ID, MsgX)
-%         end,
-%         BenchTime
-%     ),
-%     hb_formatter:eunit_print(
-%         "Scheduled ~p messages in ~p seconds (~.2f msg/s)",
-%         [Iterations, BenchTime, Iterations / BenchTime]
-%     ),
-%     ?assertMatch(
-%         #{ current := X } when X == Iterations - 1,
-%         dev_scheduler_server:info(dev_scheduler_registry:find(ID))
-%     ),
-%     ?assert(Iterations > 30).
+benchmark_test() ->
+    BenchTime = 1,
+    Wallet = ar_wallet:new(),
+    Opts = #{ <<"priv-wallet">> => Wallet },
+    SignedItem = hb_message:commit(
+        #{ <<"data">> => <<"test">>, <<"random-key">> => rand:uniform(10000) },
+        Opts
+    ),
+    ID = hb_message:id(SignedItem, all, Opts),
+    dev_scheduler_registry:find(ID, SignedItem, Opts),
+    ?event({benchmark_start, ?MODULE}),
+    Iterations = hb_test_utils:benchmark(
+        fun(X) ->
+            MsgX = #{
+                <<"path">> => <<"Schedule">>,
+                <<"method">> => <<"POST">>,
+                <<"body">> =>
+                    #{
+                        <<"type">> => <<"Message">>,
+                        <<"test-val">> => X
+                    }
+            },
+            schedule(ID, MsgX)
+        end,
+        BenchTime
+    ),
+    hb_format:eunit_print(
+        "Scheduled ~p messages in ~p seconds (~.2f msg/s)",
+        [Iterations, BenchTime, Iterations / BenchTime]
+    ),
+    ?assertMatch(
+        #{ current := X } when X == Iterations - 1,
+        dev_scheduler_server:info(dev_scheduler_registry:find(ID))
+    ),
+    ?assert(Iterations > 30).


### PR DESCRIPTION
Since the introduction of hb_parallel wired into dev_router and dev_scheduler, parallel generator tests have not been running, just returning `ok`. This PR fixes `hb_test_parallel` to run the generator tests, as well as fixes the `dev_scheduler` and `dev_router` tests which have become failing since this bug was introduced.
Additionally, uncomments + fixes dev_scheduler_server benchmark test.