### PR TITLE
feat: Support flexible, nested matching modes in `hb_message`

### DIFF
--- a/src/core/resolver/hb_message.erl
+++ b/src/core/resolver/hb_message.erl
@@ -659,7 +659,8 @@ match(Map1, Map2) ->
 match(Map1, Map2, Mode) ->
     match(Map1, Map2, Mode, #{}).
 match(Map1, Map2, Mode, Opts) ->
-    try unsafe_match(Map1, Map2, Mode, [], Opts)
+    try
+        unsafe_match(hb_ao:normalize_keys(Map1, Opts), Map2, Mode, [], Opts)
     catch
         throw:{mismatch, Type, Path, Val1, Val2} ->
             {mismatch, Type, Path, Val1, Val2};
@@ -668,6 +669,19 @@ match(Map1, Map2, Mode, Opts) ->
 
 %% @doc Match two maps, returning `true' if they match, or throwing an error
 %% if they do not.
+unsafe_match(#{ <<"match-type">> := Type, <<"body">> := Inner } = RawMap1,
+        RawMap2, _Mode, Path, Opts) when map_size(RawMap1) == 2 ->
+    case catch hb_util:key_to_atom(Type) of
+        Mode when Mode == strict; Mode == primary; Mode == only_present ->
+            unsafe_match(
+                hb_ao:normalize_keys(Inner, Opts),
+                hb_ao:normalize_keys(RawMap2, Opts),
+                Mode,
+                Path,
+                Opts
+            );
+        _ -> throw(invalid_match_type)
+    end;
 unsafe_match(RawMap1, RawMap2, Mode, Path, Opts) ->
     {_, SignedCommitments1} = 
         lists:partition(

--- a/src/preloaded/test/hb_codec_test_vectors.erl
+++ b/src/preloaded/test/hb_codec_test_vectors.erl
@@ -402,7 +402,71 @@ match_modes_test() ->
     ?assert(hb_message:match(Base, Req, only_present)),
     ?assert(hb_message:match(Req, Base, strict) =/= true),
     ?assert(hb_message:match(Base, Res, primary)),
-    ?assert(hb_message:match(Res, Base, primary) =/= true).
+    ?assert(hb_message:match(Res, Base, primary) =/= true),
+    StrictMap =
+        #{
+            <<"x">> => #{
+                <<"match-type">> => <<"strict">>,
+                <<"body">> => #{}
+            }
+        },
+    ?assert(
+        hb_message:match(
+            StrictMap,
+            #{ <<"x">> => #{ <<"y">> => true } },
+            primary
+        ) =/= true
+    ),
+    ?assert(hb_message:match(StrictMap, #{ <<"x">> => #{} }, primary)),
+    StrictList =
+        #{
+            <<"x">> => #{
+                'match-type' => <<"strict">>,
+                body => [<<"a">>]
+            }
+        },
+    ?assert(
+        hb_message:match(
+            StrictList,
+            #{ <<"x">> => [<<"a">>, <<"b">>] },
+            primary
+        ) =/= true
+    ),
+    ?assert(hb_message:match(StrictList, #{ <<"x">> => [<<"a">>] }, primary)),
+    PrimaryMap =
+        #{
+            <<"x">> => #{
+                <<"match-type">> => <<"primary">>,
+                <<"body">> => #{ <<"a">> => true }
+            }
+        },
+    ?assert(
+        hb_message:match(
+            PrimaryMap,
+            #{ <<"x">> => #{ <<"a">> => true, <<"b">> => true } },
+            strict
+        )
+    ),
+    ?assert(
+        hb_message:match(
+            #{ <<"x">> => #{ <<"a">> => true } },
+            #{ <<"x">> => #{ <<"a">> => true, <<"b">> => true } },
+            primary
+        )
+    ),
+    ?assertMatch(
+        {error, {invalid_match_type, {trace, _}}},
+        hb_message:match(
+            StrictMap#{
+                <<"x">> := #{
+                    <<"match-type">> => <<"bogus">>,
+                    <<"body">> => #{}
+                }
+            },
+            #{ <<"x">> => #{} },
+            primary
+        )
+    ).
 
 basic_message_codec_test(Codec, Opts) ->
     Msg = #{ <<"normal_key">> => <<"NORMAL_VALUE">> },


### PR DESCRIPTION
Enables defining `match-type` directives (`strict`, `primary`, `only-present`) within nested map structures. This provides more granular control over message comparison.
