### PR TITLE
fix: bind community docker wallet to default key path

### DIFF
--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -151,6 +151,11 @@ machine.
 Index data is persisted in a Docker volume (`hyperbeam-data`). Continuous
 indexing starts automatically.
 
+Create the operator wallet file at `../../wallets/operator.json`, relative to
+`docs/community`. The compose file mounts this wallet to both `/app/wallet.json`
+and `/app/hb/hyperbeam-key.json`. These paths must point to the same wallet so
+the configured key path and the runtime default key path use the same signer.
+
 Other environment variables:
 - `HB_PORT`: HyperBEAM listen port (default: `8001`)
 - `DATA_DIR`: LMDB path inside the container (default: `/data/rolling`)

--- a/docs/community/docker-compose.yml
+++ b/docs/community/docker-compose.yml
@@ -9,6 +9,18 @@ services:
       - DATA_DIR=/data/rolling
     volumes:
       - hyperbeam-data:/data
+      - type: bind
+        source: ../../wallets/operator.json
+        target: /app/wallet.json
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ../../wallets/operator.json
+        target: /app/hb/hyperbeam-key.json
+        read_only: true
+        bind:
+          create_host_path: false
 
 volumes:
   hyperbeam-data:

--- a/docs/community/entrypoint.sh
+++ b/docs/community/entrypoint.sh
@@ -10,6 +10,7 @@ cat > /app/config.json <<EOF
 {
   "ao-types": "generate_index=atom,max_connections=integer,num_acceptors=integer",
   "port": ${HB_PORT},
+  "priv_key_location": "/app/wallet.json",
   "num_acceptors": 32,
   "max_connections": 512,
   "arweave_index_workers": 16,


### PR DESCRIPTION
## Summary

This PR updates the community Docker setup so the operator wallet is mounted at both key paths used by the container runtime:

- `/app/wallet.json`
- `/app/hb/hyperbeam-key.json`

It also keeps `priv_key_location` explicitly set to `/app/wallet.json` and documents that both paths must point to the same wallet.

## Why

The Docker entrypoint writes `priv_key_location` to `/app/wallet.json`, while HyperBEAM can also use its default key path under `/app/hb/hyperbeam-key.json`.

Mounting the same wallet at both paths keeps the configured key path and runtime default key path aligned, so the node exposes the intended signer consistently.

## How to use

Create the operator wallet at the repository root:

```text
wallets/operator.json
```

For example, if the repository is checked out at `~/HyperBEAM`, the full path is:

```text
~/HyperBEAM/wallets/operator.json
```

Then start the community Docker stack from `docs/community`:

```bash
cd docs/community
docker compose up --build -d
```

The compose file references the wallet from that directory as:

```text
../../wallets/operator.json
```

and mounts the same file into the container at both runtime key paths:

```text
/app/wallet.json
/app/hb/hyperbeam-key.json
```

No extra environment variable is required for this wallet binding.

## Validation

- `git diff --check origin/feat/community-node..HEAD`
- `bash -n docs/community/entrypoint.sh`