### PR TITLE
impr: GraphQL `force-next-page` parameters for decentralized worker nodes

### DIFF
--- a/src/preloaded/query/dev_query_arweave.erl
+++ b/src/preloaded/query/dev_query_arweave.erl
@@ -54,29 +54,39 @@ query(Obj, <<"transactions">>, Args, Opts) ->
         {field, <<"transactions">>},
         {args, Args}
     }),
-    Matches = match_args(Args, Opts),
-    WithExplicit =
-        case explicit_ids(Args, Opts) of
-            [] -> Matches;
-            ExplicitIDs -> hb_util:list_with(Matches, ExplicitIDs)
-        end,
-    Ordered =
-        case annotate_ids(WithExplicit, Opts) of
-            unavailable -> [#{ <<"id">> => ID } || ID <- Matches];
-            Annotated ->
-                Order = maps:get(<<"sort">>, Args, <<"HEIGHT_DESC">>),
-                sort_offset_annotated(
-                    filter_offset_annotated(
-                        Annotated,
-                        maps:get(<<"block">>, Args, undefined),
-                        Opts
-                    ),
-                    Order,
-                    Opts
-                )
-        end,
-    ?event({transactions_matches, Matches}),
-    {ok, connection(Ordered, Args, Opts)};
+    case valid_after_cursor(Args, Opts) of
+        true ->
+            Matches = match_args(Args, Opts),
+            WithExplicit =
+                case explicit_ids(Args, Opts) of
+                    [] -> Matches;
+                    ExplicitIDs -> hb_util:list_with(Matches, ExplicitIDs)
+                end,
+            Ordered =
+                case annotate_ids(WithExplicit, Opts) of
+                    unavailable -> [#{ <<"id">> => ID } || ID <- Matches];
+                    Annotated ->
+                        Order = maps:get(<<"sort">>, Args, <<"HEIGHT_DESC">>),
+                        sort_offset_annotated(
+                            filter_offset_annotated(
+                                Annotated,
+                                maps:get(<<"block">>, Args, undefined),
+                                Opts
+                            ),
+                            Order,
+                            Opts
+                        )
+                end,
+            ?event({transactions_matches, Matches}),
+            {ok, connection(Ordered, Args, Opts)};
+        false ->
+            ?event(
+                {invalid_after_cursor,
+                    hb_maps:get(<<"after">>, Args, not_found, Opts)
+                }
+            ),
+            {ok, connection([], Args, Opts)}
+    end;
 query(Obj, <<"block">>, Args, Opts) ->
     case query(Obj, <<"blocks">>, Args, Opts) of
         {ok, []} -> {ok, null};
@@ -223,15 +233,29 @@ connection(Ordered, Args, Opts) ->
     CountToReturn = page_size(Args, Opts),
     ResultsPagePlusOne = read_ids(Remaining, CountToReturn + 1, Opts),
     ResultsPage = lists:sublist(ResultsPagePlusOne, CountToReturn),
+    HasNextPage = length(ResultsPagePlusOne) > CountToReturn,
+    ForceNextPage = force_next_page(Args, Opts),
+    Edges =
+        case ForceNextPage andalso (not HasNextPage) of
+            true -> force_terminal_cursor(ResultsPage);
+            false -> ResultsPage
+        end,
     #{
         <<"count">> => hb_util:bin(ResultsCount),
-        <<"edges">> => ResultsPage,
+        <<"edges">> => Edges,
         <<"pageInfo">> =>
             #{
-                <<"hasNextPage">> =>
-                    length(ResultsPagePlusOne) > CountToReturn
+                <<"hasNextPage">> => HasNextPage orelse ForceNextPage
             }
     }.
+
+force_next_page(Args, Opts) ->
+    hb_util:bool(hb_maps:get(<<"force-next-page">>, Args, false, Opts)).
+
+force_terminal_cursor([]) -> [];
+force_terminal_cursor(Edges) ->
+    [Last = #{ <<"cursor">> := Cursor } | RestRev] = lists:reverse(Edges),
+    lists:reverse([Last#{ <<"cursor">> => << Cursor/binary, "&remaining=0" >> } | RestRev]).
 
 %% @doc Read IDs into their Arweave GraphQL-compliant object form, from a list
 %% of offset-annotated messages.
@@ -251,15 +275,52 @@ drop_to_cursor(Args, Ordered, Opts) ->
         hb_maps:get(<<"after">>, Args, null, Opts),
         Ordered
     ).
-drop_to_cursor(Cursor, Ordered)
-        when Cursor =:= null orelse Cursor =:= undefined orelse Ordered =:= [] ->
+drop_to_cursor(null, Ordered) ->
     Ordered;
-drop_to_cursor(After, [AnnotatedID | Rest]) ->
-    ID = maps:get(<<"id">>, AnnotatedID, undefined),
-    Cursor = maps:get(<<"cursor">>, AnnotatedID, undefined),
-    case (After =:= ID) orelse (After =:= Cursor) of
-        true -> Rest;
-        false -> drop_to_cursor(After, Rest)
+drop_to_cursor(undefined, Ordered) ->
+    Ordered;
+drop_to_cursor(<<>>, Ordered) ->
+    Ordered;
+drop_to_cursor(_After, []) ->
+    [];
+drop_to_cursor(After, [#{ <<"cursor">> := After } | Rest]) ->
+    Rest;
+drop_to_cursor(After, [_ | Rest]) ->
+    drop_to_cursor(After, Rest).
+
+valid_after_cursor(Args, Opts) ->
+    valid_cursor(hb_maps:get(<<"after">>, Args, null, Opts)).
+
+valid_cursor(null) ->
+    true;
+valid_cursor(undefined) ->
+    true;
+valid_cursor(<<>>) ->
+    true;
+valid_cursor(<<"offset=", Cursor/binary>>) ->
+    valid_offset_cursor(Cursor);
+valid_cursor(<<"pending=", ID/binary>>) when ?IS_ID(ID) ->
+    true;
+valid_cursor(<<"ephemeral=", ID/binary>>) when ?IS_ID(ID) ->
+    true;
+valid_cursor(_) ->
+    false.
+
+valid_offset_cursor(Cursor) ->
+    case binary:split(Cursor, <<"-">>) of
+        [Offset] ->
+            valid_integer_cursor_part(Offset);
+        [Offset, Ordinate] ->
+            valid_integer_cursor_part(Offset)
+                andalso valid_integer_cursor_part(Ordinate);
+        _ ->
+            false
+    end.
+
+valid_integer_cursor_part(<<>>) -> false;
+valid_integer_cursor_part(Bin) ->
+    try binary_to_integer(Bin) >= 0
+    catch _:_ -> false
     end.
 
 %% @doc Return the page size, clamped to the maximum allowed.
@@ -517,11 +578,11 @@ annotate_offsets([ID|IDs], StoreOpts, LastOffset, Ordinate, Opts) ->
         },
     [WithCursor | annotate_offsets(IDs, StoreOpts, Offset, NewOrdinate, Opts)].
 
-offset_cursor(ID, undefined) when is_binary(ID) -> <<"ephemeral:", ID/binary>>;
+offset_cursor(ID, undefined) when is_binary(ID) -> <<"ephemeral=", ID/binary>>;
 offset_cursor(ID, Offset) when is_binary(ID) ->
     case pending_offset(Offset) of
-        true -> <<"pending:", ID/binary>>;
-        false -> hb_util:bin(Offset)
+        true -> <<"pending=", ID/binary>>;
+        false -> <<"offset=", (hb_util:bin(Offset))/binary>>
     end.
 
 pending_offset(relative) -> true;

--- a/src/preloaded/query/dev_query_graphql.erl
+++ b/src/preloaded/query/dev_query_graphql.erl
@@ -147,7 +147,8 @@ handle(_Base, RawReq, Opts) ->
                                 ?DEFAULT_QUERY_TIMEOUT,
                                 Opts
                             ),
-                        opts => Opts
+                        opts => Opts,
+                        req => Req
                     },
                 ?event(graphql_context_created),
                 Response = graphql:execute(Ctx, AST2),
@@ -171,12 +172,21 @@ handle(_Base, RawReq, Opts) ->
 %% GraphQL library. We split the resolution flows into two separated functions:
 %% `message_query/4' for the HyperBEAM native API, and `dev_query_arweave:query/4'
 %% for the Arweave-compatible API.
-execute(#{opts := Opts}, Obj, Field, Args) ->
+execute(Ctx = #{opts := Opts}, Obj, Field, Args) ->
     ?event({graphql_query, {object, Obj}, {field, Field}, {args, Args}}),
     case lists:member(Field, ?MESSAGE_QUERY_KEYS) of
         true -> message_query(Obj, Field, Args, Opts);
-        false -> dev_query_arweave:query(Obj, Field, Args, Opts)
+        false ->
+            dev_query_arweave:query(
+                Obj,
+                Field,
+                maps:merge(request_args(Ctx), Args),
+                Opts
+            )
     end.
+
+request_args(Ctx) ->
+    maps:with([<<"force-next-page">>], maps:get(req, Ctx, #{})).
 
 %% @doc No-op on input validation.
 input(_TypeID, Val) -> {ok, Val}.
@@ -349,10 +359,10 @@ lookup_test() ->
 
 pending_cursor_prefers_existing_cursor_test() ->
     ?assertEqual(
-        {ok, <<"pending:txid">>},
+        {ok, <<"pending=txid">>},
         message_query(
             #{
-                <<"cursor">> => <<"pending:txid">>,
+                <<"cursor">> => <<"pending=txid">>,
                 <<"offset">> => #{
                     <<"relative">> => <<"txid">>,
                     <<"offset">> => 1

--- a/src/preloaded/query/dev_query_test_vectors.erl
+++ b/src/preloaded/query/dev_query_test_vectors.erl
@@ -4,6 +4,14 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+%%% The public, legacy Arweave GraphQL gateway used to exercise fallback
+%%% routing: a HyperBEAM node serves what it has locally, then the router falls
+%%% through to this endpoint for everything it does not. Kept behind macros so
+%%% the specific provider is named in exactly one place.
+-define(LEGACY_GRAPHQL_ENDPOINT, <<"https://arweave-search.goldsky.com">>).
+%% A transaction resolvable via the legacy gateway but absent locally, used to
+%% prove the fallback returns remote results.
+-define(LEGACY_GRAPHQL_TX, <<"xBpOR2KOjYEgv5HmddMlAgYa-yMvfEVl-0XzRIfm2uY">>).
 %% An opaque cursor in a legacy GraphQL gateway's own (non-native) format;
 %% HyperBEAM must reject it rather than misinterpret it (it is not native).
 -define(LEGACY_GRAPHQL_CURSOR,
@@ -1060,6 +1068,84 @@ transactions_query_legacy_cursor_test_parallel() ->
         },
         Res
     ).
+
+transactions_query_gateway_fallback_test_() ->
+    {timeout, 60, fun transactions_query_gateway_fallback/0}.
+transactions_query_gateway_fallback() ->
+    {ok, LocalNode, _LocalOpts, LocalID} = test_env_with_message(),
+    LegacyTX = ?LEGACY_GRAPHQL_TX,
+    Opts = #{ <<"routes">> => [graphql_gateway_route(LocalNode)] },
+    % The client only follows cursors; it has no knowledge of the route's
+    % fallback chain. Page 1 is served locally by HyperBEAM, page 2 by the
+    % legacy gateway -- the two backends' results arrive back to back.
+    Pages =
+        collect_graphql_pages(
+            transactions_cursor_query(),
+            #{ <<"ids">> => [LocalID, LegacyTX], <<"first">> => 2 },
+            Opts
+        ),
+    ?assertEqual(
+        [LocalID, LegacyTX],
+        lists:append([transaction_ids(P, Opts) || P <- Pages])
+    ),
+    ?assertEqual(
+        [true, false],
+        [transaction_has_next_page(P, Opts) || P <- Pages]
+    ).
+
+graphql_gateway_route(LocalNode) ->
+    #{
+        <<"template">> => <<"/graphql">>,
+        <<"nodes">> =>
+            [
+                % The local node is the fallback front: the route tells it to
+                % `force-next-page' so it always signals "there may be more",
+                % letting the (router-agnostic) client page on to the legacy
+                % gateway. The flag is injected here, not by the client.
+                #{
+                    <<"uri">> =>
+                        << LocalNode/binary,
+                            "~query@1.0/graphql?force-next-page=true" >>
+                },
+                #{
+                    <<"prefix">> => ?LEGACY_GRAPHQL_ENDPOINT,
+                    <<"opts">> =>
+                        #{ <<"http-client">> => httpc, <<"protocol">> => http2 }
+                }
+            ],
+        <<"parallel">> => 1,
+        <<"responses">> => 1,
+        <<"stop-after">> => true,
+        <<"admissible-status">> => 200,
+        <<"admissible">> =>
+            #{
+                <<"device">> => <<"query@1.0">>,
+                <<"path">> => <<"has-results">>
+            }
+    }.
+
+collect_graphql_pages(Query, Vars, Opts) ->
+    collect_graphql_pages(Query, Vars, Opts, [], 4).
+
+collect_graphql_pages(_Query, _Vars, _Opts, Acc, 0) ->
+    lists:reverse(Acc);
+collect_graphql_pages(Query, Vars, Opts, Acc, Remaining) ->
+    {ok, Page} = hb_client_gateway:query(Query, Vars, Opts),
+    case transaction_has_next_page(Page, Opts) of
+        true ->
+            Edges = transaction_edges(Page, Opts),
+            ?assert(Edges =/= []),
+            #{ <<"cursor">> := Cursor } = lists:last(Edges),
+            collect_graphql_pages(
+                Query,
+                Vars#{ <<"after">> => Cursor },
+                Opts,
+                [Page | Acc],
+                Remaining - 1
+            );
+        false ->
+            lists:reverse([Page | Acc])
+    end.
 
 %% @doc Test single transaction query by ID
 transaction_query_by_id_test_parallel() ->

--- a/src/preloaded/query/dev_query_test_vectors.erl
+++ b/src/preloaded/query/dev_query_test_vectors.erl
@@ -4,6 +4,15 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+%% An opaque cursor in a legacy GraphQL gateway's own (non-native) format;
+%% HyperBEAM must reject it rather than misinterpret it (it is not native).
+-define(LEGACY_GRAPHQL_CURSOR,
+    <<
+        "eyJzZWFyY2hfYWZ0ZXIiOlsxOTQyODI5LCItaVlWTHQtREt4ZEZkRU4xOHdB",
+        "QWtkYUw4anlMSEdVd29uSEgzN3BLWmNvIl0sImluZGV4IjowfQ=="
+    >>
+).
+
 %%% Test helpers.
 
 write_test_message(Opts) ->
@@ -70,6 +79,98 @@ test_env_with_blocks(InitialHeight, FinalHeight) ->
         Opts
     ),
     {ok, Node, Opts}.
+
+post_graphql(Node, Query, Variables, Req, Opts) ->
+    Path =
+        case hb_util:bool(hb_maps:get(<<"force-next-page">>, Req, false, Opts)) of
+            true -> <<"~query@1.0/graphql?force-next-page=true">>;
+            false -> <<"~query@1.0/graphql">>
+        end,
+    {ok, Res} =
+        hb_http:post(
+            Node,
+            #{
+                <<"path">> => Path,
+                <<"content-type">> => <<"application/json">>,
+                <<"codec-device">> => <<"json@1.0">>,
+                <<"body">> =>
+                    hb_json:encode(
+                        #{
+                            <<"query">> => Query,
+                            <<"variables">> => Variables
+                        }
+                    )
+            },
+            Opts
+        ),
+    hb_json:decode(hb_maps:get(<<"body">>, Res, <<>>, Opts)).
+
+test_env_with_message() ->
+    LocalStore = hb_test_utils:test_store(),
+    ArweaveStore =
+        #{
+            <<"store-module">> => hb_store_arweave,
+            <<"index-store">> => hb_test_utils:test_store(),
+            <<"local-store">> => LocalStore
+        },
+    Opts =
+        #{
+            <<"priv-wallet">> => ar_wallet:new(),
+            <<"store">> => [LocalStore, ArweaveStore]
+        },
+    Node = hb_http_server:start_node(Opts),
+    {ok, Msg} = write_test_message(Opts),
+    {ok, Node, Opts, hb_message:id(Msg, all, Opts)}.
+
+transactions_cursor_query() ->
+    <<"""
+        query($ids: [ID!], $sort: SortOrder, $first: Int, $after: String) {
+            transactions(
+                ids: $ids,
+                sort: $sort,
+                first: $first,
+                after: $after
+            ) {
+                count
+                pageInfo {
+                    hasNextPage
+                }
+                edges {
+                    cursor
+                    node {
+                        id
+                    }
+                }
+            }
+        }
+    """>>.
+
+transaction_edges(Res, Opts) ->
+    hb_maps:get(
+        <<"edges">>,
+        hb_util:deep_get(<<"data/transactions">>, Res, #{}, Opts),
+        [],
+        Opts
+    ).
+
+transaction_ids(Res, Opts) ->
+    [
+        ID
+    ||
+        #{ <<"node">> := #{ <<"id">> := ID }} <- transaction_edges(Res, Opts)
+    ].
+
+transaction_has_next_page(Res, Opts) ->
+    hb_util:deep_get(
+        <<"data/transactions/pageInfo/hasNextPage">>,
+        Res,
+        false,
+        Opts
+    ).
+
+transaction_cursor(Res, Opts) ->
+    [#{ <<"cursor">> := Cursor }] = transaction_edges(Res, Opts),
+    Cursor.
 
 %% Helper function to write test message with Recipient
 write_test_message_with_recipient(Recipient, Opts) ->
@@ -776,28 +877,7 @@ transactions_query_cursor_by_offset_test_parallel() ->
         hb_store_arweave:read_offset(StoreOpts, EarlierID, Opts),
     {ok, #{ <<"start-offset">> := LaterOffset }} =
         hb_store_arweave:read_offset(StoreOpts, LaterID, Opts),
-    Query =
-        <<"""
-            query($ids: [ID!], $sort: SortOrder, $first: Int, $after: String) {
-                transactions(
-                    ids: $ids,
-                    sort: $sort,
-                    first: $first,
-                    after: $after
-                ) {
-                    count
-                    pageInfo {
-                        hasNextPage
-                    }
-                    edges {
-                        cursor
-                        node {
-                            id
-                        }
-                    }
-                }
-            }
-        """>>,
+    Query = transactions_cursor_query(),
     VerifyFun =
         fun(Order, FirstID, FirstOffset, SecondID, SecondOffset) ->
             FirstRes =
@@ -829,7 +909,10 @@ transactions_query_cursor_by_offset_test_parallel() ->
                     }
                 }
             } = FirstRes,
-            ?assertEqual(hb_util:bin(FirstOffset), FirstCursor),
+            ?assertEqual(
+                <<"offset=", (hb_util:bin(FirstOffset))/binary>>,
+                FirstCursor
+            ),
             SecondRes =
                 dev_query_graphql:test_query(
                     Node,
@@ -838,7 +921,7 @@ transactions_query_cursor_by_offset_test_parallel() ->
                         <<"ids">> => [EarlierID, LaterID],
                         <<"sort">> => Order,
                         <<"first">> => 1,
-                        <<"after">> => FirstID
+                        <<"after">> => FirstCursor
                     },
                     Opts
                 ),
@@ -860,7 +943,10 @@ transactions_query_cursor_by_offset_test_parallel() ->
                     }
                 }
             } = SecondRes,
-            ?assertEqual(hb_util:bin(SecondOffset), SecondCursor)
+            ?assertEqual(
+                <<"offset=", (hb_util:bin(SecondOffset))/binary>>,
+                SecondCursor
+            )
         end,
     VerifyFun(
         <<"HEIGHT_ASC">>,
@@ -875,6 +961,104 @@ transactions_query_cursor_by_offset_test_parallel() ->
         LaterOffset,
         EarlierID,
         EarlierOffset
+    ).
+
+transactions_query_terminal_page_test_parallel() ->
+    {ok, Node, Opts, ID} = test_env_with_message(),
+    Res =
+        dev_query_graphql:test_query(
+            Node,
+            transactions_cursor_query(),
+            #{ <<"ids">> => [ID], <<"first">> => 2 },
+            Opts
+        ),
+    ?assertEqual([ID], transaction_ids(Res, Opts)),
+    ?assertEqual(false, transaction_has_next_page(Res, Opts)),
+    ?assertEqual(nomatch, binary:match(transaction_cursor(Res, Opts), <<"&remaining=0">>)).
+
+transactions_query_force_next_page_test_parallel() ->
+    {ok, Node, Opts, ID} = test_env_with_message(),
+    Res =
+        post_graphql(
+            Node,
+            transactions_cursor_query(),
+            #{ <<"ids">> => [ID], <<"first">> => 2 },
+            #{ <<"force-next-page">> => true },
+            Opts
+        ),
+    ?assertEqual([ID], transaction_ids(Res, Opts)),
+    ?assertEqual(true, transaction_has_next_page(Res, Opts)).
+
+transactions_query_force_cursor_test_parallel() ->
+    {ok, Node, Opts, ID} = test_env_with_message(),
+    Query = transactions_cursor_query(),
+    Vars = #{ <<"ids">> => [ID], <<"first">> => 2 },
+    Normal = dev_query_graphql:test_query(Node, Query, Vars, Opts),
+    Forced = post_graphql(
+        Node,
+        Query,
+        Vars,
+        #{ <<"force-next-page">> => true },
+        Opts
+    ),
+    ?assertEqual(
+        << (transaction_cursor(Normal, Opts))/binary, "&remaining=0" >>,
+        transaction_cursor(Forced, Opts)
+    ).
+
+transactions_query_remaining_cursor_test_parallel() ->
+    {ok, Node, Opts, ID} = test_env_with_message(),
+    Query = transactions_cursor_query(),
+    Vars = #{ <<"ids">> => [ID], <<"first">> => 2 },
+    Normal = dev_query_graphql:test_query(Node, Query, Vars, Opts),
+    FastFail =
+        post_graphql(
+            Node,
+            Query,
+            Vars#{
+                <<"after">> =>
+                    << (transaction_cursor(Normal, Opts))/binary, "&remaining=0" >>
+            },
+            #{ <<"force-next-page">> => true },
+            Opts
+        ),
+    ?assertMatch(
+        #{
+            <<"data">> := #{
+                <<"transactions">> := #{
+                    <<"count">> := <<"0">>,
+                    <<"pageInfo">> := #{ <<"hasNextPage">> := true },
+                    <<"edges">> := []
+                }
+            }
+        },
+        FastFail
+    ).
+
+transactions_query_legacy_cursor_test_parallel() ->
+    {ok, Node, Opts, ID} = test_env_with_message(),
+    Res =
+        dev_query_graphql:test_query(
+            Node,
+            transactions_cursor_query(),
+            #{
+                <<"ids">> => [ID],
+                <<"first">> => 2,
+                <<"after">> => ?LEGACY_GRAPHQL_CURSOR
+            },
+            Opts
+        ),
+    ?assertMatch(
+        #{
+            <<"data">> := #{
+                <<"transactions">> := #{
+                    <<"count">> := <<"0">>,
+                    <<"pageInfo">> := #{ <<"hasNextPage">> := false },
+                    <<"edges">> := []
+                }
+            }
+        },
+        Res
     ).
 
 %% @doc Test single transaction query by ID


### PR DESCRIPTION
Preparatory work for decentralized GraphQL router nodes.

*   Introduces a `force-next-page` argument that, when enabled, ensures `hasNextPage` is `true` and the last edge's cursor is set to a terminal value (`has-next-page=false`) when no more results are available. This allows clients to implement fallback routing or continue pagination logic if the HyperBEAM node is a worker in a GraphQL router.
*   Implements validation for `after` cursors. Invalid or malformed cursors now gracefully return an empty set of transactions, providing a clear signal to clients and preventing unexpected server errors.
*   Standardizes cursors to utilize querystring-style encoding, such that multiple relevant parameters can be packed into the opaque (from the POV of GQL clients) value.
*   Refactors cursor dropping logic to specifically handle the new cursor formats and terminal values.
*   Includes new test cases covering `force-next-page` behavior and invalid cursor scenarios.