### PR TITLE
feat: devX forge flags

### DIFF
--- a/src/forge/plugin/src/hb_forge_args.erl
+++ b/src/forge/plugin/src/hb_forge_args.erl
@@ -74,9 +74,9 @@ opts() ->
         {help, $h, "help", {boolean, false},
             "Show command help."},
         {dry_run, undefined, "dry-run", {boolean, false},
-            "Sign and print package IDs without uploading to Arweave."},
+            "Sign packages and print their IDs without uploading to Arweave."},
         {verbose, undefined, "verbose", {boolean, false},
-            "Print locally preloaded devices IDs."}
+            "Print locally preloaded device IDs."}
     ].
 
 %% @doc Convert parsed rebar command arguments into Forge's binary-keyed map.

--- a/src/forge/plugin/src/hb_forge_args.erl
+++ b/src/forge/plugin/src/hb_forge_args.erl
@@ -74,7 +74,9 @@ opts() ->
         {help, $h, "help", {boolean, false},
             "Show command help."},
         {dry_run, undefined, "dry-run", {boolean, false},
-            "Sign and print package IDs without uploading to Arweave."}
+            "Sign and print package IDs without uploading to Arweave."},
+        {verbose, undefined, "verbose", {boolean, false},
+            "Print locally preloaded devices IDs."}
     ].
 
 %% @doc Convert parsed rebar command arguments into Forge's binary-keyed map.
@@ -100,6 +102,7 @@ parse(State, DefaultOutput) ->
             false -> undefined
         end,
     DryRun = proplists:get_value(dry_run, Args, false),
+    Verbose = proplists:get_value(verbose, Args, false),
     Bundler = maybe_bin(BundlerRaw),
     #{
         <<"device-src">> => split_list(SrcRaw),
@@ -116,6 +119,7 @@ parse(State, DefaultOutput) ->
         <<"timeout">> => parse_number(TimeoutRaw),
         <<"timeout-multiplier">> => parse_number(TimeoutMultiplierRaw),
         <<"dry-run">> => DryRun,
+        <<"verbose">> => Verbose,
         <<"device-roots">> =>
             case RootsRaw of
                 undefined -> all;

--- a/src/forge/plugin/src/hb_forge_args.erl
+++ b/src/forge/plugin/src/hb_forge_args.erl
@@ -72,7 +72,9 @@ opts() ->
         {record, undefined, "record", string,
             "Write recorder@1.0 test flights; --record means errors, --record=all means every test."},
         {help, $h, "help", {boolean, false},
-            "Show command help."}
+            "Show command help."},
+        {dry_run, undefined, "dry-run", {boolean, false},
+            "Sign and print package IDs without uploading to Arweave."}
     ].
 
 %% @doc Convert parsed rebar command arguments into Forge's binary-keyed map.
@@ -97,6 +99,7 @@ parse(State, DefaultOutput) ->
             true -> proplists:get_value(record, Args, "errors");
             false -> undefined
         end,
+    DryRun = proplists:get_value(dry_run, Args, false),
     Bundler = maybe_bin(BundlerRaw),
     #{
         <<"device-src">> => split_list(SrcRaw),
@@ -112,6 +115,7 @@ parse(State, DefaultOutput) ->
         <<"test-specs">> => parse_test_specs(TestRaw),
         <<"timeout">> => parse_number(TimeoutRaw),
         <<"timeout-multiplier">> => parse_number(TimeoutMultiplierRaw),
+        <<"dry-run">> => DryRun,
         <<"device-roots">> =>
             case RootsRaw of
                 undefined -> all;

--- a/src/forge/plugin/src/hb_forge_preload.erl
+++ b/src/forge/plugin/src/hb_forge_preload.erl
@@ -44,6 +44,7 @@ run(Args, NodeOpts) ->
     Dirs = maps:get(<<"device-src">>, Args),
     OutputDir = maps:get(<<"output-dir">>, Args),
     KeyPath = maps:get(<<"key">>, Args),
+    Verbose = maps:get(<<"verbose">>, Args, false),
     Wallet = hb_forge_args:load_wallet(KeyPath),
     case hb_forge_args:default_preloaded_dirs(Dirs) of
         {ok, DefaultDirs} ->
@@ -67,6 +68,10 @@ run(Args, NodeOpts) ->
                 "device preload: store ~s, index ~s",
                 [OutputDir, maps:get(index, Result)]
             ),
+            case Verbose of
+                true -> print_device_ids(Result);
+                false -> ok
+            end,
             {ok, Result};
         {error, _} = Error ->
             Error
@@ -95,3 +100,18 @@ header_path(OutputDir) ->
 %% @doc Render provider failures for rebar3.
 format_error(Reason) ->
     io_lib:format("device preload failed: ~p", [Reason]).
+
+print_device_ids(Result) ->
+    Specs = maps:get(specs, Result),
+    Impls = maps:get(impls, Result),
+    Pkgs = maps:get(pkgs, Result),
+    lists:foreach(
+        fun({Pkg, ImplID}) ->
+            Name = maps:get(device_name, Pkg),
+            rebar_api:info(
+                "device preload: ~s spec=~s impl=~s",
+                [Name, maps:get(Name, Specs), ImplID]
+            )
+        end,
+        lists:zip(Pkgs, Impls)
+    ).

--- a/src/forge/plugin/src/hb_forge_preload.erl
+++ b/src/forge/plugin/src/hb_forge_preload.erl
@@ -65,7 +65,7 @@ run(Args, NodeOpts) ->
                     HeaderPath
                 ),
             rebar_api:info(
-                "device preload: store ~s, index ~s",
+                "Device preload complete: Store: ~s; Index: ~s.",
                 [OutputDir, maps:get(index, Result)]
             ),
             case Verbose of
@@ -109,7 +109,7 @@ print_device_ids(Result) ->
         fun({Pkg, ImplID}) ->
             Name = maps:get(device_name, Pkg),
             rebar_api:info(
-                "device preload: ~s spec=~s impl=~s",
+                "Preloaded device: ~s; Specification ID: ~s; Implementation ID: ~s.",
                 [Name, maps:get(Name, Specs), ImplID]
             )
         end,

--- a/src/forge/plugin/src/hb_forge_publish.erl
+++ b/src/forge/plugin/src/hb_forge_publish.erl
@@ -68,9 +68,14 @@ publish(State) ->
                     {ok, _} = upload(Spec, NodeOpts, PublishCodec),
                     {ok, _} = upload(Impl, NodeOpts, PublishCodec)
             end,
+            Action =
+                case DryRun of
+                    true -> "Signed device (dry run)";
+                    false -> "Published device"
+                end,
             rebar_api:info(
-                "device publish: ~s spec=~s impl=~s signer=~s",
-                [maps:get(device_name, Pkg), SpecID, ImplID, Signer]
+                "~s: ~s; Specification ID: ~s; Implementation ID: ~s; Signer: ~s.",
+                [Action, maps:get(device_name, Pkg), SpecID, ImplID, Signer]
             )
         end,
         hb_packager:package_all(

--- a/src/forge/plugin/src/hb_forge_publish.erl
+++ b/src/forge/plugin/src/hb_forge_publish.erl
@@ -27,6 +27,7 @@ publish(State) ->
     Args = hb_forge_args:parse(State, <<"_build/device-publish-store">>),
     KeyPath = maps:get(<<"key">>, Args),
     PublishCodec = maps:get(<<"publish-codec">>, Args),
+    DryRun = maps:get(<<"dry-run">>, Args),
     Wallet = hb_forge_args:load_wallet(KeyPath),
     Signer = hb:address(Wallet),
     Opts =
@@ -51,7 +52,6 @@ publish(State) ->
                     NodeOpts,
                     PublishCodec
                 ),
-            {ok, _} = upload(Spec, NodeOpts, PublishCodec),
             SpecID = hb_message:id(Spec, all, NodeOpts),
             % Sign and upload the implementation message.
             Impl =
@@ -60,8 +60,14 @@ publish(State) ->
                     NodeOpts,
                     PublishCodec
                 ),
-            {ok, _} = upload(Impl, NodeOpts, PublishCodec),
             ImplID = hb_message:id(Impl, all, NodeOpts),
+            case DryRun of
+                true ->
+                    ok;
+                false ->
+                    {ok, _} = upload(Spec, NodeOpts, PublishCodec),
+                    {ok, _} = upload(Impl, NodeOpts, PublishCodec)
+            end,
             rebar_api:info(
                 "device publish: ~s spec=~s impl=~s signer=~s",
                 [maps:get(device_name, Pkg), SpecID, ImplID, Signer]


### PR DESCRIPTION
introduces 2 new dev/debug friendly Forge flags

* `rebar3 device publish --dry-run`: sings and print package IDs without uploading to Arweave
* `rebar3 device preload --verbose` : prints the locally preloaded device IDs (name, spec, impl)