### PR TITLE
perf: export trie reserved-keys helpers

### DIFF
--- a/src/preloaded/message/dev_trie.erl
+++ b/src/preloaded/message/dev_trie.erl
@@ -15,7 +15,6 @@
 %%% 4 children!)
 -module(dev_trie).
 -export([info/0, keys/2, set/3, get/3, get/4]).
--export([reserved_keys/0, is_reserved_key/1]).
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
 
@@ -36,17 +35,12 @@
 
 info() ->
     #{
-        default => fun get/4
+        default => fun get/4,
+        reserved => ?RESERVED_KEYS
      }.
 
 keys(Trie, Opts) ->
     collect_keys(Trie, <<>>, Opts, []).
-
-reserved_keys() ->
-    ?RESERVED_KEYS.
-
-is_reserved_key(Key) ->
-    lists:member(Key, ?RESERVED_KEYS).
 
 collect_keys(TrieNode, Prefix, Opts, Acc) ->
     EdgeLabels = edges(TrieNode, Opts),

--- a/src/preloaded/message/dev_trie.erl
+++ b/src/preloaded/message/dev_trie.erl
@@ -15,6 +15,7 @@
 %%% 4 children!)
 -module(dev_trie).
 -export([info/0, keys/2, set/3, get/3, get/4]).
+-export([reserved_keys/0, is_reserved_key/1]).
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
 
@@ -24,6 +25,15 @@
 %%% but cannot be properly normalized.
 -define(RADIX, 256).
 
+%%% @doc Trie node metadata keys that must not be treated as edge labels.
+-define(RESERVED_KEYS, [
+    <<"node-value">>,
+    <<"device">>,
+    <<"commitments">>,
+    <<"priv">>,
+    <<"hashpath">>
+]).
+
 info() ->
     #{
         default => fun get/4
@@ -31,6 +41,12 @@ info() ->
 
 keys(Trie, Opts) ->
     collect_keys(Trie, <<>>, Opts, []).
+
+reserved_keys() ->
+    ?RESERVED_KEYS.
+
+is_reserved_key(Key) ->
+    lists:member(Key, ?RESERVED_KEYS).
 
 collect_keys(TrieNode, Prefix, Opts, Acc) ->
     EdgeLabels = edges(TrieNode, Opts),
@@ -240,16 +256,10 @@ retrieve(TrieNode, Key, Opts, KeyPrefixSizeAcc) ->
     end.
 
 %% @doc Get a list of edge labels for a given trie node.
-edges(TrieNode, Opts) when not is_map(TrieNode) -> [];
+edges(TrieNode, _Opts) when not is_map(TrieNode) -> [];
 edges(TrieNode, Opts) ->
     Filtered = hb_maps:without(
-        [
-            <<"node-value">>,
-            <<"device">>,
-            <<"commitments">>,
-            <<"priv">>,
-            <<"hashpath">>
-        ],
+        ?RESERVED_KEYS,
         TrieNode,
         Opts
     ),
@@ -286,7 +296,7 @@ test_opts() ->
         <<"store">> => [hb_test_utils:test_store()],
         <<"priv-wallet">> => hb:wallet()
     }.
-count_nodes(TrieNode, Opts) when not is_map(TrieNode) -> 0;
+count_nodes(TrieNode, _Opts) when not is_map(TrieNode) -> 0;
 count_nodes(TrieNode, Opts) ->
     EdgeLabels = edges(TrieNode, Opts),
     CountsChildren =
@@ -297,7 +307,7 @@ count_nodes(TrieNode, Opts) ->
         ],
     1 + lists:sum(CountsChildren).
 
-verify_nodes(TrieNode, Opts) when not is_map(TrieNode) -> true;
+verify_nodes(TrieNode, _Opts) when not is_map(TrieNode) -> true;
 verify_nodes(TrieNode, Opts) ->
     ThisNode = hb_message:verify(TrieNode, all, Opts),
     EdgeLabels = edges(TrieNode, Opts),


### PR DESCRIPTION
export trie's `RESERVED_KEYS` macro so other devices/packages can easily reuse them (required for `token@1.0`)

all tests pass

```
=======================================================
  All 12 tests passed.
  ```