### PR TITLE
impr: GraphQL query performance

### DIFF
--- a/src/core/store/hb_store_gateway.erl
+++ b/src/core/store/hb_store_gateway.erl
@@ -520,6 +520,7 @@ remote_hyperbeam_node_ans104_test() ->
             #{ <<"commitment-device">> => <<"ans104@1.0">> }
         ),
     {ok, ID} = hb_cache:write(Msg, ServerOpts),
+    PublicID = hb_message:id(Msg, all, ServerOpts),
     {ok, ReadMsg} = hb_cache:read(ID, ServerOpts),
     ?assert(hb_message:verify(ReadMsg)),
     LocalStore = hb_test_utils:test_store(),
@@ -535,6 +536,6 @@ remote_hyperbeam_node_ans104_test() ->
                     }
                 ]
         },
-    {ok, Req} = hb_cache:read(ID, ClientOpts),
+    {ok, Req} = hb_cache:read(PublicID, ClientOpts),
     ?assert(hb_message:verify(Req)),
     ?assert(hb_message:match(Msg, Req)).

--- a/src/preloaded/query/dev_query_arweave.erl
+++ b/src/preloaded/query/dev_query_arweave.erl
@@ -428,27 +428,15 @@ match_args(Args, Opts) when is_map(Args) ->
         Opts
     ).
 match_args([], [], _Opts) -> [];
-match_args([], Results, Opts) ->
+match_args([], Results, _Opts) ->
     ?event({match_args_results, Results}),
-    Store = scoped_store(Opts),
-    % For every ID in every result, we resolve it to its uncommitted ID form.
-    ResolvedResults =
-        [
-            [ hb_util:ok(hb_store:resolve(Store, ID, Opts)) || ID <- Result ]
-        ||
-            Result <- Results
-        ],
-    % Next, we find the intersection of all the results. Having the uncommitted 
-    % ID gives us their 'neutral' form: correctly returning a result with `SignedID1`
-    % from one matcher and `SignedID2` from another matcher -- while they are
-    % unequal, but pertain to the same message.
-    Matches =
+    hb_util:unique(
         lists:foldl(
             fun(Result, Acc) -> hb_util:list_with(Result, Acc) end,
-            hd(ResolvedResults),
-            tl(ResolvedResults)
-        ),
-    hb_util:unique(lists:flatten([ all_signed_ids(ID, Store, Opts) || ID <- Matches ]));
+            hd(Results),
+            tl(Results)
+        )
+    );
 match_args([{Field, X} | Rest], Acc, Opts) ->
     ?event({match, {field, Field}, {arg, X}}),
     case match(Field, X, Opts) of
@@ -616,45 +604,6 @@ commitment_id_to_base_id(ID, Opts) ->
             hb_util:encode(hb_crypto:sha256(Sig));
         _ -> not_found
     end.
-
-%% @doc Find all IDs for a message, by any of its other IDs. It achieves this
-%% by resolving the given ID, recursing through its links, then returning all
-%% of the IDs found in that `BaseID/commitments' key.
-all_signed_ids(ID, Store, Opts) ->
-    ResolvedID = hb_util:ok_or(hb_store:resolve(Store, ID, Opts), ID),
-    case hb_store:read(Store, << ResolvedID/binary, "/commitments">>, Opts) of
-        {composite, CommitmentIDs} ->
-            lists:filter(
-                fun(CommitmentID) ->
-                    CommitmentPath =
-                        <<
-                            ResolvedID/binary,
-                            "/commitments/",
-                            CommitmentID/binary,
-                            "/committer"
-                        >>,
-                    CommitmentMsgID =
-                        hb_util:ok_or(
-                            hb_store:resolve(Store, CommitmentPath, Opts),
-                            CommitmentPath
-                        ),
-                    case hb_store:read(Store, CommitmentMsgID, Opts) of
-                        {ok, _} -> true;
-                        _ ->
-                            false
-                    end
-                end,
-                CommitmentIDs
-            );
-        _ ->
-            [ID]
-    end.
-
-%% @doc Scope the stores used for block matching. The searched stores can be
-%% scoped by setting the `query_arweave_scope' option.
-scoped_store(Opts) ->
-    Scope = hb_opts:get(query_arweave_scope, [local], Opts),
-    hb_opts:get(store, no_store, hb_store:scope(Opts, Scope)).
 
 %% @doc Return the explicit IDs from the arguments, if given. Searches for
 %% both `ids' and `id' keys.


### PR DESCRIPTION
Removes 50 lines, improves performance ~2-10x:

<img width="724" height="432" alt="image" src="https://github.com/user-attachments/assets/2a72f355-27b3-44a0-a92a-de30f053bc26" />

This is achieved by removing a series of unnecessary store resolutions. Before, `match_args` treated different IDs for the same stored message as equivalent. It did this by resolving every candidate ID through the store, intersecting on the resolved/base ID, then expanding back out through `all_signed_ids/3`. Now we only match exact IDs already present in every relevant result set. Functionally the same in the end, but much faster.