### PR TITLE
Fix starting shell with custom sname

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -145,7 +145,16 @@
         "sh -c '"
             "case \"$PWD\" in "
             "*/_build/*) ;; "
-            "*) ERL_FLAGS= escript scripts/build-preloaded-store.escript ;; "
+            "*) "
+                "set -- $ERL_FLAGS; ERL_FLAGS=; "
+                "while [ $# -gt 0 ]; do "
+                    "case \"$1\" in "
+                    "-sname|-name) shift 2 ;; "
+                    "*) ERL_FLAGS=\"${ERL_FLAGS:+$ERL_FLAGS }$1\"; shift ;; "
+                    "esac; "
+                "done; "
+                "export ERL_FLAGS; "
+                "escript scripts/build-preloaded-store.escript ;; "
             "esac"
         "'"}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -145,7 +145,7 @@
         "sh -c '"
             "case \"$PWD\" in "
             "*/_build/*) ;; "
-            "*) escript scripts/build-preloaded-store.escript ;; "
+            "*) ERL_FLAGS= escript scripts/build-preloaded-store.escript ;; "
             "esac"
         "'"}
 ]}.


### PR DESCRIPTION
Trying to run a shell with a custom sname (to call `hb:top()` on a remote node for example) return the following error.

```
Post-compile hooks executed
Protocol 'inet_tcp': the name observer_cl123@neo-arweave seems to be in use by another Erlang node
```

This PR fix the ERL_FLAGS not being used on the `scripts/build-preloaded-store.escript` script.

# TODO
- [ ] The call changed from ´rebar.configtoMakefile`. This PR needs to be updated.

