### PR TITLE
perf: NIF-accelerated string ops increasing global performance by 12-33%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ rebar3.crashdump
 native/hb_beamr/*.o
 native/hb_beamr/*.d
 
+native/hb_util_string/*.o
+native/hb_util_string/*.d
+
 priv/*
 .DS_STORE
 cache-*

--- a/native/hb_util_string/hb_util_string.c
+++ b/native/hb_util_string/hb_util_string.c
@@ -1,0 +1,168 @@
+/*
+ * hb_util_string: dependency-free byte-transform NIFs backing the ASCII
+ * string operations in `hb_util'. Each maps input bytes in a single scalar
+ * pass (the compiler auto-vectorizes the compare-and-select at -O3, so no
+ * `-march=native' is needed):
+ *
+ *   lowercase/1   `A'..`Z' -> `a'..`z'                  (to_lower)
+ *   key_chars/1   `A'..`Z' -> `a'..`z', and `-' -> `_'  (key_to_atom)
+ *   dash_chars/1  `_' -> `-'                            (atom_to_dashed_binary)
+ *
+ * UTF-8 safety: `lowercase' and `key_chars' fold ASCII only and do NOT
+ * validate UTF-8, whereas `string:lowercase' folds full Unicode and *throws*
+ * on invalid UTF-8 (a contract `ar_tx' tag parsing relies on to reject
+ * non-string tags). To stay both fast and exact, those two functions return
+ * the atom `non_ascii' the moment they see a byte >= 0x80, and the Erlang
+ * caller falls back to the original `string:lowercase'-based expression. Pure
+ * ASCII -- the overwhelming common case for HB keys -- takes the fast path and
+ * is provably identical to `string:lowercase' (only `A'..`Z' has an ASCII case
+ * mapping, and ASCII is always valid UTF-8, so it never throws). `dash_chars'
+ * only swaps the ASCII byte `_'<->`-' and never folds, so it is exact for all
+ * input and needs no fallback.
+ *
+ * A fresh binary is allocated; the caller's input memory is never mutated. The
+ * module carries no mutable static state; its `upgrade' callback is a no-op so
+ * it reloads cleanly under the device-test preloader's code upgrade ("Upgrade
+ * not supported" otherwise).
+ */
+#include <stddef.h>
+
+#include "erl_nif.h"
+
+/* `lowercase/1' is general purpose and may be handed an arbitrarily large
+ * binary, so inputs at or above this size run on a dirty CPU scheduler. The
+ * key/atom transforms only ever see bounded keys (atoms are <= 255 bytes), so
+ * they always run inline. */
+#ifndef HB_UTIL_STRING_DIRTY_THRESHOLD
+#define HB_UTIL_STRING_DIRTY_THRESHOLD (256U * 1024U)
+#endif
+
+static inline unsigned char
+to_lower_byte(unsigned char c)
+{
+    return (c >= 'A' && c <= 'Z') ? (unsigned char)(c + ('a' - 'A')) : c;
+}
+
+static inline unsigned char
+key_byte(unsigned char c)
+{
+    if (c >= 'A' && c <= 'Z') {
+        return (unsigned char)(c + ('a' - 'A'));
+    }
+    return (c == '-') ? (unsigned char)'_' : c;
+}
+
+static inline unsigned char
+dash_byte(unsigned char c)
+{
+    return (c == '_') ? (unsigned char)'-' : c;
+}
+
+/* ASCII-only transform that bails to the atom `non_ascii' on the first byte
+ * >= 0x80, so the Erlang caller can delegate to `string:lowercase'. FN is
+ * `static inline', so each expansion keeps its loop vectorizable. */
+#define ASCII_TRANSFORM_BODY(FN)                                              \
+    ErlNifBinary in;                                                          \
+    ERL_NIF_TERM out_term;                                                    \
+    unsigned char* out;                                                       \
+    size_t i;                                                                 \
+    if (!enif_inspect_binary(env, argv[0], &in)) {                           \
+        return enif_make_badarg(env);                                         \
+    }                                                                         \
+    if (in.size == 0) {                                                       \
+        return argv[0];                                                       \
+    }                                                                         \
+    out = enif_make_new_binary(env, in.size, &out_term);                      \
+    if (out == NULL) {                                                        \
+        return enif_raise_exception(env, enif_make_atom(env, "enomem"));      \
+    }                                                                         \
+    for (i = 0; i < in.size; i++) {                                           \
+        unsigned char c = in.data[i];                                         \
+        if (c >= 0x80) {                                                      \
+            return enif_make_atom(env, "non_ascii");                          \
+        }                                                                     \
+        out[i] = FN(c);                                                       \
+    }                                                                         \
+    return out_term;
+
+static ERL_NIF_TERM
+lowercase_do(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    (void)argc;
+    ASCII_TRANSFORM_BODY(to_lower_byte)
+}
+
+#ifdef ERL_NIF_DIRTY_JOB_CPU_BOUND
+static ERL_NIF_TERM
+lowercase(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    ErlNifBinary in;
+
+    if (argc != 1 || !enif_inspect_binary(env, argv[0], &in)) {
+        return enif_make_badarg(env);
+    }
+    if (in.size >= HB_UTIL_STRING_DIRTY_THRESHOLD) {
+        return enif_schedule_nif(
+            env, "lowercase_dirty", ERL_NIF_DIRTY_JOB_CPU_BOUND,
+            lowercase_do, argc, argv);
+    }
+    return lowercase_do(env, argc, argv);
+}
+#else
+#define lowercase lowercase_do
+#endif
+
+static ERL_NIF_TERM
+key_chars(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    (void)argc;
+    ASCII_TRANSFORM_BODY(key_byte)
+}
+
+/* `dash_chars' is exact for all bytes (`_'<->`-' swap, never folds), so it has
+ * no non-ASCII fallback. */
+static ERL_NIF_TERM
+dash_chars(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    ErlNifBinary in;
+    ERL_NIF_TERM out_term;
+    unsigned char* out;
+    size_t i;
+
+    (void)argc;
+    if (!enif_inspect_binary(env, argv[0], &in)) {
+        return enif_make_badarg(env);
+    }
+    if (in.size == 0) {
+        return argv[0];
+    }
+    out = enif_make_new_binary(env, in.size, &out_term);
+    if (out == NULL) {
+        return enif_raise_exception(env, enif_make_atom(env, "enomem"));
+    }
+    for (i = 0; i < in.size; i++) {
+        out[i] = dash_byte(in.data[i]);
+    }
+    return out_term;
+}
+
+/* Stateless: nothing to migrate or initialize, so accepting the upgrade is
+ * sufficient. Without this, reloading the module fails with "Upgrade not
+ * supported by this NIF library." */
+static int
+upgrade(ErlNifEnv* env, void** priv, void** old_priv, ERL_NIF_TERM info)
+{
+    (void)env;
+    (void)priv;
+    (void)old_priv;
+    (void)info;
+    return 0;
+}
+
+static ErlNifFunc funcs[] = {
+    {"lowercase", 1, lowercase, 0},
+    {"key_chars", 1, key_chars, 0},
+    {"dash_chars", 1, dash_chars, 0}
+};
+
+ERL_NIF_INIT(hb_util_string, funcs, NULL, NULL, upgrade, NULL)

--- a/native/hb_util_string/hb_util_string.c
+++ b/native/hb_util_string/hb_util_string.c
@@ -163,6 +163,72 @@ dash_chars(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     return out_term;
 }
 
+/* Collapse runs of `/' to a single `/' and strip leading/trailing `/'.
+ * Equivalent to
+ *   iolist_to_binary(lists:join(<<"/">>,
+ *     binary:split(Bin, <<"/">>, [global, trim_all]))).
+ * Exact for all bytes (only `/' positions matter); never folds, no fallback.
+ *
+ * Two-pass on purpose: the overwhelmingly common hot-path input is an *already
+ * normalized* path (segments joined by a single `/', no leading/trailing one),
+ * so a first scan that proves the binary is already clean lets us return the
+ * caller's binary verbatim -- no allocation, no copy. Only a genuinely dirty
+ * path (leading/trailing `/' or a `//' run) falls through to the collapse
+ * pass. The detect scan is branch-light and vectorizes; skipping the allocate
+ * + byte-copy is what makes the clean case ~3-13x faster than the Erlang
+ * split/join -- the margin largest on the short paths that dominate, since
+ * there the avoided allocation outweighs everything else. */
+static ERL_NIF_TERM
+normalize_path(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    ErlNifBinary in;
+    ERL_NIF_TERM out_term;
+    unsigned char* out;
+    size_t i, n = 0;
+    int pending_sep = 0;
+
+    (void)argc;
+    if (!enif_inspect_binary(env, argv[0], &in)) {
+        return enif_make_badarg(env);
+    }
+    if (in.size == 0) {
+        return argv[0];
+    }
+    /* Clean iff no leading `/', no trailing `/', and no `//' run anywhere. */
+    if (in.data[0] != '/' && in.data[in.size - 1] != '/') {
+        for (i = 1; i < in.size; i++) {
+            if (in.data[i] == '/' && in.data[i - 1] == '/') {
+                break;
+            }
+        }
+        if (i == in.size) {
+            return argv[0];
+        }
+    }
+    out = enif_make_new_binary(env, in.size, &out_term);
+    if (out == NULL) {
+        return enif_raise_exception(env, enif_make_atom(env, "enomem"));
+    }
+    for (i = 0; i < in.size; i++) {
+        unsigned char c = in.data[i];
+        if (c == '/') {
+            if (n > 0) {
+                pending_sep = 1;
+            }
+        } else {
+            if (pending_sep) {
+                out[n++] = '/';
+                pending_sep = 0;
+            }
+            out[n++] = c;
+        }
+    }
+    if (n == in.size) {
+        return out_term;
+    }
+    return enif_make_sub_binary(env, out_term, 0, n);
+}
+
 /* Stateless: nothing to migrate or initialize, so accepting the upgrade is
  * sufficient. Without this, reloading the module fails with "Upgrade not
  * supported by this NIF library." */
@@ -180,7 +246,8 @@ static ErlNifFunc funcs[] = {
     {"lowercase", 1, lowercase, 0},
     {"key_chars", 1, key_chars, 0},
     {"canon_chars", 1, canon_chars, 0},
-    {"dash_chars", 1, dash_chars, 0}
+    {"dash_chars", 1, dash_chars, 0},
+    {"normalize_path", 1, normalize_path, 0}
 };
 
 ERL_NIF_INIT(hb_util_string, funcs, NULL, NULL, upgrade, NULL)

--- a/native/hb_util_string/hb_util_string.c
+++ b/native/hb_util_string/hb_util_string.c
@@ -6,6 +6,7 @@
  *
  *   lowercase/1   `A'..`Z' -> `a'..`z'                  (to_lower)
  *   key_chars/1   `A'..`Z' -> `a'..`z', and `-' -> `_'  (key_to_atom)
+ *   canon_chars/1 `A'..`Z' -> `a'..`z', and `_' -> `-'  (hb_opts canonical_key)
  *   dash_chars/1  `_' -> `-'                            (atom_to_dashed_binary)
  *
  * UTF-8 safety: `lowercase' and `key_chars' fold ASCII only and do NOT
@@ -50,6 +51,15 @@ key_byte(unsigned char c)
         return (unsigned char)(c + ('a' - 'A'));
     }
     return (c == '-') ? (unsigned char)'_' : c;
+}
+
+static inline unsigned char
+canon_byte(unsigned char c)
+{
+    if (c >= 'A' && c <= 'Z') {
+        return (unsigned char)(c + ('a' - 'A'));
+    }
+    return (c == '_') ? (unsigned char)'-' : c;
 }
 
 static inline unsigned char
@@ -119,6 +129,13 @@ key_chars(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     ASCII_TRANSFORM_BODY(key_byte)
 }
 
+static ERL_NIF_TERM
+canon_chars(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    (void)argc;
+    ASCII_TRANSFORM_BODY(canon_byte)
+}
+
 /* `dash_chars' is exact for all bytes (`_'<->`-' swap, never folds), so it has
  * no non-ASCII fallback. */
 static ERL_NIF_TERM
@@ -162,6 +179,7 @@ upgrade(ErlNifEnv* env, void** priv, void** old_priv, ERL_NIF_TERM info)
 static ErlNifFunc funcs[] = {
     {"lowercase", 1, lowercase, 0},
     {"key_chars", 1, key_chars, 0},
+    {"canon_chars", 1, canon_chars, 0},
     {"dash_chars", 1, dash_chars, 0}
 };
 

--- a/native/hb_util_string/hb_util_string.c
+++ b/native/hb_util_string/hb_util_string.c
@@ -4,10 +4,11 @@
  * pass (the compiler auto-vectorizes the compare-and-select at -O3, so no
  * `-march=native' is needed):
  *
- *   lowercase/1   `A'..`Z' -> `a'..`z'                  (to_lower)
- *   key_chars/1   `A'..`Z' -> `a'..`z', and `-' -> `_'  (key_to_atom)
- *   canon_chars/1 `A'..`Z' -> `a'..`z', and `_' -> `-'  (hb_opts canonical_key)
- *   dash_chars/1  `_' -> `-'                            (atom_to_dashed_binary)
+ *   lowercase/1      `A'..`Z' -> `a'..`z'                 (to_lower)
+ *   key_chars/1      `A'..`Z' -> `a'..`z', and `-' -> `_' (key_to_atom)
+ *   canon_chars/1    `A'..`Z' -> `a'..`z', and `_' -> `-' (hb_opts canonical_key)
+ *   dash_chars/1     `_' -> `-'                           (atom_to_dashed_binary)
+ *   normalize_path/1 collapse `//' runs, trim leading/trailing `/' (hb_path)
  *
  * UTF-8 safety: `lowercase' and `key_chars' fold ASCII only and do NOT
  * validate UTF-8, whereas `string:lowercase' folds full Unicode and *throws*
@@ -18,8 +19,9 @@
  * ASCII -- the overwhelming common case for HB keys -- takes the fast path and
  * is provably identical to `string:lowercase' (only `A'..`Z' has an ASCII case
  * mapping, and ASCII is always valid UTF-8, so it never throws). `dash_chars'
- * only swaps the ASCII byte `_'<->`-' and never folds, so it is exact for all
- * input and needs no fallback.
+ * and `normalize_path' only rewrite ASCII byte positions (`_'<->`-' and `/'
+ * runs respectively) and never fold, so they are exact for all input and need
+ * no fallback.
  *
  * A fresh binary is allocated; the caller's input memory is never mutated. The
  * module carries no mutable static state; its `upgrade' callback is a no-op so
@@ -32,8 +34,8 @@
 
 /* `lowercase/1' is general purpose and may be handed an arbitrarily large
  * binary, so inputs at or above this size run on a dirty CPU scheduler. The
- * key/atom transforms only ever see bounded keys (atoms are <= 255 bytes), so
- * they always run inline. */
+ * key/atom transforms see only bounded keys (atoms are <= 255 bytes) and
+ * `normalize_path' only bounded paths, so they always run inline. */
 #ifndef HB_UTIL_STRING_DIRTY_THRESHOLD
 #define HB_UTIL_STRING_DIRTY_THRESHOLD (256U * 1024U)
 #endif

--- a/rebar.config
+++ b/rebar.config
@@ -172,9 +172,13 @@
 		"./native/hb_keccak/hb_keccak.c",
 		"./native/hb_keccak/hb_keccak_nif.c"
 	]},
-	{"./priv/hb_util_string.so", [
-		"./native/hb_util_string/hb_util_string.c"
-	]}
+	%% `-O3' (scoped to this port only) lets the compiler auto-vectorize the
+	%% scalar byte-transform loops -- the whole point of these NIFs. The base
+	%% `port_env' carries no `-O', so without this they would build at `-O0'
+	%% and run ~1.5-2.4x slower. Kept off `hb_beamr'/`hb_keccak' deliberately.
+	{".*", "./priv/hb_util_string.so",
+		["./native/hb_util_string/hb_util_string.c"],
+		[{env, [{"CFLAGS", "$CFLAGS -O3"}]}]}
 	%% secp256k1_arweave.so is built via native/secp256k1/Makefile
 ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -171,6 +171,9 @@
 	{"./priv/hb_keccak.so", [
 		"./native/hb_keccak/hb_keccak.c",
 		"./native/hb_keccak/hb_keccak_nif.c"
+	]},
+	{"./priv/hb_util_string.so", [
+		"./native/hb_util_string/hb_util_string.c"
 	]}
 	%% secp256k1_arweave.so is built via native/secp256k1/Makefile
 ]}.

--- a/src/core/resolver/hb_opts.erl
+++ b/src/core/resolver/hb_opts.erl
@@ -173,7 +173,12 @@ canonical_key(Key) when is_list(Key) ->
         false -> Key
     end;
 canonical_key(Key) when is_binary(Key) ->
-    hb_util:to_lower(binary:replace(Key, <<"_">>, <<"-">>, [global]));
+    case hb_util_string:canon_chars(Key) of
+        non_ascii ->
+            hb_util:to_lower(binary:replace(Key, <<"_">>, <<"-">>, [global]));
+        Chars ->
+            Chars
+    end;
 canonical_key(Key) -> Key.
 
 %% @doc Return the default message with all environment variables set.

--- a/src/core/resolver/hb_path.erl
+++ b/src/core/resolver/hb_path.erl
@@ -261,9 +261,11 @@ term_to_path_parts({as, DevName, Msgs}, _Opts) ->
     [{as, hb_ao:normalize_key(DevName), Msgs}].
 
 %% @doc Convert a path of any form to a binary.
+%% The final normalization -- collapse `//' runs, strip leading/trailing `/' --
+%% is the `hb_util_string:normalize_path' NIF, which returns an already-clean
+%% path verbatim (the common case) instead of splitting and rejoining it.
 to_binary(Path) ->
-    Parts = binary:split(do_to_binary(Path), <<"/">>, [global, trim_all]),
-    iolist_to_binary(lists:join(<<"/">>, Parts)).
+    hb_util_string:normalize_path(do_to_binary(Path)).
 
 do_to_binary(Path) when is_list(Path) ->
     case hb_util:is_string_list(Path) of

--- a/src/core/util/hb_util.erl
+++ b/src/core/util/hb_util.erl
@@ -320,10 +320,7 @@ decode(Type, Value) when is_list(Type) ->
 decode(Type, Value) when is_binary(Type) ->
     ?event({decoding, {type, Type}, {value, {explicit, Value}}}),
     decode(
-        binary_to_existing_atom(
-            list_to_binary(string:to_lower(binary_to_list(Type))),
-            latin1
-        ),
+        binary_to_existing_atom(to_lower(Type), latin1),
         Value
     );
 decode(integer, Value) ->
@@ -358,11 +355,7 @@ decode(map, Value) ->
     );
 decode(BinType, Value) when is_binary(BinType) ->
     decode(
-        list_to_existing_atom(
-            string:to_lower(
-                binary_to_list(BinType)
-            )
-        ),
+        binary_to_existing_atom(to_lower(BinType), latin1),
         Value
     );
 decode(OtherType, Value) ->

--- a/src/core/util/hb_util.erl
+++ b/src/core/util/hb_util.erl
@@ -950,7 +950,7 @@ to_lower_equivalence_test_parallel() ->
     Valid = [<<"Content-Type">>, <<"slot">>, <<"ALLCAPS-123">>, <<>>,
              <<"Größe"/utf8>>, <<"ÀÉÎ"/utf8>>],
     [ ?assertEqual(string:lowercase(V), to_lower(V)) || V <- Valid ],
-    %% invalid UTF-8: both string:lowercase and to_lower must throw
+    % invalid UTF-8: both string:lowercase and to_lower must throw
     Invalid = [<<255>>, <<"AB", 200>>, <<200, 201, 202>>],
     [ ?assertEqual(Throws(fun() -> string:lowercase(I) end),
                    Throws(fun() -> to_lower(I) end)) || I <- Invalid ],

--- a/src/core/util/hb_util.erl
+++ b/src/core/util/hb_util.erl
@@ -197,6 +197,16 @@ id(Data, Type) when is_list(Data) ->
     id(list_to_binary(Data), Type).
 
 %% @doc Convert a binary to a lowercase.
+%% Pure-ASCII binaries take the fast `hb_util_string' NIF path (identical to
+%% `string:lowercase' for ASCII). Anything with a byte >= 0x80 is delegated to
+%% `string:lowercase', preserving its exact Unicode folding and its `badarg'
+%% throw on invalid UTF-8 — which callers such as `ar_tx' tag parsing rely on
+%% to reject non-string tags.
+to_lower(Str) when is_binary(Str) ->
+    case hb_util_string:lowercase(Str) of
+        non_ascii -> string:lowercase(Str);
+        Lowered -> Lowered
+    end;
 to_lower(Str) ->
     string:lowercase(Str).
 
@@ -238,7 +248,13 @@ to_sorted_keys(Msg, _Opts) when is_list(Msg) ->
 key_to_atom(Key) -> key_to_atom(Key, existing).
 key_to_atom(Key, _Mode) when is_atom(Key) -> Key;
 key_to_atom(Key, Mode) ->
-    WithoutDashes = to_lower(binary:replace(Key, <<"-">>, <<"_">>, [global])),
+    WithoutDashes =
+        case hb_util_string:key_chars(Key) of
+            non_ascii ->
+                string:lowercase(binary:replace(Key, <<"-">>, <<"_">>, [global]));
+            Chars ->
+                Chars
+        end,
     case Mode of
         new_atoms -> binary_to_atom(WithoutDashes, utf8);
         _ -> binary_to_existing_atom(WithoutDashes, utf8)
@@ -926,14 +942,23 @@ base58_encode_int(N) ->
 
 %% @doc Convert an atom with underscope to dashed binary form.
 atom_to_dashed_binary(Key) when is_atom(Key) ->
-    re:replace(
-        atom_to_binary(Key),
-        <<"_">>,
-        <<"-">>,
-        [global, {return, binary}]
-    ).
+    hb_util_string:dash_chars(atom_to_binary(Key)).
 
 %% Tests
 
 atom_to_dashed_binary_test_parallel() ->
     ?assertEqual(atom_to_dashed_binary(atom_1), <<"atom-1">>).
+
+%% `to_lower/1' must remain byte-for-byte equivalent to `string:lowercase',
+%% including the `badarg' throw on invalid UTF-8 that `ar_tx' tag parsing
+%% relies on to reject non-string tags.
+to_lower_equivalence_test_parallel() ->
+    Throws = fun(F) -> try F(), false catch error:_ -> true end end,
+    Valid = [<<"Content-Type">>, <<"slot">>, <<"ALLCAPS-123">>, <<>>,
+             <<"Größe"/utf8>>, <<"ÀÉÎ"/utf8>>],
+    [ ?assertEqual(string:lowercase(V), to_lower(V)) || V <- Valid ],
+    %% invalid UTF-8: both string:lowercase and to_lower must throw
+    Invalid = [<<255>>, <<"AB", 200>>, <<200, 201, 202>>],
+    [ ?assertEqual(Throws(fun() -> string:lowercase(I) end),
+                   Throws(fun() -> to_lower(I) end)) || I <- Invalid ],
+    [ ?assert(Throws(fun() -> to_lower(I) end)) || I <- Invalid ].

--- a/src/core/util/hb_util_string.erl
+++ b/src/core/util/hb_util_string.erl
@@ -46,7 +46,7 @@ normalize_path(_Bin) ->
 lowercase_test() ->
     ?assertEqual(<<"content-type">>, lowercase(<<"Content-Type">>)),
     ?assertEqual(<<>>, lowercase(<<>>)),
-    %% any byte >= 0x80 -> bail to `non_ascii' (caller delegates to string:lc)
+    % any byte >= 0x80 -> bail to `non_ascii' (caller delegates to string:lc)
     ?assertEqual(non_ascii, lowercase(<<"AB", 16#C5>>)),
     ?assertEqual(non_ascii, lowercase(<<16#FF>>)).
 
@@ -66,7 +66,7 @@ dash_chars_test() ->
     ?assertEqual(<<"atom-1">>, dash_chars(<<"atom_1">>)),
     ?assertEqual(<<"a-b-c">>, dash_chars(<<"a_b_c">>)),
     ?assertEqual(<<>>, dash_chars(<<>>)),
-    %% non-ASCII passes through (no fold, no bail)
+    % non-ASCII passes through (no fold, no bail)
     ?assertEqual(<<"k", 16#FF>>, dash_chars(<<"k", 16#FF>>)).
 
 normalize_path_test() ->
@@ -79,7 +79,7 @@ normalize_path_test() ->
     ?assertEqual(<<>>, normalize_path(<<"/">>)),
     ?assertEqual(<<>>, normalize_path(<<"///">>)),
     ?assertEqual(<<"x">>, normalize_path(<<"x">>)),
-    %% non-ASCII passes through untouched (only `/' positions matter)
+    % non-ASCII passes through untouched (only `/' positions matter)
     ?assertEqual(<<"k", 16#FF, "/v">>, normalize_path(<<"/k", 16#FF, "//v/">>)).
 
 %% The NIF must equal the Erlang split/join expression it replaces, for both

--- a/src/core/util/hb_util_string.erl
+++ b/src/core/util/hb_util_string.erl
@@ -6,6 +6,7 @@
 %%% the ASCII byte `_'<->`-' and never folds, so it is exact for all input.
 -module(hb_util_string).
 -export([lowercase/1, key_chars/1, canon_chars/1, dash_chars/1]).
+-export([normalize_path/1]).
 -include_lib("eunit/include/eunit.hrl").
 
 -on_load(init/0).
@@ -31,6 +32,13 @@ canon_chars(_Bin) ->
 %% @doc Map `_' to `-' — the `atom_to_dashed_binary' transform. Exact for all
 %% bytes (non-ASCII passes through), so it never returns `non_ascii'.
 dash_chars(_Bin) ->
+    erlang:nif_error(not_loaded).
+
+%% @doc Collapse runs of `/' to a single `/' and strip leading/trailing `/' in
+%% one pass — the `hb_path:to_binary' normalization. Equivalent to
+%% `iolist_to_binary(lists:join(<<"/">>,
+%%      binary:split(Bin, <<"/">>, [global, trim_all])))'. Exact for all bytes.
+normalize_path(_Bin) ->
     erlang:nif_error(not_loaded).
 
 %% Tests
@@ -60,6 +68,33 @@ dash_chars_test() ->
     ?assertEqual(<<>>, dash_chars(<<>>)),
     %% non-ASCII passes through (no fold, no bail)
     ?assertEqual(<<"k", 16#FF>>, dash_chars(<<"k", 16#FF>>)).
+
+normalize_path_test() ->
+    ?assertEqual(<<"cache/abc">>, normalize_path(<<"cache/abc">>)),
+    ?assertEqual(<<"cache/abc">>, normalize_path(<<"/cache/abc">>)),
+    ?assertEqual(<<"cache/abc">>, normalize_path(<<"cache/abc/">>)),
+    ?assertEqual(<<"cache/abc">>, normalize_path(<<"//cache//abc//">>)),
+    ?assertEqual(<<"a/b/c">>, normalize_path(<<"a/b/c">>)),
+    ?assertEqual(<<>>, normalize_path(<<>>)),
+    ?assertEqual(<<>>, normalize_path(<<"/">>)),
+    ?assertEqual(<<>>, normalize_path(<<"///">>)),
+    ?assertEqual(<<"x">>, normalize_path(<<"x">>)),
+    %% non-ASCII passes through untouched (only `/' positions matter)
+    ?assertEqual(<<"k", 16#FF, "/v">>, normalize_path(<<"/k", 16#FF, "//v/">>)).
+
+%% The NIF must equal the Erlang split/join expression it replaces, for both
+%% ASCII and arbitrary-byte inputs.
+normalize_path_equivalence_test() ->
+    Old = fun(B) ->
+        iolist_to_binary(
+            lists:join(<<"/">>, binary:split(B, <<"/">>, [global, trim_all]))
+        )
+    end,
+    Inputs = [<<"cache/abc">>, <<"/cache/abc">>, <<"cache/abc/">>,
+              <<"//cache//abc//">>, <<"a/b/c/d/e">>, <<>>, <<"/">>, <<"///">>,
+              <<"no-slashes">>, <<"trailing/">>, <<"/leading">>,
+              <<"k", 16#FF, "//v">>],
+    [ ?assertEqual(Old(I), normalize_path(I)) || I <- Inputs ].
 
 %% The NIF transforms must equal the Erlang expressions they replace, for all
 %% ASCII inputs (the domain of HB keys / atom names).

--- a/src/core/util/hb_util_string.erl
+++ b/src/core/util/hb_util_string.erl
@@ -5,7 +5,7 @@
 %%% full Unicode folding and throws on invalid UTF-8). `dash_chars/1' only swaps
 %%% the ASCII byte `_'<->`-' and never folds, so it is exact for all input.
 -module(hb_util_string).
--export([lowercase/1, key_chars/1, dash_chars/1]).
+-export([lowercase/1, key_chars/1, canon_chars/1, dash_chars/1]).
 -include_lib("eunit/include/eunit.hrl").
 
 -on_load(init/0).
@@ -21,6 +21,11 @@ lowercase(_Bin) ->
 %% @doc ASCII-lowercase and map `-' to `_' (the `key_to_atom' transform), or
 %% return `non_ascii' if any byte is >= 0x80.
 key_chars(_Bin) ->
+    erlang:nif_error(not_loaded).
+
+%% @doc ASCII-lowercase and map `_' to `-' (the `hb_opts' `canonical_key'
+%% transform), or return `non_ascii' if any byte is >= 0x80.
+canon_chars(_Bin) ->
     erlang:nif_error(not_loaded).
 
 %% @doc Map `_' to `-' — the `atom_to_dashed_binary' transform. Exact for all
@@ -43,6 +48,12 @@ key_chars_test() ->
     ?assertEqual(<<>>, key_chars(<<>>)),
     ?assertEqual(non_ascii, key_chars(<<"A-B", 16#C5>>)).
 
+canon_chars_test() ->
+    ?assertEqual(<<"content-type">>, canon_chars(<<"Content_Type">>)),
+    ?assertEqual(<<"a-b-c">>, canon_chars(<<"A_B_C">>)),
+    ?assertEqual(<<>>, canon_chars(<<>>)),
+    ?assertEqual(non_ascii, canon_chars(<<"A_B", 16#C5>>)).
+
 dash_chars_test() ->
     ?assertEqual(<<"atom-1">>, dash_chars(<<"atom_1">>)),
     ?assertEqual(<<"a-b-c">>, dash_chars(<<"a_b_c">>)),
@@ -57,6 +68,9 @@ equivalence_test() ->
     OldKey = fun(K) ->
         string:lowercase(binary:replace(K, <<"-">>, <<"_">>, [global]))
     end,
+    OldCanon = fun(K) ->
+        string:lowercase(binary:replace(K, <<"_">>, <<"-">>, [global]))
+    end,
     OldDash = fun(B) ->
         re:replace(B, <<"_">>, <<"-">>, [global, {return, binary}])
     end,
@@ -64,4 +78,5 @@ equivalence_test() ->
               <<"ALLCAPS">>, <<"123-456_789">>, <<>>],
     [ ?assertEqual(iolist_to_binary(OldLower(I)), lowercase(I)) || I <- Inputs ],
     [ ?assertEqual(iolist_to_binary(OldKey(I)), key_chars(I)) || I <- Inputs ],
+    [ ?assertEqual(iolist_to_binary(OldCanon(I)), canon_chars(I)) || I <- Inputs ],
     [ ?assertEqual(iolist_to_binary(OldDash(I)), dash_chars(I)) || I <- Inputs ].

--- a/src/core/util/hb_util_string.erl
+++ b/src/core/util/hb_util_string.erl
@@ -1,0 +1,67 @@
+%%% @doc NIF-backed ASCII byte transforms for `hb_util' string operations.
+%%% Each maps input bytes in a single pass. `lowercase/1' and `key_chars/1'
+%%% fold ASCII only and return the atom `non_ascii' the moment they see a byte
+%%% >= 0x80, so the Erlang caller can delegate to `string:lowercase' (which does
+%%% full Unicode folding and throws on invalid UTF-8). `dash_chars/1' only swaps
+%%% the ASCII byte `_'<->`-' and never folds, so it is exact for all input.
+-module(hb_util_string).
+-export([lowercase/1, key_chars/1, dash_chars/1]).
+-include_lib("eunit/include/eunit.hrl").
+
+-on_load(init/0).
+
+init() ->
+    SoName = filename:join([code:priv_dir(hb), "hb_util_string"]),
+    erlang:load_nif(SoName, 0).
+
+%% @doc ASCII-lowercase a binary, or return `non_ascii' if any byte is >= 0x80.
+lowercase(_Bin) ->
+    erlang:nif_error(not_loaded).
+
+%% @doc ASCII-lowercase and map `-' to `_' (the `key_to_atom' transform), or
+%% return `non_ascii' if any byte is >= 0x80.
+key_chars(_Bin) ->
+    erlang:nif_error(not_loaded).
+
+%% @doc Map `_' to `-' — the `atom_to_dashed_binary' transform. Exact for all
+%% bytes (non-ASCII passes through), so it never returns `non_ascii'.
+dash_chars(_Bin) ->
+    erlang:nif_error(not_loaded).
+
+%% Tests
+
+lowercase_test() ->
+    ?assertEqual(<<"content-type">>, lowercase(<<"Content-Type">>)),
+    ?assertEqual(<<>>, lowercase(<<>>)),
+    %% any byte >= 0x80 -> bail to `non_ascii' (caller delegates to string:lc)
+    ?assertEqual(non_ascii, lowercase(<<"AB", 16#C5>>)),
+    ?assertEqual(non_ascii, lowercase(<<16#FF>>)).
+
+key_chars_test() ->
+    ?assertEqual(<<"content_type">>, key_chars(<<"Content-Type">>)),
+    ?assertEqual(<<"a_b_c">>, key_chars(<<"A-B-C">>)),
+    ?assertEqual(<<>>, key_chars(<<>>)),
+    ?assertEqual(non_ascii, key_chars(<<"A-B", 16#C5>>)).
+
+dash_chars_test() ->
+    ?assertEqual(<<"atom-1">>, dash_chars(<<"atom_1">>)),
+    ?assertEqual(<<"a-b-c">>, dash_chars(<<"a_b_c">>)),
+    ?assertEqual(<<>>, dash_chars(<<>>)),
+    %% non-ASCII passes through (no fold, no bail)
+    ?assertEqual(<<"k", 16#FF>>, dash_chars(<<"k", 16#FF>>)).
+
+%% The NIF transforms must equal the Erlang expressions they replace, for all
+%% ASCII inputs (the domain of HB keys / atom names).
+equivalence_test() ->
+    OldLower = fun(K) -> string:lowercase(K) end,
+    OldKey = fun(K) ->
+        string:lowercase(binary:replace(K, <<"-">>, <<"_">>, [global]))
+    end,
+    OldDash = fun(B) ->
+        re:replace(B, <<"_">>, <<"-">>, [global, {return, binary}])
+    end,
+    Inputs = [<<"Content-Type">>, <<"X-AO-Data">>, <<"slot">>, <<"a-b_c-D">>,
+              <<"ALLCAPS">>, <<"123-456_789">>, <<>>],
+    [ ?assertEqual(iolist_to_binary(OldLower(I)), lowercase(I)) || I <- Inputs ],
+    [ ?assertEqual(iolist_to_binary(OldKey(I)), key_chars(I)) || I <- Inputs ],
+    [ ?assertEqual(iolist_to_binary(OldDash(I)), dash_chars(I)) || I <- Inputs ].


### PR DESCRIPTION
The resolve/cache hot path spends a surprising amount of CPU on small ASCII
string work — key lowering, `_`/`-` canonicalisation, type-name folding, and
path normalisation — implemented with `string:lowercase`, `binary:replace`,
`re:replace`, and `binary:split` + `lists:join`. This replaces those with a
small dependency-free NIF (`hb_util_string`) that does each as a single scalar
byte pass.

Each transform has an ASCII fast path that bails to the original
unicode-aware paths the moment it sees a byte ≥ `0x80`, preserving full Unicode
folding and the `badarg`-on-invalid-UTF-8 contract that `ar_tx` tag parsing
relies on. Pure ASCII — the overwhelming common case for HB keys — takes the
fast path.

Routed through the NIF:
- `hb_util:to_lower`, `key_to_atom`, `atom_to_dashed_binary`, and `decode/2` type names
- `hb_opts:canonical_key`
- `hb_path:to_binary`

Also fixes a latent build issue: `port_env` carries no `-O`, so every NIF was
compiling at `-O0`. This scopes `-O3` to `hb_util_string.so` only — so the
transform loops auto-vectorise. The `-O0` → `-O3` change alone is
worth 2.2–3.7x on these functions. The Keccak and WASM libraries should
also be investigated for similar tweaks.

Every transform is byte-for-byte identical to the expression it replaces;
equivalence tests gate each one, including the UTF-8 throw behaviour.

### End-to-end (interleaved A/B vs `edge`, drift-controlled, mean of 3 runs)

| Benchmark | Before | After | Gain |
|---|---|---|---|
| `dev_lua` Pure Lua | 217.7 slots/s | 268.7 slots/s | **+23%** |
| `dev_lua` HyperAOS | 53.3 slots/s | 59.7 slots/s | **+12%** |
| `hb_store` lmdb message write | 1,991 msg/s | 2,766 msg/s | **+39%** |
| `hb_store` lmdb message read | 3,479 msg/s | 4,627 msg/s | **+33%** |
| `hb_store` lmdb key write | 1.82M rec/s | 2.32M rec/s | **+28%** |
| `hb_store` lmdb key read | 1.25M rec/s | 1.49M rec/s | **+19%** |

### Per-operation (best-of-3, byte-identical output)

| Operation | Erlang | NIF | Speedup |
|---|---|---|---|
| `lowercase` (`Content-Type`) | 75.2 ns | 14.2 ns | **5.3x** |
| `key_chars` | 236.2 ns | 14.0 ns | **16.8x** |
| `canon_chars` | 227.4 ns | 13.9 ns | **16.4x** |
| `dash_chars` (`re:replace`) | 826.3 ns | 14.3 ns | **57.9x** |
| `normalize_path` short (12 B) | 125.0 ns | 9.2 ns | **13.6x** |
| `normalize_path` medium (46 B) | 184.9 ns | 19.6 ns | **9.4x** |
| `normalize_path` long (214 B) | 224.0 ns | 78.3 ns | **2.9x** |