### PR TITLE
dev_process_worker:compute_cached/3 — unwrap AO-Core {ao-result, body} envelope (#942)

### DIFF
--- a/src/preloaded/process/dev_process_worker.erl
+++ b/src/preloaded/process/dev_process_worker.erl
@@ -42,6 +42,14 @@ compute_group(Base, Req, Opts) ->
     end.
 
 %% @doc Return `true' if the requested compute result is already cached.
+compute_cached(ProcID, RawSlot, Opts) when is_map(RawSlot) ->
+    %% Defensively unwrap the AO-Core message envelope when the v0.9 HTTP
+    %% resolve path delivers RawSlot wrapped instead of as a bare binary.
+    %% The slot id lives at the `body' key; everything else is unchanged.
+    case maps:find(<<"body">>, RawSlot) of
+        {ok, Body} -> compute_cached(ProcID, Body, Opts);
+        error -> false
+    end;
 compute_cached(ProcID, not_found, Opts) ->
     case dev_process_cache:latest(ProcID, Opts) of
         {ok, _Slot, _Msg} -> true;


### PR DESCRIPTION
Companion to #942.

#### Summary

Adds one clause to `compute_cached/3` in `src/preloaded/process/dev_process_worker.erl` that unwraps the AO-Core message envelope (`#{<<"ao-result">> => <<"body">>, <<"body">> => <<"14040">>}`) when the v0.9 HTTP resolve path delivers `RawSlot` wrapped instead of as a bare binary. Without this, every `/compute` request on a production node running v0.9-FINAL crashes via `function_clause` in `hb_util:int/1` (no map clause). Full diagnosis + stacktrace in #942.

#### Change

`src/preloaded/process/dev_process_worker.erl`, inserted before the existing `compute_cached(ProcID, not_found, Opts) ->` head:

```erlang
compute_cached(ProcID, RawSlot, Opts) when is_map(RawSlot) ->
    %% Defensively unwrap the AO-Core message envelope when the v0.9 HTTP
    %% resolve path delivers RawSlot wrapped instead of as a bare binary.
    %% The slot id lives at the `body' key; everything else is unchanged.
    case maps:find(<<"body">>, RawSlot) of
        {ok, Body} -> compute_cached(ProcID, Body, Opts);
        error -> false
    end;
```

#### Rationale

- Bare-binary contract preserved on every existing call site.
- Wrapped calls unwrap once and recurse into the original clause; `hb_util:int(Body)` then sees the binary the existing `is_binary` clause handles.
- `maps:find/2` returning `error` falls through to `false`, matching `compute_cached/3`'s existing "not cached" semantics.
- Recursion terminates in one step.

If maintainers prefer the unwrap upstream in `dev_process:target_slot/2` (closer to where the envelope is introduced), happy to rework.

#### Validation

Applied against `permaweb/HyperBEAM/main` HEAD on a production node serving a custom (non-aos) Lua process at PID `Dwnuy4MbuQkgwxw4-P08wxeny2KcwCh8Kd22mehacTc`. Pre-patch: 100% of `/compute` requests crash with `function_clause`. Post-patch: `function_clause` does not recur.

The two related v0.9 bugs reported in #942 (LMDB `mdb_page_dirty` assertion against existing cache, `loadMessages` "Body is not valid" against a fresh cache) are out of scope here.

#### Follow-ups welcome

1. Whether the unwrap belongs here or in `dev_process:target_slot/2`.
2. Whether the related LMDB / `loadMessages` envelope issues point at one upstream seam we could fix together.
3. Whether a regression test should land alongside — happy to write one if pointed at the right test module pattern.

---

— **Tad MacPherson**, Metavolve Labs / Golden Codex
  `curator@golden-codex.com` · `@codex-curator` · `golden-codex.com`
+ **Claude** (Anthropic) — Jedi Code Master
