### PR TITLE
fix(http): avoid duplicate multirequest refill

### DIFF
--- a/src/core/http/hb_http_multi.erl
+++ b/src/core/http/hb_http_multi.erl
@@ -282,12 +282,18 @@ parallel_responses(AdmissibleRes, AllRes, Procs, Queue, {Method, Path, Message},
     receive
         {Ref, Pid, {Status, NewRes}} ->
             WorkersWithoutPid = lists:delete(Pid, Procs),
-            {RefilledWorkers, NewQueue} =
-                start_workers(1, Ref, Queue, Method, Path, Message, Opts),
-            NewProcs = RefilledWorkers ++ WorkersWithoutPid,
             NewAllRes = [{Status, NewRes} | AllRes],
             case is_admissible(Status, NewRes, Admissible, Statuses, Opts) of
                 true ->
+                    NewAwaiting = Awaiting - 1,
+                    {NewProcs, NewQueue} =
+                        case NewAwaiting of
+                            0 -> {WorkersWithoutPid, Queue};
+                            _ ->
+                                {RefilledWorkers, RemainingQueue} =
+                                    start_workers(1, Ref, Queue, Method, Path, Message, Opts),
+                                {RefilledWorkers ++ WorkersWithoutPid, RemainingQueue}
+                        end,
                     parallel_responses(
                         [{Status, NewRes} | AdmissibleRes],
                         NewAllRes,
@@ -295,17 +301,19 @@ parallel_responses(AdmissibleRes, AllRes, Procs, Queue, {Method, Path, Message},
                         NewQueue,
                         {Method, Path, Message},
                         Ref,
-                        Awaiting - 1,
+                        NewAwaiting,
                         StopAfter,
                         Admissible,
                         Statuses,
                         Opts
                 );
             false ->
+                {RefilledWorkers, NewQueue} =
+                    start_workers(1, Ref, Queue, Method, Path, Message, Opts),
                 parallel_responses(
                     AdmissibleRes,
                     NewAllRes,
-                    NewProcs,
+                    RefilledWorkers ++ WorkersWithoutPid,
                     NewQueue,
                     {Method, Path, Message},
                     Ref,


### PR DESCRIPTION
Previously `hb_http_multi` requests would trigger their next worker before assessing whether a result gained was admissible. This would lead to large amounts of needless process and HTTP queue churn, and in some cases duplicated bandwidth consumption.