### PR TITLE
fix: `~recorder@1.0` tests using forge bootstrap

### DIFF
--- a/src/forge/plugin/src/hb_forge_test.erl
+++ b/src/forge/plugin/src/hb_forge_test.erl
@@ -780,8 +780,8 @@ safe_clear_event_recording(Result) ->
     catch _:_ -> ok
     end.
 
-event_opts(Result) ->
-    (event_plain_opts(Result))#{
+event_opts(#{ result := Result }) ->
+    (test_opts(Result))#{
         <<"on">> =>
             #{
                 <<"event">> =>
@@ -793,22 +793,17 @@ event_opts(Result) ->
             }
     }.
 
-event_plain_opts(#{ result := Result, recorder_mod := RecorderMod }) ->
-    (test_opts(Result))#{
-        <<"forge-bootstrap">> => #{ <<"recorder@1.0">> => RecorderMod }
-    }.
-
 recorder_mod(#{ recorder_mod := RecorderMod }) ->
     RecorderMod.
 
-recorder_call(Result, Fun, Req) ->
+recorder_call(#{ result := Result } = Ctx, Fun, Req) ->
     apply(
-        recorder_mod(Result),
+        recorder_mod(Ctx),
         Fun,
         [
             #{ <<"device">> => <<"recorder@1.0">> },
             Req,
-            event_plain_opts(Result)
+            test_opts(Result)
         ]
     ).
 

--- a/src/preloaded/debug/dev_recorder.erl
+++ b/src/preloaded/debug/dev_recorder.erl
@@ -749,7 +749,7 @@ ao_take_off_land_test() ->
             #{
                 <<"path">> => <<"/~recorder@1.0/take-off/keys/land~recorder@1.0&format=raw">>
             },
-            #{ <<"forge-bootstrap">> => #{ ?DEVICE => ?MODULE } }
+            #{}
         ),
     ?assert(length(Events) > 0),
     clear_recording().
@@ -849,7 +849,7 @@ record_installs_hook_test() ->
                         <<"path">> => <<"keys">>
                     }
             },
-            #{ <<"forge-bootstrap">> => #{ ?DEVICE => ?MODULE } }
+            #{}
         ),
     ?assert(length(Events) > 0),
     ?assert(


### PR DESCRIPTION
Fixes errant test failures caused by forge bootstrap override. This returns us to 100% tests passing on `edge`.