### PR TITLE
Fix avro on ans104 implicit tag terminator

### DIFF
--- a/src/core/lib/ar_bundles.erl
+++ b/src/core/lib/ar_bundles.erl
@@ -599,8 +599,11 @@ decode_avro_tag_section(TagsBinary) ->
         {_Tags, _Residue} -> throw({invalid_ans104_tags, residue_in_tag_section})
     end.
 
-decode_avro_tag_array(<<>>, _Acc) ->
-    throw({invalid_ans104_tags, missing_avro_array_terminator});
+decode_avro_tag_array(<<>>, Acc) ->
+    %% `TagSize' already bounds the tag section. Reaching the end after
+    %% complete items is equivalent to an explicit Avro zero-block terminator;
+    %% `decode_tags/1' still enforces the declared `TagCount'.
+    {lists:reverse(Acc), <<>>};
 decode_avro_tag_array(Binary, Acc) ->
     {Count, Rest} = decode_zigzag(Binary),
     decode_avro_tag_array_block(Count, Rest, Acc).
@@ -728,7 +731,9 @@ tag_size_boundary_test() ->
         >>,
     ?assertEqual({Tags, Body}, decode_tags(Wrapped)).
 
-missing_avro_tag_terminator_test() ->
+implicit_tag_terminator_test() ->
+    %% Accept a complete tag section whose `TagSize' ends at the final item;
+    %% the declared `TagCount' still proves the section is complete.
     Tags = [{<<"Content-Type">>, <<"application/json">>}],
     EncodedTags = encode_tags(Tags),
     TagsWithoutTerminator = binary:part(EncodedTags, 0, byte_size(EncodedTags) - 1),
@@ -740,10 +745,7 @@ missing_avro_tag_terminator_test() ->
             TagsWithoutTerminator/binary,
             Body/binary
         >>,
-    ?assertThrow(
-        {invalid_ans104_tags, missing_avro_array_terminator},
-        decode_tags(Wrapped)
-    ).
+    ?assertEqual({Tags, Body}, decode_tags(Wrapped)).
 
 tag_count_mismatch_test() ->
     Tags = [{<<"Content-Type">>, <<"application/json">>}],

--- a/src/preloaded/arweave/dev_arweave.erl
+++ b/src/preloaded/arweave/dev_arweave.erl
@@ -1504,7 +1504,7 @@ head_raw_ans104_test_parallel() ->
 head_raw_ans104_invalid_tags_test() ->
     Tags = [{<<"Content-Type">>, <<"application/json">>}],
     EncodedTags = ar_bundles:encode_tags(Tags),
-    TagsWithoutTerminator = binary:part(EncodedTags, 0, byte_size(EncodedTags) - 1),
+    CorruptedTags = <<EncodedTags/binary, 0>>,
     Body = <<"{\"$schema\":\"https://example.invalid/schema\"}">>,
     DataItem =
         <<
@@ -1514,8 +1514,8 @@ head_raw_ans104_invalid_tags_test() ->
             0,
             0,
             (length(Tags)):64/little,
-            (byte_size(TagsWithoutTerminator)):64/little,
-            TagsWithoutTerminator/binary,
+            (byte_size(CorruptedTags)):64/little,
+            CorruptedTags/binary,
             Body/binary
         >>,
     ?assertMatch(


### PR DESCRIPTION
Example txids affected:
XxAUuYu1XkWtSqHEwt9vfcifTEYC6e7qbi74BUi96-s
2QypU0DzlTb7SrlJleMrLiMcv0YETtA9huGPC_oUmdc
NXzB_T3jKk84xKw64SHojE6HCaFShGdlfYNhCbFwQ8s
odnUUsNzKX7M3R-oY_ltEd04mNx5Okweb9-WPgX3VrE

The lack of the terminator seems to be accepted on other places if it is the last item on the declared ANS104 tags.