### PR TITLE
impr: Device compilation errors

### DIFF
--- a/scripts/build-preloaded-store.escript
+++ b/scripts/build-preloaded-store.escript
@@ -10,8 +10,19 @@
 
 -include("../include/hb.hrl").
 
-main(_Args) ->
+main(Args) ->
     add_code_paths(),
+    try run(Args)
+    catch
+        error:{device_compile_failed, _, _, _, _} = Reason ->
+            io:put_chars(
+                standard_error,
+                hb_packager:format_error(Reason)
+            ),
+            halt(1)
+    end.
+
+run(_Args) ->
     {ok, _} = application:ensure_all_started(crypto),
     {ok, _} = application:ensure_all_started(asn1),
     {ok, _} = application:ensure_all_started(public_key),

--- a/src/forge/hb_packager.erl
+++ b/src/forge/hb_packager.erl
@@ -31,6 +31,7 @@
 -export([scan/2, scan/1]).
 -export([package/2, package_all/2, group_device_name/1]).
 -export([spec_message/2, impl_message/3]).
+-export([format_error/1]).
 
 -include("include/hb.hrl").
 -include_lib("kernel/include/file.hrl").
@@ -590,13 +591,47 @@ compile_module(Old, Path, RenameMap, IncludeDirs, Opts) ->
             erlang:error({device_module_name_mismatch, Old, New, Other});
         {error, Errors, Warnings} ->
             erlang:error(
-                {device_compile_failed, Old,
-                    [{errors, Errors}, {warnings, Warnings},
-                     {source_path, Path}]}
+                {device_compile_failed, Old, Path, Errors, Warnings}
             );
         Other ->
-            erlang:error({device_compile_failed, Old, Other})
+            erlang:error(
+                {device_compile_failed,
+                    Old,
+                    Path,
+                    [{Path, [{none, ?MODULE, Other}]}],
+                    []}
+            )
     end.
+
+%% @doc Render packager errors for user-facing forge providers.
+format_error({device_compile_failed, Device, Path, Errors, Warnings}) ->
+    [
+        io_lib:format(
+            "While building device package ~p from ~ts:~n",
+            [Device, hb_util:list(Path)]
+        ),
+        compile_messages("", Errors),
+        compile_messages("Warning: ", Warnings)
+    ];
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).
+
+compile_messages(Prefix, Messages) ->
+    [
+        Text
+     ||
+        {File, Infos} <- Messages,
+        {_Where, Text} <-
+            sys_messages:format_messages(
+                hb_util:list(compile_file(File)),
+                Prefix,
+                Infos,
+                []
+            )
+    ].
+
+compile_file({Path, _Line}) -> Path;
+compile_file(Path) -> Path.
 
 %% @doc Build the old-module -> generated-module mapping.
 module_renamings(RootMod, Root, Entries) ->

--- a/src/forge/plugin/src/hb_forge_args.erl
+++ b/src/forge/plugin/src/hb_forge_args.erl
@@ -14,7 +14,7 @@
 %%% {@link parse/2} to convert the parsed options into a normalised map.
 -module(hb_forge_args).
 -export([provider/6, opts/0, parse/2, scan_devices/1, package_opts/0, package_opts/1]).
--export([maybe_help/2]).
+-export([run_provider/3]).
 -export([set_preloaded_env/1, restore_preloaded_env/1, with_preloaded_env/2]).
 -export([load_wallet/1, bootstrap_preloaded_dirs/0, bootstrap_preloaded_dirs/1]).
 -export([default_preloaded_dirs/1]).
@@ -119,8 +119,8 @@ parse(State, DefaultOutput) ->
             end
     }.
 
-%% @doc Print the current provider's generated help if `--help' was given.
-maybe_help(State, Module) ->
+%% @doc Run a provider body after shared `rebar3 device' boundary handling.
+run_provider(State, Module, Fun) when is_function(Fun, 1) ->
     {Args, _Rest} = rebar_state:command_parsed_args(State),
     case proplists:get_value(help, Args, false) of
         true ->
@@ -130,9 +130,13 @@ maybe_help(State, Module) ->
                     rebar_state:providers(State)
                 ),
             providers:help(Provider),
-            true;
+            {ok, State};
         false ->
-            false
+            try Fun(State)
+            catch
+                error:{device_compile_failed, _, _, _, _} = Reason ->
+                    {error, hb_packager:format_error(Reason)}
+            end
     end.
 
 %% @doc Parse a comma-separated provider option into atoms, or `all'.

--- a/src/forge/plugin/src/hb_forge_local.erl
+++ b/src/forge/plugin/src/hb_forge_local.erl
@@ -21,10 +21,7 @@ init(State) ->
 
 %% @doc Build a preloaded-store and start a shell pointed at it.
 do(State) ->
-    case hb_forge_args:maybe_help(State, ?MODULE) of
-        true -> {ok, State};
-        false -> do_run(State)
-    end.
+    hb_forge_args:run_provider(State, ?MODULE, fun do_run/1).
 
 do_run(State) ->
     Args = hb_forge_args:parse(State, <<"_build/device-local-store">>),

--- a/src/forge/plugin/src/hb_forge_package.erl
+++ b/src/forge/plugin/src/hb_forge_package.erl
@@ -21,10 +21,7 @@ init(State) ->
 
 %% @doc Parse CLI args and emit generated package archives.
 do(State) ->
-    case hb_forge_args:maybe_help(State, ?MODULE) of
-        true -> {ok, State};
-        false -> do_run(State)
-    end.
+    hb_forge_args:run_provider(State, ?MODULE, fun do_run/1).
 
 do_run(State) ->
     Args = hb_forge_args:parse(State, <<"_build/device-packages">>),

--- a/src/forge/plugin/src/hb_forge_preload.erl
+++ b/src/forge/plugin/src/hb_forge_preload.erl
@@ -29,10 +29,7 @@ init(State) ->
 
 %% @doc Parse CLI args and build a signed preloaded-store.
 do(State) ->
-    case hb_forge_args:maybe_help(State, ?MODULE) of
-        true -> {ok, State};
-        false -> do_run(State)
-    end.
+    hb_forge_args:run_provider(State, ?MODULE, fun do_run/1).
 
 do_run(State) ->
     Args = hb_forge_args:parse(State, <<"_build/preloaded-store">>),

--- a/src/forge/plugin/src/hb_forge_publish.erl
+++ b/src/forge/plugin/src/hb_forge_publish.erl
@@ -21,12 +21,9 @@ init(State) ->
 
 %% @doc Package, sign, and upload selected devices.
 do(State) ->
-    case hb_forge_args:maybe_help(State, ?MODULE) of
-        true -> {ok, State};
-        false -> do_run(State)
-    end.
+    hb_forge_args:run_provider(State, ?MODULE, fun publish/1).
 
-do_run(State) ->
+publish(State) ->
     Args = hb_forge_args:parse(State, <<"_build/device-publish-store">>),
     KeyPath = maps:get(<<"key">>, Args),
     PublishCodec = maps:get(<<"publish-codec">>, Args),

--- a/src/forge/plugin/src/hb_forge_test.erl
+++ b/src/forge/plugin/src/hb_forge_test.erl
@@ -23,12 +23,9 @@ init(State) ->
 
 %% @doc Build a test preloaded-store and run selected package EUnit modules.
 do(State) ->
-    case hb_forge_args:maybe_help(State, ?MODULE) of
-        true -> {ok, State};
-        false -> do_run(State)
-    end.
+    hb_forge_args:run_provider(State, ?MODULE, fun run_tests/1).
 
-do_run(State) ->
+run_tests(State) ->
     Args = hb_forge_args:parse(State, <<"_build/device-test-store">>),
     % Build a complete store from the configured source set so selected
     % device tests can resolve their dependencies.

--- a/src/forge/plugin/src/hb_forge_verify.erl
+++ b/src/forge/plugin/src/hb_forge_verify.erl
@@ -24,12 +24,9 @@ init(State) ->
 
 %% @doc Package selected devices and load each archive via the runtime loader.
 do(State) ->
-    case hb_forge_args:maybe_help(State, ?MODULE) of
-        true -> {ok, State};
-        false -> do_run(State)
-    end.
+    hb_forge_args:run_provider(State, ?MODULE, fun verify/1).
 
-do_run(State) ->
+verify(State) ->
     Args = hb_forge_args:parse(State, <<"_build/device-packages">>),
     Failures =
         hb_forge_seed:with_forge_bootstrap(


### PR DESCRIPTION
Restores standard Erlang compilation errors while compiling and packaging devices. This includes line numbers and column references, etc. These were accidentally replaced with less intuitive Erlang term errors during the transition to packaged devices.