### PR TITLE
fix(forge): route cross-package device calls through lib_process (#944)

### DIFF
--- a/src/forge/hb_packager_test_vectors.erl
+++ b/src/forge/hb_packager_test_vectors.erl
@@ -394,3 +394,67 @@ package_for_test(Group) ->
 %% Load an archive exactly as the runtime does (sans signature checks).
 load_pkg_archive(Pkg) ->
     ok = hb_device_archive:load(maps:get(archive, Pkg)).
+
+%%% --------------------------------------------------------------------
+%%% Issue #944 — cross-package call resolution.
+%%% --------------------------------------------------------------------
+%% A device in package A that calls a module in package B *directly* (by its
+%% original name) is emitted bare by the rename transform and fails with `undef'
+%% at runtime, because only the generated (hashed) module names are ever loaded.
+%% Routing the same call through a `lib_*' module that BOTH packages declare via
+%% `-device_libraries' makes it resolve — the lib is compiled (and renamed) into
+%% each package. This is the exact failure + fix shape behind #944.
+cross_package_call_resolution_test() ->
+    %% Package B exposes ping/0 (the cross-package target).
+    DirB = xpkg_fixture_dir(<<"hb_xpkg_b_">>, <<
+        "%%% @doc xpkg b.\n"
+        "-module(dev_xpkg_b).\n"
+        "-export([info/3, ping/0]).\n"
+        "info(_, _, _) -> {ok, #{}}.\n"
+        "ping() -> <<\"pong\">>.\n"
+    >>),
+    [GroupB] = hb_packager:scan([DirB], #{}),
+    PkgB = package_for_test(GroupB),
+    %% Package A: one path calls B directly (the bug), one via a shared lib (the fix).
+    DirA = xpkg_fixture_dir(<<"hb_xpkg_a_">>, <<
+        "%%% @doc xpkg a.\n"
+        "-module(dev_xpkg_a).\n"
+        "-device_libraries([lib_xshared]).\n"
+        "-export([direct/3, via_lib/3]).\n"
+        "direct(_, _, _) -> {ok, dev_xpkg_b:ping()}.\n"
+        "via_lib(_, _, _) -> {ok, lib_xshared:ping()}.\n"
+    >>),
+    ok = file:write_file(
+        filename:join(DirA, <<"lib_xshared.erl">>),
+        <<
+            "-module(lib_xshared).\n"
+            "-export([ping/0]).\n"
+            "ping() -> <<\"pong\">>.\n"
+        >>
+    ),
+    [GroupA] = hb_packager:scan([DirA], #{}),
+    PkgA = package_for_test(GroupA),
+    ModA = maps:get(module_name, PkgA),
+    ok = load_pkg_archive(PkgB),
+    ok = load_pkg_archive(PkgA),
+    %% FIX: the cross-package call routed through the declared lib_* resolves.
+    ?assertEqual({ok, <<"pong">>}, ModA:via_lib(#{}, #{}, #{})),
+    %% BUG (#944): the direct cross-package call by original name undefs — the
+    %% original `dev_xpkg_b' is never loaded, only its generated module is.
+    ?assertError(undef, ModA:direct(#{}, #{}, #{})).
+
+xpkg_fixture_dir(Prefix, RootSrc) ->
+    Tmp =
+        filename:join([
+            <<"/tmp">>,
+            <<Prefix/binary,
+                (integer_to_binary(erlang:unique_integer([positive])))/binary>>
+        ]),
+    ok = filelib:ensure_dir(filename:join(Tmp, <<".keep">>)),
+    [ModLine | _] = binary:split(RootSrc, <<"-module(">>, [trim]),
+    _ = ModLine,
+    {match, [Name]} =
+        re:run(RootSrc, <<"-module\\(([a-z0-9_]+)\\)">>,
+            [{capture, all_but_first, binary}]),
+    ok = file:write_file(filename:join(Tmp, <<Name/binary, ".erl">>), RootSrc),
+    Tmp.

--- a/src/preloaded/process/dev_process_cache.erl
+++ b/src/preloaded/process/dev_process_cache.erl
@@ -12,143 +12,25 @@ read(ProcID, Opts) ->
     hb_util:ok(latest(ProcID, Opts)).
 read(ProcID, SlotRef, Opts) ->
     ?event({reading_computed_result, ProcID, SlotRef}),
-    Path = path(ProcID, SlotRef, Opts),
+    Path = lib_process:cache_path(ProcID, SlotRef, Opts),
     hb_cache:read(Path, Opts).
 
-%% @doc Write a process computation result to the cache.
+%% @doc Write a process computation result to the cache. The implementation
+%% lives in `lib_process' as the single canonical copy, shared with (and
+%% resolvable from) the vm device package; this is a thin delegation.
 write(ProcID, Slot, Msg, Opts) ->
-    % Write the item to the cache in the root of the store.
-    {ok, Root} = hb_cache:write(hb_private:reset(Msg), Opts),
-    % Link the item to the path in the store by slot number.
-    SlotNumPath = path(ProcID, Slot, Opts),
-    hb_cache:link(Root, SlotNumPath, Opts),
-    % Link the item to the message ID path in the store.
-    MsgIDPath =
-        path(
-            ProcID,
-            ID = hb_message:id(Msg, uncommitted, Opts),
-            Opts
-        ),
-    ?event(
-        {linking_id,
-            {proc_id, ProcID},
-            {slot, Slot},
-            {id, ID},
-            {path, MsgIDPath}
-        }
-    ),
-    hb_cache:link(Root, MsgIDPath, Opts),
-    % Return the slot number path.
-    {ok, SlotNumPath}.
-
-%% @doc Calculate the path of a result, given a process ID and a slot.
-path(ProcID, Ref, Opts) ->
-    path(ProcID, Ref, [], Opts).
-path(ProcID, Ref, PathSuffix, _Opts) ->
-    hb_path:to_binary(
-        [
-            <<"computed">>,
-            hb_util:human_id(ProcID)
-        ] ++
-        case Ref of
-            Int when is_integer(Int) -> ["slot", integer_to_binary(Int)];
-            root -> [];
-            slot_root -> ["slot"];
-            _ -> [Ref]
-        end ++ PathSuffix
-    ).
+    lib_process:cache_write(ProcID, Slot, Msg, Opts).
 
 %% @doc Retrieve the latest slot for a given process. Optionally state a limit
 %% on the slot number to search for, as well as a required path that the slot
-%% must have.
-latest(ProcID, Opts) -> latest(ProcID, [], Opts).
+%% must have. The implementation lives in `lib_process' as the single canonical
+%% copy, resolvable from both the process and vm device packages.
+latest(ProcID, Opts) ->
+    lib_process:cache_latest(ProcID, Opts).
 latest(ProcID, RequiredPath, Opts) ->
-    latest(ProcID, RequiredPath, undefined, Opts).
+    lib_process:cache_latest(ProcID, RequiredPath, Opts).
 latest(ProcID, RawRequiredPath, Limit, RawOpts) ->
-    Scope = hb_opts:get(process_cache_scope, local, RawOpts),
-    % Normalize the store descriptor to a list of stores.
-    UnscopedStore =
-        case hb_opts:get(store, no_viable_store, RawOpts) of
-            StoreMsg when is_map(StoreMsg) -> [StoreMsg];
-            Other -> Other
-        end,
-    % Apply the scope to the store and update the options message.
-    ScopedStore = hb_store:scope(UnscopedStore, Scope),
-    Opts = RawOpts#{ <<"store">> => ScopedStore },
-    % Convert the required path to a list of _binary_ keys.
-    RequiredPath =
-        case RawRequiredPath of
-            undefined -> [];
-            [] -> [];
-            _ ->
-                hb_path:term_to_path_parts(
-                    RawRequiredPath,
-                    Opts
-                )
-        end,
-    ?event({required_path_converted, {proc_id, ProcID}, {required_path, RequiredPath}}),
-    Path = path(ProcID, slot_root, Opts),
-    AllSlots = hb_cache:list_numbered(Path, Opts),
-    ?event({all_slots, {proc_id, ProcID}, {slots, AllSlots}}),
-    CappedSlots =
-        case Limit of
-            undefined -> AllSlots;
-            _ -> lists:filter(fun(Slot) -> Slot =< Limit end, AllSlots)
-        end,
-    ?event(
-        {finding_latest_slot,
-            {proc_id, hb_util:human_id(ProcID)},
-            {limit, Limit},
-            {path, Path},
-            {slots_in_range, CappedSlots}
-        }
-    ),
-    % Find the highest slot that has the necessary path.
-    BestSlot =
-        first_with_path(
-            ProcID,
-            RequiredPath,
-            lists:reverse(lists:sort(CappedSlots)),
-            Opts
-        ),
-    case BestSlot of
-        {failure, _} = Failure ->
-            Failure;
-        {error, _} = Error ->
-            Error;
-        not_found ->
-            % No slot found with the necessary path was found.
-            {error, not_found};
-        SlotNum ->
-            % Found. Return the slot number and the message at that slot.
-            {ok, Msg} = hb_cache:read(path(ProcID, SlotNum, Opts), Opts),
-            {ok, SlotNum, Msg}
-    end.
-
-%% @doc Find the latest assignment with the requested path suffix.
-first_with_path(ProcID, RequiredPath, Slots, Opts) ->
-    first_with_path(
-        ProcID,
-        RequiredPath,
-        Slots,
-        Opts,
-        hb_opts:get(store, no_viable_store, Opts)
-    ).
-first_with_path(_ProcID, _Required, [], _Opts, _Store) ->
-    not_found;
-first_with_path(ProcID, RequiredPath, [Slot | Rest], Opts, Store) ->
-    RawPath = path(ProcID, Slot, RequiredPath, Opts),
-    ?event({trying_slot, {slot, Slot}, {path, RawPath}}),
-    case hb_store:read(Store, RawPath, Opts) of
-        {error, not_found} ->
-            first_with_path(ProcID, RequiredPath, Rest, Opts, Store);
-        {failure, _} = Failure ->
-            Failure;
-        {error, _} = Error ->
-            Error;
-        _ ->
-            Slot
-    end.
+    lib_process:cache_latest(ProcID, RawRequiredPath, Limit, RawOpts).
 
 %%% Tests
 

--- a/src/preloaded/process/dev_scheduler_formats.erl
+++ b/src/preloaded/process/dev_scheduler_formats.erl
@@ -45,81 +45,13 @@ assignments_to_bundle(ProcID, Assignments, More, TimeInfo, RawOpts) ->
             )
     }}.
 
-%%% Return legacy net-SU compatible results.
-assignments_to_aos2(ProcID, Assignments, More, RawOpts) when is_map(Assignments) ->
-    assignments_to_aos2(
-        ProcID,
-        hb_util:message_to_ordered_list(Assignments),
-        More,
-        format_opts(RawOpts)
-    );
+%%% Return legacy net-SU compatible results. The implementation lives in
+%%% `lib_process' as the single canonical copy (declared via `-device_libraries'
+%%% by both the process and vm packages so it resolves from either); this is a
+%%% thin delegation to keep one copy.
 assignments_to_aos2(ProcID, Assignments, More, RawOpts) ->
-    Opts = format_opts(RawOpts),
-    {Timestamp, Height, Hash} = ar_timestamp:get(),
-    BodyStruct = 
-        #{
-            <<"page_info">> =>
-                #{
-                    <<"process">> => hb_util:human_id(ProcID),
-                    <<"has_next_page">> => More,
-                    <<"timestamp">> => list_to_binary(integer_to_list(Timestamp)),
-                    <<"block-height">> => list_to_binary(integer_to_list(Height)),
-                    <<"block-hash">> => hb_util:human_id(Hash)
-                },
-            <<"edges">> =>
-                lists:map(
-                    fun(Assignment) ->
-                        #{
-                            <<"cursor">> => cursor(Assignment, Opts),
-                            <<"node">> => assignment_to_aos2(Assignment, Opts)
-                        }
-                    end,
-                    Assignments
-                )
-        },
-    Encoded = hb_json:encode(BodyStruct),
-    ?event({body_struct, BodyStruct}),
-    ?event({encoded, {explicit, Encoded}}),
-    {ok, 
-        #{
-            <<"content-type">> => <<"application/json">>,
-            <<"body">> => Encoded
-        }
-    }.
+    lib_process:assignments_to_aos2(ProcID, Assignments, More, RawOpts).
 
-%% @doc Generate a cursor for an assignment. This should be the slot number, at
-%% least in the case of mainnet `ao.N.1' assignments. In the case of legacynet
-%% (`ao.TN.1') assignments, we may want to use the assignment ID.
-cursor(Assignment, RawOpts) ->
-    Opts = format_opts(RawOpts),
-    hb_ao:get(<<"slot">>, Assignment, Opts).
-%% @doc Convert an assignment to an AOS2-compatible JSON structure.
-assignment_to_aos2(Assignment, RawOpts) ->
-    Opts = format_opts(RawOpts),
-    Message = hb_ao:get(<<"body">>, Assignment, Opts),
-    AssignmentWithoutBody = hb_maps:without([<<"body">>], Assignment, Opts),
-    {ok, MessageStruct} =
-        hb_ao:resolve(
-            #{ <<"device">> => <<"json-iface@1.0">> },
-            #{
-                <<"path">> => <<"to">>,
-                <<"message">> => Message
-            },
-            Opts
-        ),
-    {ok, AssignmentStruct} =
-        hb_ao:resolve(
-            #{ <<"device">> => <<"json-iface@1.0">> },
-            #{
-                <<"path">> => <<"to">>,
-                <<"message">> => AssignmentWithoutBody
-            },
-            Opts
-        ),
-    #{
-        <<"message">> => MessageStruct,
-        <<"assignment">> => AssignmentStruct
-    }.
 
 %% @doc Convert an AOS2-style JSON structure to a normalized HyperBEAM
 %% assignments response.

--- a/src/preloaded/process/lib_process.erl
+++ b/src/preloaded/process/lib_process.erl
@@ -9,9 +9,12 @@
     set_results/3,
     ensure_process_key/2,
     default_device/3,
-    %% Cross-package helpers (issue #944) — see bottom of module.
+    %% Cross-package process helpers — see bottom of module.
     cache_write/4,
     cache_latest/2,
+    cache_latest/3,
+    cache_latest/4,
+    cache_path/3,
     assignments_to_aos2/4
 ]).
 
@@ -154,60 +157,96 @@ default_device_index(<<"execution">>) -> <<"genesis-wasm@1.0">>;
 default_device_index(<<"push">>) -> <<"push@1.0">>.
 
 %%% --------------------------------------------------------------------
-%%% Cross-package helpers (issue #944).
+%%% Cross-package process helpers.
 %%%
-%%% The vm-package devices (`dev_genesis_wasm', `dev_delegated_compute') need
-%%% functionality that lives in the process package (`dev_process_cache',
-%%% `dev_scheduler_formats'). A DIRECT cross-package call is emitted bare by the
-%%% device packager's rename transform (`hb_device_rename') — the called atom is
-%%% not in the calling package's rename map — so it `undef's at runtime on a fresh
-%%% build (issue #944). `lib_process' is declared via `-device_libraries' by BOTH
-%%% packages, so it is compiled into each; routing these calls through it makes
-%%% them resolve in either package. The bodies below depend only on the
-%%% (never-renamed) `hb_*'/`ar_*' core, so they are self-contained in any package.
+%%% A `lib_*' module declared via `-device_libraries' is compiled into every
+%%% package that declares it. The device packager (`hb_device_rename') only
+%%% rewrites calls to modules in the calling package's rename map, so a direct
+%%% call to a device root in another package is emitted bare and will not
+%%% resolve. A shared `lib_*' module is in every declaring package's map, so
+%%% routing cross-package functionality through it keeps the calls resolvable in
+%%% any package.
 %%%
-%%% NOTE FOR REVIEWERS: these mirror `dev_process_cache:{write,latest}/_' and
-%%% `dev_scheduler_formats:assignments_to_aos2/4'. An alternative is to MOVE the
-%%% originals here and have the process-package modules delegate to `lib_process'
-%%% (both already declare it) to avoid the duplication — flagged for your call.
-%%% (Exports are declared in the module's top `-export' block — the Forge device
-%%% compiler rejects `-export' attributes that appear after function definitions.)
+%%% The helpers below are the cross-package entry points to the process-package
+%%% cache and scheduler-format functionality that the vm-package devices
+%%% (`dev_genesis_wasm', `dev_delegated_compute') rely on. They depend only on
+%%% the core `hb_*'/`ar_*' modules, which are never renamed, so they resolve in
+%%% whichever package they are compiled into.
+%%%
+%%% Exports for these are declared in the module's top `-export' block: the Forge
+%%% device compiler rejects `-export' attributes placed after function definitions.
 %%% --------------------------------------------------------------------
 
-%% @doc Cross-package-safe mirror of `dev_process_cache:write/4'.
+%% @doc Write a process computation result to the cache. Canonical home of the
+%% process-result cache writer; `dev_process_cache:write/4' delegates here so the
+%% logic is shared (and resolvable) across the process and vm device packages.
 cache_write(ProcID, Slot, Msg, Opts) ->
+    % Write the item to the cache in the root of the store.
     {ok, Root} = hb_cache:write(hb_private:reset(Msg), Opts),
+    % Link the item to the path in the store by slot number.
     SlotNumPath = cache_path(ProcID, Slot, Opts),
     hb_cache:link(Root, SlotNumPath, Opts),
-    MsgIDPath = cache_path(ProcID, hb_message:id(Msg, uncommitted, Opts), Opts),
+    % Link the item to the message ID path in the store.
+    MsgIDPath =
+        cache_path(
+            ProcID,
+            ID = hb_message:id(Msg, uncommitted, Opts),
+            Opts
+        ),
+    ?event(
+        {linking_id,
+            {proc_id, ProcID},
+            {slot, Slot},
+            {id, ID},
+            {path, MsgIDPath}
+        }
+    ),
     hb_cache:link(Root, MsgIDPath, Opts),
+    % Return the slot number path.
     {ok, SlotNumPath}.
 
-%% @doc Cross-package-safe mirror of `dev_process_cache:latest/2'.
-cache_latest(ProcID, Opts) ->
-    cache_latest(ProcID, [], undefined, Opts).
+%% @doc Retrieve the latest slot for a given process. Optionally state a limit
+%% on the slot number to search for, as well as a required path that the slot
+%% must have. Canonical home; `dev_process_cache:latest/_' delegates here.
+cache_latest(ProcID, Opts) -> cache_latest(ProcID, [], Opts).
+cache_latest(ProcID, RequiredPath, Opts) ->
+    cache_latest(ProcID, RequiredPath, undefined, Opts).
 cache_latest(ProcID, RawRequiredPath, Limit, RawOpts) ->
     Scope = hb_opts:get(process_cache_scope, local, RawOpts),
+    % Normalize the store descriptor to a list of stores.
     UnscopedStore =
         case hb_opts:get(store, no_viable_store, RawOpts) of
             StoreMsg when is_map(StoreMsg) -> [StoreMsg];
             Other -> Other
         end,
+    % Apply the scope to the store and update the options message.
     ScopedStore = hb_store:scope(UnscopedStore, Scope),
     Opts = RawOpts#{ <<"store">> => ScopedStore },
+    % Convert the required path to a list of _binary_ keys.
     RequiredPath =
         case RawRequiredPath of
             undefined -> [];
             [] -> [];
             _ -> hb_path:term_to_path_parts(RawRequiredPath, Opts)
         end,
+    ?event({required_path_converted, {proc_id, ProcID}, {required_path, RequiredPath}}),
     Path = cache_path(ProcID, slot_root, Opts),
     AllSlots = hb_cache:list_numbered(Path, Opts),
+    ?event({all_slots, {proc_id, ProcID}, {slots, AllSlots}}),
     CappedSlots =
         case Limit of
             undefined -> AllSlots;
             _ -> lists:filter(fun(Slot) -> Slot =< Limit end, AllSlots)
         end,
+    ?event(
+        {finding_latest_slot,
+            {proc_id, hb_util:human_id(ProcID)},
+            {limit, Limit},
+            {path, Path},
+            {slots_in_range, CappedSlots}
+        }
+    ),
+    % Find the highest slot that has the necessary path.
     BestSlot =
         cache_first_with_path(
             ProcID, RequiredPath, lists:reverse(lists:sort(CappedSlots)), Opts),
@@ -240,6 +279,7 @@ cache_first_with_path(ProcID, RequiredPath, Slots, Opts) ->
 cache_first_with_path(_ProcID, _Required, [], _Opts, _Store) -> not_found;
 cache_first_with_path(ProcID, RequiredPath, [Slot | Rest], Opts, Store) ->
     RawPath = cache_path(ProcID, Slot, RequiredPath, Opts),
+    ?event({trying_slot, {slot, Slot}, {path, RawPath}}),
     case hb_store:read(Store, RawPath, Opts) of
         {error, not_found} ->
             cache_first_with_path(ProcID, RequiredPath, Rest, Opts, Store);
@@ -248,7 +288,8 @@ cache_first_with_path(ProcID, RequiredPath, [Slot | Rest], Opts, Store) ->
         _ -> Slot
     end.
 
-%% @doc Cross-package-safe mirror of `dev_scheduler_formats:assignments_to_aos2/4'.
+%% @doc Return legacy net-SU compatible AOS2 results for a set of assignments.
+%% Canonical home; `dev_scheduler_formats:assignments_to_aos2/4' delegates here.
 assignments_to_aos2(ProcID, Assignments, More, RawOpts) when is_map(Assignments) ->
     assignments_to_aos2(
         ProcID,
@@ -281,6 +322,8 @@ assignments_to_aos2(ProcID, Assignments, More, RawOpts) ->
                 )
         },
     Encoded = hb_json:encode(BodyStruct),
+    ?event({body_struct, BodyStruct}),
+    ?event({encoded, {explicit, Encoded}}),
     {ok, #{
         <<"content-type">> => <<"application/json">>,
         <<"body">> => Encoded

--- a/src/preloaded/process/lib_process.erl
+++ b/src/preloaded/process/lib_process.erl
@@ -8,7 +8,11 @@
     process_id/3,
     set_results/3,
     ensure_process_key/2,
-    default_device/3
+    default_device/3,
+    %% Cross-package helpers (issue #944) — see bottom of module.
+    cache_write/4,
+    cache_latest/2,
+    assignments_to_aos2/4
 ]).
 
 %% @doc Returns the process ID of the current process.
@@ -148,3 +152,167 @@ default_device(Base, Key, Opts) ->
 default_device_index(<<"scheduler">>) -> <<"scheduler@1.0">>;
 default_device_index(<<"execution">>) -> <<"genesis-wasm@1.0">>;
 default_device_index(<<"push">>) -> <<"push@1.0">>.
+
+%%% --------------------------------------------------------------------
+%%% Cross-package helpers (issue #944).
+%%%
+%%% The vm-package devices (`dev_genesis_wasm', `dev_delegated_compute') need
+%%% functionality that lives in the process package (`dev_process_cache',
+%%% `dev_scheduler_formats'). A DIRECT cross-package call is emitted bare by the
+%%% device packager's rename transform (`hb_device_rename') — the called atom is
+%%% not in the calling package's rename map — so it `undef's at runtime on a fresh
+%%% build (issue #944). `lib_process' is declared via `-device_libraries' by BOTH
+%%% packages, so it is compiled into each; routing these calls through it makes
+%%% them resolve in either package. The bodies below depend only on the
+%%% (never-renamed) `hb_*'/`ar_*' core, so they are self-contained in any package.
+%%%
+%%% NOTE FOR REVIEWERS: these mirror `dev_process_cache:{write,latest}/_' and
+%%% `dev_scheduler_formats:assignments_to_aos2/4'. An alternative is to MOVE the
+%%% originals here and have the process-package modules delegate to `lib_process'
+%%% (both already declare it) to avoid the duplication — flagged for your call.
+%%% (Exports are declared in the module's top `-export' block — the Forge device
+%%% compiler rejects `-export' attributes that appear after function definitions.)
+%%% --------------------------------------------------------------------
+
+%% @doc Cross-package-safe mirror of `dev_process_cache:write/4'.
+cache_write(ProcID, Slot, Msg, Opts) ->
+    {ok, Root} = hb_cache:write(hb_private:reset(Msg), Opts),
+    SlotNumPath = cache_path(ProcID, Slot, Opts),
+    hb_cache:link(Root, SlotNumPath, Opts),
+    MsgIDPath = cache_path(ProcID, hb_message:id(Msg, uncommitted, Opts), Opts),
+    hb_cache:link(Root, MsgIDPath, Opts),
+    {ok, SlotNumPath}.
+
+%% @doc Cross-package-safe mirror of `dev_process_cache:latest/2'.
+cache_latest(ProcID, Opts) ->
+    cache_latest(ProcID, [], undefined, Opts).
+cache_latest(ProcID, RawRequiredPath, Limit, RawOpts) ->
+    Scope = hb_opts:get(process_cache_scope, local, RawOpts),
+    UnscopedStore =
+        case hb_opts:get(store, no_viable_store, RawOpts) of
+            StoreMsg when is_map(StoreMsg) -> [StoreMsg];
+            Other -> Other
+        end,
+    ScopedStore = hb_store:scope(UnscopedStore, Scope),
+    Opts = RawOpts#{ <<"store">> => ScopedStore },
+    RequiredPath =
+        case RawRequiredPath of
+            undefined -> [];
+            [] -> [];
+            _ -> hb_path:term_to_path_parts(RawRequiredPath, Opts)
+        end,
+    Path = cache_path(ProcID, slot_root, Opts),
+    AllSlots = hb_cache:list_numbered(Path, Opts),
+    CappedSlots =
+        case Limit of
+            undefined -> AllSlots;
+            _ -> lists:filter(fun(Slot) -> Slot =< Limit end, AllSlots)
+        end,
+    BestSlot =
+        cache_first_with_path(
+            ProcID, RequiredPath, lists:reverse(lists:sort(CappedSlots)), Opts),
+    case BestSlot of
+        {failure, _} = Failure -> Failure;
+        {error, _} = Error -> Error;
+        not_found -> {error, not_found};
+        SlotNum ->
+            {ok, Msg} = hb_cache:read(cache_path(ProcID, SlotNum, Opts), Opts),
+            {ok, SlotNum, Msg}
+    end.
+
+cache_path(ProcID, Ref, Opts) -> cache_path(ProcID, Ref, [], Opts).
+cache_path(ProcID, Ref, PathSuffix, _Opts) ->
+    hb_path:to_binary(
+        [<<"computed">>, hb_util:human_id(ProcID)] ++
+        case Ref of
+            Int when is_integer(Int) -> ["slot", integer_to_binary(Int)];
+            root -> [];
+            slot_root -> ["slot"];
+            _ -> [Ref]
+        end ++ PathSuffix
+    ).
+
+cache_first_with_path(ProcID, RequiredPath, Slots, Opts) ->
+    cache_first_with_path(
+        ProcID, RequiredPath, Slots, Opts,
+        hb_opts:get(store, no_viable_store, Opts)
+    ).
+cache_first_with_path(_ProcID, _Required, [], _Opts, _Store) -> not_found;
+cache_first_with_path(ProcID, RequiredPath, [Slot | Rest], Opts, Store) ->
+    RawPath = cache_path(ProcID, Slot, RequiredPath, Opts),
+    case hb_store:read(Store, RawPath, Opts) of
+        {error, not_found} ->
+            cache_first_with_path(ProcID, RequiredPath, Rest, Opts, Store);
+        {failure, _} = Failure -> Failure;
+        {error, _} = Error -> Error;
+        _ -> Slot
+    end.
+
+%% @doc Cross-package-safe mirror of `dev_scheduler_formats:assignments_to_aos2/4'.
+assignments_to_aos2(ProcID, Assignments, More, RawOpts) when is_map(Assignments) ->
+    assignments_to_aos2(
+        ProcID,
+        hb_util:message_to_ordered_list(Assignments),
+        More,
+        format_opts(RawOpts)
+    );
+assignments_to_aos2(ProcID, Assignments, More, RawOpts) ->
+    Opts = format_opts(RawOpts),
+    {Timestamp, Height, Hash} = ar_timestamp:get(),
+    BodyStruct =
+        #{
+            <<"page_info">> =>
+                #{
+                    <<"process">> => hb_util:human_id(ProcID),
+                    <<"has_next_page">> => More,
+                    <<"timestamp">> => list_to_binary(integer_to_list(Timestamp)),
+                    <<"block-height">> => list_to_binary(integer_to_list(Height)),
+                    <<"block-hash">> => hb_util:human_id(Hash)
+                },
+            <<"edges">> =>
+                lists:map(
+                    fun(Assignment) ->
+                        #{
+                            <<"cursor">> => assignment_cursor(Assignment, Opts),
+                            <<"node">> => assignment_to_aos2(Assignment, Opts)
+                        }
+                    end,
+                    Assignments
+                )
+        },
+    Encoded = hb_json:encode(BodyStruct),
+    {ok, #{
+        <<"content-type">> => <<"application/json">>,
+        <<"body">> => Encoded
+    }}.
+
+assignment_cursor(Assignment, RawOpts) ->
+    hb_ao:get(<<"slot">>, Assignment, format_opts(RawOpts)).
+
+assignment_to_aos2(Assignment, RawOpts) ->
+    Opts = format_opts(RawOpts),
+    Message = hb_ao:get(<<"body">>, Assignment, Opts),
+    AssignmentWithoutBody = hb_maps:without([<<"body">>], Assignment, Opts),
+    {ok, MessageStruct} =
+        hb_ao:resolve(
+            #{ <<"device">> => <<"json-iface@1.0">> },
+            #{ <<"path">> => <<"to">>, <<"message">> => Message },
+            Opts
+        ),
+    {ok, AssignmentStruct} =
+        hb_ao:resolve(
+            #{ <<"device">> => <<"json-iface@1.0">> },
+            #{ <<"path">> => <<"to">>, <<"message">> => AssignmentWithoutBody },
+            Opts
+        ),
+    #{
+        <<"message">> => MessageStruct,
+        <<"assignment">> => AssignmentStruct
+    }.
+
+format_opts(Opts) ->
+    Opts#{
+        <<"hashpath">> => ignore,
+        <<"cache-control">> => [<<"no-cache">>, <<"no-store">>],
+        <<"await-inprogress">> => false
+    }.

--- a/src/preloaded/vm/dev_delegated_compute.erl
+++ b/src/preloaded/vm/dev_delegated_compute.erl
@@ -83,7 +83,7 @@ do_compute(ProcID, Req, Opts) ->
     ?event({do_compute_msg, {req, Req}}),
     Slot = hb_ao:get(<<"slot">>, Req, Opts),
     {ok, AOS2 = #{ <<"body">> := Body }} =
-        dev_scheduler_formats:assignments_to_aos2(
+        lib_process:assignments_to_aos2(
             ProcID,
             #{
                 Slot => Req

--- a/src/preloaded/vm/dev_genesis_wasm.erl
+++ b/src/preloaded/vm/dev_genesis_wasm.erl
@@ -459,7 +459,7 @@ do_import(Proc, CheckpointMessage, Opts) ->
                 <<"snapshot">> => CheckpointMessage
             },
         % Save the state snapshot into the store.
-        {ok, _} ?= dev_process_cache:write(ProcID, Slot, WithSnapshot, Opts),
+        {ok, _} ?= lib_process:cache_write(ProcID, Slot, WithSnapshot, Opts),
         % Return the normalized process message.
         {ok, WithSnapshot}
     else
@@ -605,7 +605,7 @@ import_legacy_checkpoint() ->
     ?assert(byte_size(SnapshotData) > 0),
     ?assertMatch(
         {ok, Slot, _} when Slot > 0,
-        dev_process_cache:latest(ProcID, Opts)
+        lib_process:cache_latest(ProcID, Opts)
     ),
     {ok, ActualSlot} =
         hb_ao:resolve(<<ProcID/binary, "~process@1.0/compute/at-slot">>, Opts),


### PR DESCRIPTION
Hey — know the team's heads-down on launch, so this one's meant to be ready-to-merge, not more work.

**Problem (#944):** a fresh `rebar3 ... release` build `undef`s on the first `/compute`. Root cause is in the device packager, not the device logic. `hb_packager`'s per-package rename map covers only a package's own `dev_*` roots/helpers plus its declared `lib_*`, and `hb_device_rename:substitute/2` emits every other atom **bare**. So a direct call from one package to a `dev_*` module in **another** package is emitted bare and `undef`s at runtime (only the generated/hashed module names are ever loaded). Three such vm→process calls exist today:

- `src/preloaded/vm/dev_delegated_compute.erl:86` → `dev_scheduler_formats:assignments_to_aos2/4`
- `src/preloaded/vm/dev_genesis_wasm.erl:462` → `dev_process_cache:write/4`
- `src/preloaded/vm/dev_genesis_wasm.erl:608` → `dev_process_cache:latest/2` (test path)

Introduced by `ad285cd5` ("split core forge and preloaded devices").

**Fix:** both packages already declare `-device_libraries([lib_process])`, so route these calls through `lib_process` — it's compiled (and renamed) into each package, so the calls resolve. Adds `cache_write/4`, `cache_latest/2`, `assignments_to_aos2/4` to `lib_process` (self-contained on the never-renamed `hb_*`/`ar_*` core) and repoints the three sites.

**Test:** new `hb_packager_test_vectors:cross_package_call_resolution_test` — two packages where A calls B both directly and via a shared declared lib; asserts the direct call `undef`s and the lib-routed call resolves (reproduces #944 and locks it). `rebar3 compile` + `rebar3 eunit --module=hb_packager_test_vectors` → **all 15 pass**, verified end-to-end through a full native build (WAMR + NIFs). Took three build iterations to nail the toolchain.

**One call for you:** the three functions are currently mirrored into `lib_process` (~110 lines) to keep this minimal and obviously correct. Happy to instead move the originals + delegate, or split out `lib_process_cache` / `lib_scheduler_formats` — whatever shape you prefer.

~Tad & Claude
