### PR TITLE
fix: show all hyperbuddy format keys by default

### DIFF
--- a/src/preloaded/node/dev_hyperbuddy.erl
+++ b/src/preloaded/node/dev_hyperbuddy.erl
@@ -116,12 +116,10 @@ format(Base, Req, Opts) ->
         end,
     MsgLoaded = hb_cache:ensure_all_loaded(MsgBeforeLoad, Opts),
     TruncateKeys =
-        hb_maps:get(
-            <<"truncate-keys">>,
-            Req,
-            hb_opts:get(debug_print_truncate, infinity, Opts),
-            Opts
-        ),
+        case hb_maps:get(<<"truncate-keys">>, Req, infinity, Opts) of
+            infinity -> infinity;
+            Value -> hb_util:int(Value)
+        end,
     ?event(debug_format, {using_truncation, TruncateKeys}),
     {ok,
         #{


### PR DESCRIPTION
This change ensures that all component keys are displayed by default when the `truncate-keys` parameter is not explicitly provided in `~hyperbuddy@1.0/format` requests. If a result is particularly large the caller can still provide an `&truncate-keys=X` which determines the maximum number to render per nested layer.