### PR TITLE
impr: Disable match-index by default

### DIFF
--- a/src/core/resolver/hb_opts.erl
+++ b/src/core/resolver/hb_opts.erl
@@ -471,7 +471,7 @@ raw_default_message() ->
                     <<"local-store">> => [?DEFAULT_PRIMARY_STORE]
                 }
             ],
-        <<"match-index">> => [?DEFAULT_PRIMARY_STORE],
+        <<"match-index">> => false,
         <<"priv-store">> =>
             [
                 #{


### PR DESCRIPTION
This was previously enabled, but due to some code restructure (I couldn't pinpoint the exact change), it started to write to `cache-mainnet/lmdb` the user requests to the HyperBEAM node, taking a large amount of space for heavily used nodes.