### PR TITLE
feat: enable load-remote-devices based on trusted-device-signers

### DIFF
--- a/docs/build/device-packaging.md
+++ b/docs/build/device-packaging.md
@@ -157,9 +157,8 @@ Use `--bundler` to override the endpoint. Forge posts ANS-104 items to
 | `<<"preloaded-store">>` | store map | LMDB preloaded device store. |
 | `<<"preloaded-devices-index">>` | binary | Committed ID of the flat preloaded resolver message. Embedded into `hb_opts` from `_build/hb_preloaded_index.hrl` during compilation. |
 | `<<"loaded-device-store">>` | store map | Optional shared cache of name/spec-ID → loaded module atom. |
-| `<<"trusted-device-signers">>` | `[Address \| SignerPolicy]` | Acceptable signer addresses for impl messages. Defaults to the node wallet. A signer policy object may include `<<"address">>`, `<<"valid-until-height">>` to cap remote GraphQL lookup by block height, and `<<"devices">>` to scope that signer to package names or spec IDs. |
+| `<<"trusted-device-signers">>` | `[Address \| SignerPolicy]` | Acceptable signer addresses for impl messages. A non-empty configured list enables remote implementation lookup; omitted or empty disables it. A signer policy object may include `<<"address">>`, `<<"valid-until-height">>` to cap remote GraphQL lookup by block height, and `<<"devices">>` to scope that signer to device refs or spec IDs. |
 | `<<"trusted-devices">>` | `#{NameOrSpecID => ImplID}` | Operator-pinned implementation IDs trusted directly for the named device or spec ID. |
-| `<<"load-remote-devices">>` | bool | Whether unmatched devices may be fetched via the Arweave gateway. |
 | `<<"admissible-devices">>` | `all` or `[Name]` | Per-execution allowlist (used by the Lua sandbox). |
 
 In `config.json`, signer entries may be plain addresses or policy
@@ -181,7 +180,8 @@ objects:
 Plain signer entries have no lookup cutoff. `valid-until-height` only limits
 remote implementation lookup; loaded implementations must still be signed
 by an address in `trusted-device-signers`. `devices` scopes a signer
-to matching package names or resolved spec IDs; omitted means all packages.
+to matching device refs or resolved spec IDs; omitted means all devices.
+Omit `trusted-device-signers` or set it to `[]` to disable remote lookup.
 
 `HB_PRELOADED_STORE` and `HB_PRELOADED_DEVICES_INDEX` override the
 first two fields for provider-driven test runs, so the nested EUnit

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -11478,8 +11478,7 @@ float, atom, or list of such values).
 
 Devices can be expressed as either modules or maps. They can also be
 referenced by an Arweave ID, which can be used to load a device from
-the network (depending on the value of the `load_remote_devices` and
-`trusted_device_signers` environment settings).
+the network when `trusted_device_signers` are configured.
 
 HyperBEAM device implementations are defined as follows:
 
@@ -20406,9 +20405,8 @@ These options control how HyperBEAM executes messages and processes.
 
 These options control how HyperBEAM manages devices.
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `load_remote_devices` | Boolean | false | Whether to load devices from remote signers |
+Remote device loading is enabled by configuring `trusted_device_signers`;
+omit it or set it to `[]` to disable remote signer lookup.
 <!-- Complex options like preloaded-store, devices are omitted -->
 
 ### Debug & Development

--- a/docs/misc/installation-core/hyperbeam-setup-config/configuration/configuration-options.md
+++ b/docs/misc/installation-core/hyperbeam-setup-config/configuration/configuration-options.md
@@ -44,7 +44,7 @@ These options control identity and security settings.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `trusted_device_signers` | List | [] | List of device signer addresses or signer policy objects the node should trust; policy objects may set `valid-until-height` and `devices` |
+| `trusted_device_signers` | List | [] | List of device signer addresses or signer policy objects the node should trust; non-empty enables remote device lookup; policy objects may set `valid-until-height` and `devices` |
 | `trusted` | Map | {} | Trusted entities |
 | `scheduler_location_ttl` | Integer | 604800000 | TTL for scheduler registration (7 days in ms) |
 
@@ -81,7 +81,6 @@ These options control how HyperBEAM manages devices.
 | `preloaded_store` | Store map | `{store-module: hb_store_lmdb, name: "_build/preloaded-store"}` | LMDB store of signed device specs and impl messages baked at build time. |
 | `preloaded_devices_index` | Binary | (filled by build) | Committed ID of the preloaded-store resolver message. |
 | `device_store` | Store map | falls back to `store` | Volatile cache of name/spec-ID → loaded module atom. |
-| `load_remote_devices` | Boolean | false | Whether to load devices from remote signers |
 | `devices` | List | [] | Additional devices to load |
 
 ## Routing & Connectivity

--- a/docs/resources/source-code/hb_ao.md
+++ b/docs/resources/source-code/hb_ao.md
@@ -38,8 +38,7 @@ float, atom, or list of such values).
 
 Devices can be expressed as either modules or maps. They can also be
 referenced by an Arweave ID, which can be used to load a device from
-the network (depending on the value of the `load_remote_devices` and
-`trusted_device_signers` environment settings).
+the network when `trusted_device_signers` are configured.
 
 HyperBEAM device implementations are defined as follows:
 
@@ -530,4 +529,3 @@ actually takes.
 `verify_device_compatibility(Msg, Opts) -> any()`
 
 Verify that a device is compatible with the current machine.
-

--- a/docs/run/configuring-your-machine.md
+++ b/docs/run/configuring-your-machine.md
@@ -107,9 +107,8 @@ These options control how HyperBEAM executes messages and processes.
 
 These options control how HyperBEAM manages devices.
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `load_remote_devices` | Boolean | false | Whether to load devices from remote signers |
+Remote device loading is enabled by configuring `trusted_device_signers`;
+omit it or set it to `[]` to disable remote signer lookup.
 <!-- Complex options like preloaded-store, devices are omitted -->
 
 ### Debug & Development

--- a/src/core/device/hb_device_load.erl
+++ b/src/core/device/hb_device_load.erl
@@ -179,11 +179,10 @@ preloaded(Opts) ->
 %% @doc Resolve the name through `name@1.0' (safe here -- the codecs are
 %% already loaded via the high-trust path), then load the first signed,
 %% compatible implementation. Local caches are always searched -- gateway
-%% lookup is gated by `load-remote-devices'.
+%% lookup is gated by an explicit `trusted-device-signers' list.
 from_low_trust(Ref, Opts) ->
     maybe
         {ok, SpecID} ?= resolve_spec(Ref, Opts),
-        TrustedSigners = trusted_signer_entries(Ref, SpecID, Opts),
         LocalIterators =
             [
                 fun() ->
@@ -193,15 +192,22 @@ from_low_trust(Ref, Opts) ->
                     )
                 end
             ],
+        RemoteSigners =
+            case hb_opts:get(trusted_device_signers, [], Opts) of
+                [_ | _] = Signers ->
+                    trusted_signer_entries(Ref, SpecID, Signers, Opts);
+                _ ->
+                    []
+            end,
         RemoteIterators =
-            case {hb_opts:get(<<"load-remote-devices">>, false, Opts), TrustedSigners} of
-                {true, [_ | _]} ->
+            case RemoteSigners of
+                [_ | _] ->
                     [
                         fun() ->
                             hb_util:ok_or(
                                 hb_client_gateway:device(
                                     SpecID,
-                                    TrustedSigners,
+                                    RemoteSigners,
                                     Opts
                                 ),
                                 []
@@ -328,10 +334,13 @@ trusted_signers(Ref, SpecID, Opts) ->
     ].
 
 trusted_signer_entries(Ref, SpecID, Opts) ->
+    trusted_signer_entries(Ref, SpecID, trusted_signer_entries(Opts), Opts).
+
+trusted_signer_entries(Ref, SpecID, Signers, Opts) ->
     [
         Signer
     ||
-        Signer <- trusted_signer_entries(Opts),
+        Signer <- Signers,
         trusted_signer_accepts(Ref, SpecID, Signer, Opts)
     ].
 

--- a/src/core/http/hb_http.erl
+++ b/src/core/http/hb_http.erl
@@ -852,7 +852,7 @@ codec_to_content_type(Codec, Opts) ->
             <<"hashpath">> => ignore,
             <<"cache-control">> => [<<"no-cache">>, <<"no-store">>],
             <<"cache-lookup-hueristics">> => false,
-            <<"load-remote-devices">> => false,
+            <<"trusted-device-signers">> => [],
             <<"error-strategy">> => continue
         },
     case hb_ao:get(<<"content-type">>, #{ <<"device">> => Codec }, FastOpts) of

--- a/src/core/resolver/hb_ao.erl
+++ b/src/core/resolver/hb_ao.erl
@@ -32,8 +32,7 @@
 %%% 
 %%% Devices can be expressed as either modules or maps. They can also be 
 %%% referenced by an Arweave ID, which can be used to load a device from 
-%%% the network (depending on the value of the `load-remote-devices' and
-%%% `trusted-device-signers' environment settings).
+%%% the network when `trusted-device-signers' are configured.
 %%% 
 %%% HyperBEAM device implementations are defined as follows:
 %%% <pre>

--- a/src/core/resolver/hb_opts.erl
+++ b/src/core/resolver/hb_opts.erl
@@ -262,8 +262,6 @@ raw_default_message() ->
         % Should the node attempt to access data from remote caches for
         % client requests?
         <<"access-remote-cache-for-client">> => false,
-        % Should the node attempt to load devices from remote signers?
-        <<"load-remote-devices">> => false,
         % The list of device signers that the node should trust.
         <<"trusted-device-signers">> => [],
         % Map of device name/spec ID -> trusted implementation ID,

--- a/src/core/test/hb_ao_test_vectors.erl
+++ b/src/core/test/hb_ao_test_vectors.erl
@@ -286,7 +286,6 @@ load_device_test() ->
     % Establish an execution environment which trusts the device author.
     Wallet = ar_wallet:new(),
     Opts = #{
-        <<"load-remote-devices">> => true,
         <<"trusted-device-signers">> =>
             [hb:address(), hb_util:human_id(ar_wallet:to_address(Wallet))],
         <<"store">> => Store = hb_test_utils:test_store(hb_store_fs),
@@ -300,7 +299,6 @@ untrusted_load_device_test() ->
     UntrustedWallet = ar_wallet:new(),
     TrustedWallet = ar_wallet:new(),
     Opts = #{
-        <<"load-remote-devices">> => true,
         <<"trusted-device-signers">> =>
             [hb:address(), hb_util:human_id(ar_wallet:to_address(TrustedWallet))],
         <<"store">> => Store = hb_test_utils:test_store(hb_store_fs),
@@ -312,10 +310,9 @@ untrusted_load_device_test() ->
         exec_dummy_device(Opts)
     ).
 
-load_remote_devices_false_skips_gateway_test() ->
+no_trusted_device_signers_skips_gateway_test() ->
     Wallet = ar_wallet:new(),
     Opts = #{
-        <<"load-remote-devices">> => false,
         <<"routes">> => invalid,
         <<"store">> => Store = hb_test_utils:test_store(hb_store_fs),
         <<"priv-wallet">> => Wallet


### PR DESCRIPTION
a followup to #956 -- where in this PR we have the `<<"load-remote-devices">> => bool` removed and replaced logically with `<<"trusted-device-signers">> => []` being configured.

an empty (or set to empty) trusted-device-signers is a kill-switch for the functionality of loading remote devices.

N.B: the hyperbeam node operator's `hb:address()` is no longer implicitly preseeding the trusted-device-signers list to avoid accidental remote-lookup enabling