### PR TITLE
Fix native pointer type mismatches

### DIFF
--- a/native/hb_beamr/hb_beamr.c
+++ b/native/hb_beamr/hb_beamr.c
@@ -174,11 +174,16 @@ static void wasm_driver_output(ErlDrvData raw, char *buff, ErlDrvSizeT bufflen) 
         ei_decode_tuple_header(buff, &index, &arity);
         ei_decode_long(buff, &index, &ptr);
         ei_get_type(buff, &index, &type, &size);
-        size_t size_l;
+        size_t size_l = 0;
         const char* wasm_binary;
         int res = ei_decode_bitstring(buff, &index, &wasm_binary, NULL, &size_l);
         DRV_DEBUG("Decoded binary. Res: %d. Size (bits): %zu", res, size_l);
-        long size_bytes = size_l / 8;
+        if(res != 0 || size_l % 8 != 0) {
+            DRV_DEBUG("Failed to decode byte-aligned binary.");
+            send_error(proc, "Failed to decode byte-aligned binary");
+            return;
+        }
+        long size_bytes = (long)(size_l / 8);
         DRV_DEBUG("Write received. Ptr: %ld. Bytes: %ld", ptr, size_bytes);
         long memory_size = get_memory_size(proc);
         if(ptr + size_bytes > memory_size) {

--- a/native/hb_beamr/hb_beamr.c
+++ b/native/hb_beamr/hb_beamr.c
@@ -169,15 +169,15 @@ static void wasm_driver_output(ErlDrvData raw, char *buff, ErlDrvSizeT bufflen) 
         }
     } else if (strcmp(command, "write") == 0) {
         DRV_DEBUG("Write received");
-        long ptr, size;
-        int type;
+        long ptr;
+        int type, size;
         ei_decode_tuple_header(buff, &index, &arity);
         ei_decode_long(buff, &index, &ptr);
         ei_get_type(buff, &index, &type, &size);
-        long size_l = (long)size;
-        char* wasm_binary;
+        size_t size_l;
+        const char* wasm_binary;
         int res = ei_decode_bitstring(buff, &index, &wasm_binary, NULL, &size_l);
-        DRV_DEBUG("Decoded binary. Res: %d. Size (bits): %ld", res, size_l);
+        DRV_DEBUG("Decoded binary. Res: %d. Size (bits): %zu", res, size_l);
         long size_bytes = size_l / 8;
         DRV_DEBUG("Write received. Ptr: %ld. Bytes: %ld", ptr, size_bytes);
         long memory_size = get_memory_size(proc);

--- a/native/hb_beamr/hb_helpers.c
+++ b/native/hb_beamr/hb_helpers.c
@@ -120,11 +120,11 @@ ei_term* decode_list(char* buff, int* index) {
     }
     else if(type == ERL_STRING_EXT) {
         //DRV_DEBUG("Decoding list encoded as string");
-        unsigned char* str = driver_alloc(arity * sizeof(char) + 1);
+        char* str = driver_alloc(arity * sizeof(char) + 1);
         ei_decode_string(buff, index, str);
         for(int i = 0; i < arity; i++) {
             res[i].ei_type = ERL_INTEGER_EXT;
-            res[i].value.i_val = (long) str[i];
+            res[i].value.i_val = (long) (unsigned char) str[i];
             DRV_DEBUG("Decoded term %d: %d", i, res[i].value.i_val);
         }
         driver_free(str);

--- a/native/hb_beamr/hb_helpers.c
+++ b/native/hb_beamr/hb_helpers.c
@@ -124,7 +124,7 @@ ei_term* decode_list(char* buff, int* index) {
         ei_decode_string(buff, index, str);
         for(int i = 0; i < arity; i++) {
             res[i].ei_type = ERL_INTEGER_EXT;
-            res[i].value.i_val = (long) (unsigned char) str[i];
+            res[i].value.i_val = (unsigned char) str[i];
             DRV_DEBUG("Decoded term %d: %d", i, res[i].value.i_val);
         }
         driver_free(str);

--- a/native/hb_beamr/hb_wasm.c
+++ b/native/hb_beamr/hb_wasm.c
@@ -469,12 +469,61 @@ int wasm_execute_indirect_function(Proc* proc, const char *field_name, const was
     wasm_val_vec_new(&prepared_args, input_args->size - 1, prepared_data);
     DRV_DEBUG("Prepared %zu arguments for function call", prepared_args.size);
 
-    uint32_t argc = prepared_args.size;
+    if(prepared_args.size != param_types->size) {
+        DRV_DEBUG("Prepared argument count does not match function type");
+        free(prepared_args.data);
+        return -1;
+    }
+
+    uint32_t argc = 0;
+    for (size_t i = 0; i < prepared_args.size; ++i) {
+        wasm_valkind_t kind = wasm_valtype_kind(param_types->data[i]);
+        argc += (kind == WASM_I64 || kind == WASM_F64) ? 2 : 1;
+    }
     uint32_t* argv = malloc(sizeof(uint32_t) * argc);
+    if(!argv) {
+        DRV_DEBUG("Failed to allocate WAMR argv");
+        free(prepared_args.data);
+        return -1;
+    }
     
     // Convert prepared arguments to the 32-bit cell array expected by WAMR
-    for (uint32_t i = 0; i < argc; ++i) {
-        argv[i] = prepared_args.data[i].of.i32;
+    uint32_t arg_i = 0;
+    for (size_t i = 0; i < prepared_args.size; ++i) {
+        wasm_valkind_t kind = wasm_valtype_kind(param_types->data[i]);
+        switch(kind) {
+            case WASM_I32:
+                argv[arg_i++] = (uint32_t) prepared_args.data[i].of.i32;
+                break;
+            case WASM_F32:
+                memcpy(
+                    &argv[arg_i++],
+                    &prepared_args.data[i].of.f32,
+                    sizeof(uint32_t)
+                );
+                break;
+            case WASM_I64:
+                memcpy(
+                    &argv[arg_i],
+                    &prepared_args.data[i].of.i64,
+                    sizeof(uint64_t)
+                );
+                arg_i += 2;
+                break;
+            case WASM_F64:
+                memcpy(
+                    &argv[arg_i],
+                    &prepared_args.data[i].of.f64,
+                    sizeof(uint64_t)
+                );
+                arg_i += 2;
+                break;
+            default:
+                DRV_DEBUG("Unsupported indirect argument type: %d", kind);
+                free(argv);
+                free(prepared_args.data);
+                return -1;
+        }
     }
 
 

--- a/native/hb_beamr/hb_wasm.c
+++ b/native/hb_beamr/hb_wasm.c
@@ -469,12 +469,12 @@ int wasm_execute_indirect_function(Proc* proc, const char *field_name, const was
     wasm_val_vec_new(&prepared_args, input_args->size - 1, prepared_data);
     DRV_DEBUG("Prepared %zu arguments for function call", prepared_args.size);
 
-    uint64_t argc = prepared_args.size;
-    uint64_t* argv = malloc(sizeof(uint64_t) * argc);
+    uint32_t argc = prepared_args.size;
+    uint32_t* argv = malloc(sizeof(uint32_t) * argc);
     
-    // Convert prepared arguments to an array of 64-bit integers
-    for (uint64_t i = 0; i < argc; ++i) {
-        argv[i] = prepared_args.data[i].of.i64;
+    // Convert prepared arguments to the 32-bit cell array expected by WAMR
+    for (uint32_t i = 0; i < argc; ++i) {
+        argv[i] = prepared_args.data[i].of.i32;
     }
 
 
@@ -491,8 +491,10 @@ int wasm_execute_indirect_function(Proc* proc, const char *field_name, const was
 
     // Attempt to call the function and check for any exceptions
     if (!wasm_runtime_call_indirect(proc->exec_env, function_index, argc, argv)) {
-        if (wasm_runtime_get_exception(proc->exec_env)) {
-            DRV_DEBUG("%s", wasm_runtime_get_exception(proc->exec_env));
+        wasm_module_inst_t module_inst = wasm_runtime_get_module_inst(proc->exec_env);
+        const char* exception = wasm_runtime_get_exception(module_inst);
+        if (exception) {
+            DRV_DEBUG("%s", exception);
         }
         DRV_DEBUG("WASM function call failed");
         result = -1;
@@ -568,7 +570,8 @@ int wasm_execute_exported_function(Proc* proc, const char *function_name, wasm_v
     if (wasm_runtime_call_wasm_a(proc->exec_env, func->func_comm_rt, result_types->size, results, param_types->size, params)) {
         DRV_DEBUG("=   Function call successful");
     } else {
-        const char* exception = wasm_runtime_get_exception(proc->exec_env);
+        wasm_module_inst_t module_inst = wasm_runtime_get_module_inst(proc->exec_env);
+        const char* exception = wasm_runtime_get_exception(module_inst);
         DRV_DEBUG("=   Function call failed: %s", exception);
         return -1;
     }
@@ -579,4 +582,3 @@ int wasm_execute_exported_function(Proc* proc, const char *function_name, wasm_v
 
     return 0;
 }
-


### PR DESCRIPTION
Fixes a compatibility error caused by gcc v13 (and older) silently allowing type mismatches that gcc v14+ does not.

Users on LTS releases would not notice this, but users of rolling release distros with newer gcc versions would be unable to build HyperBEAM without this fix. 

Discovered on gcc 16.1. Validated the fix on gcc 12.5, 14.3, 13.3 and 16.1. 