### PR TITLE
impr: device caching and store option propagation

### DIFF
--- a/src/core/device/hb_device_load.erl
+++ b/src/core/device/hb_device_load.erl
@@ -33,18 +33,16 @@ reference(Loaded, _Opts) when is_map(Loaded) ->
 reference(Ref, Opts) when is_binary(Ref) ->
     NormRef = hb_ao:normalize_key(Ref),
     case from_forge_bootstrap(NormRef, Opts) of
-        {ok, _} = Ok ->
-            Ok;
-        {error, not_found} ->
-            resolve_cached(NormRef, Opts);
-        {error, _} = Error ->
-            Error
+        {ok, Mod} -> {ok, Mod};
+        {error, not_found} -> resolve_cached(NormRef, Opts);
+        {error, Err} -> {error, Err}
     end.
 
 resolve_cached(Ref, Opts) ->
     case resolve(Ref, Opts) of
+        {cached, Mod} -> {ok, Mod};
         {ok, Mod} = Ok -> put_resolved_device(Ref, Mod, Opts), Ok;
-        {error, _} = Error -> Error
+        {error, Err} -> {error, Err}
     end.
 
 %% @doc The resolved-device store, then the high-trust sources, then the
@@ -65,15 +63,20 @@ resolve(Ref, Opts) ->
 get_resolved_device(Ref, Opts) ->
     case erlang:get({?MODULE, Ref}) of
         Mod when is_atom(Mod), Mod =/= undefined ->
-            {ok, Mod};
+            {cached, Mod};
         _ ->
             maybe
                 {ok, Bin} ?=
                     hb_store:read(
-                        loaded_device_store(Opts), store_key(Ref), Opts),
+                        loaded_device_store(Opts),
+                        store_key(Ref),
+                        Opts
+                    ),
                 Mod = hb_util:atom(Bin),
+                % We always stash in the process dictionary, despite the fact
+                % the reference was already in the global store.
                 erlang:put({?MODULE, Ref}, Mod),
-                {ok, Mod}
+                {cached, Mod}
             end
     end.
 

--- a/src/core/store/hb_store_arweave.erl
+++ b/src/core/store/hb_store_arweave.erl
@@ -6,7 +6,7 @@
 %%% Unused Store API:
 -export([resolve/3, write/3, link/3, group/3]).
 %%% Indexing API:
--export([store_from_opts/1, write_offset/5, read_offset/2, read_chunks/3]).
+-export([store_from_opts/1, write_offset/5, read_offset/3, read_chunks/3]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -71,7 +71,7 @@ type(_Store, #{ <<"type">> := _ID }, _NodeOpts) ->
     {error, not_found}.
 
 %% @doc Read the offset of the data at the given key.
-read_offset(StoreOpts = #{ <<"index-store">> := IndexStore }, ID) ->
+read_offset(StoreOpts = #{ <<"index-store">> := IndexStore }, ID, Opts) ->
     ReadRes =
         hb_prometheus:measure_and_report(
             fun() ->
@@ -92,16 +92,17 @@ read_offset(StoreOpts = #{ <<"index-store">> := IndexStore }, ID) ->
         _ ->
             not_found
     end;
-read_offset(_, _) -> not_found.
+read_offset(_, _, _) -> not_found.
 
 %% @doc Read the data at the given key, reading the `local-store' first if
 %% available.
-read(StoreOpts, #{ <<"read">> := ID }, _NodeOpts) when ?IS_ID(ID) ->
-    case hb_store_remote_node:read_local_cache(StoreOpts, ID) of
+read(StoreOpts, #{ <<"read">> := ID }, NodeOpts) when ?IS_ID(ID) ->
+    MergedOpts = maps:merge(NodeOpts, StoreOpts),
+    case hb_store_remote_node:read_local_cache(StoreOpts, ID, MergedOpts) of
         {ok, Message} ->
             {ok, Message};
         {error, not_found} ->
-            case do_read(StoreOpts, ID) of
+            case do_read(StoreOpts, ID, MergedOpts) of
                 not_found -> {error, not_found};
                 Result -> Result
             end;
@@ -116,8 +117,8 @@ read(_StoreOpts, #{ <<"read">> := _ID }, _NodeOpts) ->
 %% @doc Read the data at the given key, reading the provided Arweave index store
 %% as a source of offsets. After offsets have been found, the data is loaded
 %% through the `~arweave@2.9` device -- either as an ANS-104 item or a TX.
-do_read(StoreOpts, ID) ->
-    case read_offset(StoreOpts, ID) of
+do_read(StoreOpts, ID, Opts) ->
+    case read_offset(StoreOpts, ID, Opts) of
         {ok,
             #{
                 <<"version">> := Version,
@@ -127,10 +128,8 @@ do_read(StoreOpts, ID) ->
             }} ->
             Loaded =
                 case CodecName of
-                    <<"ans104@1.0">> ->
-                        load_item(ID, StartOffset, Length, StoreOpts);
-                    <<"tx@1.0">> ->
-                        load_tx(ID, StartOffset, Length, StoreOpts)
+                    <<"ans104@1.0">> -> load_item(ID, StartOffset, Length, Opts);
+                    <<"tx@1.0">> -> load_tx(ID, StartOffset, Length, Opts)
                 end,
             case Loaded of
                 {ok, Message} ->
@@ -145,7 +144,7 @@ do_read(StoreOpts, ID) ->
                             {length, Length}
                         }
                     ),
-                    record_partition_metric(StartOffset, ok, StoreOpts),
+                    record_partition_metric(StartOffset, ok, Opts),
                     Loaded;
                 {error, Reason} ->
                     ?event(
@@ -159,7 +158,7 @@ do_read(StoreOpts, ID) ->
                             {reason, Reason}
                         }
                     ),
-                    record_partition_metric(StartOffset, not_found, StoreOpts),
+                    record_partition_metric(StartOffset, not_found, Opts),
                     if Reason =:= not_found -> not_found;
                     true -> {error, Reason}
                     end

--- a/src/core/store/hb_store_gateway.erl
+++ b/src/core/store/hb_store_gateway.erl
@@ -59,12 +59,12 @@ extract_path_value(Message, Rest, StoreOpts) ->
 
 %% @doc Read the data at the given key from the GraphQL route. Will only attempt
 %% to read the data if the key is an ID.
-read(BaseStoreOpts, #{ <<"read">> := Key }, _NodeOpts) ->
+read(BaseStoreOpts, #{ <<"read">> := Key }, NodeOpts) ->
     StoreOpts = opts(BaseStoreOpts),
     GatewayReadOpts = maps:remove(<<"local-store">>, StoreOpts),
     case hb_path:term_to_path_parts(Key, StoreOpts) of
         [ID|Rest] when ?IS_ID(ID) ->
-            case hb_store_remote_node:read_local_cache(StoreOpts, ID) of
+            case hb_store_remote_node:read_local_cache(StoreOpts, ID, NodeOpts) of
                 {error, not_found} ->
                     ?event({gateway_read, {opts, StoreOpts}, {id, ID}, {subpath, Rest}}),
                     try hb_client_gateway:read(ID, GatewayReadOpts) of

--- a/src/core/store/hb_store_remote_node.erl
+++ b/src/core/store/hb_store_remote_node.erl
@@ -6,7 +6,7 @@
 -module(hb_store_remote_node).
 -export([scope/1, type/3, read/3, write/3, link/3, group/3, resolve/3]).
 %%% Public utilities.
--export([maybe_cache/2, maybe_cache/3, read_local_cache/2]).
+-export([maybe_cache/2, maybe_cache/3, read_local_cache/3]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -132,12 +132,14 @@ maybe_cache(StoreOpts, Data, Links) ->
         ignored
     end.
 
-%% @doc Read local store cached value.
-read_local_cache(StoreOpts, ID) ->
+%% @doc Read local store cached value. Maintains the `Opts` for the recursive
+%% `hb_cache:read` call, but uses the `StoreOpts` as the source of the
+%% `local-store` value.
+read_local_cache(StoreOpts, ID, Opts) ->
     ?event({read_local_cache, StoreOpts, ID}),
     case hb_maps:get(<<"local-store">>, StoreOpts, false, StoreOpts) of
         false -> {error, not_found};
-        Store -> hb_cache:read(ID, #{ <<"store">> => Store })
+        Store -> hb_cache:read(ID, Opts#{ <<"store">> => Store })
     end.
 
 %% @doc Write a key to the remote node.

--- a/src/preloaded/arweave/dev_arweave.erl
+++ b/src/preloaded/arweave/dev_arweave.erl
@@ -171,7 +171,7 @@ head_raw(Base, Request, Opts) ->
         TXID when ?IS_ID(TXID) ->
             % Read the data from the local cache.
             IndexStore = hb_store_arweave:store_from_opts(Opts),
-            case hb_store_arweave:read_offset(IndexStore, TXID) of
+            case hb_store_arweave:read_offset(IndexStore, TXID, Opts) of
                 {ok,
                     #{
                         <<"codec-device">> := CodecDevice,
@@ -1317,7 +1317,7 @@ index_test_tx(TXID, IndexStore, Opts) ->
             StartOffset,
             Size
         ),
-    ?assertMatch({ok, _}, hb_store_arweave:read_offset(IndexStore, TXID)),
+    ?assertMatch({ok, _}, hb_store_arweave:read_offset(IndexStore, TXID, Opts)),
     ok.
 
 tx_index_block(<<"ptBC0UwDmrUTBQX3MqZ1lB57ex20ygwzkjjCrQjIx3o">>) -> 1749502;

--- a/src/preloaded/query/dev_query_arweave.erl
+++ b/src/preloaded/query/dev_query_arweave.erl
@@ -490,7 +490,7 @@ annotate_ids(IDs, Opts) ->
 annotate_offsets([], _StoreOpts, _LastOffset, _Ordinate, _Opts) -> [];
 annotate_offsets([ID|IDs], StoreOpts, LastOffset, Ordinate, Opts) ->
     {Offset, Annotated} =
-        case hb_store_arweave:read_offset(StoreOpts, ID) of
+        case hb_store_arweave:read_offset(StoreOpts, ID, Opts) of
             {ok, #{ <<"start-offset">> := StartOffset, <<"length">> := Length }} ->
                 {
                     StartOffset,

--- a/src/preloaded/query/dev_query_test_vectors.erl
+++ b/src/preloaded/query/dev_query_test_vectors.erl
@@ -680,7 +680,7 @@ transactions_query_filter_by_block_excludes_unknown_offsets_test_parallel() ->
         ),
     ?assertEqual(
         not_found,
-        hb_store_arweave:read_offset(hb_store_arweave:store_from_opts(Opts), ID)
+        hb_store_arweave:read_offset(hb_store_arweave:store_from_opts(Opts), ID, Opts)
     ),
     ?assertMatch(
         {ok, #{
@@ -741,7 +741,7 @@ transactions_query_ids_preserve_arweave_tx_id_test_parallel() ->
     ID = <<"mT7pIQx9ORnemXoIzWmKwymiZJxtOSvzxm3P44M9C1A">>,
     ?assertMatch(
         {ok, #{ <<"start-offset">> := _ }},
-        hb_store_arweave:read_offset(hb_store_arweave:store_from_opts(Opts), ID)
+        hb_store_arweave:read_offset(hb_store_arweave:store_from_opts(Opts), ID, Opts)
     ),
     ?assertMatch(
         {ok, #{
@@ -773,9 +773,9 @@ transactions_query_cursor_by_offset_test_parallel() ->
     LaterID = <<"HVr7EpRhlPkbwdnoXKHf25p7BPa0qJOs6C7XueLthA0">>,
     StoreOpts = hb_store_arweave:store_from_opts(Opts),
     {ok, #{ <<"start-offset">> := EarlierOffset }} =
-        hb_store_arweave:read_offset(StoreOpts, EarlierID),
+        hb_store_arweave:read_offset(StoreOpts, EarlierID, Opts),
     {ok, #{ <<"start-offset">> := LaterOffset }} =
-        hb_store_arweave:read_offset(StoreOpts, LaterID),
+        hb_store_arweave:read_offset(StoreOpts, LaterID, Opts),
     Query =
         <<"""
             query($ids: [ID!], $sort: SortOrder, $first: Int, $after: String) {


### PR DESCRIPTION
Optimizes device loading by introducing explicit `cached` return values for devices already present in the process dictionary or global store. Upon return, these `cached` values avoid redundant new writes to the `loaded-device-store`, improving lookup efficiency.

Additionally, forwards `NodeOpts` consistently through `remote`-style store lookups and local cache reads. This ensures that all downstream function calls still have the correct (rather than default) node options.