### PR TITLE
impr: do not force load of headers during reply

### DIFF
--- a/src/core/http/hb_http.erl
+++ b/src/core/http/hb_http.erl
@@ -751,18 +751,17 @@ encode_reply(Status, TABMReq, Message, Opts) ->
         _ ->
             % Other codecs are already in binary format, so we can just convert
             % the message to the codec. We also include all of the top-level 
-            % fields, except for maps and lists, in the message and return them 
-            % as headers.
+            % scalar fields in the message and return them as headers.
             ExtraHdrs =
-                hb_maps:filter(
-                    fun(Key, V) ->
-                        not is_map(V)
-                            andalso not is_list(V)
-                            andalso Key =/= <<"body">>
-                            andalso Key =/= <<"data">>
+                maps:filter(
+                    fun(<<"body">>, _V) -> false;
+                       (<<"data">>, _V) -> false;
+                       (_Key, V) ->
+                            not ?IS_LINK(V)
+                                andalso not is_map(V)
+                                andalso not is_list(V)
                     end,
-                    Message,
-                    Opts
+                    Message
                 ),
             % Encode all header values as strings.
             EncodedExtraHdrs =


### PR DESCRIPTION
Build extra reply headers with plain map filtering so linkified values are not forced to load while encoding headers. This removes an unnecessary cache read and, when no writable store is known to the node, 5xx failures.