### PR TITLE
feat: arbitrary depth offset and data indexing for confirmed + pending Arweave IDs

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -215,7 +215,8 @@
 		{mkdir, "bin/priv"},
 		{copy, "priv", "bin/priv"},
 		{copy, "config.flat", "config.flat"},
-		{copy, "_build/preloaded-store", "_build/preloaded-store"}
+		{copy, "_build/preloaded-store", "_build/preloaded-store"},
+        {copy, "scripts/schema.gql", "scripts/schema.gql"}
 	]}
 ]}.
 

--- a/src/core/store/hb_store_arweave.erl
+++ b/src/core/store/hb_store_arweave.erl
@@ -207,6 +207,23 @@ load_item(ExpectedID, StartOffset, Length, Opts) ->
 %% @doc Load a TX from the given start offset and length. The `StartOffset' is
 %% the start of the first chunk of the data and runs for the length of the data
 %% segment, ignoring header size.
+%% Pending TX offsets are fetched by ID.
+load_tx(ID, relative, _Length, Opts) ->
+    hb_prometheus:measure_and_report(
+        fun() ->
+            hb_ao:resolve(
+                #{ <<"device">> => <<"arweave@2.9">> },
+                #{
+                    <<"path">> => <<"pending">>,
+                    <<"pending">> => ID,
+                    <<"exclude-data">> => false
+                },
+                Opts
+            )
+        end,
+        hb_store_arweave_chunk_fetch_duration_seconds,
+        [load_tx]
+    );
 load_tx(ID, StartOffset, Length, Opts) ->
     hb_prometheus:measure_and_report(
         fun() ->
@@ -303,7 +320,8 @@ record_partition_metric(Offset, Result, StoreOpts) when is_integer(Offset) ->
             end);
         false ->
             ok
-    end.
+    end;
+record_partition_metric(_, _, _) -> ok.
 
 %% @doc Initialize the Prometheus metrics for the Arweave store. Executed on
 %% `start/1' of the store.

--- a/src/core/store/hb_store_arweave.erl
+++ b/src/core/store/hb_store_arweave.erl
@@ -270,6 +270,17 @@ load_tx(ID, StartOffset, Length, Opts) ->
 
 %% @doc Read the chunks from the given start offset and length using the 
 %% `~arweave@2.9` device.
+read_chunks(#{ <<"relative">> := TXID, <<"offset">> := Offset }, Length, Opts) ->
+    hb_ao:resolve(
+        #{ <<"device">> => <<"arweave@2.9">> },
+        #{
+            <<"path">> => <<"chunk">>,
+            <<"pending">> => TXID,
+            <<"offset">> => Offset,
+            <<"length">> => Length
+        },
+        Opts
+    );
 read_chunks(StartOffset, Length, Opts) ->
     hb_ao:resolve(
         #{ <<"device">> => <<"arweave@2.9">> },

--- a/src/core/store/hb_store_arweave_offset.erl
+++ b/src/core/store/hb_store_arweave_offset.erl
@@ -6,6 +6,8 @@
 %%% 
 %%% The encoding is as follows:
 %%%     << Version:4, Codec:4, StartOffset:64, Length/binary >>
+%%% Pending TXs omit the offset and length:
+%%%     << Version:4, 0:4 >>
 %%% where:
 %%%     - Version: 4-bit unsigned integer. Max: 15. Current: version `1`.
 %%%     - Codec: 4-bit unsigned integer. Max: 15.
@@ -44,6 +46,8 @@ path(ID) -> throw({cannot_encode_path, ID}).
 
 %% @doc Encode the offset of the data if it is valid. Throws `cannot_encode_offset'
 %% if invalid.
+encode(<<"tx@1.0">>, relative, _Length) ->
+    <<?FORMAT_VERSION:4, 0:4>>;
 encode(Type, StartOffset, Length)
         when
         (Type == true orelse Type == false orelse is_binary(Type))
@@ -58,6 +62,8 @@ encode(Type, StartOffset, Length)
 encode(IsTX, StartOffset, Length) ->
     throw({cannot_encode_offset, {IsTX, StartOffset, Length}}).
 
+decode(<<?FORMAT_VERSION:4, 0:4>>) ->
+    {?FORMAT_VERSION, <<"tx@1.0">>, relative, 0};
 decode(<<Format:1/binary, StartOffset:?OFFSET_SZ, Length/binary>>) ->
     {Version, CodecName} = decode_format(Format),
     {Version, CodecName, StartOffset, binary:decode_unsigned(Length)};

--- a/src/core/store/hb_store_arweave_offset.erl
+++ b/src/core/store/hb_store_arweave_offset.erl
@@ -8,6 +8,8 @@
 %%%     << Version:4, Codec:4, StartOffset:64, Length/binary >>
 %%% Pending TXs omit the offset and length:
 %%%     << Version:4, 0:4 >>
+%%% Pending TX children use the maximum offset as a relative marker:
+%%%     << Version:4, Codec:4, 2^64-1:64, ParentID:256, Offset:64, Length/binary >>
 %%% where:
 %%%     - Version: 4-bit unsigned integer. Max: 15. Current: version `1`.
 %%%     - Codec: 4-bit unsigned integer. Max: 15.
@@ -30,11 +32,13 @@
 -module(hb_store_arweave_offset).
 -export([encode/3, decode/1, path/1]).
 -include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
 
 %% @doc Determine if a value is within a given unsigned bit range.
 -define(IN_BIT_RANGE(X, Bits), (X >= 0 andalso X < (1 bsl Bits))).
 
 -define(OFFSET_SZ, (8*8)). % 64-bit uint. Max: 2^64-1.
+-define(OFFSET_MAX, ((1 bsl ?OFFSET_SZ) - 1)).
 -define(FORMAT_VERSION, 1). % 4-bit uint. Max: 15.
 
 %% @doc Reserved for future use. At the present time, store containing offsets are
@@ -48,10 +52,24 @@ path(ID) -> throw({cannot_encode_path, ID}).
 %% if invalid.
 encode(<<"tx@1.0">>, relative, _Length) ->
     <<?FORMAT_VERSION:4, 0:4>>;
+encode(Type, #{ <<"relative">> := ParentID, <<"offset">> := RelOffset }, Length)
+        when
+        is_binary(Type)
+        andalso ?IS_ID(ParentID)
+        andalso ?IN_BIT_RANGE(RelOffset, ?OFFSET_SZ)
+        andalso is_integer(Length) andalso Length >= 0
+    ->
+    <<
+        (encode_format(Type))/binary,
+        ?OFFSET_MAX:?OFFSET_SZ,
+        (hb_util:native_id(ParentID))/binary,
+        RelOffset:?OFFSET_SZ,
+        (binary:encode_unsigned(Length))/binary
+    >>;
 encode(Type, StartOffset, Length)
         when
         (Type == true orelse Type == false orelse is_binary(Type))
-        andalso ?IN_BIT_RANGE(StartOffset, ?OFFSET_SZ*8)
+        andalso ?IN_BIT_RANGE(StartOffset, ?OFFSET_SZ)
         andalso is_integer(Length) andalso Length >= 0
     ->
     <<
@@ -64,6 +82,18 @@ encode(IsTX, StartOffset, Length) ->
 
 decode(<<?FORMAT_VERSION:4, 0:4>>) ->
     {?FORMAT_VERSION, <<"tx@1.0">>, relative, 0};
+decode(<<Format:1/binary, ?OFFSET_MAX:?OFFSET_SZ,
+        ParentID:32/binary, RelOffset:?OFFSET_SZ, Length/binary>>) ->
+    {Version, CodecName} = decode_format(Format),
+    {
+        Version,
+        CodecName,
+        #{
+            <<"relative">> => hb_util:encode(ParentID),
+            <<"offset">> => RelOffset
+        },
+        binary:decode_unsigned(Length)
+    };
 decode(<<Format:1/binary, StartOffset:?OFFSET_SZ, Length/binary>>) ->
     {Version, CodecName} = decode_format(Format),
     {Version, CodecName, StartOffset, binary:decode_unsigned(Length)};
@@ -87,12 +117,19 @@ decode_type(Type) -> throw({cannot_decode_type, Type}).
 %% @doc Encode the format of the offset. See the module documentation for the
 %% present index of supported codecs.
 encode_format(CodecName) ->
-    << ?FORMAT_VERSION:4, (encode_type(CodecName)):4 >>;
-encode_format(CodecName) ->
-    throw({cannot_encode_format, CodecName}).
+    << ?FORMAT_VERSION:4, (encode_type(CodecName)):4 >>.
 
 %% @doc Decode the format of the offset.
 decode_format(<<FormatVersion:4, CodecName:4>>) ->
     {FormatVersion, decode_type(CodecName)};
 decode_format(Binary) ->
     throw({cannot_decode_format, Binary}).
+
+relative_ref_round_trip_test() ->
+    ParentID = hb_util:encode(crypto:strong_rand_bytes(32)),
+    Offset = #{ <<"relative">> => ParentID, <<"offset">> => 321 },
+    Encoded = encode(<<"ans104@1.0">>, Offset, 654),
+    ?assertEqual(
+        {?FORMAT_VERSION, <<"ans104@1.0">>, Offset, 654},
+        decode(Encoded)
+    ).

--- a/src/hb.app.src
+++ b/src/hb.app.src
@@ -11,7 +11,8 @@
         cowboy,
         os_mon,
         gun,
-        hackney
+        hackney,
+        graphql
     ]},
     {env, []},
     {modules, []},

--- a/src/preloaded/arweave/dev_arweave.erl
+++ b/src/preloaded/arweave/dev_arweave.erl
@@ -457,39 +457,44 @@ get_chunk_range_variable_size(Offset, EndOffset, Opts) ->
 %% @doc Return a chunk or range of bytes relative to a specific, unconfirmed,
 %% transaction's data root.
 get_chunk_range_relative(Offset, Length, RelativeTXID, Opts) ->
-    hb_prometheus:observe(
-        Length,
-        arweave_chunk_load_requested_bytes,
-        []
-    ),
-    Offsets =
-        generate_offsets(
-            max(1, Offset + 1),
-            (Offset + Length),
-            ?DATA_CHUNK_SIZE
-        ),
-    GETFun =
-        fun(XOffset) ->
-            pending(
-                #{},
-                #{ <<"offset">> => XOffset, <<"pending">> => RelativeTXID },
-                Opts
-            )
-        end,
-    case fetch_and_collect(Offsets, GETFun, Opts) of
-        {ok, ChunkInfos} ->
-            Concatenated =
-                hb_util:bin(
-                    lists:map(
-                        fun(JSONStruct) ->
-                            hb_util:decode(maps:get(<<"chunk">>, JSONStruct))
-                        end,
-                        ChunkInfos
+    case pending(
+        #{},
+        #{ <<"pending">> => RelativeTXID, <<"exclude-data">> => true },
+        Opts
+    ) of
+        {ok, PendingTX} ->
+            DataSize = hb_util:int(maps:get(<<"data_size">>, PendingTX)),
+            hb_prometheus:observe(
+                Length,
+                arweave_chunk_load_requested_bytes,
+                []
+            ),
+            Offsets = pending_relative_chunk_offsets(Offset, Length, DataSize),
+            GETFun =
+                fun(XOffset) ->
+                    decode_relative_chunk(
+                        pending(
+                            #{},
+                            #{ <<"offset">> => XOffset, <<"pending">> => RelativeTXID },
+                            Opts
+                        )
                     )
-                ),
-            {ok, Concatenated};
-        Error -> Error
+                end,
+            case fetch_and_collect(Offsets, GETFun, Opts) of
+                {ok, ChunkInfos} ->
+                    {ok, Binaries} = assemble_chunks(ChunkInfos, Offset + 1),
+                    {ok, iolist_to_binary(Binaries)};
+                Error -> Error
+            end;
+        Error ->
+            Error
     end.
+
+decode_relative_chunk({ok, JSON}) ->
+    {ok, decode_chunk_tuple(JSON, ar_merkle:extract_note(
+        hb_util:decode(maps:get(<<"data_path">>, JSON))))};
+decode_relative_chunk({error, _} = Err) ->
+    Err.
 
 %% @doc Iteratively detect gaps in coverage and fetch the chunk at the start
 %% of each gap until the entire range [Offset, EndOffset] is covered.
@@ -548,20 +553,36 @@ generate_offsets(Current, End, _Step, Acc) when Current > End ->
 generate_offsets(Current, End, Step, Acc) ->
     generate_offsets(Current + Step, End, Step, [Current | Acc]).
 
+pending_relative_chunk_offsets(Offset, Length, DataSize) ->
+    RangeStart = max(1, Offset + 1),
+    RangeEnd = min(Offset + Length, DataSize),
+    case RangeStart > RangeEnd of
+        true ->
+            [];
+        false ->
+            FirstChunk = ((RangeStart - 1) div ?DATA_CHUNK_SIZE) + 1,
+            LastChunk = ((RangeEnd - 1) div ?DATA_CHUNK_SIZE) + 1,
+            [min(Chunk * ?DATA_CHUNK_SIZE, DataSize) ||
+                Chunk <- lists:seq(FirstChunk, LastChunk)]
+    end.
+
 %% @doc Decode a chunk response into a {Start, End, Binary} tuple.
 %% Runs inside the pmap worker so raw JSON is GC'd per-worker.
 decode_chunk({ok, JSON}) ->
-    Chunk = hb_util:decode(maps:get(<<"chunk">>, JSON)),
     AbsEnd = hb_util:int(maps:get(<<"absolute_end_offset">>, JSON)),
-    AbsStart = AbsEnd - byte_size(Chunk) + 1,
+    {AbsStart, _AbsEnd, Chunk} = ChunkTuple = decode_chunk_tuple(JSON, AbsEnd),
     ?event(debug_arweave,
         {decode_chunk,
             {abs_start, AbsStart},
             {abs_end, AbsEnd},
             {size, byte_size(Chunk)}}),
-    {ok, {AbsStart, AbsEnd, Chunk}};
+    {ok, ChunkTuple};
 decode_chunk({error, _} = Err) ->
     Err.
+
+decode_chunk_tuple(JSON, ChunkEnd) ->
+    Chunk = hb_util:decode(maps:get(<<"chunk">>, JSON)),
+    {ChunkEnd - byte_size(Chunk) + 1, ChunkEnd, Chunk}.
 
 %% @doc Collect decoded chunk results. Fails fast on the first error.
 collect_chunks(Results) ->
@@ -776,7 +797,14 @@ pending(Base, Request, Opts) ->
             case hb_maps:find(<<"offset">>, Request, Opts) of
                 error ->
                     % Retreive a bare TX header by its TXID
-                    request(<<"GET">>, <<"/unconfirmed_tx/", TXID/binary>>, Opts);
+                    ExcludeData =
+                        hb_util:bool(
+                            find_key(<<"exclude-data">>, Base, Request, Opts)),
+                    request(
+                        <<"GET">>,
+                        <<"/unconfirmed_tx/", TXID/binary>>,
+                        Opts#{ <<"exclude-data">> => ExcludeData }
+                    );
                 {ok, RawOffset} ->
                     Offset = hb_util:int(RawOffset),
                     % Download an unconfirmed chunk by its offset
@@ -788,17 +816,7 @@ pending(Base, Request, Opts) ->
                             "/",
                             (hb_util:bin(Offset))/binary
                         >>,
-                        Opts#{
-                            <<"exclude-data">> =>
-                                hb_util:bool(
-                                    find_key(
-                                        <<"exclude-data">>,
-                                        Base,
-                                        Request,
-                                        Opts
-                                    )
-                                )
-                        }
+                        Opts
                     )
             end
     end.
@@ -1665,6 +1683,66 @@ get_bad_tx_test_parallel() ->
     Res = hb_http:get(Node, Path, #{}),
     ?assertEqual({error, not_found}, Res).
 
+pending_offset_handling_test() ->
+    ClientOpts = post_tx_json_client_opts(),
+    PendingData = <<"test-data">>,
+    PendingLength = byte_size(PendingData),
+    #tx{ data_root = DataRoot, data_tree = DataTree } =
+        ar_tx:generate_chunk_tree(
+            #tx{
+                data = PendingData,
+                data_size = PendingLength,
+                format = 2
+            }
+    ),
+    DataPath = ar_merkle:generate_path(DataRoot, 0, DataTree),
+    HeaderJSON = hb_json:decode(post_tx_json_payload(ClientOpts)),
+    TXID = maps:get(<<"id">>, HeaderJSON),
+    ChunkBody =
+        hb_json:encode(
+            #{
+                <<"chunk">> => hb_util:encode(PendingData),
+                <<"data_path">> => hb_util:encode(DataPath)
+            }
+        ),
+    {ok, MockNode, MockHandle} = hb_mock_server:start([
+        {"/unconfirmed_chunk/:id/:offset", pending_chunk, {200, ChunkBody}},
+        {"/unconfirmed_tx/:id", pending_tx, {200, hb_json:encode(HeaderJSON)}}
+    ]),
+    Routes = [
+        #{
+            <<"template">> => <<"^/arweave">>,
+            <<"nodes">> => [
+                #{
+                    <<"match">> => <<"^/arweave">>,
+                    <<"with">> => MockNode,
+                    <<"opts">> => #{ <<"http-client">> => httpc }
+                }
+            ],
+            <<"stop-after">> => true
+        }
+    ],
+    IndexStore =
+        #{
+            <<"index-store">> => [hb_test_utils:test_store()],
+            <<"routes">> => Routes
+        },
+    try
+        ok = hb_store_arweave:write_offset(
+            IndexStore,
+            TXID,
+            <<"tx@1.0">>,
+            relative,
+            PendingLength
+        ),
+        {ok, StoreTX} =
+            hb_store_arweave:read(IndexStore, #{ <<"read">> => TXID }, ClientOpts),
+        ?assertEqual(TXID, hb_message:id(StoreTX, signed, ClientOpts)),
+        ?assertEqual(PendingData, maps:get(<<"data">>, StoreTX))
+    after
+        hb_mock_server:stop(MockHandle)
+    end.
+
 %% @doc: helper test to generate and write a dataitem to disk so that we
 %% can validate it using 3rd-party js libraries and gateways.
 serialize_data_item_test_disabled() ->
@@ -1697,6 +1775,12 @@ serialize_data_item_test_disabled() ->
     ?assertEqual(length(DataItem#tx.tags), length(VerifiedItem#tx.tags)),
     ?assert(ar_bundles:verify_item(VerifiedItem)),
     ok.
+
+pending_relative_chunk_helpers_test_parallel() ->
+    DataSize = 315127,
+    ?assertEqual([?DATA_CHUNK_SIZE], pending_relative_chunk_offsets(0, 1, DataSize)),
+    ?assertEqual([DataSize], pending_relative_chunk_offsets(?DATA_CHUNK_SIZE, 1, DataSize)),
+    ?assertEqual([?DATA_CHUNK_SIZE, DataSize], pending_relative_chunk_offsets(0, DataSize, DataSize)).
 
 get_partial_chunk_post_split_test_parallel() ->
     %% https://arweave.net/tx/QL7_EnmrFtx-0wVgPr2IwaGWQT8vmPcF3R20CKMO3D4/offset

--- a/src/preloaded/arweave/dev_arweave.erl
+++ b/src/preloaded/arweave/dev_arweave.erl
@@ -200,13 +200,38 @@ head_raw(Base, Request, Opts) ->
 %% @doc Arweave transaction headers are not part of the Arweave data tree, and
 %% thus we do not add their header bytes to the offset in order to read their
 %% data.
+head_raw_tx(TXID, relative, Length, Opts) ->
+    case pending(
+        #{ <<"pending">> => TXID },
+        #{ <<"exclude-data">> => true },
+        Opts
+    ) of
+        {ok, StructuredTXHeader} ->
+            head_raw_tx_response(
+                TXID,
+                relative,
+                hb_util:int(
+                    hb_ao:get(<<"data_size">>, StructuredTXHeader, Length, Opts)
+                ),
+                StructuredTXHeader,
+                Opts
+            );
+        _ ->
+            head_raw_confirmed_tx(TXID, relative, Length, Opts)
+    end;
 head_raw_tx(TXID, StartOffset, Length, Opts) ->
+    head_raw_confirmed_tx(TXID, StartOffset, Length, Opts).
+
+head_raw_confirmed_tx(TXID, StartOffset, Length, Opts) ->
     {ok, StructuredTXHeader} =
         get_tx(
             #{ <<"tx">> => TXID },
             #{ <<"exclude-data">> => true },
             Opts
         ),
+    head_raw_tx_response(TXID, StartOffset, Length, StructuredTXHeader, Opts).
+
+head_raw_tx_response(TXID, StartOffset, Length, StructuredTXHeader, Opts) ->
     ContentType =
         hb_ao:get(
             <<"content-type">>,

--- a/src/preloaded/arweave/dev_arweave.erl
+++ b/src/preloaded/arweave/dev_arweave.erl
@@ -221,7 +221,7 @@ head_raw_tx(TXID, StartOffset, Length, Opts) ->
         #{
             <<"raw-id">> => TXID,
             <<"offset">> => StartOffset,
-            <<"data-offset">> => StartOffset,
+            <<"data-offset">> => pending_root_offset(TXID, StartOffset),
             <<"content-type">> => ContentType,
             <<"header-length">> => 0,
             <<"content-length">> => Length,
@@ -234,13 +234,8 @@ head_raw_tx(TXID, StartOffset, Length, Opts) ->
 %% chunk, deserialize it, and offset our data read from its starting offset.
 head_raw_ans104(TXID, ArweaveOffset, Length, Opts) ->
     ?event(debug_raw, {head_raw_ans104, {txid, TXID}, {arweave_offset, ArweaveOffset}, {length, Length}}),
-    HeaderReq =
-        #{
-            <<"path">> => <<"chunk">>,
-            <<"offset">> => ArweaveOffset + 1,
-            <<"length">> => min(Length, ?DATA_CHUNK_SIZE)
-        },
-    case hb_ao:resolve(#{ <<"device">> => <<"arweave@2.9">> }, HeaderReq, Opts) of
+    case hb_store_arweave:read_chunks(
+        ArweaveOffset, min(Length, ?DATA_CHUNK_SIZE), Opts) of
         {ok, HeaderChunk} ->
             do_head_raw_ans104(TXID, ArweaveOffset, Length, HeaderChunk, Opts);
         {error, Error} -> {error, Error}
@@ -258,7 +253,8 @@ do_head_raw_ans104(TXID, ArweaveOffset, Length, Data, _Opts) ->
                 #{
                     <<"raw-id">> => TXID,
                     <<"offset">> => ArweaveOffset,
-                    <<"data-offset">> => ArweaveOffset + HeaderSize,
+                    <<"data-offset">> =>
+                        add_data_offset(ArweaveOffset, HeaderSize),
                     <<"content-type">> => ContentType,
                     <<"header-length">> => HeaderSize,
                     <<"content-length">> => Length - HeaderSize,
@@ -280,6 +276,16 @@ deserialize_ans104_header(Data) ->
                 }
             }
     end.
+
+pending_root_offset(TXID, relative) ->
+    #{ <<"relative">> => TXID, <<"offset">> => 0 };
+pending_root_offset(_TXID, Offset) ->
+    Offset.
+
+add_data_offset(#{ <<"relative">> := TXID, <<"offset">> := Offset }, Add) ->
+    #{ <<"relative">> => TXID, <<"offset">> => Offset + Add };
+add_data_offset(Offset, Add) ->
+    Offset + Add.
 
 %% @doc Get raw transaction *data* and `content-type` of an Arweave message.
 %% Does not deserialize the message, nor return signature information. Included
@@ -304,7 +310,7 @@ get_raw(Base, Request, Opts) ->
                 RangeLength = (EndRange - StartRange) + 1,
                 {ok, Data} =
                     hb_store_arweave:read_chunks(
-                        ArweaveDataOffset + StartRange,
+                        add_data_offset(ArweaveDataOffset, StartRange),
                         RangeLength,
                         Opts
                     ),

--- a/src/preloaded/query/dev_copycat_arweave.erl
+++ b/src/preloaded/query/dev_copycat_arweave.erl
@@ -17,18 +17,28 @@
 %% latest known block towards the Genesis block. If no range is provided, we
 %% fetch blocks from the latest known block towards the Genesis block.
 arweave(_Base, Request, Opts) ->
-    case parse_range(Request, Opts) of
-        {error, unavailable} ->
-            {error, unavailable};
-        {ok, {From, To}} ->
-            case hb_maps:get(<<"mode">>, Request, <<"write">>, Opts) of
-                <<"write">> ->
-                    Depth = max(2,
-                        hb_util:int(hb_maps:get(<<"depth">>, Request, 2, Opts))),
-                    fetch_blocks(Request, From, To, Depth, Opts);
-                <<"list">> -> list_index(From, To, Opts);
-                Mode ->
-                    {error, <<"Unsupported mode `", (hb_util:bin(Mode))/binary, "`. Supported modes are: write, list">>}
+    case hb_maps:get(<<"mode">>, Request, <<"write">>, Opts) of
+        <<"pending">> ->
+            Depth = max(2,
+                hb_util:int(hb_maps:get(<<"depth">>, Request, 2, Opts))),
+            index_pending(Depth, Opts);
+        Mode ->
+            case parse_range(Request, Opts) of
+                {error, unavailable} ->
+                    {error, unavailable};
+                {ok, {From, To}} ->
+                    case Mode of
+                        <<"write">> ->
+                            Depth = max(2,
+                                hb_util:int(
+                                    hb_maps:get(
+                                        <<"depth">>, Request, 2, Opts))),
+                            fetch_blocks(Request, From, To, Depth, Opts);
+                        <<"list">> ->
+                            list_index(From, To, Opts);
+                        _ ->
+                            {error, <<"Unsupported mode `", (hb_util:bin(Mode))/binary, "`. Supported modes are: write, pending, list">>}
+                    end
             end
     end.
 
@@ -413,9 +423,10 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, Opts) 
                                     ItemStartOffset,
                                     Size
                                 ),
-                                {ItemStartOffset + Size, ItemsCountAcc + 1}
+                                {add_data_offset(ItemStartOffset, Size),
+                                    ItemsCountAcc + 1}
                             end,
-                            {TXStartOffset + HeaderSize, 0},
+                            {add_data_offset(TXStartOffset, HeaderSize), 0},
                             BundleIndex
                         )
                     end),
@@ -443,6 +454,9 @@ process_txs(ValidTXs, BlockStartOffset, TargetDepth, Opts) ->
         fun(TXWithData) -> process_tx(TXWithData, BlockStartOffset, TargetDepth, Opts) end,
         Opts
     ),
+    sum_counters(Results).
+
+sum_counters(Results) ->
     lists:foldl(
         fun(Result, Acc) ->
             maps:merge_with(
@@ -474,12 +488,81 @@ index_full_bundle_bytes(BundleData, BundleStartOffset, Depth, Store, Opts) ->
             index_full_bundle_items(
                 BundleIndex,
                 ItemsBin,
-                BundleStartOffset + HeaderSize,
+                add_data_offset(BundleStartOffset, HeaderSize),
                 Depth,
                 Store,
                 Opts,
                 0
             )
+    end.
+
+%% @doc Index unconfirmed transactions from the Arweave mempool.
+index_pending(TargetDepth, Opts) ->
+    case hb_ao:resolve(<<?ARWEAVE_DEVICE/binary, "/pending">>, Opts) of
+        {ok, TXIDs} when is_list(TXIDs) ->
+            Results = parallel_map(
+                TXIDs,
+                fun(TXID) -> process_pending_tx(TXID, TargetDepth, Opts) end,
+                Opts
+            ),
+            {ok, (sum_counters(Results))#{ total_txs => length(TXIDs) }};
+        Error ->
+            Error
+    end.
+
+process_pending_tx(TXID, TargetDepth, Opts) ->
+    case is_tx_indexed(TXID, Opts) of
+        true ->
+            counters(0, 0, 0);
+        false ->
+            case resolve_pending_tx_header(TXID, Opts) of
+                {ok, TX} ->
+                    Store = hb_store_arweave:store_from_opts(Opts),
+                    ok = hb_store_arweave:write_offset(
+                        Store, TXID, <<"tx@1.0">>, relative, TX#tx.data_size),
+                    index_pending_children(TXID, TX, TargetDepth, Store, Opts);
+                error ->
+                    counters(0, 0, 1)
+            end
+    end.
+
+resolve_pending_tx_header(TXID, Opts) ->
+    case hb_ao:resolve(
+        #{ <<"device">> => <<"arweave@2.9">> },
+        #{
+            <<"path">> => <<"pending">>,
+            <<"pending">> => TXID,
+            <<"exclude-data">> => true
+        },
+        Opts
+    ) of
+        {ok, StructuredTXHeader} ->
+            {ok,
+                hb_message:convert(
+                    StructuredTXHeader,
+                    <<"tx@1.0">>,
+                    <<"structured@1.0">>,
+                    Opts)};
+        {error, _} ->
+            error
+    end.
+
+index_pending_children(TXID, TX, TargetDepth, Store, Opts) ->
+    case is_bundle_tx(TX, Opts) of
+        false ->
+            counters(0, 0, 0);
+        true ->
+            Offset = #{ <<"relative">> => TXID, <<"offset">> => 0 },
+            case hb_store_arweave:read_chunks(Offset, TX#tx.data_size, Opts) of
+                {ok, BundleData} ->
+                    case index_full_bundle_bytes(
+                        BundleData, Offset, TargetDepth - 1, Store, Opts) of
+                        {ok, ItemsCount} -> counters(ItemsCount, 1, 0);
+                        {error, Reason} -> skip_bundle(TXID, Reason)
+                    end;
+                {error, Reason} ->
+                    skip_bundle(TXID, Reason)
+            end
     end.
 
 index_full_bundle_items(
@@ -524,7 +607,7 @@ index_full_bundle_items(
                     true ->
                         index_full_bundle_bytes(
                             ParsedItem#tx.data,
-                            ItemStartOffset + HeaderSize,
+                            add_data_offset(ItemStartOffset, HeaderSize),
                             Depth - 1,
                             Store,
                             Opts
@@ -542,7 +625,7 @@ index_full_bundle_items(
             index_full_bundle_items(
                 Rest,
                 RestBin,
-                ItemStartOffset + Size,
+                add_data_offset(ItemStartOffset, Size),
                 Depth,
                 Store,
                 Opts,
@@ -555,6 +638,11 @@ index_full_bundle_items(
         _BundleIndex, _ItemsBin, _ItemStartOffset, _Depth,
         _Store, _Opts, _Count) ->
     {error, invalid_bundle_header}.
+
+add_data_offset(#{ <<"relative">> := TXID, <<"offset">> := Offset }, Add) ->
+    #{ <<"relative">> => TXID, <<"offset">> => Offset + Add };
+add_data_offset(Offset, Add) ->
+    Offset + Add.
 
 %% @doc Check whether a TX header indicates bundle content.
 is_bundle_tx(TX, _Opts) ->
@@ -1270,6 +1358,87 @@ highest_contiguous_indexed_block(Current, Max, LastIndexed, Opts) ->
             highest_contiguous_indexed_block(Current + 1, Max, Current, Opts);
         false ->
             LastIndexed
+    end.
+
+pending_mode_indexes_bundle_children_test() ->
+    {_TestStore, StoreOpts, DefaultOpts} = setup_index_opts(),
+    Wallet = ar_wallet:new(),
+    Child = ar_bundles:sign_item(
+        #tx{
+            data = <<"pending-child">>,
+            tags = [{<<"content-type">>, <<"text/plain">>}]
+        },
+        Wallet
+    ),
+    {undefined, BundleData} =
+        ar_bundles:serialize_bundle(list, [Child], false),
+    RootTX =
+        ar_tx:sign(
+            ar_tx:generate_chunk_tree(
+                #tx{
+                    data = BundleData,
+                    data_size = byte_size(BundleData),
+                    format = 2,
+                    tags = [
+                        {<<"bundle-format">>, <<"binary">>},
+                        {<<"bundle-version">>, <<"2.0.0">>}
+                    ]
+                }
+            ),
+            Wallet
+        ),
+    TXID = hb_util:encode(RootTX#tx.id),
+    ChildID = hb_util:encode(ar_bundles:id(Child, signed)),
+    DataPath =
+        ar_merkle:generate_path(RootTX#tx.data_root, 0, RootTX#tx.data_tree),
+    HeaderJSON = ar_tx:tx_to_json_struct(RootTX#tx{ data = <<>> }),
+    ChunkBody =
+        hb_json:encode(
+            #{
+                <<"chunk">> => hb_util:encode(BundleData),
+                <<"data_path">> => hb_util:encode(DataPath)
+            }
+        ),
+    {ok, MockNode, MockHandle} = hb_mock_server:start([
+        {"/tx/pending", pending, {200, hb_json:encode([TXID])}},
+        {"/unconfirmed_tx/:id", pending_tx, {200, hb_json:encode(HeaderJSON)}},
+        {"/unconfirmed_chunk/:id/:offset", pending_chunk, {200, ChunkBody}}
+    ]),
+    Routes = [
+        #{
+            <<"template">> => <<"^/arweave">>,
+            <<"nodes">> => [
+                #{
+                    <<"match">> => <<"^/arweave">>,
+                    <<"with">> => MockNode,
+                    <<"opts">> => #{ <<"http-client">> => httpc }
+                }
+            ],
+            <<"stop-after">> => true
+        }
+    ],
+    ReadStore = StoreOpts#{ <<"routes">> => Routes },
+    Opts =
+        DefaultOpts#{
+            <<"routes">> => Routes,
+            <<"arweave-index-store">> => ReadStore
+        },
+    try
+        {ok, #{ items_count := 1, total_txs := 1 }} =
+            hb_ao:resolve(<<"~copycat@1.0/arweave&mode=pending">>, Opts),
+        ?assertMatch(
+            {ok, #{ <<"start-offset">> := relative }},
+            hb_store_arweave:read_offset(ReadStore, TXID, Opts)
+        ),
+        ?assertMatch(
+            {ok, #{ <<"start-offset">> := #{ <<"relative">> := TXID } }},
+            hb_store_arweave:read_offset(ReadStore, ChildID, Opts)
+        ),
+        {ok, ChildMsg} =
+            hb_store_arweave:read(ReadStore, #{ <<"read">> => ChildID }, Opts),
+        ?assertEqual(ChildID, hb_message:id(ChildMsg, signed, Opts))
+    after
+        hb_mock_server:stop(MockHandle)
     end.
 
 assert_indexed_range(From, To, _Opts) when From < To ->

--- a/src/preloaded/query/dev_copycat_arweave.erl
+++ b/src/preloaded/query/dev_copycat_arweave.erl
@@ -457,10 +457,8 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, IndexMode, Opts) ->
                     skip_bundle(TXID, Reason)
             end;
         true ->
-            % Lightweight processing of block transactions to depth 2. We
-            % can avoid loading the full L1 TX data into memory, and instead
-            % only load the bundle header. But as a result we're unable to
-            % recurse any deeper than L2 dataitems.
+            % Shallow confirmed indexing only needs the bundle header, avoiding
+            % a full L1 data download while still writing direct item offsets.
             ?event(debug_copycat, {fetching_bundle_header, 
                 {tx_id, {string, TXID}},
                 {tx_end_offset, TXEndOffset},

--- a/src/preloaded/query/dev_copycat_arweave.erl
+++ b/src/preloaded/query/dev_copycat_arweave.erl
@@ -83,7 +83,7 @@ needs_tip({ok, <<"pending">>}, _DefaultFrom) -> true;
 needs_tip({ok, Height}, _DefaultFrom) -> hb_util:int(Height) < 0.
 
 from_height(error, Tip) ->
-    {ok, false, Tip};
+    {ok, true, Tip};
 from_height({ok, Height}, Tip) ->
     normalize_height(<<"from">>, Height, Tip).
 
@@ -1254,6 +1254,10 @@ negative_parse_range_test_parallel() ->
         parse_range(#{ <<"from">> => <<"10">>, <<"to">> => <<"-3">> }, Opts),
     ?assertEqual(10, PositiveFrom),
     ?assertEqual(hb_util:int(Tip) - 3, NegativeTo),
+    {ok, {true, DefaultPendingFrom, DefaultNegativeTo}} =
+        parse_range(#{ <<"to">> => <<"-3">> }, Opts),
+    ?assertEqual(hb_util:int(Tip), DefaultPendingFrom),
+    ?assertEqual(hb_util:int(Tip) - 3, DefaultNegativeTo),
     {ok, {true, PendingFrom, PendingTo}} =
         parse_range(#{ <<"from">> => <<"pending">>, <<"to">> => <<"pending">> }, Opts),
     ?assertEqual(hb_util:int(Tip), PendingFrom),

--- a/src/preloaded/query/dev_copycat_arweave.erl
+++ b/src/preloaded/query/dev_copycat_arweave.erl
@@ -424,7 +424,7 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, IndexMode, Opts) ->
         {offset, TXStartOffset},
         {size, TX#tx.data_size}
     }),
-    ok = observe_event(<<"item_indexed">>, fun() ->
+    case observe_event(<<"item_indexed">>, fun() ->
         hb_store_arweave:write_offset(
             ArweaveStore,
             TXID,
@@ -432,85 +432,108 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, IndexMode, Opts) ->
             TXStartOffset,
             TX#tx.data_size
         )
-    end),
-    case is_bundle_tx(TX, Opts) of
-        false ->
-            counters(0, 0, 0);
-        true when IndexMode =/= shallow ->
-            try
-                case hb_store_arweave:read_chunks(
-                    TXStartOffset, TX#tx.data_size, Opts) of
-                    {ok, BundleData} ->
-                        {TotalTime, IndexRes} = timer:tc(
-                            fun() ->
-                                index_full_bundle_bytes(
-                                    BundleData,
-                                    TXStartOffset,
-                                    IndexMode,
-                                    ArweaveStore,
-                                    Opts
+    end) of
+        ok ->
+            case is_bundle_tx(TX, Opts) of
+                false ->
+                    counters(0, 0, 0);
+                true when IndexMode =/= shallow ->
+                    try
+                        case hb_store_arweave:read_chunks(
+                            TXStartOffset, TX#tx.data_size, Opts) of
+                            {ok, BundleData} ->
+                                {TotalTime, IndexRes} = timer:tc(
+                                    fun() ->
+                                        index_full_bundle_bytes(
+                                            BundleData,
+                                            TXStartOffset,
+                                            IndexMode,
+                                            ArweaveStore,
+                                            Opts
+                                        )
+                                    end
+                                ),
+                                case IndexRes of
+                                    {ok, ItemsCount} ->
+                                        record_event_metrics(
+                                            <<"item_indexed">>,
+                                            ItemsCount,
+                                            TotalTime
+                                        ),
+                                        counters(ItemsCount, 1, 0);
+                                    {error, IndexError} ->
+                                        skip_bundle(TXID, IndexError)
+                                end;
+                            {error, ReadError} ->
+                                skip_bundle(TXID, ReadError);
+                            not_found ->
+                                skip_bundle(TXID, not_found)
+                        end
+                    catch
+                        _:Reason:_ ->
+                            skip_bundle(TXID, Reason)
+                    end;
+                true ->
+                    % Shallow confirmed indexing only needs the bundle header, avoiding
+                    % a full L1 data download while still writing direct item offsets.
+                    ?event(debug_copycat, {fetching_bundle_header, 
+                        {tx_id, {string, TXID}},
+                        {tx_end_offset, TXEndOffset},
+                        {tx_data_size, TX#tx.data_size}
+                    }),
+                    case download_bundle_header(TXEndOffset, TX#tx.data_size, Opts) of
+                        {ok, HeaderSize, BundleIndex} ->
+                            % Batch event tracking: measure total time and count for all write_offset calls
+                            {TotalTime, IndexItemsRes} = timer:tc(fun() ->
+                                lists:foldl(
+                                    fun
+                                        (_Item, {error, _} = Error) ->
+                                            Error;
+                                        ({ItemID, Size}, {ItemStartOffset, ItemsCountAcc}) ->
+                                            case hb_store_arweave:write_offset(
+                                                ArweaveStore,
+                                                hb_util:encode(ItemID),
+                                                <<"ans104@1.0">>,
+                                                ItemStartOffset,
+                                                Size
+                                            ) of
+                                                ok ->
+                                                    {add_data_offset(ItemStartOffset, Size),
+                                                        ItemsCountAcc + 1};
+                                                WriteError ->
+                                                    {error, {write_offset_failed, WriteError}}
+                                            end
+                                    end,
+                                    {add_data_offset(TXStartOffset, HeaderSize), 0},
+                                    BundleIndex
                                 )
-                            end
-                        ),
-                        case IndexRes of
-                            {ok, ItemsCount} ->
-                                record_event_metrics(
-                                    <<"item_indexed">>,
-                                    ItemsCount,
-                                    TotalTime
-                                ),
-                                counters(ItemsCount, 1, 0);
-                            {error, IndexError} ->
-                                skip_bundle(TXID, IndexError)
-                        end;
-                    {error, ReadError} ->
-                        skip_bundle(TXID, ReadError);
-                    not_found ->
-                        skip_bundle(TXID, not_found)
-                end
-            catch
-                _:Reason:_ ->
-                    skip_bundle(TXID, Reason)
+                            end),
+                            case IndexItemsRes of
+                                {error, Reason} ->
+                                    skip_bundle(TXID, Reason);
+                                {_, ItemsCount} ->
+                                    ?event(debug_copycat,
+                                        {bundle_items_indexed,
+                                            {tx_id, {string, TXID}},
+                                            {items_count, ItemsCount}
+                                    }),
+                                    % Single event record for the batch
+                                    record_event_metrics(<<"item_indexed">>, ItemsCount, TotalTime),
+                                    counters(ItemsCount, 1, 0)
+                            end;
+                        {error, Reason} ->
+                            skip_bundle(TXID, Reason)
+                    end
             end;
-        true ->
-            % Shallow confirmed indexing only needs the bundle header, avoiding
-            % a full L1 data download while still writing direct item offsets.
-            ?event(debug_copycat, {fetching_bundle_header, 
-                {tx_id, {string, TXID}},
-                {tx_end_offset, TXEndOffset},
-                {tx_data_size, TX#tx.data_size}
-            }),
-            case download_bundle_header(TXEndOffset, TX#tx.data_size, Opts) of
-                {ok, HeaderSize, BundleIndex} ->
-                    % Batch event tracking: measure total time and count for all write_offset calls
-                    {TotalTime, {_, ItemsCount}} = timer:tc(fun() ->
-                        lists:foldl(
-                            fun({ItemID, Size}, {ItemStartOffset, ItemsCountAcc}) ->
-                                ok = hb_store_arweave:write_offset(
-                                    ArweaveStore,
-                                    hb_util:encode(ItemID),
-                                    <<"ans104@1.0">>,
-                                    ItemStartOffset,
-                                    Size
-                                ),
-                                {add_data_offset(ItemStartOffset, Size),
-                                    ItemsCountAcc + 1}
-                            end,
-                            {add_data_offset(TXStartOffset, HeaderSize), 0},
-                            BundleIndex
-                        )
-                    end),
-                    ?event(debug_copycat,
-                        {bundle_items_indexed,
-                            {tx_id, {string, TXID}},
-                            {items_count, ItemsCount}
-                        }),
-                    % Single event record for the batch
-                    record_event_metrics(<<"item_indexed">>, ItemsCount, TotalTime),
-                    counters(ItemsCount, 1, 0);
-                {error, Reason} ->
-                    skip_bundle(TXID, Reason)
-            end
+        WriteError ->
+            ?event(
+                copycat_short,
+                {arweave_tx_skipped,
+                    {tx_id, {explicit, TXID}},
+                    {reason, {write_offset_failed, WriteError}}
+                }
+            ),
+            counters(0, 0, 1)
     end.
 
 %% @doc Process transactions: spawn workers and manage the worker pool.
@@ -684,56 +707,60 @@ index_full_bundle_items(
                 catch _:_ -> error
                 end
         end,
-    ok = hb_store_arweave:write_offset(
+    case hb_store_arweave:write_offset(
         Store,
         EncodedItemID,
         <<"ans104@1.0">>,
         ItemStartOffset,
         Size
-    ),
-    ok =
-        case {IndexMode, ParseResult} of
-            {full, {ok, _, Parsed}} ->
-                LocalOpts = hb_store:scope(Opts, local),
-                Msg = hb_message:convert(
-                    Parsed, <<"structured@1.0">>, <<"ans104@1.0">>, LocalOpts),
-                {ok, _Path} = hb_cache:write(Msg, LocalOpts),
-                ok;
-            _ -> ok
-        end,
-    DescendantRes =
-        case {IndexMode =/= shallow, ParseResult} of
-            {true, {ok, HeaderSize, ParsedItem}} ->
-                case is_bundle_tx(ParsedItem, Opts) of
-                    true ->
-                        index_full_bundle_bytes(
-                            ParsedItem#tx.data,
-                            add_data_offset(ItemStartOffset, HeaderSize),
-                            IndexMode,
-                            Store,
-                            Opts
-                        );
-                    false ->
+    ) of
+        ok ->
+            ok =
+                case {IndexMode, ParseResult} of
+                    {full, {ok, _, Parsed}} ->
+                        LocalOpts = hb_store:scope(Opts, local),
+                        Msg = hb_message:convert(
+                            Parsed, <<"structured@1.0">>, <<"ans104@1.0">>, LocalOpts),
+                        {ok, _Path} = hb_cache:write(Msg, LocalOpts),
+                        ok;
+                    _ -> ok
+                end,
+            DescendantRes =
+                case {IndexMode =/= shallow, ParseResult} of
+                    {true, {ok, HeaderSize, ParsedItem}} ->
+                        case is_bundle_tx(ParsedItem, Opts) of
+                            true ->
+                                index_full_bundle_bytes(
+                                    ParsedItem#tx.data,
+                                    add_data_offset(ItemStartOffset, HeaderSize),
+                                    IndexMode,
+                                    Store,
+                                    Opts
+                                );
+                            false ->
+                                {ok, 0}
+                        end;
+                    {true, _} ->
+                        {ok, 0};
+                    _ ->
                         {ok, 0}
-                end;
-            {true, _} ->
-                {ok, 0};
-            _ ->
-                {ok, 0}
-        end,
-    case DescendantRes of
-        {ok, DescendantCount} ->
-            index_full_bundle_items(
-                Rest,
-                RestBin,
-                add_data_offset(ItemStartOffset, Size),
-                IndexMode,
-                Store,
-                Opts,
-                Count + 1 + DescendantCount
-            );
-        {error, _} = Error ->
-            Error
+                end,
+            case DescendantRes of
+                {ok, DescendantCount} ->
+                    index_full_bundle_items(
+                        Rest,
+                        RestBin,
+                        add_data_offset(ItemStartOffset, Size),
+                        IndexMode,
+                        Store,
+                        Opts,
+                        Count + 1 + DescendantCount
+                    );
+                {error, _} = Error ->
+                    Error
+            end;
+        WriteError ->
+            {error, {write_offset_failed, WriteError}}
     end;
 index_full_bundle_items(
         _BundleIndex, _ItemsBin, _ItemStartOffset, _IndexMode,

--- a/src/preloaded/query/dev_copycat_arweave.erl
+++ b/src/preloaded/query/dev_copycat_arweave.erl
@@ -567,19 +567,14 @@ index_pending(IndexMode, Opts) ->
     end.
 
 process_pending_tx(TXID, IndexMode, Opts) ->
-    case is_tx_indexed(TXID, Opts) of
-        true ->
-            counters(0, 0, 0);
-        false ->
-            case resolve_pending_tx_header(TXID, Opts) of
-                {ok, TX} ->
-                    Store = hb_store_arweave:store_from_opts(Opts),
-                    ok = hb_store_arweave:write_offset(
-                        Store, TXID, <<"tx@1.0">>, relative, TX#tx.data_size),
-                    index_pending_children(TXID, TX, IndexMode, Store, Opts);
-                error ->
-                    counters(0, 0, 1)
-            end
+    case resolve_pending_tx_header(TXID, Opts) of
+        {ok, TX} ->
+            Store = hb_store_arweave:store_from_opts(Opts),
+            ok = hb_store_arweave:write_offset(
+                Store, TXID, <<"tx@1.0">>, relative, TX#tx.data_size),
+            index_pending_children(TXID, TX, IndexMode, Store, Opts);
+        error ->
+            counters(0, 0, 1)
     end.
 
 resolve_pending_tx_header(TXID, Opts) ->
@@ -677,7 +672,7 @@ index_full_bundle_items(
                         {ok, 0}
                 end;
             {true, _} ->
-                {error, invalid_item_header};
+                {ok, 0};
             _ ->
                 {ok, 0}
         end,
@@ -1430,7 +1425,7 @@ highest_contiguous_indexed_block(Current, Max, LastIndexed, Opts) ->
             LastIndexed
     end.
 
-pending_mode_indexes_bundle_children_test() ->
+pending_range_indexes_bundle_children_test() ->
     {_TestStore, StoreOpts, DefaultOpts} = setup_index_opts(),
     Wallet = ar_wallet:new(),
     Child = ar_bundles:sign_item(
@@ -1499,6 +1494,10 @@ pending_mode_indexes_bundle_children_test() ->
         {ok, #{ items_count := 1, total_txs := 1 }} =
             hb_ao:resolve(
                 <<"~copycat@1.0/arweave&from=pending&to=pending">>, Opts),
+        {ok, #{ items_count := 1, total_txs := 1 }} =
+            hb_ao:resolve(
+                <<"~copycat@1.0/arweave&mode=full&from=pending&to=pending">>,
+                Opts),
         ?assertMatch(
             {ok, #{ <<"start-offset">> := relative }},
             hb_store_arweave:read_offset(ReadStore, TXID, Opts)
@@ -1509,6 +1508,10 @@ pending_mode_indexes_bundle_children_test() ->
         ),
         {ok, ChildMsg} =
             hb_store_arweave:read(ReadStore, #{ <<"read">> => ChildID }, Opts),
+        ?assertMatch(
+            {ok, _},
+            hb_cache:read(ChildID, hb_store:scope(Opts, local))
+        ),
         ?assertEqual(ChildID, hb_message:id(ChildMsg, signed, Opts))
     after
         hb_mock_server:stop(MockHandle)

--- a/src/preloaded/query/dev_copycat_arweave.erl
+++ b/src/preloaded/query/dev_copycat_arweave.erl
@@ -1,8 +1,8 @@
 %%% @doc A `~copycat@1.0' engine that fetches block data from an Arweave node for
 %%% replication. This engine works in _reverse_ chronological order by default.
 %%% If `to' is omitted, it keeps moving downward from `from' until it reaches a
-%%% block where at least one TX is already indexed, then stops. If `to' is
-%%% provided, every block in the range is processed.
+%%% block that is already indexed at the requested depth. If `to' is provided,
+%%% every block in the range is processed.
 -module(dev_copycat_arweave).
 -device_libraries([lib_arweave_common]).
 -export([arweave/3]).
@@ -22,7 +22,10 @@ arweave(_Base, Request, Opts) ->
             {error, unavailable};
         {ok, {From, To}} ->
             case hb_maps:get(<<"mode">>, Request, <<"write">>, Opts) of
-                <<"write">> -> fetch_blocks(Request, From, To, Opts);
+                <<"write">> ->
+                    Depth = max(2,
+                        hb_util:int(hb_maps:get(<<"depth">>, Request, 2, Opts))),
+                    fetch_blocks(Request, From, To, Depth, Opts);
                 <<"list">> -> list_index(From, To, Opts);
                 Mode ->
                     {error, <<"Unsupported mode `", (hb_util:bin(Mode))/binary, "`. Supported modes are: write, list">>}
@@ -166,8 +169,8 @@ classify_txs(TXIDs, Opts) ->
 
 %% @doc Fetch blocks from an Arweave node while moving downward from `Current'.
 %% If `To' is provided, every block in [`To', `Current'] is processed. If `To'
-%% is omitted, stop at the first block where any TX is already indexed.
-fetch_blocks(Req, Current, To, _Opts) when is_integer(To), Current < To ->
+%% is omitted, stop at the first block indexed to the target depth.
+fetch_blocks(Req, Current, To, _TargetDepth, _Opts) when is_integer(To), Current < To ->
     ?event(copycat_short,
         {arweave_block_indexing_completed,
             {reached_target, To},
@@ -175,11 +178,10 @@ fetch_blocks(Req, Current, To, _Opts) when is_integer(To), Current < To ->
         }
     ),
     {ok, To};
-fetch_blocks(_Req, Current, undefined, _Opts) when Current < 0 ->
+fetch_blocks(_Req, Current, undefined, _TargetDepth, _Opts) when Current < 0 ->
     {ok, 0};
-fetch_blocks(Req, Current, undefined, Opts) ->
-    BlockRes = fetch_block_header(Current, Opts),
-    case is_already_indexed(BlockRes, Opts) of
+fetch_blocks(Req, Current, undefined, TargetDepth, Opts) ->
+    case is_block_indexed(Current, TargetDepth, Opts) of
         true ->
             ?event(copycat_short,
                 {arweave_block_indexing_completed,
@@ -189,36 +191,24 @@ fetch_blocks(Req, Current, undefined, Opts) ->
             ),
             {ok, Current};
         false ->
+            BlockRes = fetch_block_header(Current, Opts),
             observe_event(<<"block_indexed">>, fun() ->
-                process_block(BlockRes, Current, undefined, Opts)
+                process_block(BlockRes, Current, undefined, TargetDepth, Opts)
             end),
-            fetch_blocks(Req, Current - 1, undefined, Opts)
+            fetch_blocks(Req, Current - 1, undefined, TargetDepth, Opts)
     end;
-fetch_blocks(Req, Current, To, Opts) ->
+fetch_blocks(Req, Current, To, TargetDepth, Opts) ->
     observe_event(<<"block_indexed">>, fun() ->
-        fetch_and_process_block(Current, To, Opts)
+        process_block(fetch_block_header(Current, Opts), Current, To, TargetDepth, Opts)
     end),
-    fetch_blocks(Req, Current - 1, To, Opts).
+    fetch_blocks(Req, Current - 1, To, TargetDepth, Opts).
 
-%% @doc Determine whether a fetched block is considered indexed.
-%% A block is indexed when any TX from its `txs' list is in the index.
-is_already_indexed({ok, Block}, Opts) ->
-    TXIDs = hb_maps:get(<<"txs">>, Block, [], Opts),
-    lists:any(fun(TXID) -> is_tx_indexed(TXID, Opts) end, TXIDs);
-is_already_indexed({error, _}, _Opts) ->
-    false.
-
-fetch_and_process_block(Current, To, Opts) ->
-    BlockRes = fetch_block_header(Current, Opts),
-    process_block(BlockRes, Current, To, Opts).
-
-%% @doc Process a block.
-process_block(BlockRes, Current, To, Opts) ->
+process_block(BlockRes, Current, To, TargetDepth, Opts) ->
     case BlockRes of
         {ok, Block} ->
             ?event(debug_copycat, {{processing_block, Current},
                 {indep_hash, hb_maps:get(<<"indep_hash">>, Block, <<>>)}}),
-            case maybe_index_ids(Block, Opts) of
+            case maybe_index_ids(Block, TargetDepth, Opts) of
                 {block_skipped, Results} ->
                     TotalTXs = maps:get(total_txs, Results, 0),
                     ?event(
@@ -234,6 +224,10 @@ process_block(BlockRes, Current, To, Opts) ->
                     TotalTXs = maps:get(total_txs, Results, 0),
                     BundleTXs = maps:get(bundle_count, Results, 0),
                     SkippedTXs = maps:get(skipped_count, Results, 0),
+                    case SkippedTXs of
+                        0 -> ok = write_block_index(Current, TargetDepth, Opts);
+                        _ -> ok
+                    end,
                     ?event(
                         copycat_short,
                         {arweave_block_indexed,
@@ -256,9 +250,36 @@ process_block(BlockRes, Current, To, Opts) ->
             )
     end.
 
+block_indexed_path(Height) ->
+    <<"block/", (hb_util:bin(Height))/binary, "/depth">>.
+
+write_block_index(Height, Depth, Opts) ->
+    #{ <<"index-store">> := Store } = hb_store_arweave:store_from_opts(Opts),
+    hb_store:write(
+        Store,
+        #{ block_indexed_path(Height) => integer_to_binary(Depth) },
+        Opts
+    ).
+
+is_block_indexed(Height, TargetDepth, Opts) ->
+    case hb_store_arweave:store_from_opts(Opts) of
+        no_store ->
+            false;
+        #{ <<"index-store">> := Store } ->
+            case hb_store:read(Store, block_indexed_path(Height), Opts) of
+                {ok, Bin} ->
+                    try binary_to_integer(Bin) >= TargetDepth
+                    catch _:_ -> false
+                    end;
+                _ ->
+                    false
+            end
+    end.
+
 %% @doc Index the IDs of all transactions in the block if configured to do so.
-maybe_index_ids(Block, Opts) ->
-    TotalTXs = length(hb_maps:get(<<"txs">>, Block, [], Opts)),
+maybe_index_ids(Block, TargetDepth, Opts) ->
+    TXIDs = hb_maps:get(<<"txs">>, Block, [], Opts),
+    TotalTXs = length(TXIDs),
     case hb_opts:get(arweave_index_ids, true, Opts) of
         false -> 
             {block_skipped, #{
@@ -273,7 +294,7 @@ maybe_index_ids(Block, Opts) ->
             BlockSize = hb_util:int(
                 hb_maps:get(<<"block_size">>, Block, 0, Opts)),
             BlockStartOffset = BlockEndOffset - BlockSize,
-            case resolve_tx_headers(hb_maps:get(<<"txs">>, Block, [], Opts), Opts) of
+            case resolve_tx_headers(TXIDs, Opts) of
                 error ->
                     % Skip entire block if any transaction errors
                     {block_skipped, #{
@@ -288,8 +309,9 @@ maybe_index_ids(Block, Opts) ->
                         fun({{padding, _}, _}) -> false; (_) -> true end,
                         TXsWithData
                     ),
-                    TXResults = process_txs(ValidTXs, BlockStartOffset, Opts),
-                    {block_cached, TXResults#{total_txs => TotalTXs}}
+                    TXResults = process_txs(
+                        ValidTXs, BlockStartOffset, TargetDepth, Opts),
+                    {block_cached, TXResults#{ total_txs => TotalTXs }}
             end
     end.
 
@@ -301,12 +323,17 @@ parallel_map(Items, Fun, Opts) ->
     MaxWorkers = max(1, hb_opts:get(arweave_index_workers, 1, Opts)),
     hb_pmap:parallel_map(Items, Fun, MaxWorkers).
 
+counters(Items, Bundles, Skipped) ->
+    #{
+        items_count => Items,
+        bundle_count => Bundles,
+        skipped_count => Skipped
+    }.
+
 %% @doc Process a single transaction and return its contribution to the counters.
 %% Returns a map with keys: items_count, bundle_count, skipped_count
-process_tx({{padding, _PaddingRoot}, _EndOffset}, _BlockStartOffset, _Opts) ->
-    #{items_count => 0, bundle_count => 0, skipped_count => 0};
-process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
-    IndexStore = hb_store_arweave:store_from_opts(Opts),
+process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, Opts) ->
+    ArweaveStore = hb_store_arweave:store_from_opts(Opts),
     TXID = hb_util:encode(TX#tx.id),
     TXEndOffset = BlockStartOffset + EndOffset,
     TXStartOffset = TXEndOffset - TX#tx.data_size,
@@ -315,9 +342,9 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
         {offset, TXStartOffset},
         {size, TX#tx.data_size}
     }),
-    observe_event(<<"item_indexed">>, fun() ->
+    ok = observe_event(<<"item_indexed">>, fun() ->
         hb_store_arweave:write_offset(
-            IndexStore,
+            ArweaveStore,
             TXID,
             <<"tx@1.0">>,
             TXStartOffset,
@@ -325,7 +352,44 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
         )
     end),
     case is_bundle_tx(TX, Opts) of
-        false -> #{items_count => 0, bundle_count => 0, skipped_count => 0};
+        false ->
+            counters(0, 0, 0);
+        true when TargetDepth > 2 ->
+            try
+                case hb_store_arweave:read_chunks(
+                    TXStartOffset, TX#tx.data_size, Opts) of
+                    {ok, BundleData} ->
+                        {TotalTime, IndexRes} = timer:tc(
+                            fun() ->
+                                index_full_bundle_bytes(
+                                    BundleData,
+                                    TXStartOffset,
+                                    TargetDepth - 1,
+                                    ArweaveStore,
+                                    Opts
+                                )
+                            end
+                        ),
+                        case IndexRes of
+                            {ok, ItemsCount} ->
+                                record_event_metrics(
+                                    <<"item_indexed">>,
+                                    ItemsCount,
+                                    TotalTime
+                                ),
+                                counters(ItemsCount, 1, 0);
+                            {error, IndexError} ->
+                                skip_bundle(TXID, IndexError)
+                        end;
+                    {error, ReadError} ->
+                        skip_bundle(TXID, ReadError);
+                    not_found ->
+                        skip_bundle(TXID, not_found)
+                end
+            catch
+                _:Reason:_ ->
+                    skip_bundle(TXID, Reason)
+            end;
         true ->
             % Lightweight processing of block transactions to depth 2. We
             % can avoid loading the full L1 TX data into memory, and instead
@@ -336,17 +400,14 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
                 {tx_end_offset, TXEndOffset},
                 {tx_data_size, TX#tx.data_size}
             }),
-            BundleRes = download_bundle_header(
-                TXEndOffset, TX#tx.data_size, Opts
-            ),
-            case BundleRes of
+            case download_bundle_header(TXEndOffset, TX#tx.data_size, Opts) of
                 {ok, HeaderSize, BundleIndex} ->
                     % Batch event tracking: measure total time and count for all write_offset calls
                     {TotalTime, {_, ItemsCount}} = timer:tc(fun() ->
                         lists:foldl(
                             fun({ItemID, Size}, {ItemStartOffset, ItemsCountAcc}) ->
-                                hb_store_arweave:write_offset(
-                                    IndexStore,
+                                ok = hb_store_arweave:write_offset(
+                                    ArweaveStore,
                                     hb_util:encode(ItemID),
                                     <<"ans104@1.0">>,
                                     ItemStartOffset,
@@ -365,16 +426,9 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
                         }),
                     % Single event record for the batch
                     record_event_metrics(<<"item_indexed">>, ItemsCount, TotalTime),
-                    #{items_count => ItemsCount, bundle_count => 1, skipped_count => 0};
+                    counters(ItemsCount, 1, 0);
                 {error, Reason} ->
-                    ?event(
-                        copycat_short,
-                        {arweave_bundle_skipped,
-                            {tx_id, {explicit, TXID}},
-                            {reason, Reason}
-                        }
-                    ),
-                    #{items_count => 0, bundle_count => 1, skipped_count => 1}
+                    skip_bundle(TXID, Reason)
             end
     end.
 
@@ -383,23 +437,124 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, Opts) ->
 %% When arweave_index_workers <= 1, processes sequentially (one worker at a time).
 %% When arweave_index_workers > 1, processes in parallel with the specified concurrency limit.
 %% Returns a map with keys: items_count, bundle_count, skipped_count.
-process_txs(ValidTXs, BlockStartOffset, Opts) ->
+process_txs(ValidTXs, BlockStartOffset, TargetDepth, Opts) ->
     Results = parallel_map(
         ValidTXs,
-        fun(TXWithData) -> process_tx(TXWithData, BlockStartOffset, Opts) end,
+        fun(TXWithData) -> process_tx(TXWithData, BlockStartOffset, TargetDepth, Opts) end,
         Opts
     ),
     lists:foldl(
         fun(Result, Acc) ->
-            #{
-                items_count => maps:get(items_count, Result, 0) + maps:get(items_count, Acc, 0),
-                bundle_count => maps:get(bundle_count, Result, 0) + maps:get(bundle_count, Acc, 0),
-                skipped_count => maps:get(skipped_count, Result, 0) + maps:get(skipped_count, Acc, 0)
-            }
+            maps:merge_with(
+                fun(_Key, ResultCount, AccCount) -> ResultCount + AccCount end,
+                Result,
+                Acc
+            )
         end,
-        #{items_count => 0, bundle_count => 0, skipped_count => 0},
+        counters(0, 0, 0),
         Results
     ).
+
+skip_bundle(EncodedTXID, Reason) ->
+    ?event(
+        copycat_short,
+        {arweave_bundle_skipped,
+            {tx_id, {explicit, EncodedTXID}},
+            {reason, Reason}
+        }
+    ),
+    counters(0, 1, 1).
+
+index_full_bundle_bytes(BundleData, BundleStartOffset, Depth, Store, Opts) ->
+    case ar_bundles:decode_bundle_header(BundleData) of
+        invalid_bundle_header ->
+            {error, invalid_bundle_header};
+        {ItemsBin, BundleIndex} ->
+            HeaderSize = byte_size(BundleData) - byte_size(ItemsBin),
+            index_full_bundle_items(
+                BundleIndex,
+                ItemsBin,
+                BundleStartOffset + HeaderSize,
+                Depth,
+                Store,
+                Opts,
+                0
+            )
+    end.
+
+index_full_bundle_items(
+        [], _ItemsBin, _ItemStartOffset, _Depth, _Store, _Opts, Count) ->
+    {ok, Count};
+index_full_bundle_items(
+    [{ItemID, Size} | Rest],
+    ItemsBin,
+    ItemStartOffset,
+    Depth,
+    Store,
+    Opts,
+    Count
+) when byte_size(ItemsBin) >= Size ->
+    <<ItemBinary:Size/binary, RestBin/binary>> = ItemsBin,
+    EncodedItemID = hb_util:encode(ItemID),
+    ParseResult =
+        try ar_bundles:deserialize_header(ItemBinary)
+        catch _:_ -> error
+        end,
+    ok = hb_store_arweave:write_offset(
+        Store,
+        EncodedItemID,
+        <<"ans104@1.0">>,
+        ItemStartOffset,
+        Size
+    ),
+    ok =
+        case {ParseResult, hb_opts:get(arweave_index_headers, false, Opts)} of
+            {{ok, _, Parsed}, true} ->
+                LocalOpts = hb_store:scope(Opts, local),
+                Msg = hb_message:convert(
+                    Parsed, <<"structured@1.0">>, <<"ans104@1.0">>, LocalOpts),
+                {ok, _Path} = hb_cache:write(Msg, LocalOpts),
+                ok;
+            _ -> ok
+        end,
+    DescendantRes =
+        case {Depth > 1, ParseResult} of
+            {true, {ok, HeaderSize, ParsedItem}} ->
+                case is_bundle_tx(ParsedItem, Opts) of
+                    true ->
+                        index_full_bundle_bytes(
+                            ParsedItem#tx.data,
+                            ItemStartOffset + HeaderSize,
+                            Depth - 1,
+                            Store,
+                            Opts
+                        );
+                    false ->
+                        {ok, 0}
+                end;
+            {true, _} ->
+                {error, invalid_item_header};
+            _ ->
+                {ok, 0}
+        end,
+    case DescendantRes of
+        {ok, DescendantCount} ->
+            index_full_bundle_items(
+                Rest,
+                RestBin,
+                ItemStartOffset + Size,
+                Depth,
+                Store,
+                Opts,
+                Count + 1 + DescendantCount
+            );
+        {error, _} = Error ->
+            Error
+    end;
+index_full_bundle_items(
+        _BundleIndex, _ItemsBin, _ItemStartOffset, _Depth,
+        _Store, _Opts, _Count) ->
+    {error, invalid_bundle_header}.
 
 %% @doc Check whether a TX header indicates bundle content.
 is_bundle_tx(TX, _Opts) ->
@@ -624,7 +779,7 @@ invalid_bundle_test_parallel() ->
     Block = 1307606,
     {ok, Block} =
         hb_ao:resolve(
-            <<"~copycat@1.0/arweave&from=", (hb_util:bin(Block))/binary, "&to=", (hb_util:bin(Block))/binary>>,
+            <<"~copycat@1.0/arweave&from=", (hb_util:bin(Block))/binary, "&to=", (hb_util:bin(Block))/binary, "&depth=3">>,
             Opts
         ),
     assert_bundle_read(
@@ -901,54 +1056,6 @@ explicit_to_reindexes_all_test_parallel() ->
     ?assert(has_any_indexed_tx(LowerBlock, Opts)),
     ok.
 
-%% @doc Manually write to the index to simulate a partially indexed block.
-%% This should also trigger a stop when the `to` option is omitted.
-auto_stop_partial_index_test_parallel() ->
-    {_TestStore, StoreOpts, Opts} = setup_index_opts(),
-    Block = 1826700,
-    HigherBlock = Block + 1,
-    NoIndexOpts = Opts#{
-        <<"arweave-index-ids">> => false,
-        <<"arweave-index-blocks">> => true
-    },
-    {ok, Block} =
-        hb_ao:resolve(
-            <<
-                "~copycat@1.0/arweave&"
-                "from=", (hb_util:bin(Block))/binary, "&"
-                "to=", (hb_util:bin(Block))/binary, "&"
-                "mode=write"
-            >>,
-            NoIndexOpts
-        ),
-    {ok, BlockData} =
-        hb_ao:resolve(
-            #{ <<"device">> => <<"arweave@2.9">> },
-            #{
-                <<"path">> => <<"block">>,
-                <<"block">> => Block,
-                <<"cache-control">> => [<<"only-if-cached">>]
-            },
-            Opts
-        ),
-    TXIDs = hb_maps:get(<<"txs">>, BlockData, [], Opts),
-    ?assert(length(TXIDs) > 0),
-    [OneTXID | _] = TXIDs,
-    hb_store_arweave:write_offset(StoreOpts, OneTXID, <<"tx@1.0">>, 0, 0),
-    {ok, Block} =
-        hb_ao:resolve(
-            <<
-                "~copycat@1.0/arweave&"
-                "from=", (hb_util:bin(HigherBlock))/binary, "&"
-                "mode=write"
-            >>,
-            Opts
-        ),
-    ?assert(has_any_indexed_tx(HigherBlock, Opts)),
-    ?assert(has_any_indexed_tx(Block, Opts)),
-    ?assertNot(has_any_indexed_tx(Block-1, Opts)),
-    ok.
-
 negative_parse_range_test_parallel() ->
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     {ok, Tip} =
@@ -1170,3 +1277,41 @@ assert_indexed_range(From, To, _Opts) when From < To ->
 assert_indexed_range(From, To, Opts) ->
     ?assert(has_any_indexed_tx(From, Opts)),
     assert_indexed_range(From - 1, To, Opts).
+
+small_block_depth_3_test() ->
+    {_TestStore, _StoreOpts, DefaultOpts} = setup_index_opts(),
+    Opts = DefaultOpts#{ <<"arweave-index-headers">> => true },
+    Block = 1889322,
+    {ok, Block} =
+        hb_ao:resolve(
+            <<
+                "~copycat@1.0/arweave&"
+                "from=", (hb_util:bin(Block))/binary, "&"
+                "to=", (hb_util:bin(Block))/binary, "&"
+                "depth=3"
+            >>,
+            Opts
+        ),
+    L3ID = <<"npAzk_BomjWBQQr_xnmlhdxjyl97EJnNv_MAaXffs1s">>,
+    assert_item_read(L3ID, Opts),
+    LocalOpts = hb_store:scope(Opts, local),
+    {ok, L3Header} = hb_cache:read(L3ID, LocalOpts),
+    L3Data =
+        hb_ao:get_first(
+            [
+                {{as, <<"message@1.0">>, L3Header}, <<"data">>},
+                {{as, <<"message@1.0">>, L3Header}, <<"body">>}
+            ],
+            <<>>,
+            Opts
+        ),
+    ?assert(byte_size(L3Data) > 0),
+    L3AppName = hb_maps:get(
+        <<"app-name">>, hb_message:uncommitted(L3Header, Opts), undefined, Opts),
+    ?assertNotEqual(undefined, L3AppName),
+    {ok, MessageIDs} =
+        hb_cache:match(#{<<"app-name">> => L3AppName}, LocalOpts),
+    ?assert(lists:member(L3ID, MessageIDs), {missing_match_index, L3ID}),
+    ?assert(hb_message:verify(L3Header, all, Opts), {verify_failed, L3ID}),
+    ?assertEqual(L3ID, hb_message:id(L3Header, signed, Opts)),
+    ok.

--- a/src/preloaded/query/dev_copycat_arweave.erl
+++ b/src/preloaded/query/dev_copycat_arweave.erl
@@ -239,25 +239,39 @@ fetch_blocks(_Req, Current, undefined, _IndexMode, _Opts) when Current < 0 ->
 fetch_blocks(Req, Current, undefined, IndexMode, Opts) ->
     case is_block_indexed(Current, IndexMode, Opts) of
         true ->
-            ?event(copycat_short,
-                {arweave_block_indexing_completed,
-                    {stop_at_indexed_block, Current},
-                    {initial_request, Req}
-                }
-            ),
-            {ok, Current};
+            stop_at_indexed_block(Req, Current);
         false ->
             BlockRes = fetch_block_header(Current, Opts),
-            observe_event(<<"block_indexed">>, fun() ->
-                process_block(BlockRes, Current, undefined, IndexMode, Opts)
-            end),
-            fetch_blocks(Req, Current - 1, undefined, IndexMode, Opts)
+            case IndexMode =:= shallow andalso is_already_indexed(BlockRes, Opts) of
+                true ->
+                    stop_at_indexed_block(Req, Current);
+                false ->
+                    observe_event(<<"block_indexed">>, fun() ->
+                        process_block(BlockRes, Current, undefined, IndexMode, Opts)
+                    end),
+                    fetch_blocks(Req, Current - 1, undefined, IndexMode, Opts)
+            end
     end;
 fetch_blocks(Req, Current, To, IndexMode, Opts) ->
     observe_event(<<"block_indexed">>, fun() ->
         process_block(fetch_block_header(Current, Opts), Current, To, IndexMode, Opts)
     end),
     fetch_blocks(Req, Current - 1, To, IndexMode, Opts).
+
+stop_at_indexed_block(Req, Current) ->
+    ?event(copycat_short,
+        {arweave_block_indexing_completed,
+            {stop_at_indexed_block, Current},
+            {initial_request, Req}
+        }
+    ),
+    {ok, Current}.
+
+is_already_indexed({ok, Block}, Opts) ->
+    TXIDs = hb_maps:get(<<"txs">>, Block, [], Opts),
+    lists:any(fun(TXID) -> is_tx_indexed(TXID, Opts) end, TXIDs);
+is_already_indexed({error, _}, _Opts) ->
+    false.
 
 process_block(BlockRes, Current, To, IndexMode, Opts) ->
     case BlockRes of
@@ -1201,6 +1215,28 @@ explicit_to_reindexes_all_test_parallel() ->
             Opts
         ),
     ?assert(has_any_indexed_tx(LowerBlock, Opts)),
+    ok.
+
+auto_stop_partial_index_test_parallel() ->
+    {_TestStore, StoreOpts, Opts} = setup_index_opts(),
+    IndexedBlock = 1826700,
+    HigherBlock = IndexedBlock + 1,
+    {ok, BlockData} = fetch_block_header(IndexedBlock, Opts),
+    [OneTXID | _] = hb_maps:get(<<"txs">>, BlockData, [], Opts),
+    ok = hb_store_arweave:write_offset(
+        StoreOpts, OneTXID, <<"tx@1.0">>, 0, 0),
+    {ok, IndexedBlock} =
+        hb_ao:resolve(
+            <<
+                "~copycat@1.0/arweave&"
+                "from=", (hb_util:bin(HigherBlock))/binary, "&"
+                "mode=shallow"
+            >>,
+            Opts
+        ),
+    ?assert(has_any_indexed_tx(HigherBlock, Opts)),
+    ?assert(has_any_indexed_tx(IndexedBlock, Opts)),
+    ?assertNot(has_any_indexed_tx(IndexedBlock-1, Opts)),
     ok.
 
 negative_parse_range_test_parallel() ->

--- a/src/preloaded/query/dev_copycat_arweave.erl
+++ b/src/preloaded/query/dev_copycat_arweave.erl
@@ -80,6 +80,7 @@ range_tip(FromArg, ToArg, Opts) ->
 needs_tip(error, true) -> true;
 needs_tip(error, false) -> false;
 needs_tip({ok, <<"pending">>}, _DefaultFrom) -> true;
+needs_tip({ok, <<"tip">>}, _DefaultFrom) -> true;
 needs_tip({ok, Height}, _DefaultFrom) -> hb_util:int(Height) < 0.
 
 from_height(error, Tip) ->
@@ -92,17 +93,15 @@ to_height(error, _Tip) ->
 to_height({ok, Height}, Tip) ->
     normalize_height(<<"to">>, Height, Tip).
 
-normalize_height(Key, <<"pending">>, Tip) ->
-    {ok, true, pending_height(Key, Tip)};
+normalize_height(<<"to">>, <<"pending">>, Tip) -> {ok, true, Tip + 1};
+normalize_height(_Key, <<"pending">>, Tip) -> {ok, true, Tip};
+normalize_height(_Key, <<"tip">>, Tip) -> {ok, false, Tip};
 normalize_height(_Key, Height, Tip) ->
     RequestedHeight = hb_util:int(Height),
     case RequestedHeight < 0 of
         true -> {ok, false, Tip + RequestedHeight};
         false -> {ok, false, RequestedHeight}
     end.
-
-pending_height(<<"to">>, Tip) -> Tip + 1;
-pending_height(_Key, Tip) -> Tip.
 
 latest_height(Opts) ->
     case hb_ao:resolve(
@@ -128,7 +127,10 @@ index_range(Request, true, From, To, IndexMode, Opts) ->
                     end
             end;
         Error ->
-            Error
+            case block_range_empty(From, To) of
+                true -> Error;
+                false -> fetch_blocks(Request, From, To, IndexMode, Opts)
+            end
     end;
 index_range(Request, false, From, To, IndexMode, Opts) ->
     fetch_blocks(Request, From, To, IndexMode, Opts).

--- a/src/preloaded/query/dev_copycat_arweave.erl
+++ b/src/preloaded/query/dev_copycat_arweave.erl
@@ -584,31 +584,62 @@ process_pending_tx(TXID, IndexMode, Opts) ->
     case resolve_pending_tx_header(TXID, Opts) of
         {ok, TX} ->
             Store = hb_store_arweave:store_from_opts(Opts),
-            ok = hb_store_arweave:write_offset(
-                Store, TXID, <<"tx@1.0">>, relative, TX#tx.data_size),
-            index_pending_children(TXID, TX, IndexMode, Store, Opts);
+            case hb_store_arweave:write_offset(
+                Store, TXID, <<"tx@1.0">>, relative, TX#tx.data_size) of
+                ok ->
+                    index_pending_children(TXID, TX, IndexMode, Store, Opts);
+                WriteError ->
+                    ?event(
+                        copycat_short,
+                        {arweave_pending_tx_skipped,
+                            {tx_id, {explicit, TXID}},
+                            {reason, {write_offset_failed, WriteError}}
+                        }
+                    ),
+                    counters(0, 0, 1)
+            end;
         error ->
             counters(0, 0, 1)
     end.
 
 resolve_pending_tx_header(TXID, Opts) ->
-    case hb_ao:resolve(
-        #{ <<"device">> => <<"arweave@2.9">> },
-        #{
-            <<"path">> => <<"pending">>,
-            <<"pending">> => TXID,
-            <<"exclude-data">> => true
-        },
-        Opts
-    ) of
-        {ok, StructuredTXHeader} ->
-            {ok,
-                hb_message:convert(
-                    StructuredTXHeader,
-                    <<"tx@1.0">>,
-                    <<"structured@1.0">>,
-                    Opts)};
-        {error, _} ->
+    try
+        case hb_ao:resolve(
+            #{ <<"device">> => <<"arweave@2.9">> },
+            #{
+                <<"path">> => <<"pending">>,
+                <<"pending">> => TXID,
+                <<"exclude-data">> => true
+            },
+            Opts
+        ) of
+            {ok, StructuredTXHeader} ->
+                {ok,
+                    hb_message:convert(
+                        StructuredTXHeader,
+                        <<"tx@1.0">>,
+                        <<"structured@1.0">>,
+                        Opts)};
+            {error, ResolveError} ->
+                ?event(
+                    copycat_short,
+                    {arweave_pending_tx_skipped,
+                        {tx_id, {explicit, TXID}},
+                        {reason, ResolveError}
+                    }
+                ),
+                error
+        end
+    catch
+        Class:Reason:_ ->
+            ?event(
+                copycat_short,
+                {arweave_pending_tx_skipped,
+                    {tx_id, {explicit, TXID}},
+                    {class, Class},
+                    {reason, Reason}
+                }
+            ),
             error
     end.
 

--- a/src/preloaded/query/dev_copycat_arweave.erl
+++ b/src/preloaded/query/dev_copycat_arweave.erl
@@ -1,7 +1,7 @@
 %%% @doc A `~copycat@1.0' engine that fetches block data from an Arweave node for
 %%% replication. This engine works in _reverse_ chronological order by default.
 %%% If `to' is omitted, it keeps moving downward from `from' until it reaches a
-%%% block that is already indexed at the requested depth. If `to' is provided,
+%%% block that is already indexed at the requested mode. If `to' is provided,
 %%% every block in the range is processed.
 -module(dev_copycat_arweave).
 -device_libraries([lib_arweave_common]).
@@ -17,44 +17,44 @@
 %% latest known block towards the Genesis block. If no range is provided, we
 %% fetch blocks from the latest known block towards the Genesis block.
 arweave(_Base, Request, Opts) ->
-    case hb_maps:get(<<"mode">>, Request, <<"write">>, Opts) of
-        <<"pending">> ->
-            Depth = max(2,
-                hb_util:int(hb_maps:get(<<"depth">>, Request, 2, Opts))),
-            index_pending(Depth, Opts);
-        Mode ->
+    case request_mode(Request, Opts) of
+        {ok, list} ->
             case parse_range(Request, Opts) of
                 {error, unavailable} ->
                     {error, unavailable};
-                {ok, {From, To}} ->
-                    case Mode of
-                        <<"write">> ->
-                            Depth = max(2,
-                                hb_util:int(
-                                    hb_maps:get(
-                                        <<"depth">>, Request, 2, Opts))),
-                            fetch_blocks(Request, From, To, Depth, Opts);
-                        <<"list">> ->
-                            list_index(From, To, Opts);
-                        _ ->
-                            {error, <<"Unsupported mode `", (hb_util:bin(Mode))/binary, "`. Supported modes are: write, pending, list">>}
-                    end
-            end
+                {ok, {_IncludePending, From, To}} ->
+                    list_index(From, To, Opts)
+            end;
+        {ok, IndexMode} ->
+            case parse_range(Request, Opts) of
+                {error, unavailable} ->
+                    {error, unavailable};
+                {ok, {IncludePending, From, To}} ->
+                    index_range(
+                        Request, IncludePending, From, To, IndexMode, Opts)
+            end;
+        {error, Mode} ->
+            {error, <<"Unsupported mode `", (hb_util:bin(Mode))/binary,
+                "`. Supported modes are: shallow, deep, full, list">>}
+    end.
+
+request_mode(Request, Opts) ->
+    case hb_maps:get(<<"mode">>, Request, <<"shallow">>, Opts) of
+        <<"shallow">> -> {ok, shallow};
+        <<"deep">> -> {ok, deep};
+        <<"full">> -> {ok, full};
+        <<"list">> -> {ok, list};
+        Mode -> {error, Mode}
     end.
 
 %% @doc Parse the range from the request.
 parse_range(Request, Opts) ->
+    FromArg = hb_maps:find(<<"from">>, Request, Opts),
+    ToArg = hb_maps:find(<<"to">>, Request, Opts),
     maybe
-        {ok, From} ?=
-            case hb_maps:find(<<"from">>, Request, Opts) of
-                {ok, FromHeight} -> normalize_height(FromHeight, Opts);
-                error -> latest_height(Opts)
-            end,
-        {ok, To} ?=
-            case hb_maps:find(<<"to">>, Request, Opts) of
-                {ok, ToHeight} -> normalize_height(ToHeight, Opts);
-                error -> {ok, undefined}
-            end,
+        {ok, Tip} ?= range_tip(FromArg, ToArg, Opts),
+        {ok, IncludePendingFrom, From} ?= from_height(FromArg, Tip),
+        {ok, IncludePendingTo, To} ?= to_height(ToArg, Tip),
         case From < 0 orelse (is_integer(To) andalso To < 0) of
             true ->
                 ?event(copycat_short,
@@ -62,7 +62,7 @@ parse_range(Request, Opts) ->
                         {from, From}, {to, To}}),
                 {error, unavailable};
             false ->
-                {ok, {From, To}}
+                {ok, {IncludePendingFrom orelse IncludePendingTo, From, To}}
         end
     else
         {error, Reason} ->
@@ -71,17 +71,38 @@ parse_range(Request, Opts) ->
             {error, unavailable}
     end.
 
-normalize_height(Height, Opts) ->
+range_tip(FromArg, ToArg, Opts) ->
+    case needs_tip(FromArg, true) orelse needs_tip(ToArg, false) of
+        true -> latest_height(Opts);
+        false -> {ok, undefined}
+    end.
+
+needs_tip(error, true) -> true;
+needs_tip(error, false) -> false;
+needs_tip({ok, <<"pending">>}, _DefaultFrom) -> true;
+needs_tip({ok, Height}, _DefaultFrom) -> hb_util:int(Height) < 0.
+
+from_height(error, Tip) ->
+    {ok, false, Tip};
+from_height({ok, Height}, Tip) ->
+    normalize_height(<<"from">>, Height, Tip).
+
+to_height(error, _Tip) ->
+    {ok, false, undefined};
+to_height({ok, Height}, Tip) ->
+    normalize_height(<<"to">>, Height, Tip).
+
+normalize_height(Key, <<"pending">>, Tip) ->
+    {ok, true, pending_height(Key, Tip)};
+normalize_height(_Key, Height, Tip) ->
     RequestedHeight = hb_util:int(Height),
     case RequestedHeight < 0 of
-        true ->
-            case latest_height(Opts) of
-                {ok, Tip} -> {ok, Tip + RequestedHeight};
-                {error, _} = Err -> Err
-            end;
-        false ->
-            {ok, RequestedHeight}
+        true -> {ok, false, Tip + RequestedHeight};
+        false -> {ok, false, RequestedHeight}
     end.
+
+pending_height(<<"to">>, Tip) -> Tip + 1;
+pending_height(_Key, Tip) -> Tip.
 
 latest_height(Opts) ->
     case hb_ao:resolve(
@@ -91,6 +112,31 @@ latest_height(Opts) ->
         {ok, ResolvedHeight} -> {ok, hb_util:int(ResolvedHeight)};
         {error, Reason} -> {error, Reason}
     end.
+
+index_range(Request, true, From, To, IndexMode, Opts) ->
+    case index_pending(IndexMode, Opts) of
+        {ok, PendingRes} ->
+            case block_range_empty(From, To) of
+                true ->
+                    {ok, PendingRes};
+                false ->
+                    case fetch_blocks(Request, From, To, IndexMode, Opts) of
+                        {ok, Stop} ->
+                            {ok, PendingRes#{ blocks_stop => Stop }};
+                        Error ->
+                            Error
+                    end
+            end;
+        Error ->
+            Error
+    end;
+index_range(Request, false, From, To, IndexMode, Opts) ->
+    fetch_blocks(Request, From, To, IndexMode, Opts).
+
+block_range_empty(From, To) when is_integer(To), From < To ->
+    true;
+block_range_empty(_From, _To) ->
+    false.
 
 %% @doc Check if a transaction ID is indexed in the arweave index store.
 is_tx_indexed(TXID, Opts) ->
@@ -179,8 +225,8 @@ classify_txs(TXIDs, Opts) ->
 
 %% @doc Fetch blocks from an Arweave node while moving downward from `Current'.
 %% If `To' is provided, every block in [`To', `Current'] is processed. If `To'
-%% is omitted, stop at the first block indexed to the target depth.
-fetch_blocks(Req, Current, To, _TargetDepth, _Opts) when is_integer(To), Current < To ->
+%% is omitted, stop at the first block indexed to the target mode.
+fetch_blocks(Req, Current, To, _IndexMode, _Opts) when is_integer(To), Current < To ->
     ?event(copycat_short,
         {arweave_block_indexing_completed,
             {reached_target, To},
@@ -188,10 +234,10 @@ fetch_blocks(Req, Current, To, _TargetDepth, _Opts) when is_integer(To), Current
         }
     ),
     {ok, To};
-fetch_blocks(_Req, Current, undefined, _TargetDepth, _Opts) when Current < 0 ->
+fetch_blocks(_Req, Current, undefined, _IndexMode, _Opts) when Current < 0 ->
     {ok, 0};
-fetch_blocks(Req, Current, undefined, TargetDepth, Opts) ->
-    case is_block_indexed(Current, TargetDepth, Opts) of
+fetch_blocks(Req, Current, undefined, IndexMode, Opts) ->
+    case is_block_indexed(Current, IndexMode, Opts) of
         true ->
             ?event(copycat_short,
                 {arweave_block_indexing_completed,
@@ -203,22 +249,22 @@ fetch_blocks(Req, Current, undefined, TargetDepth, Opts) ->
         false ->
             BlockRes = fetch_block_header(Current, Opts),
             observe_event(<<"block_indexed">>, fun() ->
-                process_block(BlockRes, Current, undefined, TargetDepth, Opts)
+                process_block(BlockRes, Current, undefined, IndexMode, Opts)
             end),
-            fetch_blocks(Req, Current - 1, undefined, TargetDepth, Opts)
+            fetch_blocks(Req, Current - 1, undefined, IndexMode, Opts)
     end;
-fetch_blocks(Req, Current, To, TargetDepth, Opts) ->
+fetch_blocks(Req, Current, To, IndexMode, Opts) ->
     observe_event(<<"block_indexed">>, fun() ->
-        process_block(fetch_block_header(Current, Opts), Current, To, TargetDepth, Opts)
+        process_block(fetch_block_header(Current, Opts), Current, To, IndexMode, Opts)
     end),
-    fetch_blocks(Req, Current - 1, To, TargetDepth, Opts).
+    fetch_blocks(Req, Current - 1, To, IndexMode, Opts).
 
-process_block(BlockRes, Current, To, TargetDepth, Opts) ->
+process_block(BlockRes, Current, To, IndexMode, Opts) ->
     case BlockRes of
         {ok, Block} ->
             ?event(debug_copycat, {{processing_block, Current},
                 {indep_hash, hb_maps:get(<<"indep_hash">>, Block, <<>>)}}),
-            case maybe_index_ids(Block, TargetDepth, Opts) of
+            case maybe_index_ids(Block, IndexMode, Opts) of
                 {block_skipped, Results} ->
                     TotalTXs = maps:get(total_txs, Results, 0),
                     ?event(
@@ -235,7 +281,7 @@ process_block(BlockRes, Current, To, TargetDepth, Opts) ->
                     BundleTXs = maps:get(bundle_count, Results, 0),
                     SkippedTXs = maps:get(skipped_count, Results, 0),
                     case SkippedTXs of
-                        0 -> ok = write_block_index(Current, TargetDepth, Opts);
+                        0 -> ok = write_block_index(Current, IndexMode, Opts);
                         _ -> ok
                     end,
                     ?event(
@@ -261,33 +307,43 @@ process_block(BlockRes, Current, To, TargetDepth, Opts) ->
     end.
 
 block_indexed_path(Height) ->
-    <<"block/", (hb_util:bin(Height))/binary, "/depth">>.
+    <<"block/", (hb_util:bin(Height))/binary, "/mode">>.
 
-write_block_index(Height, Depth, Opts) ->
+write_block_index(Height, IndexMode, Opts) ->
     #{ <<"index-store">> := Store } = hb_store_arweave:store_from_opts(Opts),
     hb_store:write(
         Store,
-        #{ block_indexed_path(Height) => integer_to_binary(Depth) },
+        #{ block_indexed_path(Height) => mode_name(IndexMode) },
         Opts
     ).
 
-is_block_indexed(Height, TargetDepth, Opts) ->
+is_block_indexed(Height, IndexMode, Opts) ->
     case hb_store_arweave:store_from_opts(Opts) of
         no_store ->
             false;
         #{ <<"index-store">> := Store } ->
             case hb_store:read(Store, block_indexed_path(Height), Opts) of
                 {ok, Bin} ->
-                    try binary_to_integer(Bin) >= TargetDepth
-                    catch _:_ -> false
-                    end;
+                    mode_rank(Bin) >= mode_rank(IndexMode);
                 _ ->
                     false
             end
     end.
 
+mode_name(shallow) -> <<"shallow">>;
+mode_name(deep) -> <<"deep">>;
+mode_name(full) -> <<"full">>.
+
+mode_rank(shallow) -> 1;
+mode_rank(deep) -> 2;
+mode_rank(full) -> 3;
+mode_rank(<<"shallow">>) -> mode_rank(shallow);
+mode_rank(<<"deep">>) -> mode_rank(deep);
+mode_rank(<<"full">>) -> mode_rank(full);
+mode_rank(_Other) -> 0.
+
 %% @doc Index the IDs of all transactions in the block if configured to do so.
-maybe_index_ids(Block, TargetDepth, Opts) ->
+maybe_index_ids(Block, IndexMode, Opts) ->
     TXIDs = hb_maps:get(<<"txs">>, Block, [], Opts),
     TotalTXs = length(TXIDs),
     case hb_opts:get(arweave_index_ids, true, Opts) of
@@ -320,7 +376,7 @@ maybe_index_ids(Block, TargetDepth, Opts) ->
                         TXsWithData
                     ),
                     TXResults = process_txs(
-                        ValidTXs, BlockStartOffset, TargetDepth, Opts),
+                        ValidTXs, BlockStartOffset, IndexMode, Opts),
                     {block_cached, TXResults#{ total_txs => TotalTXs }}
             end
     end.
@@ -342,7 +398,7 @@ counters(Items, Bundles, Skipped) ->
 
 %% @doc Process a single transaction and return its contribution to the counters.
 %% Returns a map with keys: items_count, bundle_count, skipped_count
-process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, Opts) ->
+process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, IndexMode, Opts) ->
     ArweaveStore = hb_store_arweave:store_from_opts(Opts),
     TXID = hb_util:encode(TX#tx.id),
     TXEndOffset = BlockStartOffset + EndOffset,
@@ -364,7 +420,7 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, Opts) 
     case is_bundle_tx(TX, Opts) of
         false ->
             counters(0, 0, 0);
-        true when TargetDepth > 2 ->
+        true when IndexMode =/= shallow ->
             try
                 case hb_store_arweave:read_chunks(
                     TXStartOffset, TX#tx.data_size, Opts) of
@@ -374,7 +430,7 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, Opts) 
                                 index_full_bundle_bytes(
                                     BundleData,
                                     TXStartOffset,
-                                    TargetDepth - 1,
+                                    IndexMode,
                                     ArweaveStore,
                                     Opts
                                 )
@@ -448,10 +504,10 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, TargetDepth, Opts) 
 %% When arweave_index_workers <= 1, processes sequentially (one worker at a time).
 %% When arweave_index_workers > 1, processes in parallel with the specified concurrency limit.
 %% Returns a map with keys: items_count, bundle_count, skipped_count.
-process_txs(ValidTXs, BlockStartOffset, TargetDepth, Opts) ->
+process_txs(ValidTXs, BlockStartOffset, IndexMode, Opts) ->
     Results = parallel_map(
         ValidTXs,
-        fun(TXWithData) -> process_tx(TXWithData, BlockStartOffset, TargetDepth, Opts) end,
+        fun(TXWithData) -> process_tx(TXWithData, BlockStartOffset, IndexMode, Opts) end,
         Opts
     ),
     sum_counters(Results).
@@ -479,7 +535,7 @@ skip_bundle(EncodedTXID, Reason) ->
     ),
     counters(0, 1, 1).
 
-index_full_bundle_bytes(BundleData, BundleStartOffset, Depth, Store, Opts) ->
+index_full_bundle_bytes(BundleData, BundleStartOffset, IndexMode, Store, Opts) ->
     case ar_bundles:decode_bundle_header(BundleData) of
         invalid_bundle_header ->
             {error, invalid_bundle_header};
@@ -489,7 +545,7 @@ index_full_bundle_bytes(BundleData, BundleStartOffset, Depth, Store, Opts) ->
                 BundleIndex,
                 ItemsBin,
                 add_data_offset(BundleStartOffset, HeaderSize),
-                Depth,
+                IndexMode,
                 Store,
                 Opts,
                 0
@@ -497,12 +553,12 @@ index_full_bundle_bytes(BundleData, BundleStartOffset, Depth, Store, Opts) ->
     end.
 
 %% @doc Index unconfirmed transactions from the Arweave mempool.
-index_pending(TargetDepth, Opts) ->
+index_pending(IndexMode, Opts) ->
     case hb_ao:resolve(<<?ARWEAVE_DEVICE/binary, "/pending">>, Opts) of
         {ok, TXIDs} when is_list(TXIDs) ->
             Results = parallel_map(
                 TXIDs,
-                fun(TXID) -> process_pending_tx(TXID, TargetDepth, Opts) end,
+                fun(TXID) -> process_pending_tx(TXID, IndexMode, Opts) end,
                 Opts
             ),
             {ok, (sum_counters(Results))#{ total_txs => length(TXIDs) }};
@@ -510,7 +566,7 @@ index_pending(TargetDepth, Opts) ->
             Error
     end.
 
-process_pending_tx(TXID, TargetDepth, Opts) ->
+process_pending_tx(TXID, IndexMode, Opts) ->
     case is_tx_indexed(TXID, Opts) of
         true ->
             counters(0, 0, 0);
@@ -520,7 +576,7 @@ process_pending_tx(TXID, TargetDepth, Opts) ->
                     Store = hb_store_arweave:store_from_opts(Opts),
                     ok = hb_store_arweave:write_offset(
                         Store, TXID, <<"tx@1.0">>, relative, TX#tx.data_size),
-                    index_pending_children(TXID, TX, TargetDepth, Store, Opts);
+                    index_pending_children(TXID, TX, IndexMode, Store, Opts);
                 error ->
                     counters(0, 0, 1)
             end
@@ -547,7 +603,7 @@ resolve_pending_tx_header(TXID, Opts) ->
             error
     end.
 
-index_pending_children(TXID, TX, TargetDepth, Store, Opts) ->
+index_pending_children(TXID, TX, IndexMode, Store, Opts) ->
     case is_bundle_tx(TX, Opts) of
         false ->
             counters(0, 0, 0);
@@ -556,7 +612,7 @@ index_pending_children(TXID, TX, TargetDepth, Store, Opts) ->
             case hb_store_arweave:read_chunks(Offset, TX#tx.data_size, Opts) of
                 {ok, BundleData} ->
                     case index_full_bundle_bytes(
-                        BundleData, Offset, TargetDepth - 1, Store, Opts) of
+                        BundleData, Offset, IndexMode, Store, Opts) of
                         {ok, ItemsCount} -> counters(ItemsCount, 1, 0);
                         {error, Reason} -> skip_bundle(TXID, Reason)
                     end;
@@ -566,13 +622,13 @@ index_pending_children(TXID, TX, TargetDepth, Store, Opts) ->
     end.
 
 index_full_bundle_items(
-        [], _ItemsBin, _ItemStartOffset, _Depth, _Store, _Opts, Count) ->
+        [], _ItemsBin, _ItemStartOffset, _IndexMode, _Store, _Opts, Count) ->
     {ok, Count};
 index_full_bundle_items(
     [{ItemID, Size} | Rest],
     ItemsBin,
     ItemStartOffset,
-    Depth,
+    IndexMode,
     Store,
     Opts,
     Count
@@ -580,8 +636,13 @@ index_full_bundle_items(
     <<ItemBinary:Size/binary, RestBin/binary>> = ItemsBin,
     EncodedItemID = hb_util:encode(ItemID),
     ParseResult =
-        try ar_bundles:deserialize_header(ItemBinary)
-        catch _:_ -> error
+        case IndexMode of
+            shallow ->
+                not_parsed;
+            _ ->
+                try ar_bundles:deserialize_header(ItemBinary)
+                catch _:_ -> error
+                end
         end,
     ok = hb_store_arweave:write_offset(
         Store,
@@ -591,8 +652,8 @@ index_full_bundle_items(
         Size
     ),
     ok =
-        case {ParseResult, hb_opts:get(arweave_index_headers, false, Opts)} of
-            {{ok, _, Parsed}, true} ->
+        case {IndexMode, ParseResult} of
+            {full, {ok, _, Parsed}} ->
                 LocalOpts = hb_store:scope(Opts, local),
                 Msg = hb_message:convert(
                     Parsed, <<"structured@1.0">>, <<"ans104@1.0">>, LocalOpts),
@@ -601,14 +662,14 @@ index_full_bundle_items(
             _ -> ok
         end,
     DescendantRes =
-        case {Depth > 1, ParseResult} of
+        case {IndexMode =/= shallow, ParseResult} of
             {true, {ok, HeaderSize, ParsedItem}} ->
                 case is_bundle_tx(ParsedItem, Opts) of
                     true ->
                         index_full_bundle_bytes(
                             ParsedItem#tx.data,
                             add_data_offset(ItemStartOffset, HeaderSize),
-                            Depth - 1,
+                            IndexMode,
                             Store,
                             Opts
                         );
@@ -626,7 +687,7 @@ index_full_bundle_items(
                 Rest,
                 RestBin,
                 add_data_offset(ItemStartOffset, Size),
-                Depth,
+                IndexMode,
                 Store,
                 Opts,
                 Count + 1 + DescendantCount
@@ -635,7 +696,7 @@ index_full_bundle_items(
             Error
     end;
 index_full_bundle_items(
-        _BundleIndex, _ItemsBin, _ItemStartOffset, _Depth,
+        _BundleIndex, _ItemsBin, _ItemStartOffset, _IndexMode,
         _Store, _Opts, _Count) ->
     {error, invalid_bundle_header}.
 
@@ -867,7 +928,12 @@ invalid_bundle_test_parallel() ->
     Block = 1307606,
     {ok, Block} =
         hb_ao:resolve(
-            <<"~copycat@1.0/arweave&from=", (hb_util:bin(Block))/binary, "&to=", (hb_util:bin(Block))/binary, "&depth=3">>,
+            <<
+                "~copycat@1.0/arweave&"
+                "from=", (hb_util:bin(Block))/binary, "&"
+                "to=", (hb_util:bin(Block))/binary, "&"
+                "mode=deep"
+            >>,
             Opts
         ),
     assert_bundle_read(
@@ -980,7 +1046,7 @@ tx_with_no_data_test_parallel() ->
                 "~copycat@1.0/arweave&"
                 "from=", BlockBin/binary, "&"
                 "to=", BlockBin/binary, "&"
-                "mode=write"
+                "mode=shallow"
             >>,
             Opts
         ),
@@ -1040,7 +1106,7 @@ non_string_tags_test_parallel() ->
 list_index_test_parallel() ->
     %% Test block: https://viewblock.io/arweave/block/1827942
     {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
-    %% First index the block using write mode
+    %% First index the block using shallow mode
     Block = 1827942,
     BlockBin = hb_util:bin(Block),
     {ok, Block} =
@@ -1049,7 +1115,7 @@ list_index_test_parallel() ->
                 "~copycat@1.0/arweave&"
                 "from=", BlockBin/binary, "&"
                 "to=", BlockBin/binary, "&"
-                "mode=write"
+                "mode=shallow"
             >>,
             Opts
         ),
@@ -1097,7 +1163,7 @@ auto_stop_on_indexed_block_test_parallel() ->
                 "~copycat@1.0/arweave&"
                 "from=", (hb_util:bin(IndexedBlock))/binary, "&"
                 "to=", (hb_util:bin(IndexedBlock))/binary, "&"
-                "mode=write"
+                "mode=shallow"
             >>,
             Opts
         ),
@@ -1106,7 +1172,7 @@ auto_stop_on_indexed_block_test_parallel() ->
             <<
                 "~copycat@1.0/arweave&"
                 "from=", (hb_util:bin(Higher2))/binary, "&"
-                "mode=write"
+                "mode=shallow"
             >>,
             Opts
         ),
@@ -1126,7 +1192,7 @@ explicit_to_reindexes_all_test_parallel() ->
                 "~copycat@1.0/arweave&"
                 "from=", (hb_util:bin(IndexedBlock))/binary, "&"
                 "to=", (hb_util:bin(IndexedBlock))/binary, "&"
-                "mode=write"
+                "mode=shallow"
             >>,
             Opts
         ),
@@ -1137,7 +1203,7 @@ explicit_to_reindexes_all_test_parallel() ->
                 "~copycat@1.0/arweave&"
                 "from=", (hb_util:bin(IndexedBlock+1))/binary, "&"
                 "to=", (hb_util:bin(LowerBlock))/binary, "&"
-                "mode=write"
+                "mode=shallow"
             >>,
             Opts
         ),
@@ -1151,14 +1217,18 @@ negative_parse_range_test_parallel() ->
             <<?ARWEAVE_DEVICE/binary, "/current/height">>,
             Opts
         ),
-    {ok, {NegativeFrom, UndefinedTo}} =
+    {ok, {false, NegativeFrom, UndefinedTo}} =
         parse_range(#{ <<"from">> => <<"-3">> }, Opts),
     ?assertEqual(hb_util:int(Tip) - 3, NegativeFrom),
     ?assertEqual(undefined, UndefinedTo),
-    {ok, {PositiveFrom, NegativeTo}} =
+    {ok, {false, PositiveFrom, NegativeTo}} =
         parse_range(#{ <<"from">> => <<"10">>, <<"to">> => <<"-3">> }, Opts),
     ?assertEqual(10, PositiveFrom),
     ?assertEqual(hb_util:int(Tip) - 3, NegativeTo),
+    {ok, {true, PendingFrom, PendingTo}} =
+        parse_range(#{ <<"from">> => <<"pending">>, <<"to">> => <<"pending">> }, Opts),
+    ?assertEqual(hb_util:int(Tip), PendingFrom),
+    ?assertEqual(hb_util:int(Tip) + 1, PendingTo),
     ok.
 
 latest_height_failure_test_parallel() ->
@@ -1192,7 +1262,7 @@ latest_height_failure_test_parallel() ->
         ?assertMatch(
             {error, unavailable},
             hb_ao:resolve(
-                <<"~copycat@1.0/arweave&mode=write">>, Opts)
+                <<"~copycat@1.0/arweave&mode=shallow">>, Opts)
         )
     after
         hb_mock_server:stop(MockHandle)
@@ -1246,7 +1316,7 @@ negative_from_index_test_parallel() ->
                 "~copycat@1.0/arweave&"
                 "from=", (hb_util:bin(StopBlock))/binary, "&"
                 "to=", (hb_util:bin(StopBlock))/binary, "&"
-                "mode=write"
+                "mode=shallow"
             >>,
             Opts
         ),
@@ -1255,7 +1325,7 @@ negative_from_index_test_parallel() ->
             <<
                 "~copycat@1.0/arweave&"
                 "from=", NegativeFrom/binary, "&"
-                "mode=write"
+                "mode=shallow"
             >>,
             Opts
         ),
@@ -1400,6 +1470,7 @@ pending_mode_indexes_bundle_children_test() ->
             }
         ),
     {ok, MockNode, MockHandle} = hb_mock_server:start([
+        {"/block/current", block_current, {200, <<"{\"height\": 10}">>}},
         {"/tx/pending", pending, {200, hb_json:encode([TXID])}},
         {"/unconfirmed_tx/:id", pending_tx, {200, hb_json:encode(HeaderJSON)}},
         {"/unconfirmed_chunk/:id/:offset", pending_chunk, {200, ChunkBody}}
@@ -1421,11 +1492,13 @@ pending_mode_indexes_bundle_children_test() ->
     Opts =
         DefaultOpts#{
             <<"routes">> => Routes,
+            <<"arweave-index-blocks">> => false,
             <<"arweave-index-store">> => ReadStore
         },
     try
         {ok, #{ items_count := 1, total_txs := 1 }} =
-            hb_ao:resolve(<<"~copycat@1.0/arweave&mode=pending">>, Opts),
+            hb_ao:resolve(
+                <<"~copycat@1.0/arweave&from=pending&to=pending">>, Opts),
         ?assertMatch(
             {ok, #{ <<"start-offset">> := relative }},
             hb_store_arweave:read_offset(ReadStore, TXID, Opts)
@@ -1447,9 +1520,8 @@ assert_indexed_range(From, To, Opts) ->
     ?assert(has_any_indexed_tx(From, Opts)),
     assert_indexed_range(From - 1, To, Opts).
 
-small_block_depth_3_test() ->
-    {_TestStore, _StoreOpts, DefaultOpts} = setup_index_opts(),
-    Opts = DefaultOpts#{ <<"arweave-index-headers">> => true },
+small_block_full_mode_test() ->
+    {_TestStore, _StoreOpts, Opts} = setup_index_opts(),
     Block = 1889322,
     {ok, Block} =
         hb_ao:resolve(
@@ -1457,7 +1529,7 @@ small_block_depth_3_test() ->
                 "~copycat@1.0/arweave&"
                 "from=", (hb_util:bin(Block))/binary, "&"
                 "to=", (hb_util:bin(Block))/binary, "&"
-                "depth=3"
+                "mode=full"
             >>,
             Opts
         ),

--- a/src/preloaded/query/dev_copycat_graphql.erl
+++ b/src/preloaded/query/dev_copycat_graphql.erl
@@ -23,7 +23,11 @@ graphql(Base, Req, Opts) ->
     case parse_query(Base, Req, Opts) of
         {ok, Query} ->
             Node = maps:get(<<"node">>, Opts, undefined),
-            OpName = hb_maps:get(<<"operationName">>, Req, undefined, Opts),
+            OpName =
+                case hb_maps:get(<<"operationName">>, Req, undefined, Opts) of
+                    Name when is_binary(Name) -> Name;
+                    _ -> undefined
+                end,
             Vars = hb_maps:get(<<"variables">>, Req, #{}, Opts),
             index_graphql(0, Query, Vars, Node, OpName, Opts);
         Other ->

--- a/src/preloaded/query/dev_query_arweave.erl
+++ b/src/preloaded/query/dev_query_arweave.erl
@@ -158,7 +158,7 @@ query(Msg, <<"recipient">>, _Args, Opts) ->
 query(Msg, <<"anchor">>, _Args, Opts) ->
     case find_field_key(<<"field-anchor">>, Msg, Opts) of
         {ok, null} -> {ok, <<"">>};
-        {ok, Anchor} -> {ok, hb_util:human_id(Anchor)}
+        {ok, Anchor} -> encode_anchor(Anchor)
     end;
 query(Msg, <<"data">>, _Args, Opts) ->
     Data =
@@ -183,6 +183,20 @@ query(Obj, Field, Args, _Opts) ->
         {args, Args}
     }),
     {ok, <<"Not implemented.">>}.
+
+%% @doc Encode a transaction anchor (`last_tx`) for the GraphQL response.
+%% Per the Arweave spec, an anchor is one of:
+%%   - empty (first TX from a wallet),
+%%   - a 32-byte raw TX ID (the wallet's last outgoing TX), or
+%%   - a 48-byte raw block hash (any of the last 50 blocks).
+%% The cached value may already be base64url-encoded (43 / 64 chars). Other
+%% sizes are not valid per the spec.
+encode_anchor(<<>>) -> {ok, <<>>};
+encode_anchor(Bin) when is_binary(Bin), byte_size(Bin) == 32 -> {ok, hb_util:encode(Bin)};
+encode_anchor(Bin) when is_binary(Bin), byte_size(Bin) == 48 -> {ok, hb_util:encode(Bin)};
+encode_anchor(Bin) when is_binary(Bin), byte_size(Bin) == 43 -> {ok, Bin};
+encode_anchor(Bin) when is_binary(Bin), byte_size(Bin) == 64 -> {ok, Bin};
+encode_anchor(Other) -> {error, <<"invalid_anchor: ", Other/binary>>}.
 
 %% @doc Find and return a value from the fields of a message (from its
 %% commitments).

--- a/src/preloaded/query/dev_query_arweave.erl
+++ b/src/preloaded/query/dev_query_arweave.erl
@@ -286,17 +286,20 @@ sort_offset_annotated(AnnotatedIDs, SortOrder, _Opts) ->
             fun(AnnotatedID) -> maps:is_key(<<"offset">>, AnnotatedID) end,
             AnnotatedIDs
         ),
-    Ascending =
-        lists:sort(
-            fun(#{ <<"offset">> := OffsetA }, #{ <<"offset">> := OffsetB }) ->
-                offset_sort_key(OffsetA) < offset_sort_key(OffsetB)
-            end,
-            WithOffset
-        ),
+    {Pending, Confirmed} =
+        lists:partition(fun(#{ <<"offset">> := Offset }) -> pending_offset(Offset) end, WithOffset),
+    ByID = fun(#{ <<"id">> := A }, #{ <<"id">> := B }) -> A < B end,
+    ByOffset = fun(#{ <<"offset">> := A }, #{ <<"offset">> := B }) -> A < B end,
     UserOrderSorted =
         case SortOrder of
-            <<"HEIGHT_ASC">> -> Ascending;
-            _ -> lists:reverse(Ascending)
+            <<"HEIGHT_ASC">> ->
+                lists:sort(ByOffset, Confirmed) ++
+                    lists:sort(ByID, Pending) ++
+                    lists:sort(ByID, WithoutOffset);
+            _ ->
+                lists:reverse(lists:sort(ByID, Pending)) ++
+                    lists:reverse(lists:sort(ByOffset, Confirmed)) ++
+                    lists:reverse(lists:sort(ByID, WithoutOffset))
         end,
     ?event(
         {order_by_block,
@@ -305,7 +308,7 @@ sort_offset_annotated(AnnotatedIDs, SortOrder, _Opts) ->
             {without_offset, length(WithoutOffset)}
         }
     ),
-    UserOrderSorted ++ WithoutOffset.
+    UserOrderSorted.
 
 %% @doc Convert a block height range (`#{<<"min">> => Min, <<"max">> => Max}')
 %% into weave byte offset boundaries `{StartOffset, EndOffset}'. Notably, the
@@ -518,7 +521,7 @@ annotate_offsets([ID|IDs], StoreOpts, LastOffset, Ordinate, Opts) ->
                 {undefined, #{ <<"id">> => ID }}
         end,
     {NewOrdinate, Postfix} =
-        case Offset =:= LastOffset of
+        case Offset =/= undefined andalso not pending_offset(Offset) andalso Offset =:= LastOffset of
             true -> {Ordinate + 1, <<"-", (hb_util:bin(Ordinate + 1))/binary>>};
             false -> {0, <<>>}
         end,
@@ -528,6 +531,7 @@ annotate_offsets([ID|IDs], StoreOpts, LastOffset, Ordinate, Opts) ->
         },
     [WithCursor | annotate_offsets(IDs, StoreOpts, Offset, NewOrdinate, Opts)].
 
+offset_cursor(ID, undefined) when is_binary(ID) -> <<"ephemeral:", ID/binary>>;
 offset_cursor(ID, Offset) when is_binary(ID) ->
     case pending_offset(Offset) of
         true -> <<"pending:", ID/binary>>;
@@ -537,12 +541,6 @@ offset_cursor(ID, Offset) when is_binary(ID) ->
 pending_offset(relative) -> true;
 pending_offset(#{ <<"relative">> := _, <<"offset">> := _ }) -> true;
 pending_offset(_) -> false.
-
-offset_sort_key(Offset) ->
-    case pending_offset(Offset) of
-        true -> {pending, Offset};
-        false -> {confirmed, Offset}
-    end.
 
 %% @doc Apply the `block' height range as a post-filter over candidate IDs.
 %% Each candidate's offset is checked against the block range boundaries,

--- a/src/preloaded/query/dev_query_arweave.erl
+++ b/src/preloaded/query/dev_query_arweave.erl
@@ -510,9 +510,14 @@ annotate_offsets([ID|IDs], StoreOpts, LastOffset, Ordinate, Opts) ->
         end,
     WithCursor =
         Annotated#{
-            <<"cursor">> => << (hb_util:bin(Offset))/binary, Postfix/binary >>
+            <<"cursor">> => << (offset_cursor(ID, Offset))/binary, Postfix/binary >>
         },
     [WithCursor | annotate_offsets(IDs, StoreOpts, Offset, NewOrdinate, Opts)].
+
+offset_cursor(ID, relative) when is_binary(ID) ->
+    <<"pending:", ID/binary>>;
+offset_cursor(_ID, Offset) ->
+    hb_util:bin(Offset).
 
 %% @doc Apply the `block' height range as a post-filter over candidate IDs.
 %% Each candidate's offset is checked against the block range boundaries,
@@ -532,7 +537,10 @@ do_filter_offset_annotated(AnnotatedIDs, Heights, Opts) ->
         block_range_to_offset_range(Heights, Opts),
     Filtered =
         lists:filter(
-            fun(#{ <<"offset">> := IDOffset, <<"length">> := Length }) ->
+            fun(#{ <<"offset">> := relative }) ->
+                    EndOffset =:= infinity;
+                (#{ <<"offset">> := IDOffset, <<"length">> := Length })
+                        when is_integer(IDOffset) ->
                     ((StartOffset =:= 0) orelse (IDOffset >= StartOffset)) andalso
                         (
                             (EndOffset =:= infinity) orelse
@@ -636,3 +644,43 @@ explicit_ids(Args, Opts) ->
             _ -> []
         end
     ).
+
+pending_offsets_page_by_cursor_test() ->
+    Store = hb_test_utils:test_store(),
+    ArweaveStore = #{ <<"store-module">> => hb_store_arweave, <<"index-store">> => [Store] },
+    Opts = #{ <<"store">> => [Store], <<"arweave-index-store">> => ArweaveStore },
+    {ok, NumericID} =
+        hb_cache:write(#{ <<"type">> => <<"Message">>, <<"data">> => <<"numeric">> }, Opts),
+    {ok, PendingA} =
+        hb_cache:write(#{ <<"type">> => <<"Message">>, <<"data">> => <<"pending-a">> }, Opts),
+    ok = hb_store_arweave:write_offset(
+        ArweaveStore, NumericID, <<"tx@1.0">>, 10, 1),
+    ok = hb_store_arweave:write_offset(
+        ArweaveStore, PendingA, <<"tx@1.0">>, relative, 0),
+    BaseArgs =
+        #{
+            <<"ids">> => [PendingA, NumericID],
+            <<"block">> => #{ <<"min">> => 0 },
+            <<"first">> => 1
+        },
+    Page =
+        fun(Args) ->
+            {ok, #{ <<"edges">> := [Edge] }} =
+                query(#{}, <<"transactions">>, Args, Opts),
+            Edge
+        end,
+    {ok, BlockMsgID} =
+        hb_cache:write(
+            #{ <<"height">> => 1, <<"weave_size">> => 100, <<"block_size">> => 100 },
+            Opts
+        ),
+    hb_cache:link(
+        BlockMsgID,
+        [<<"~arweave@2.9">>, <<"block">>, <<"height">>, <<"1">>],
+        Opts
+    ),
+    #{ <<"id">> := NumericID } = Page(BaseArgs#{ <<"block">> => #{ <<"max">> => 1 } }),
+    #{ <<"id">> := NumericID } = Page(BaseArgs#{ <<"sort">> => <<"HEIGHT_ASC">> }),
+    #{ <<"id">> := PendingA, <<"cursor">> := FirstCursor } = Page(BaseArgs),
+    #{ <<"id">> := NumericID } = Page(BaseArgs#{ <<"after">> => FirstCursor }),
+    ok.

--- a/src/preloaded/query/dev_query_arweave.erl
+++ b/src/preloaded/query/dev_query_arweave.erl
@@ -275,7 +275,7 @@ sort_offset_annotated(AnnotatedIDs, SortOrder, _Opts) ->
     Ascending =
         lists:sort(
             fun(#{ <<"offset">> := OffsetA }, #{ <<"offset">> := OffsetB }) ->
-                OffsetA < OffsetB
+                offset_sort_key(OffsetA) < offset_sort_key(OffsetB)
             end,
             WithOffset
         ),
@@ -514,10 +514,21 @@ annotate_offsets([ID|IDs], StoreOpts, LastOffset, Ordinate, Opts) ->
         },
     [WithCursor | annotate_offsets(IDs, StoreOpts, Offset, NewOrdinate, Opts)].
 
-offset_cursor(ID, relative) when is_binary(ID) ->
-    <<"pending:", ID/binary>>;
-offset_cursor(_ID, Offset) ->
-    hb_util:bin(Offset).
+offset_cursor(ID, Offset) when is_binary(ID) ->
+    case pending_offset(Offset) of
+        true -> <<"pending:", ID/binary>>;
+        false -> hb_util:bin(Offset)
+    end.
+
+pending_offset(relative) -> true;
+pending_offset(#{ <<"relative">> := _, <<"offset">> := _ }) -> true;
+pending_offset(_) -> false.
+
+offset_sort_key(Offset) ->
+    case pending_offset(Offset) of
+        true -> {pending, Offset};
+        false -> {confirmed, Offset}
+    end.
 
 %% @doc Apply the `block' height range as a post-filter over candidate IDs.
 %% Each candidate's offset is checked against the block range boundaries,
@@ -537,7 +548,9 @@ do_filter_offset_annotated(AnnotatedIDs, Heights, Opts) ->
         block_range_to_offset_range(Heights, Opts),
     Filtered =
         lists:filter(
-            fun(#{ <<"offset">> := relative }) ->
+            fun(#{ <<"offset">> := Offset }) when Offset =:= relative ->
+                    EndOffset =:= infinity;
+                (#{ <<"offset">> := Offset }) when is_map(Offset) ->
                     EndOffset =:= infinity;
                 (#{ <<"offset">> := IDOffset, <<"length">> := Length })
                         when is_integer(IDOffset) ->

--- a/src/preloaded/query/dev_query_graphql.erl
+++ b/src/preloaded/query/dev_query_graphql.erl
@@ -108,7 +108,11 @@ handle(_Base, RawReq, Opts) ->
         end,
     ?event({request, {processed, Req}}),
     Query = hb_maps:get(<<"query">>, Req, <<>>, Opts),
-    OpName = hb_maps:get(<<"operationName">>, Req, undefined, Opts),
+    OpName = 
+        case hb_maps:get(<<"operationName">>, Req, undefined, Opts) of
+            Name when is_binary(Name) -> Name;
+            _ -> undefined
+        end,
     Vars = 
         hb_message:uncommitted_deep(
             hb_maps:get(<<"variables">>, Req, #{}, Opts),

--- a/src/preloaded/query/dev_query_graphql.erl
+++ b/src/preloaded/query/dev_query_graphql.erl
@@ -236,7 +236,10 @@ message_query(Msg, <<"id">>, _Args, Opts) ->
     ?event({message_query_id, {object, Msg}}),
     {ok, hb_message:id(Msg, all, Opts)};
 message_query(Msg, <<"cursor">>, _Args, Opts) ->
-    {ok, hb_maps:get(<<"cursor">>, Msg, hb_util:bin(hb_maps:get(<<"offset">>, Msg, <<>>, Opts)), Opts)};
+    case hb_maps:find(<<"cursor">>, Msg, Opts) of
+        {ok, Cursor} -> {ok, Cursor};
+        error -> {ok, hb_util:bin(hb_maps:get(<<"offset">>, Msg, <<>>, Opts))}
+    end;
 message_query(_Obj, _Field, _, _) ->
     {ok, <<"Not found.">>}.
 
@@ -338,6 +341,23 @@ lookup_test() ->
             } 
         },
         Res
+    ).
+
+pending_cursor_prefers_existing_cursor_test() ->
+    ?assertEqual(
+        {ok, <<"pending:txid">>},
+        message_query(
+            #{
+                <<"cursor">> => <<"pending:txid">>,
+                <<"offset">> => #{
+                    <<"relative">> => <<"txid">>,
+                    <<"offset">> => 1
+                }
+            },
+            <<"cursor">>,
+            #{},
+            #{}
+        )
     ).
 
 %%% Tests for the GraphQL interface of the dev_query module.


### PR DESCRIPTION
This PR introduces a number of features whose net effect is viability of search/querying via GraphQL requests on confirmed and pending Arweave data, optionally served via trust-minimized TEE/LapEE permawebOS nodes. This PR finishes a marathon of work from #903 (h/t @speeddragon , @Lucifer0x17 , et al), and builds upon the earlier `~query@1.0` and `~match@1.0` PRs in this repo.

Key features:
- Index Arweave data offsets to any depth, specified through the `mode` parameter to `~copycat@1.0/arweave`: `shallow` (only TXs and primary bundles), `deep` (all ID offsets), and `full` (storing all transaction data for querying, as well as the offsets of every ID).
- Index pending as well as confirmed Arweave data using the `to|from=pending` copycat parameter.
- Run GraphQL queries of pending data from Arweave mempools, indexed via copycat.

When taken with the recent permawebOS ships, this gives us the groundwork needed for fully decentralized and trust-minimized GraphQL services.

Full stack decentralized web.