### PR TITLE
feat:`~bundler@1.0` `await` support, allowing single request confirmed uploads

### DIFF
--- a/src/core/include/dev_bundler.hrl
+++ b/src/core/include/dev_bundler.hrl
@@ -33,6 +33,7 @@
     status,
     tx,
     proofs,
+    waiters = [],
     start_time
 }).
 

--- a/src/core/test/hb_examples.erl
+++ b/src/core/test/hb_examples.erl
@@ -305,52 +305,39 @@ bundler_completion_payment_hook() ->
         hb_mock_server:stop(ServerHandle)
     end.
 
-%% @doc Route an awaited bundle upload across two bundlers in serial. The router
-%% has no balance with the first peer, so it falls through to the second.
+%% @doc Route an awaited bundle upload across two bundlers in serial. The first
+%% bundler's wallet is unfunded on the Arweave node, so its upload is rejected
+%% and it holds the awaited request open while retrying; the router gives up on
+%% it (a short receive timeout) and falls through to the second, funded bundler.
+%% We confirm the outcome by reading the completed bundle from the second
+%% bundler's cache and checking that it was signed by the second bundler.
 bundler_routing_fallback_test_() ->
     {timeout, 30, fun bundler_routing_fallback/0}.
 bundler_routing_fallback() ->
-    Parent = self(),
-    RouterWallet = ar_wallet:new(),
-    RouterAddress = hb_util:human_id(ar_wallet:to_address(RouterWallet)),
-    UploaderWallet = ar_wallet:new(),
+    ClientWallet = ar_wallet:new(),
+    FirstWallet = ar_wallet:new(),
+    SecondWallet = ar_wallet:new(),
+    SecondAddress = hb_util:human_id(ar_wallet:to_address(SecondWallet)),
     {ServerHandle, GatewayOpts} =
         hb_mock_server:start_arweave_gateway(
             #{
                 price => {200, <<"12345">>},
-                tx_anchor => {200, hb_util:encode(rand:bytes(32))}
+                tx_anchor => {200, hb_util:encode(rand:bytes(32))},
+                tx => bundler_route_balance_gate([SecondAddress])
             }
         ),
     try
-        FirstBundler =
-            hb_http_server:start_node(
-                bundler_route_peer_opts(
-                    first,
-                    Parent,
-                    GatewayOpts,
-                    #{}
-                )
-            ),
-        SecondBundler =
-            hb_http_server:start_node(
-                bundler_route_peer_opts(
-                    second,
-                    Parent,
-                    GatewayOpts,
-                    #{ RouterAddress => 1 }
-                )
-            ),
+        FirstOpts = bundler_route_peer_opts(FirstWallet, GatewayOpts),
+        SecondOpts = bundler_route_peer_opts(SecondWallet, GatewayOpts),
+        FirstBundler = hb_http_server:start_node(FirstOpts),
+        SecondBundler = hb_http_server:start_node(SecondOpts),
         Router =
             hb_http_server:start_node(
-                bundler_route_router_opts(
-                    RouterWallet,
-                    FirstBundler,
-                    SecondBundler
-                )
+                bundler_route_router_opts(FirstBundler, SecondBundler)
             ),
         StructuredItem =
             hb_message:convert(
-                bundler_route_item(),
+                bundler_route_item(ClientWallet),
                 <<"structured@1.0">>,
                 <<"ans104@1.0">>,
                 GatewayOpts
@@ -360,68 +347,51 @@ bundler_routing_fallback() ->
                 #{
                     <<"path">> => <<"/~bundler@1.0/tx">>,
                     <<"bundler-subject">> => <<"body">>,
-                    <<"commit-request">> => true,
                     <<"await">> => true,
                     <<"body">> => StructuredItem
                 },
-                #{ <<"priv-wallet">> => UploaderWallet }
+                #{ <<"priv-wallet">> => ClientWallet }
             ),
+        {ok, Response} = hb_http:post(Router, UploadReq, #{}),
         ?assertMatch(
-            {ok, #{
+            #{
                 <<"bundle-id">> := _,
                 <<"bundle-status">> := <<"complete">>
-            }},
-            hb_http:post(Router, UploadReq, #{})
+            },
+            Response
         ),
-        ?assertEqual([first, second], bundler_route_seen_peers()),
-        ?assertEqual(1, length(hb_mock_server:get_requests(price, 1, ServerHandle))),
-        ?assertEqual(1, length(hb_mock_server:get_requests(tx_anchor, 1, ServerHandle))),
-        ?assertEqual(1, length(hb_mock_server:get_requests(tx, 1, ServerHandle))),
+        #{ <<"bundle-id">> := BundleID } = Response,
+        {ok, Bundle} = hb_cache:read(BundleID, SecondOpts),
+        Loaded = hb_cache:ensure_all_loaded(Bundle, SecondOpts),
+        ?assertEqual([SecondAddress], hb_message:signers(Loaded, SecondOpts)),
         ?assertEqual(1, length(hb_mock_server:get_requests(chunk, 1, ServerHandle)))
     after
         hb_mock_server:stop(ServerHandle)
     end.
 
-%% @doc Build a bundler node that records admission attempts and gates uploads
-%% through simple-pay.
-bundler_route_peer_opts(Peer, Parent, GatewayOpts, Ledger) ->
-    ProcessorMsg =
-        #{
-            <<"device">> => <<"p4@1.0">>,
-            <<"ledger-device">> => <<"simple-pay@1.0">>,
-            <<"pricing-device">> => <<"simple-pay@1.0">>
-        },
-    Wallet = ar_wallet:new(),
+%% @doc Build a bundler node that signs bundles with the given wallet. The only
+%% gate on an upload is whether the Arweave node accepts the bundle TX, so a
+%% node whose wallet is unfunded cannot complete an upload.
+bundler_route_peer_opts(Wallet, GatewayOpts) ->
     GatewayOpts#{
         <<"priv-wallet">> => Wallet,
         <<"store">> => hb_test_utils:test_store(),
-        <<"bundler-max-items">> => 1,
-        <<"simple-pay-ledger">> => Ledger,
-        <<"simple-pay-price">> => 0,
-        <<"operator">> => ar_wallet:to_address(Wallet),
-        <<"router-opts">> => #{
-            <<"offered">> => [
-                #{
-                    <<"template">> => <<"/~bundler@1.0/tx">>,
-                    <<"price">> => 1
-                }
-            ]
-        },
-        <<"on">> => #{
-            <<"request">> => [
-                bundler_route_record_hook(Peer, Parent),
-                ProcessorMsg
-            ],
-            <<"response">> => ProcessorMsg
-        }
+        <<"bundler-max-items">> => 1
     }.
 
-%% @doc Build the routing node that relays bundle uploads to peers in order.
-bundler_route_router_opts(RouterWallet, FirstBundler, SecondBundler) ->
+%% @doc Build the routing node that relays bundle uploads to peers in order. Each
+%% peer is given a short receive timeout so the router gives up on the unfunded
+%% first bundler (which holds the awaited request open while it retries) and
+%% falls through to the second.
+bundler_route_router_opts(FirstBundler, SecondBundler) ->
+    PeerOpts =
+        #{
+            <<"http-client">> => hackney,
+            <<"http-client-hackney-recv-timeout">> => 4000
+        },
     #{
-        <<"priv-wallet">> => RouterWallet,
+        <<"priv-wallet">> => ar_wallet:new(),
         <<"store">> => hb_test_utils:test_store(),
-        <<"relay-allow-commit-request">> => true,
         <<"routes">> => [
             #{
                 <<"template">> => #{
@@ -429,8 +399,8 @@ bundler_route_router_opts(RouterWallet, FirstBundler, SecondBundler) ->
                     <<"method">> => <<"POST">>
                 },
                 <<"nodes">> => [
-                    #{ <<"prefix">> => FirstBundler },
-                    #{ <<"prefix">> => SecondBundler }
+                    #{ <<"prefix">> => FirstBundler, <<"opts">> => PeerOpts },
+                    #{ <<"prefix">> => SecondBundler, <<"opts">> => PeerOpts }
                 ],
                 <<"parallel">> => false,
                 <<"responses">> => 1,
@@ -440,39 +410,28 @@ bundler_route_router_opts(RouterWallet, FirstBundler, SecondBundler) ->
         <<"on">> => #{ <<"request">> => #{ <<"device">> => <<"relay@1.0">> } }
     }.
 
-%% @doc Record a peer admission attempt before payment admission runs.
-bundler_route_record_hook(Peer, Parent) ->
-    #{
-        <<"device">> => #{
-            request =>
-                fun(_Base, Req, _Opts) ->
-                    Parent ! {bundler_route_peer, Peer},
-                    {ok, Req}
-                end
-        }
-    }.
-
-%% @doc Receive the observed peer order for the routed bundle upload.
-bundler_route_seen_peers() ->
-    lists:map(
-        fun(_) ->
-            receive
-                {bundler_route_peer, Peer} -> Peer
-            after 1000 ->
-                error(bundler_route_peer_timeout)
-            end
-        end,
-        [first, second]
-    ).
+%% @doc Build a mock `/tx' handler that accepts a bundle TX only when its signer
+%% is funded, mimicking an Arweave node rejecting an upload from a wallet with
+%% insufficient balance.
+bundler_route_balance_gate(FundedAddresses) ->
+    fun(Req) ->
+        Body = maps:get(<<"body">>, Req, <<>>),
+        Owner = maps:get(<<"owner">>, hb_json:decode(Body), <<>>),
+        Address = hb_util:human_id(ar_wallet:to_address(hb_util:decode(Owner))),
+        case lists:member(Address, FundedAddresses) of
+            true -> {200, <<"OK">>};
+            false -> {400, <<"Transaction verification failed.">>}
+        end
+    end.
 
 %% @doc Build a signed data item for the routed bundle example.
-bundler_route_item() ->
+bundler_route_item(Wallet) ->
     ar_bundles:sign_item(
         #tx{
             data = <<"routed-bundle">>,
             tags = [{<<"example">>, <<"bundler-routing-fallback">>}]
         },
-        ar_wallet:new()
+        Wallet
     ).
 
 %% @doc Build a per-message hook that validates the item payload and releases pay.

--- a/src/core/test/hb_examples.erl
+++ b/src/core/test/hb_examples.erl
@@ -305,6 +305,176 @@ bundler_completion_payment_hook() ->
         hb_mock_server:stop(ServerHandle)
     end.
 
+%% @doc Route an awaited bundle upload across two bundlers in serial. The router
+%% has no balance with the first peer, so it falls through to the second.
+bundler_routing_fallback_test_() ->
+    {timeout, 30, fun bundler_routing_fallback/0}.
+bundler_routing_fallback() ->
+    Parent = self(),
+    RouterWallet = ar_wallet:new(),
+    RouterAddress = hb_util:human_id(ar_wallet:to_address(RouterWallet)),
+    UploaderWallet = ar_wallet:new(),
+    {ServerHandle, GatewayOpts} =
+        hb_mock_server:start_arweave_gateway(
+            #{
+                price => {200, <<"12345">>},
+                tx_anchor => {200, hb_util:encode(rand:bytes(32))}
+            }
+        ),
+    try
+        FirstBundler =
+            hb_http_server:start_node(
+                bundler_route_peer_opts(
+                    first,
+                    Parent,
+                    GatewayOpts,
+                    #{}
+                )
+            ),
+        SecondBundler =
+            hb_http_server:start_node(
+                bundler_route_peer_opts(
+                    second,
+                    Parent,
+                    GatewayOpts,
+                    #{ RouterAddress => 1 }
+                )
+            ),
+        Router =
+            hb_http_server:start_node(
+                bundler_route_router_opts(
+                    RouterWallet,
+                    FirstBundler,
+                    SecondBundler
+                )
+            ),
+        StructuredItem =
+            hb_message:convert(
+                bundler_route_item(),
+                <<"structured@1.0">>,
+                <<"ans104@1.0">>,
+                GatewayOpts
+            ),
+        UploadReq =
+            hb_message:commit(
+                #{
+                    <<"path">> => <<"/~bundler@1.0/tx">>,
+                    <<"bundler-subject">> => <<"body">>,
+                    <<"commit-request">> => true,
+                    <<"await">> => true,
+                    <<"body">> => StructuredItem
+                },
+                #{ <<"priv-wallet">> => UploaderWallet }
+            ),
+        ?assertMatch(
+            {ok, #{
+                <<"bundle-id">> := _,
+                <<"bundle-status">> := <<"complete">>
+            }},
+            hb_http:post(Router, UploadReq, #{})
+        ),
+        ?assertEqual([first, second], bundler_route_seen_peers()),
+        ?assertEqual(1, length(hb_mock_server:get_requests(price, 1, ServerHandle))),
+        ?assertEqual(1, length(hb_mock_server:get_requests(tx_anchor, 1, ServerHandle))),
+        ?assertEqual(1, length(hb_mock_server:get_requests(tx, 1, ServerHandle))),
+        ?assertEqual(1, length(hb_mock_server:get_requests(chunk, 1, ServerHandle)))
+    after
+        hb_mock_server:stop(ServerHandle)
+    end.
+
+%% @doc Build a bundler node that records admission attempts and gates uploads
+%% through simple-pay.
+bundler_route_peer_opts(Peer, Parent, GatewayOpts, Ledger) ->
+    ProcessorMsg =
+        #{
+            <<"device">> => <<"p4@1.0">>,
+            <<"ledger-device">> => <<"simple-pay@1.0">>,
+            <<"pricing-device">> => <<"simple-pay@1.0">>
+        },
+    Wallet = ar_wallet:new(),
+    GatewayOpts#{
+        <<"priv-wallet">> => Wallet,
+        <<"store">> => hb_test_utils:test_store(),
+        <<"bundler-max-items">> => 1,
+        <<"simple-pay-ledger">> => Ledger,
+        <<"simple-pay-price">> => 0,
+        <<"operator">> => ar_wallet:to_address(Wallet),
+        <<"router-opts">> => #{
+            <<"offered">> => [
+                #{
+                    <<"template">> => <<"/~bundler@1.0/tx">>,
+                    <<"price">> => 1
+                }
+            ]
+        },
+        <<"on">> => #{
+            <<"request">> => [
+                bundler_route_record_hook(Peer, Parent),
+                ProcessorMsg
+            ],
+            <<"response">> => ProcessorMsg
+        }
+    }.
+
+%% @doc Build the routing node that relays bundle uploads to peers in order.
+bundler_route_router_opts(RouterWallet, FirstBundler, SecondBundler) ->
+    #{
+        <<"priv-wallet">> => RouterWallet,
+        <<"store">> => hb_test_utils:test_store(),
+        <<"relay-allow-commit-request">> => true,
+        <<"routes">> => [
+            #{
+                <<"template">> => #{
+                    <<"path">> => <<"^/~bundler@1\\.0/tx">>,
+                    <<"method">> => <<"POST">>
+                },
+                <<"nodes">> => [
+                    #{ <<"prefix">> => FirstBundler },
+                    #{ <<"prefix">> => SecondBundler }
+                ],
+                <<"parallel">> => false,
+                <<"responses">> => 1,
+                <<"admissible-status">> => 200
+            }
+        ],
+        <<"on">> => #{ <<"request">> => #{ <<"device">> => <<"relay@1.0">> } }
+    }.
+
+%% @doc Record a peer admission attempt before payment admission runs.
+bundler_route_record_hook(Peer, Parent) ->
+    #{
+        <<"device">> => #{
+            request =>
+                fun(_Base, Req, _Opts) ->
+                    Parent ! {bundler_route_peer, Peer},
+                    {ok, Req}
+                end
+        }
+    }.
+
+%% @doc Receive the observed peer order for the routed bundle upload.
+bundler_route_seen_peers() ->
+    lists:map(
+        fun(_) ->
+            receive
+                {bundler_route_peer, Peer} -> Peer
+            after 1000 ->
+                error(bundler_route_peer_timeout)
+            end
+        end,
+        [first, second]
+    ).
+
+%% @doc Build a signed data item for the routed bundle example.
+bundler_route_item() ->
+    ar_bundles:sign_item(
+        #tx{
+            data = <<"routed-bundle">>,
+            tags = [{<<"example">>, <<"bundler-routing-fallback">>}]
+        },
+        ar_wallet:new()
+    ).
+
 %% @doc Build a per-message hook that validates the item payload and releases pay.
 bundle_payment_message_hook(
         ExpectedItemID,

--- a/src/core/test/hb_examples.erl
+++ b/src/core/test/hb_examples.erl
@@ -335,12 +335,11 @@ bundler_routing_fallback() ->
             hb_http_server:start_node(
                 bundler_route_router_opts(FirstBundler, SecondBundler)
             ),
-        StructuredItem =
-            hb_message:convert(
-                bundler_route_item(ClientWallet),
-                <<"structured@1.0">>,
-                <<"ans104@1.0">>,
-                GatewayOpts
+        Item =
+            hb_message:commit(
+                #{ <<"data">> => <<"routed-bundle">> },
+                #{ <<"priv-wallet">> => ClientWallet },
+                #{ <<"commitment-device">> => <<"ans104@1.0">> }
             ),
         UploadReq =
             hb_message:commit(
@@ -348,23 +347,15 @@ bundler_routing_fallback() ->
                     <<"path">> => <<"/~bundler@1.0/tx">>,
                     <<"bundler-subject">> => <<"body">>,
                     <<"await">> => true,
-                    <<"body">> => StructuredItem
+                    <<"body">> => Item
                 },
                 #{ <<"priv-wallet">> => ClientWallet }
             ),
-        {ok, Response} = hb_http:post(Router, UploadReq, #{}),
-        ?assertMatch(
-            #{
-                <<"bundle-id">> := _,
-                <<"bundle-status">> := <<"complete">>
-            },
-            Response
-        ),
-        #{ <<"bundle-id">> := BundleID } = Response,
+        {ok, #{ <<"bundle-id">> := BundleID }} =
+            hb_http:post(Router, UploadReq, #{}),
         {ok, Bundle} = hb_cache:read(BundleID, SecondOpts),
         Loaded = hb_cache:ensure_all_loaded(Bundle, SecondOpts),
-        ?assertEqual([SecondAddress], hb_message:signers(Loaded, SecondOpts)),
-        ?assertEqual(1, length(hb_mock_server:get_requests(chunk, 1, ServerHandle)))
+        ?assertEqual([SecondAddress], hb_message:signers(Loaded, SecondOpts))
     after
         hb_mock_server:stop(ServerHandle)
     end.
@@ -423,16 +414,6 @@ bundler_route_balance_gate(FundedAddresses) ->
             false -> {400, <<"Transaction verification failed.">>}
         end
     end.
-
-%% @doc Build a signed data item for the routed bundle example.
-bundler_route_item(Wallet) ->
-    ar_bundles:sign_item(
-        #tx{
-            data = <<"routed-bundle">>,
-            tags = [{<<"example">>, <<"bundler-routing-fallback">>}]
-        },
-        Wallet
-    ).
 
 %% @doc Build a per-message hook that validates the item payload and releases pay.
 bundle_payment_message_hook(

--- a/src/preloaded/arweave/dev_bundler.erl
+++ b/src/preloaded/arweave/dev_bundler.erl
@@ -52,13 +52,18 @@ item(_Base, Req, Opts) ->
                     {ok, Metering} =
                         hb_device_load:reference(<<"metering@1.0">>, Opts),
                     Metering:consume(<<"arweave-bytes">>, BundledSize, Opts),
-                    % Queue the item for bundling
-                    % (fire-and-forget, ignore errors)
-                    ServerPID ! {enqueue_item, Item, BundledSize},
-                    {ok, #{
+                    Response = #{
                         <<"id">> => ItemID,
                         <<"timestamp">> => erlang:system_time(millisecond)
-                    }};
+                    },
+                    enqueue_item(
+                        ServerPID,
+                        Item,
+                        BundledSize,
+                        Response,
+                        Req,
+                        Opts
+                    );
                 {error, Reason} ->
                     ?event(
                         bundler_short,
@@ -128,6 +133,30 @@ cache_item(Item, Opts) ->
     catch
         Type:ExceptionReason ->
             {error, {Type, ExceptionReason}}
+    end.
+
+%% @doc Queue an item, optionally blocking until its bundle is complete.
+enqueue_item(ServerPID, Item, BundledSize, Response, Req, Opts) ->
+    case hb_util:bool(hb_maps:get(<<"await">>, Req, false, Opts)) of
+        true ->
+            Ref = make_ref(),
+            MonitorRef = erlang:monitor(process, ServerPID),
+            ServerPID ! {enqueue_item, Item, BundledSize, {self(), Ref}},
+            receive
+                {bundle_complete, Ref, Completion} ->
+                    erlang:demonitor(MonitorRef, [flush]),
+                    {ok, maps:merge(Response, Completion)};
+                {'DOWN', MonitorRef, process, ServerPID, Reason} ->
+                    {error, #{
+                        <<"status">> => 500,
+                        <<"error">> => <<"bundle-dispatch-failed">>,
+                        <<"details">> => error_to_bin(Reason)
+                    }}
+            end;
+        false ->
+            % Queue the item for bundling (fire-and-forget, ignore errors).
+            ServerPID ! {enqueue_item, Item, BundledSize, undefined},
+            {ok, Response}
     end.
 
 %%% Bundling server.
@@ -207,12 +236,13 @@ server(State = #state{max_idle_time = MaxIdleTime}, Opts) ->
                 add_to_queue(
                     Item,
                     bundled_item_size(Item, Opts),
+                    undefined,
                     State,
                     Opts
                 ),
             server(assign_tasks(maybe_dispatch(State1)), Opts);
-        {enqueue_item, Item, BundledSize} ->
-            State1 = add_to_queue(Item, BundledSize, State, Opts),
+        {enqueue_item, Item, BundledSize, Waiter} ->
+            State1 = add_to_queue(Item, BundledSize, Waiter, State, Opts),
             server(assign_tasks(maybe_dispatch(State1)), Opts);
         {dispatch_queue, Timestamp} ->
             ?event(bundler_short, {dispatched_queue_start, calendar:now_to_universal_time(Timestamp)}),
@@ -245,12 +275,12 @@ server(State = #state{max_idle_time = MaxIdleTime}, Opts) ->
 %% @doc Add an item to the queue. Update the state with the queue's total
 %% bundled byte size.
 %% Note: Item has already been verified and cached before reaching here.
-add_to_queue(Item, BundledSize, State = #state{
+add_to_queue(Item, BundledSize, Waiter, State = #state{
         queue = Queue,
         bytes = Bytes,
         dispatch_ref = DispatchRef
     }, Opts) ->
-    NewQueue = [{Item, BundledSize} | Queue],
+    NewQueue = [{Item, BundledSize, Waiter} | Queue],
     NewBytes = Bytes + BundledSize,
     ?event(bundler_short, {queueing_item, 
         {id, {explicit, hb_message:id(Item, signed, Opts)}},
@@ -307,11 +337,7 @@ dispatchable(_State) ->
 
 %% @doc Return the total size of a queue of items.
 queue_bytes(Items) ->
-    lists:foldl(
-        fun({_Item, BundledSize}, Acc) -> Acc + BundledSize end,
-        0,
-        Items
-    ).
+    lists:sum([BundledSize || {_Item, BundledSize, _Waiter} <- Items]).
 
 %% @doc Dispatch all currently queued items immediately.
 dispatch_queue(State = #state{queue = []}) ->
@@ -327,7 +353,7 @@ dispatch_queue(State = #state{queue = Queue, dispatch_ref = DispatchRef}) ->
 create_bundle([], State) ->
     State;
 create_bundle(QueuedItems, State = #state{bundles = Bundles, opts = Opts}) ->
-    {Items, ItemSizes} = lists:unzip(QueuedItems),
+    {Items, ItemSizes, Waiters} = lists:unzip3(QueuedItems),
     BundleID = make_ref(),
     Bundle = #bundle{
         id = BundleID,
@@ -336,6 +362,7 @@ create_bundle(QueuedItems, State = #state{bundles = Bundles, opts = Opts}) ->
         status = initializing,
         tx = undefined,
         proofs = #{},
+        waiters = Waiters,
         start_time = erlang:timestamp()
     },
     State1 = State#state{
@@ -509,6 +536,10 @@ task_completed(
 %% @doc Mark a bundle as complete and remove it from state.
 bundle_complete(Bundle, State = #state{opts = Opts}) ->
     ok = dev_bundler_cache:complete_tx(Bundle#bundle.tx, Opts),
+    Completion = #{
+        <<"bundle-id">> => hb_message:id(Bundle#bundle.tx, signed, Opts),
+        <<"bundle-status">> => <<"complete">>
+    },
     ElapsedTime =
         timer:now_diff(erlang:timestamp(), Bundle#bundle.start_time) / 1000000,
     ?event(
@@ -520,8 +551,21 @@ bundle_complete(Bundle, State = #state{opts = Opts}) ->
             {elapsed_time_s, ElapsedTime}
         }
     ),
+    notify_waiters(Bundle#bundle.waiters, Completion),
     run_completion_hooks(Bundle, Opts),
     State#state{bundles = maps:remove(Bundle#bundle.id, State#state.bundles)}.
+
+%% @doc Notify callers waiting for a bundle to finish seeding chunks.
+notify_waiters(Waiters, Completion) ->
+    lists:foreach(
+        fun
+            (undefined) ->
+                ok;
+            ({PID, Ref}) ->
+                PID ! {bundle_complete, Ref, Completion}
+        end,
+        Waiters
+    ).
 
 %% @doc Execute hooks for each completed bundled item and the full bundle.
 run_completion_hooks(Bundle, Opts) ->
@@ -1030,6 +1074,78 @@ complete_task_sequence_test_parallel() ->
         ?assert(queue:is_empty(Queue)),
         Bundles = State#state.bundles,
         ?assertEqual(0, maps:size(Bundles)),
+        ok
+    after
+        stop_test_servers(ServerHandle, NodeOpts)
+    end.
+
+await_bundle_test_parallel() ->
+    Anchor = rand:bytes(32),
+    Price = 12345,
+    Parent = self(),
+    {ServerHandle, NodeOpts} = hb_mock_server:start_arweave_gateway(#{
+        chunk => fun(_Req) ->
+            Parent ! {chunk_started, self()},
+            receive release_chunk -> ok after 1000 -> ok end,
+            {200, <<"OK">>}
+        end,
+        price => {200, integer_to_binary(Price)},
+        tx_anchor => {200, hb_util:encode(Anchor)}
+    }),
+    try
+        ClientOpts = #{},
+        Node = hb_http_server:start_node(NodeOpts#{
+            <<"priv-wallet">> => ar_wallet:new(),
+            <<"store">> => hb_test_utils:test_store(),
+            <<"bundler-max-items">> => 1
+        }),
+        Item = new_data_item(1, 10),
+        StructuredItem = hb_message:convert(
+            Item,
+            <<"structured@1.0">>,
+            <<"ans104@1.0">>,
+            ClientOpts
+        ),
+        AwaitReq = #{
+            <<"path">> => <<"/~bundler@1.0/tx">>,
+            <<"bundler-subject">> => <<"body">>,
+            <<"await">> => true,
+            <<"body">> => StructuredItem
+        },
+        spawn_link(fun() ->
+            Result = hb_http:post(Node, AwaitReq, ClientOpts),
+            Parent ! {await_bundle_result, Result}
+        end),
+        ChunkHandler =
+            receive
+                {chunk_started, PID} -> PID
+            after 1000 ->
+                error(await_bundle_chunk_not_started)
+            end,
+        receive
+            {await_bundle_result, _EarlyResult} ->
+                error(await_bundle_returned_before_chunks_seeded)
+        after 50 ->
+            ok
+        end,
+        ChunkHandler ! release_chunk,
+        Result =
+            receive
+                {await_bundle_result, AwaitResult} -> AwaitResult
+            after 2000 ->
+                error(await_bundle_result_timeout)
+            end,
+        ?assertMatch(
+            {ok, #{
+                <<"bundle-id">> := _,
+                <<"bundle-status">> := <<"complete">>
+            }},
+            Result
+        ),
+        ?assertEqual(
+            1,
+            length(hb_mock_server:get_requests(chunk, 1, ServerHandle))
+        ),
         ok
     after
         stop_test_servers(ServerHandle, NodeOpts)


### PR DESCRIPTION
This PR introduces an optional `await` key (defaulting false) for `~bundler@1.0` requests. Setting this key allows the caller to wait on the wire for the bundling node to `POST` the transaction that contains their data before returning. A consequence of this is that the TXID of the parent can be granted directly to the caller, so that they can track its progress syncing with the network.

When combined with `~router@1.0`'s work distribution strategies, this mechanism can be used to ensure that a node out of a group always succeeds in uploading a message to Arweave, without forcing upload to multiple peers. A new test setup in `hb_examples` demonstrates a configuration for orchestrating such a router.