### PR TITLE
perf: introduce `read_prefix` in LMDB for ~50x message read speed improvement

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -182,7 +182,11 @@
 ]}.
 
 {deps, [
-    {elmdb, {git, "https://github.com/permaweb/elmdb-rs.git", {ref, "06ccf937abc250cb22c782d568efcaa39f5452ff"}}},
+    %% elmdb pinned to faa7623 on permaweb/elmdb-rs `feat/read-prefix': adds
+    %% `elmdb:read_prefix/2' (packed single-buffer row materialization) used by
+    %% the LMDB composite reads below (edge's 06ccf937 + the read_prefix NIF
+    %% commits). Repin to the default branch once read_prefix lands there.
+    {elmdb, {git, "https://github.com/permaweb/elmdb-rs.git", {ref, "faa762323be6bad2db26abfa1d4243863a877f0f"}}},
     {b64veryfast, {git, "https://github.com/permaweb/b64veryfast.git", {ref, "673388c8d46968f90e1da902146a8367d63226d2"}}},
     {base32, "1.0.0"},
     {cowlib, "2.16.0"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -11,7 +11,7 @@
  {<<"ddskerl">>,{pkg,<<"ddskerl">>,<<"0.4.2">>},1},
  {<<"elmdb">>,
   {git,"https://github.com/permaweb/elmdb-rs.git",
-       {ref,"06ccf937abc250cb22c782d568efcaa39f5452ff"}},
+       {ref,"faa762323be6bad2db26abfa1d4243863a877f0f"}},
   0},
  {<<"eqwalizer_support">>,
   {git_subdir,"https://github.com/whatsapp/eqwalizer.git",

--- a/src/core/resolver/hb_cache.erl
+++ b/src/core/resolver/hb_cache.erl
@@ -46,6 +46,7 @@
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -define(MATCH_PREFIX, <<"~match@1.0">>).
+-define(DIRECT_VALUE_LENGTH, 60).
 
 %% @doc Ensure that a value is loaded from the cache if it is an ID or a link.
 %% If it is not loadable we raise an error. If the value is a message, we will
@@ -109,6 +110,13 @@ ensure_loaded(Ref,
             end;
         {error, not_found} ->
             report_ensure_loaded_not_found(Ref, Lk, Opts)
+    end;
+ensure_loaded(_Ref, {link, _ID, LinkOpts = #{ <<"value">> := DirectValue }}, Opts) ->
+    % The composite read already supplied this value inline, so resolve it
+    % without a further store read, applying the `ao-type' if one is present.
+    case hb_maps:get(<<"type">>, LinkOpts, undefined, Opts) of
+        undefined -> DirectValue;
+        Type -> hb_util:decode(Type, DirectValue)
     end;
 ensure_loaded(Ref, Link = {link, ID, LinkOpts = #{ <<"lazy">> := true }}, RawOpts) ->
     % If the user provided their own options, we merge them and _overwrite_
@@ -192,7 +200,7 @@ list(Path, Store) ->
     list(Path, Store, #{}).
 list(Path, Store, Opts) ->
     case hb_store:read(Store, Path, Opts) of
-        {composite, Names} -> Names;
+        {composite, Names} -> lists:map(fun child_name/1, Names);
         _ -> []
     end.
 
@@ -236,7 +244,7 @@ normalize_match_spec(MatchSpec, _ReadMode, Opts) ->
 store_match(NormalizedSpec, Opts) ->
     ConvertedMatchSpec =
         maps:map(
-            fun(_, Value) -> generate_binary_path(Value, Opts) end,
+            fun(_, Value) -> store_match_value(Value, Opts) end,
             NormalizedSpec
         ),
     case hb_store:match(
@@ -306,49 +314,60 @@ do_write_message(List, Store, Opts) when is_list(List) ->
         Opts
     );
 do_write_message(Msg, Store, Opts) when is_map(Msg) ->
-    ?event_debug(debug_cache, {writing_message, Msg}),
-    % Calculate the IDs of the message.
-    UncommittedID = hb_message:id(Msg, none, Opts#{ <<"linkify-mode">> => discard }),
-    AllIDs = calculate_all_ids(Msg, Opts),
-    AltIDs = AllIDs -- [UncommittedID],
-    MsgHashpathAlg = hb_path:hashpath_alg(Msg, Opts),
-    ?event_debug(debug_cache, {writing_message, {id, UncommittedID}, {alt_ids, AltIDs}, {original, Msg}}),
-    % Write all of the keys of the message into the store.
-    hb_store:group(Store, UncommittedID, Opts),
-    maps:map(
-        fun(Key, Value) ->
-            write_key(UncommittedID, Key, MsgHashpathAlg, Value, Store, Opts)
-        end,
-        maps:without([<<"priv">>], Msg)
-    ),
-    % Optionally store the message into the match index, if configured.
-    case hb_opts:get(match_index, false, Opts) of
-        false -> ok;
-        _ -> write_match_index(AllIDs, Msg, Opts)
-    end,
-    % Write the commitments to the store, linking each commitment ID to the
-    % uncommitted message.
-    lists:map(
-        fun(AltID) ->
-            ?event_debug(debug_cache,
-                {linking_commitment,
-                    {uncommitted_id, UncommittedID},
-                    {committed_id, AltID}
-            }),
-            hb_store:link(Store, #{ AltID => UncommittedID }, Opts)
-        end,
-        AltIDs
-    ),
+    {ok, UncommittedID, Ops} = write_message_ops(Msg, Opts),
+    run_write_ops(Store, Ops, Opts),
     {ok, UncommittedID}.
 
-%% @doc Write a single key for a message into the store.
-write_key(Base, <<"commitments">>, _HPAlg, RawCommitments, Store, Opts) ->
-    % The commitments are a special case: We calculate the single-part hashpath
-    % for the `baseID/commitments` key, then write each commitment to the store
-    % and link it to `baseCommHP/commitmentID`.
+write_message_ops(Bin, Opts) when is_binary(Bin) ->
+    Path = generate_binary_path(Bin, Opts),
+    {ok, Path, [{write, Path, Bin}]};
+write_message_ops(List, Opts) when is_list(List) ->
+    write_message_ops(hb_message:convert(List, tabm, <<"structured@1.0">>, Opts), Opts);
+write_message_ops(Msg, Opts) when is_map(Msg) ->
+    ?event_debug(debug_cache, {writing_message, Msg}),
+    UncommittedID = hb_message:id(Msg, none, Opts#{ <<"linkify-mode">> => discard }),
+    AllIDs = calculate_all_ids(Msg, UncommittedID, Opts),
+    AltIDs = AllIDs -- [UncommittedID],
+    MsgHashpathAlg = hb_path:hashpath_alg(Msg, Opts),
+    ?event_debug(debug_cache,
+        {writing_message,
+            {id, UncommittedID},
+            {alt_ids, AltIDs},
+            {original, Msg}
+        }
+    ),
+    KeyOps =
+        maps:fold(
+            fun(Key, Value, Acc) ->
+                write_key_ops(UncommittedID, Key, MsgHashpathAlg, Value, Opts, Acc)
+            end,
+            [{group, UncommittedID}],
+            maps:without([<<"priv">>], Msg)
+        ),
+    MatchOps =
+        case hb_opts:get(match_index, false, Opts) of
+            false -> KeyOps;
+            _ -> [{match, AllIDs, Msg} | KeyOps]
+        end,
+    Ops =
+        lists:foldl(
+            fun(AltID, Acc) ->
+                ?event_debug(debug_cache,
+                    {linking_commitment,
+                        {uncommitted_id, UncommittedID},
+                        {committed_id, AltID}
+                    }
+                ),
+                [{link, AltID, UncommittedID} | Acc]
+            end,
+            MatchOps,
+            AltIDs
+        ),
+    {ok, UncommittedID, lists:reverse(Ops)}.
+
+write_key_ops(Base, <<"commitments">>, _HPAlg, RawCommitments, Opts, Acc) ->
     Commitments = prepare_commitments(RawCommitments, Opts),
     CommitmentsBase = commitment_path(Base, Opts),
-    hb_store:group(Store, CommitmentsBase, Opts),
     ?event(
         {writing_commitments,
             {base, Base},
@@ -356,25 +375,22 @@ write_key(Base, <<"commitments">>, _HPAlg, RawCommitments, Store, Opts) ->
             {commitments_base, CommitmentsBase}
         }
     ),
-    maps:map(
-        fun(BaseCommID, Commitment) ->
-            ?event_debug(debug_cache, {writing_commitment, {commitment, Commitment}}),
-            {ok, CommMsgID} = do_write_message(Commitment, Store, Opts),
-            hb_store:link(
-                Store,
-                #{ << CommitmentsBase/binary, "/", BaseCommID/binary >> => CommMsgID },
-                Opts
-            )
-        end,
-        Commitments
-    ),
-    % Link the commitments base to `base/commitments`.
-    hb_store:link(
-        Store,
-        #{ <<Base/binary, "/commitments">> => CommitmentsBase },
-        Opts
-    );
-write_key(Base, Key, HPAlg, Value, Store, Opts) ->
+    Acc1 = [{group, CommitmentsBase} | Acc],
+    Acc2 =
+        maps:fold(
+            fun(BaseCommID, Commitment, InnerAcc) ->
+                ?event_debug(debug_cache, {writing_commitment, {commitment, Commitment}}),
+                {ok, CommMsgID, CommOps} = write_message_ops(Commitment, Opts),
+                [
+                    {link, <<CommitmentsBase/binary, "/", BaseCommID/binary>>, CommMsgID}
+                    | prepend_reversed(CommOps, InnerAcc)
+                ]
+            end,
+            Acc1,
+            Commitments
+        ),
+    [{link, <<Base/binary, "/commitments">>, CommitmentsBase} | Acc2];
+write_key_ops(Base, Key, HPAlg, Value, Opts, Acc) ->
     KeyHashPath =
         hb_path:hashpath(
             Base,
@@ -382,9 +398,68 @@ write_key(Base, Key, HPAlg, Value, Store, Opts) ->
             HPAlg,
             Opts
         ),
-    {ok, Path} = do_write_message(Value, Store, Opts),
-    hb_store:link(Store, #{ KeyHashPath => Path }, Opts),
-    {ok, Path}.
+    {ok, Path, ValueOps} = write_message_ops(Value, Opts),
+    [
+        write_key_op(KeyHashPath, Value, Path)
+        | prepend_reversed(ValueOps, Acc)
+    ].
+
+write_key_op(KeyHashPath, Value, _Path)
+        when is_binary(Value), byte_size(Value) < ?DIRECT_VALUE_LENGTH ->
+    {write, KeyHashPath, <<"raw:", Value/binary>>};
+write_key_op(KeyHashPath, _Value, Path) ->
+    {link, KeyHashPath, Path}.
+
+prepend_reversed(Ops, Acc) ->
+    lists:foldl(fun(Op, InnerAcc) -> [Op | InnerAcc] end, Acc, Ops).
+
+run_write_ops(Store, Ops, Opts) ->
+    run_write_ops(Store, Ops, Opts, []).
+run_write_ops(Store, [], Opts, Pending) ->
+    flush_write_ops(Store, Pending, Opts);
+run_write_ops(Store, [{match, IDs, Msg} | Rest], Opts, Pending) ->
+    flush_write_ops(Store, Pending, Opts),
+    write_match_index(IDs, Msg, Opts),
+    run_write_ops(Store, Rest, Opts, []);
+run_write_ops(Store, [Op | Rest], Opts, Pending) ->
+    run_write_ops(Store, Rest, Opts, [Op | Pending]).
+
+flush_write_ops(_Store, [], _Opts) ->
+    ok;
+flush_write_ops(Store, Pending, Opts) ->
+    apply_write_ops(Store, lists:reverse(Pending), Opts).
+
+%% @doc Apply a list of write/group/link operations through the store's existing
+%% interfaces, collapsing a message's per-key store round-trips into a small
+%% constant number of calls: the group markers, then all values in a single
+%% `write' map, then all links in a single `link' map. Links stay links -- the
+%% store decides how to represent them -- so this is store-agnostic.
+apply_write_ops(Store, Ops, Opts) ->
+    {Groups, Writes, Links} =
+        lists:foldl(
+            fun({group, Path}, {Gs, Ws, Ls}) ->
+                    {[Path | Gs], Ws, Ls};
+               ({write, Path, Value}, {Gs, Ws, Ls}) ->
+                    {Gs, Ws#{ Path => Value }, Ls};
+               ({link, New, Existing}, {Gs, Ws, Ls}) ->
+                    {Gs, Ws, Ls#{ New => Existing }}
+            end,
+            {[], #{}, #{}},
+            Ops
+        ),
+    lists:foreach(
+        fun(Group) -> hb_store:group(Store, Group, Opts) end,
+        lists:reverse(Groups)
+    ),
+    case map_size(Writes) of
+        0 -> ok;
+        _ -> hb_store:write(Store, Writes, Opts)
+    end,
+    case map_size(Links) of
+        0 -> ok;
+        _ -> hb_store:link(Store, Links, Opts)
+    end,
+    ok.
 
 %% @doc Write all message keys to the optional match index.
 write_match_index(IDs, Base, Opts) ->
@@ -392,26 +467,25 @@ write_match_index(IDs, Base, Opts) ->
         [] -> {skip, <<"No store configured for match index.">>};
         Store ->
             IndexBase = hb_message:uncommitted(hb_private:reset(Base)),
-            hb_maps:map(
-                fun(RawKey, Value) ->
+            Ops =
+                hb_maps:fold(
+                fun(RawKey, Value, Acc) ->
                     Key = hb_ao:normalize_key(RawKey),
                     ValuePath = match_value_path(Value, Opts),
-                    hb_store:group(Store, match_address(Key, ValuePath), Opts),
-                    lists:foreach(
-                        fun(ID) ->
-                            Address = match_address(Key, ValuePath, ID),
-                            ?event(
-                                debug_match,
-                                {writing_reverse_index, {address, Address}},
-                                Opts
-                            ),
-                            hb_store:write(Store, #{ Address => <<"">> }, Opts)
+                    MatchAddress = match_address(Key, ValuePath),
+                    lists:foldl(
+                        fun(ID, InnerAcc) ->
+                            Address = match_address_id(MatchAddress, ID),
+                            [{write, Address, <<"">>} | InnerAcc]
                         end,
+                        [{group, MatchAddress} | Acc],
                         IDs
                     )
                 end,
+                [],
                 IndexBase
-            )
+            ),
+            apply_write_ops(Store, lists:reverse(Ops), Opts)
     end.
 
 %% @doc Select the store that should receive reverse match-index writes.
@@ -436,9 +510,9 @@ match_address(Key, Value) ->
     KeyBin = match_bin(Key),
     ValueBin = match_bin(Value),
     iolist_to_binary([?MATCH_PREFIX, "&", KeyBin, "=", ValueBin]).
-match_address(Key, Value, ID) ->
+match_address_id(Address, ID) ->
     IDBin = match_bin(ID),
-    <<(match_address(Key, Value))/binary, "/", IDBin/binary>>.
+    <<Address/binary, "/", IDBin/binary>>.
 
 %% @doc Normalize a match-index path part.
 match_bin(Bin) when is_binary(Bin) -> Bin;
@@ -454,7 +528,7 @@ match_bin(Other) ->
 
 %% @doc Return the path representation used by cache key-value links.
 match_value_path(Bin, Opts) when is_binary(Bin) ->
-    <<"data/", (hb_path:hashpath(Bin, Opts))/binary>>;
+    generate_binary_path(Bin, Opts);
 match_value_path(Map, Opts) when is_map(Map) ->
     hb_message:id(Map, none, Opts#{ <<"linkify-mode">> => discard });
 match_value_path(List, Opts) when is_list(List) ->
@@ -469,6 +543,35 @@ match_value_path(List, Opts) when is_list(List) ->
     end;
 match_value_path(Other, Opts) ->
     match_value_path(hb_path:to_binary(Other), Opts).
+
+store_match_value(Bin, Opts) when is_binary(Bin) ->
+    cache_link_value(Bin, generate_binary_path(Bin, Opts));
+store_match_value(Map, Opts) when is_map(Map) ->
+    <<"link:",
+        (hb_message:id(
+            Map,
+            none,
+            Opts#{ <<"linkify-mode">> => discard }
+        ))/binary
+    >>;
+store_match_value(List, Opts) when is_list(List) ->
+    case io_lib:printable_unicode_list(List) of
+        true ->
+            store_match_value(iolist_to_binary(List), Opts);
+        false ->
+            store_match_value(
+                hb_message:convert(List, tabm, <<"structured@1.0">>, Opts),
+                Opts
+            )
+    end;
+store_match_value(Other, Opts) ->
+    store_match_value(hb_path:to_binary(Other), Opts).
+
+cache_link_value(Value, _Path)
+        when is_binary(Value), byte_size(Value) < ?DIRECT_VALUE_LENGTH ->
+    <<"raw:", Value/binary>>;
+cache_link_value(_Value, Path) ->
+    <<"link:", Path/binary>>.
 
 %% @doc The `structured@1.0` encoder does not typically encode `commitments`,
 %% subsequently, when we encounter a commitments message we prepare its contents
@@ -487,8 +590,8 @@ commitment_path(Base, Opts) ->
     hb_path:hashpath(<<Base/binary, "/commitments">>, Opts).
 
 %% @doc Calculate the IDs for a message.
-calculate_all_ids(Bin, _Opts) when is_binary(Bin) -> [];
-calculate_all_ids(Msg, Opts) ->
+calculate_all_ids(Bin, _UncommittedID, _Opts) when is_binary(Bin) -> [];
+calculate_all_ids(Msg, UncommittedID, Opts) ->
     Commitments =
         hb_maps:without(
             [<<"priv">>],
@@ -497,10 +600,17 @@ calculate_all_ids(Msg, Opts) ->
         ),
     CommIDs = hb_maps:keys(Commitments, Opts),
     ?event_debug({calculating_ids, {msg, Msg}, {commitments, Commitments}, {comm_ids, CommIDs}}),
-    All = hb_message:id(Msg, all, Opts#{ <<"linkify-mode">> => discard }),
-    case lists:member(All, CommIDs) of
-        true -> CommIDs;
-        false -> [All | CommIDs]
+    case hb_maps:size(Commitments, Opts) of
+        0 ->
+            % With no commitments the `all' id is the uncommitted id we already
+            % computed; skip re-serializing the message to recompute it.
+            [UncommittedID];
+        _ ->
+            All = hb_message:id(Msg, all, Opts#{ <<"linkify-mode">> => discard }),
+            case lists:member(All, CommIDs) of
+                true -> CommIDs;
+                false -> [All | CommIDs]
+            end
     end.
 
 %% @doc Write a hashpath and its message to the store and link it.
@@ -526,8 +636,7 @@ write_binary(Hashpath, Bin, Store, Opts) ->
 
 %% @doc Read the message at a path. Returns in `structured@1.0' format: Either
 %% a richly typed map or a direct binary. If `cache-read-mode' is `raw',
-%% composite reads return lazy links without decoding `ao-types' or normalizing
-%% commitments.
+%% composite reads return lazy links without decoding `ao-types'.
 read(Path, Opts) ->
     Store = hb_opts:get(store, no_viable_store, Opts),
     case {
@@ -538,7 +647,7 @@ read(Path, Opts) ->
             {ok, Res};
         {{ok, Res}, _} ->
             hb_message:paranoid_verify(cache_read, Res, Opts),
-            {ok, hb_message:normalize_commitments(Res, Opts)};
+            {ok, Res};
         {Other, _} ->
             Other
     end.
@@ -596,6 +705,8 @@ store_read(Path, Store, Opts) ->
     store_read(Path, Path, Store, Opts).
 store_read(_Target, _Path, no_viable_store, _) ->
     {error, not_found};
+store_read(Target, <<"data/", _/binary>> = PathBin, Store, Opts) ->
+    read_resolved_path(Target, PathBin, Store, Opts);
 store_read(Target, Path, Store, Opts) ->
     PathBin = hb_path:to_binary(Path),
     case hb_store:resolve(Store, PathBin, Opts) of
@@ -605,81 +716,124 @@ store_read(Target, Path, Store, Opts) ->
                 {fully_resolved_path, ResolvedFullPath},
                 {store, Store}
             }),
-            case hb_store:read(Store, ResolvedFullPath, Opts) of
-                {ok, Bin} ->
-                    ?event_debug({reading_data, ResolvedFullPath}),
-                    {ok, Bin};
-                {composite, RawSubpaths} ->
-                    ?event_debug({reading_composite, ResolvedFullPath}),
-                    Subpaths = lists:map(fun hb_util:bin/1, RawSubpaths),
-                    ?event(
-                        {listed,
-                            {original_path, Path},
-                            {subpaths, {explicit, Subpaths}}
-                        }
-                    ),
-                    Msg =
-                        prepare_links(
-                            Target,
-                            ResolvedFullPath,
-                            Subpaths,
-                            Store,
-                            Opts
-                        ),
-                    ?event(
-                        {completed_read,
-                            {resolved_path, ResolvedFullPath},
-                            {explicit, Msg}
-                        }
-                    ),
-                    {ok, Msg};
-                {error, _} = Error ->
-                    Error;
-                {failure, _} = Failure ->
-                    Failure
-            end;
+            read_resolved_path(Target, ResolvedFullPath, Store, Opts);
         {error, _} = Error ->
             Error;
         {failure, _} = Failure ->
             Failure
     end.
 
-%% @doc Prepare a set of links from a listing of subpaths.
-prepare_links(Target, RootPath, Subpaths, Store, Opts) ->
-    case hb_opts:get(cache_read_mode, normal, Opts) of
-        raw -> prepare_raw_links(RootPath, Subpaths, Store);
-        _ -> prepare_typed_links(Target, RootPath, Subpaths, Store, Opts)
+%% @doc Read a path whose intermediate links are already resolved, skipping the
+%% redundant per-segment `hb_store:resolve' round-trip. Used for content-
+%% addressed `data' leaves, where re-resolving a path the store maps to itself
+%% is pure overhead.
+read_resolved_path(_Target, _Path, no_viable_store, _) ->
+    {error, not_found};
+read_resolved_path(Target, ResolvedFullPath, Store, Opts) ->
+    case hb_store:read(Store, ResolvedFullPath, Opts) of
+        {ok, Bin} ->
+            ?event_debug({reading_data, ResolvedFullPath}),
+            {ok, cache_row_value(ResolvedFullPath, Bin)};
+        {composite, Children} ->
+            ?event_debug({reading_composite, ResolvedFullPath}),
+            Subpaths =
+                [
+                    case Child of
+                        {Subpath, _Value} -> hb_util:bin(Subpath);
+                        Subpath -> hb_util:bin(Subpath)
+                    end
+                ||
+                    Child <- Children
+                ],
+            ?event(
+                {listed,
+                    {original_path, Target},
+                    {subpaths, {explicit, Subpaths}}
+                }
+            ),
+            Msg =
+                case hb_opts:get(cache_read_mode, normal, Opts) of
+                    raw ->
+                        maps:from_list(
+                            [
+                                {
+                                    Subpath,
+                                    {link,
+                                        hb_path:to_binary([ResolvedFullPath, Subpath]),
+                                        #{ <<"lazy">> => true, <<"store">> => Store }
+                                    }
+                                }
+                            ||
+                                Subpath <- Subpaths,
+                                Subpath =/= <<"ao-types">>
+                            ]
+                        );
+                    _ ->
+                        Values =
+                            maps:from_list([
+                                {hb_util:bin(Subpath), Value}
+                            ||
+                                {Subpath, Value} <- Children
+                            ]),
+                        prepare_typed_values(
+                            Target,
+                            ResolvedFullPath,
+                            Subpaths,
+                            Values,
+                            Store,
+                            Opts
+                        )
+                end,
+            ?event(
+                {completed_read,
+                    {resolved_path, ResolvedFullPath},
+                    {explicit, Msg}
+                }
+            ),
+            {ok, Msg};
+        {error, _} = Error ->
+            Error;
+        {failure, _} = Failure ->
+            Failure
     end.
 
-%% @doc Prepare lazy links without touching typed codec helpers. Used in
-%% circumstances where codec devices have not yet been loaded.
-prepare_raw_links(RootPath, Subpaths, Store) ->
-    maps:from_list(
-        [
-            {
-                Subpath,
-                {link,
-                    hb_path:to_binary([RootPath, Subpath]),
-                    #{ <<"lazy">> => true, <<"store">> => Store }
-                }
-            }
-        ||
-            Subpath <- Subpaths,
-            Subpath =/= <<"ao-types">>
-        ]
-    ).
+%% @doc Normalize a composite child entry to its subpath name, dropping any
+%% inline value the prefix read supplied alongside it.
+child_name({Subpath, _Value}) -> Subpath;
+child_name(Subpath) -> Subpath.
 
-%% @doc Prepare typed links using `ao-types' and commitment normalization.
-prepare_typed_links(Target, RootPath, Subpaths, Store, Opts) ->
-    {ok, Implicit, Types} = read_ao_types(RootPath, Subpaths, Store, Opts),
+cache_row_value(<<"data/", _/binary>>, Value) -> Value;
+cache_row_value(_Path, <<"raw:", Value/binary>>) -> Value;
+cache_row_value(_Path, Value) -> Value.
+
+%% @doc Prepare typed values using `ao-types'. Small values supplied inline by
+%% the prefix read are decoded directly; larger values and nested messages are
+%% returned as lazy links to their subpaths.
+prepare_typed_values(Target, RootPath, Subpaths, Values, Store, Opts) ->
+    {ok, Implicit, Types} = read_ao_types(RootPath, Subpaths, Values, Store, Opts),
     Res =
         maps:from_list(lists:filtermap(
             fun(<<"ao-types">>) -> false;
                 (<<"commitments">>) ->
                     % List the commitments for this message, and load them into
                     % memory. If there no commitments at the path, we exclude
-                    % commitments from the list of links.
-                    CommPath = hb_path:to_binary([RootPath, <<"commitments">>, Target]),
+                    % commitments from the list of links. The `commitments' key is
+                    % itself a link to the hashpath-addressed commitments group.
+                    % The composite read already returned that link inline, so
+                    % when it is present we address the commitment straight from
+                    % the resolved group, skipping the redundant re-reads of
+                    % `RootPath' and `RootPath/commitments' that the scan just
+                    % materialised. Only when the inline value is absent (or is
+                    % not the usual link) do we fall back to resolving the full
+                    % `RootPath/commitments/Target' path from scratch.
+                    CommPath =
+                        case maps:get(<<"commitments">>, Values, none) of
+                            <<"link:", CommGroup/binary>> when byte_size(CommGroup) > 0 ->
+                                hb_path:to_binary([CommGroup, Target]);
+                            _ ->
+                                hb_path:to_binary(
+                                    [RootPath, <<"commitments">>, Target])
+                        end,
                     ?event(read_commitment,
                         {reading_commitment,
                             {target, Target},
@@ -689,7 +843,7 @@ prepare_typed_links(Target, RootPath, Subpaths, Store, Opts) ->
                     ),
                     case do_read_commitment(CommPath, Opts) of
                         {ok, Commitment} ->
-                            LoadedCommitment = 
+                            LoadedCommitment =
                                 ensure_all_loaded(
                                     Commitment,
                                     Opts#{ <<"commitment">> => true }
@@ -724,35 +878,38 @@ prepare_typed_links(Target, RootPath, Subpaths, Store, Opts) ->
                             % The key is a literal value, not a nested composite
                             % message. Subsequently, we return a resolvable link
                             % to the subpath, leaving the key as-is.
-                            {true,
-                                {
-                                    Subpath,
-                                    {link,
-                                        SubkeyPath,
-                                        (case Types of
-                                            #{ Subpath := Type } ->
-                                                % We have an `ao-types' entry for the
-                                                % subpath, so we return a link to the
-                                                % subpath with `lazy' set to `true'
-                                                % because we need to resolve the link
-                                                % to get the final value.
-                                                #{
-                                                    <<"type">> => Type,
-                                                    <<"lazy">> => true
-                                                };
+                            LinkOpts =
+                                (case Types of
+                                    #{ Subpath := Type } ->
+                                        % We have an `ao-types' entry for the
+                                        % subpath, so the link carries its type
+                                        % and resolves lazily to the final value.
+                                        #{
+                                            <<"type">> => Type,
+                                            <<"lazy">> => true
+                                        };
+                                    _ ->
+                                        % No `ao-types' entry: the subpath is a
+                                        % literal value, resolved lazily.
+                                        #{
+                                            <<"lazy">> => true
+                                        }
+                                end)#{ <<"store">> => Store },
+                            PreparedValue =
+                                case maps:get(Subpath, Values, none) of
+                                    <<"raw:", DirectValue/binary>> ->
+                                        case LinkOpts of
+                                            #{ <<"type">> := DirectType } ->
+                                                hb_util:decode(DirectType, DirectValue);
                                             _ ->
-                                                % We do not have an `ao-types' entry for the
-                                                % subpath, so we return a link to the
-                                                % subpath with `lazy' set to `true',
-                                                % because the subpath is a literal
-                                                % value.
-                                                #{
-                                                    <<"lazy">> => true
-                                                }
-                                        end)#{ <<"store">> => Store }
-                                    }
-                                }
-                            };
+                                                DirectValue
+                                        end;
+                                    <<"link:", Path/binary>> ->
+                                        {link, Path, LinkOpts};
+                                    _ ->
+                                        {link, SubkeyPath, LinkOpts}
+                                end,
+                            {true, {Subpath, PreparedValue}};
                         true ->
                             % The key is an encoded link, so we create a resolvable
                             % link to the underlying link. This requires that we
@@ -775,8 +932,7 @@ prepare_typed_links(Target, RootPath, Subpaths, Store, Opts) ->
         )),
     Merged = maps:merge(Res, Implicit),
     % Convert the message to an ordered list if the ao-types indicate that it
-    % should be so. If it is a message, we ensure that the commitments are 
-    % normalized (have an unsigned comm. ID) and loaded into memory.
+    % should be so.
     case hb_maps:get(<<".">>, Types, undefined, Opts) of
         <<"list">> ->
             hb_util:message_to_ordered_list(Merged, Opts);
@@ -788,13 +944,26 @@ prepare_typed_links(Target, RootPath, Subpaths, Store, Opts) ->
     end.
 
 %% @doc Read and parse the ao-types for a given path if it is in the supplied
-%% list of subpaths, returning a map of keys and their types.
-read_ao_types(Path, Subpaths, Store, Opts) ->
+%% list of subpaths, returning a map of keys and their types. The composite
+%% read already returns the `ao-types' value alongside every other child, so we
+%% reuse it from `Values' when present and only fall back to a dedicated store
+%% read for the per-key (non-prefix) path.
+read_ao_types(Path, Subpaths, Values, Store, Opts) ->
     ?event_debug({reading_ao_types, {path, Path}, {subpaths, {explicit, Subpaths}}}),
     case lists:member(<<"ao-types">>, Subpaths) of
         true ->
-            {ok, TypesBin} =
-                hb_store:read(Store, hb_path:to_binary([Path, <<"ao-types">>]), Opts),
+            TypesBin =
+                case Values of
+                    #{ <<"ao-types">> := <<"raw:", Direct/binary>> } ->
+                        % The composite read already supplied the small inline
+                        % value, so we use it directly. Larger (`link:') values
+                        % fall through to a dedicated read that follows the link.
+                        Direct;
+                    _ ->
+                        TypesPath = hb_path:to_binary([Path, <<"ao-types">>]),
+                        {ok, Bin} = hb_store:read(Store, TypesPath, Opts),
+                        cache_row_value(TypesPath, Bin)
+                end,
             Types = structured_decode_types(TypesBin, Opts),
             ?event_debug({parsed_ao_types, {types, Types}}),
             {ok, types_to_implicit(Types), Types};
@@ -1158,19 +1327,13 @@ test_match_linked_message(Store) ->
     {ok, [MatchedID]} = match(#{ <<"b">> => <<"c">> }, Opts),
     {ok, Read1} = read(MatchedID, Opts),
     ?assertEqual(
-        hb_message:normalize_commitments(
-            #{ <<"b">> => <<"c">>, <<"d">> => <<"e">> },
-            Opts
-        ),
+        #{ <<"b">> => <<"c">>, <<"d">> => <<"e">> },
         hb_cache:ensure_all_loaded(Read1, Opts)
     ),
     {ok, [MatchedID2]} = match(#{ <<"a">> => Inner }, Opts),
     {ok, Read2} = read(MatchedID2, Opts),
     ?assertEqual(
-        hb_message:normalize_commitments(
-            #{ <<"a">> => Inner },
-            Opts
-        ),
+        #{ <<"a">> => Inner },
         ensure_all_loaded(Read2, Opts)
     ).
 
@@ -1193,13 +1356,13 @@ test_match_typed_message(Store) ->
     {ok, [MatchedID]} = match(#{ <<"int-key">> => 1337 }, Opts),
     {ok, Read1} = read(MatchedID, Opts),
     ?assertEqual(
-        hb_message:normalize_commitments(Msg, Opts),
+        Msg,
         ensure_all_loaded(Read1, Opts)
     ),
     {ok, [MatchedID2]} = match(#{ <<"atom-key">> => atom }, Opts),
     {ok, Read2} = read(MatchedID2, Opts),
     ?assertEqual(
-        hb_message:normalize_commitments(Msg, Opts),
+        Msg,
         ensure_all_loaded(Read2, Opts)
     ).
 

--- a/src/core/resolver/hb_cache.erl
+++ b/src/core/resolver/hb_cache.erl
@@ -322,10 +322,14 @@ write_message_ops(Bin, Opts) when is_binary(Bin) ->
     Path = generate_binary_path(Bin, Opts),
     {ok, Path, [{write, Path, Bin}]};
 write_message_ops(List, Opts) when is_list(List) ->
-    write_message_ops(hb_message:convert(List, tabm, <<"structured@1.0">>, Opts), Opts);
+    write_message_ops(
+        hb_message:convert(List, tabm, <<"structured@1.0">>, Opts),
+        Opts
+    );
 write_message_ops(Msg, Opts) when is_map(Msg) ->
     ?event_debug(debug_cache, {writing_message, Msg}),
-    UncommittedID = hb_message:id(Msg, none, Opts#{ <<"linkify-mode">> => discard }),
+    UncommittedID =
+        hb_message:id(Msg, none, Opts#{ <<"linkify-mode">> => discard }),
     AllIDs = calculate_all_ids(Msg, UncommittedID, Opts),
     AltIDs = AllIDs -- [UncommittedID],
     MsgHashpathAlg = hb_path:hashpath_alg(Msg, Opts),
@@ -592,15 +596,13 @@ commitment_path(Base, Opts) ->
 %% @doc Calculate the IDs for a message.
 calculate_all_ids(Bin, _UncommittedID, _Opts) when is_binary(Bin) -> [];
 calculate_all_ids(Msg, UncommittedID, Opts) ->
-    Commitments =
-        hb_maps:without(
-            [<<"priv">>],
+    CommIDs = 
+        hb_maps:keys(
             hb_maps:get(<<"commitments">>, Msg, #{}, Opts),
-			Opts
+            Opts
         ),
-    CommIDs = hb_maps:keys(Commitments, Opts),
-    ?event_debug({calculating_ids, {msg, Msg}, {commitments, Commitments}, {comm_ids, CommIDs}}),
-    case hb_maps:size(Commitments, Opts) of
+    ?event_debug({calculating_ids, {msg, Msg}, {comm_ids, CommIDs}}),
+    case length(CommIDs) of
         0 ->
             % With no commitments the `all' id is the uncommitted id we already
             % computed; skip re-serializing the message to recompute it.
@@ -738,10 +740,7 @@ read_resolved_path(Target, ResolvedFullPath, Store, Opts) ->
             ?event_debug({reading_composite, ResolvedFullPath}),
             Subpaths =
                 [
-                    case Child of
-                        {Subpath, _Value} -> hb_util:bin(Subpath);
-                        Subpath -> hb_util:bin(Subpath)
-                    end
+                    hb_util:bin(child_name(Child))
                 ||
                     Child <- Children
                 ],

--- a/src/core/store/hb_store.erl
+++ b/src/core/store/hb_store.erl
@@ -79,7 +79,7 @@
 -define(STORE_BENCH_LIST_GROUP_SIZE, 10).
 -define(STORE_BENCH_LIST_OPS, 20_000).
 -define(BENCH_MSG_WRITE_OPS, 250).
--define(BENCH_MSG_READ_OPS, 250).
+-define(BENCH_MSG_READ_OPS, 100_000).
 -define(BENCH_MSG_DATA_SIZE, 1024).
 
 behavior_info(callbacks) ->

--- a/src/core/store/hb_store.erl
+++ b/src/core/store/hb_store.erl
@@ -29,8 +29,11 @@
 %%%                   if it is a `simple' value, or a message if it is a complex
 %%%                   term, using a request map of the form `#{<<"read">> => Path}`.
 %%%     write/3:      Write a request map of the form `#{Path => Value}`.
-%%%     list/3:       For `composite' type keys, return a list of child keys
-%%%                   using a request map of the form `#{<<"list">> => Path}`.
+%%%     list/3:       For `composite' type keys, return child keys using a
+%%%                   request map of the form `#{<<"list">> => Path}`.
+%%%                   Composite read results may also return children as
+%%%                   `{Key, Value}' pairs when the store can provide a child
+%%%                   value without an additional read.
 %%% '''
 %%% Each function takes a `store' message first, containing an arbitrary set
 %%% of its necessary configuration keys, as well as the `store-module' key which
@@ -1083,29 +1086,9 @@ benchmark_message_read_write(Store, WriteOps, ReadOps) ->
         timer:tc(
             fun() ->
                 lists:foldl(
-                    fun({MsgID, Msg}, Count) -> 
-                        NormalizedMsg =
-                            hb_cache:ensure_all_loaded(
-                                hb_message:normalize_commitments(Msg, Opts),
-                                Opts
-                            ),
+                    fun({MsgID, _Msg}, Count) ->
                         case hb_cache:read(MsgID, Opts) of
-                            {ok, CacheMsg} ->
-                                NormalizedCacheMsg = 
-                                    hb_message:normalize_commitments(
-                                        hb_cache:read_all_commitments(
-                                            hb_cache:ensure_all_loaded(
-                                                CacheMsg,
-                                                Opts
-                                            ),
-                                            Opts
-                                        ),
-                                        Opts
-                                    ),
-                                case NormalizedCacheMsg of
-                                    NormalizedMsg -> Count;
-                                    _ -> Count + 1
-                                end;
+                            {ok, _CacheMsg} -> Count;
                             _ -> Count + 1
                         end
                     end,

--- a/src/core/store/hb_store_lmdb.erl
+++ b/src/core/store/hb_store_lmdb.erl
@@ -200,17 +200,31 @@ read(Opts, #{ <<"read">> := Path }, _NodeOpts) ->
 %% reached through an intermediate link) falls through to the resolver.
 read_result(Opts, Path) ->
     EnvOpts = ensure_env(Opts),
-    case read_prefix_rows(EnvOpts, Path) of
-        {ok, Rows} ->
-            case prefix_read_result(EnvOpts, Path, Rows) of
-                {error, not_found} -> read_prefix_miss(EnvOpts, Path);
-                Result -> Result
-            end;
-        not_found ->
-            read_prefix_miss(EnvOpts, Path);
-        {error, _} = Error ->
-            Error
-    end.
+    StartTime = erlang:monotonic_time(),
+    Result = 
+        case read_prefix_rows(EnvOpts, Path) of
+            {ok, Rows} ->
+                case prefix_read_result(EnvOpts, Path, Rows) of
+                    {error, not_found} -> read_prefix_miss(EnvOpts, Path);
+                    R -> R
+                end;
+            not_found ->
+                read_prefix_miss(EnvOpts, Path);
+            {error, _} = Error ->
+                Error;
+            {error, Type, _} ->
+                {error, Type}
+        end,
+    MetricStatus = 
+        case Result of
+            {ok, _} -> hit;
+            {composite, _} -> hit;
+            {error, not_found} -> miss;
+            not_found -> miss;
+            _ -> unknown
+        end,
+    sample_metrics(EnvOpts, StartTime, MetricStatus),
+    Result.
 
 %% The literal `Path' was not present in the scan. Resolve any intermediate
 %% links in the path and, if that yields a different key, retry the read against
@@ -753,7 +767,8 @@ sample_metrics(Name, StartTime, Type) ->
     hb_prometheus:observe(ReadTime, hb_store_lmdb_duration_seconds, [read, Name]),
     case Type of
         hit -> hb_prometheus:inc(counter, hb_store_lmdb_hit, [Name], 1024);
-        miss -> ok
+        miss -> ok;
+        error -> ok
     end.
 
 init_prometheus() ->

--- a/src/core/store/hb_store_lmdb.erl
+++ b/src/core/store/hb_store_lmdb.erl
@@ -109,7 +109,12 @@ ensure_dir(DataDirPath) ->
 %% @returns `{ok, composite}` for group entries, `{ok, simple}` for regular
 %%          values, or `{error, not_found}`.
 type(Opts, #{ <<"type">> := Key }, _NodeOpts) ->
-    case read_resolved(Opts, hb_path:to_binary(Key)) of
+    KeyBin =
+        case is_binary(Key) of
+            true -> Key;
+            false -> hb_path:to_binary(Key)
+        end,
+    case read_resolved(Opts, KeyBin) of
         {ok, _ResolvedKey, <<"group">>} -> {ok, composite};
         {ok, _ResolvedKey, _Value} -> {ok, simple};
         not_found -> {error, not_found}
@@ -135,7 +140,9 @@ write(#{ <<"read-only">> := true }, _Req, _NodeOpts) when is_map(_Req) ->
     {error, not_found};
 write(Opts, Req, _NodeOpts) when is_map(Req) ->
     maps:fold(
-        fun(Path, Value, ok) ->
+        fun(Path, Value, ok) when is_binary(Path) ->
+            write(Opts, Path, Value);
+           (Path, Value, ok) ->
             write(Opts, hb_path:to_binary(Path), Value);
            (_Path, _Value, Error) ->
             Error
@@ -181,19 +188,74 @@ write(Opts, Path, Value) ->
 %% @param PathReq Request of the form `#{<<"read">> => Path}`.
 %% @returns `{ok, Value}` on success, `{composite, Keys}` for groups, or
 %%          `{error, not_found}` on failure
+read(Opts, #{ <<"read">> := Path }, _NodeOpts) when is_binary(Path) ->
+    read_result(Opts, Path);
 read(Opts, #{ <<"read">> := Path }, _NodeOpts) ->
-    case read_resolved(Opts, hb_path:to_binary(Path)) of
-        {ok, ResolvedPath, <<"group">>} ->
-            {composite, hb_util:ok(list_children(Opts, ResolvedPath))};
-        {ok, _ResolvedPath, Value} ->
-            {ok, Value};
+    read_result(Opts, hb_path:to_binary(Path)).
+
+%% A single `read_prefix' over the bare `Path' (no trailing slash) returns the
+%% marker row (key == `Path') alongside every descendant in one cursor scan, so
+%% the marker that classifies the entry — value, link, or group — arrives in the
+%% same seek as the children. Only a genuine miss (the key is absent and must be
+%% reached through an intermediate link) falls through to the resolver.
+read_result(Opts, Path) ->
+    EnvOpts = ensure_env(Opts),
+    case read_prefix_rows(EnvOpts, Path) of
+        {ok, Rows} ->
+            case prefix_read_result(EnvOpts, Path, Rows) of
+                {error, not_found} -> read_prefix_miss(EnvOpts, Path);
+                Result -> Result
+            end;
         not_found ->
-            {error, not_found}
+            read_prefix_miss(EnvOpts, Path);
+        {error, _} = Error ->
+            Error
+    end.
+
+%% The literal `Path' was not present in the scan. Resolve any intermediate
+%% links in the path and, if that yields a different key, retry the read against
+%% the resolved target. Content-addressed `data' keys never carry links, so they
+%% short-circuit straight to `not_found' without a resolver walk.
+read_prefix_miss(Opts, Path) ->
+    case is_data_path(Path) of
+        true ->
+            {error, not_found};
+        false ->
+            try
+                PathParts = binary:split(Path, <<"/">>, [global, trim_all]),
+                case resolve_path_links(Opts, PathParts) of
+                    {ok, ResolvedPathParts} ->
+                        case to_path(ResolvedPathParts) of
+                            Path -> {error, not_found};
+                            ResolvedPath -> read_result(Opts, ResolvedPath)
+                        end;
+                    {error, _} ->
+                        {error, not_found}
+                end
+            catch
+                Class:Reason:Stacktrace ->
+                    ?event(error,
+                        {
+                            resolve_path_links_failed,
+                            {class, Class},
+                            {reason, Reason},
+                            {stacktrace, {trace, Stacktrace}},
+                            {path, Path}
+                        }
+                    ),
+                    {error, not_found}
+            end
     end.
 
 read_resolved(#{<<"name">> := Name} = Opts, Path) ->
+    EnvOpts = ensure_env(Opts),
+    PathBin =
+        case is_binary(Path) of
+            true -> Path;
+            false -> hb_path:to_binary(Path)
+        end,
     StartTime = erlang:monotonic_time(),
-    case do_read_resolved(Opts, hb_path:to_binary(Path)) of
+    case do_read_resolved(EnvOpts, PathBin) of
         {ok, _ResolvedPath, _Value} = Result ->
             sample_metrics(Name, StartTime, hit),
             Result;
@@ -207,45 +269,41 @@ do_read_resolved(Opts, Path) ->
         {ok, _ResolvedPath, _Value} = Result ->
             Result;
         not_found ->
-            try
-                PathParts = binary:split(Path, <<"/">>, [global, trim_all]),
-                case resolve_path_links(Opts, PathParts) of
-                    {ok, ResolvedPathParts} ->
-                        read_with_links(Opts, to_path(ResolvedPathParts));
-                    {error, _} ->
-                        not_found
-                end
-            catch
-                Class:Reason:Stacktrace ->
-                    ?event(error,
-                        {
-                            resolve_path_links_failed, 
-                            {class, Class},
-                            {reason, Reason},
-                            {stacktrace, {trace, Stacktrace}},
-                            {path, Path}
-                        }
-                    ),
-                    not_found
+            case Path of
+                <<"data">> ->
+                    not_found;
+                <<"data/", _/binary>> ->
+                    not_found;
+                _ ->
+                    try
+                        PathParts = binary:split(Path, <<"/">>, [global, trim_all]),
+                        case resolve_path_links(Opts, PathParts) of
+                            {ok, ResolvedPathParts} ->
+                                read_with_links(Opts, to_path(ResolvedPathParts));
+                            {error, _} ->
+                                not_found
+                        end
+                    catch
+                        Class:Reason:Stacktrace ->
+                            ?event(error,
+                                {
+                                    resolve_path_links_failed,
+                                    {class, Class},
+                                    {reason, Reason},
+                                    {stacktrace, {trace, Stacktrace}},
+                                    {path, Path}
+                                }
+                            ),
+                            not_found
+                    end
             end
     end.
 
 %% @doc Helper function to check if a value is a link and extract the target.
-is_link(Value) ->
-    LinkPrefixSize = byte_size(<<"link:">>),
-    case byte_size(Value) > LinkPrefixSize andalso
-        binary:part(Value, 0, LinkPrefixSize) =:= <<"link:">> of
-        true -> 
-            Link =
-                binary:part(
-                    Value,
-                    LinkPrefixSize,
-                    byte_size(Value) - LinkPrefixSize
-                ),
-            {true, Link};
-        false ->
-            false
-    end.
+is_link(<<"link:", Link/binary>>) when byte_size(Link) > 0 ->
+    {true, Link};
+is_link(_) ->
+    false.
 
 %% @doc Helper function to convert to a path
 to_path(PathParts) ->
@@ -255,8 +313,15 @@ to_path(PathParts) ->
 %% in-process pending writes, if necessary.
 %%
 %% Returns `{ok, Value}` or `not_found`.
+read_direct(#{<<"db">> := DBInstance, <<"name">> := Name}, Path) ->
+    read_direct(DBInstance, Name, Path);
+read_direct(#{<<"db">> := DBInstance}, Path) ->
+    read_direct(DBInstance, undefined, Path);
 read_direct(#{<<"name">> := Name} = Opts, Path) ->
     #{ <<"db">> := DBInstance } = find_env(Opts),
+    read_direct(DBInstance, Name, Path).
+
+read_direct(DBInstance, Name, Path) ->
     case elmdb:get(DBInstance, Path) of
         {ok, Value} -> {ok, Value};
         {error, not_found} -> not_found;
@@ -281,6 +346,15 @@ read_direct(#{<<"name">> := Name} = Opts, Path) ->
 %% This is the internal implementation that handles actual database reads.
 read_with_links(Opts, Path) ->
     case read_direct(Opts, Path) of
+        {ok, <<"raw:", Value/binary>>} ->
+            case is_data_path(Path) of
+                true -> {ok, Path, <<"raw:", Value/binary>>};
+                false -> {ok, Path, Value}
+            end;
+        {ok, <<"link:data">>} ->
+            read_with_links(Opts, <<"data">>);
+        {ok, <<"link:data/", Link/binary>>} ->
+            read_with_links(Opts, <<"data/", Link/binary>>);
         {ok, Value} ->
             case is_link(Value) of
                 {true, Link} -> 
@@ -291,6 +365,10 @@ read_with_links(Opts, Path) ->
         not_found ->
             not_found
     end.
+
+is_data_path(<<"data">>) -> true;
+is_data_path(<<"data/", _/binary>>) -> true;
+is_data_path(_) -> false.
 
 %% @doc Resolve links in a path, checking each segment except the last.
 %% Returns the resolved path where any intermediate links have been followed.
@@ -377,9 +455,15 @@ scope(_) -> scope().
 %% @param Path Binary prefix to search for
 %% @returns {ok, [Key]} list of matching keys, {error, Reason} on failure
 list(Opts, #{ <<"list">> := Path }, _NodeOpts) ->
-    case read_resolved(Opts, hb_path:to_binary(Path)) of
+    EnvOpts = ensure_env(Opts),
+    PathBin =
+        case is_binary(Path) of
+            true -> Path;
+            false -> hb_path:to_binary(Path)
+        end,
+    case read_resolved(EnvOpts, PathBin) of
         {ok, ResolvedPath, <<"group">>} ->
-            list_children(Opts, ResolvedPath);
+            list_children(EnvOpts, ResolvedPath);
         {ok, _ResolvedPath, _Value} ->
             {error, not_found};
         not_found ->
@@ -387,22 +471,76 @@ list(Opts, #{ <<"list">> := Path }, _NodeOpts) ->
     end.
 
 list_children(Opts, ResolvedPath) ->
-    SearchPath = 
-        case ResolvedPath of
-            <<>> -> <<>>;
-            <<"/">> -> <<>>;
-            _ -> 
-                case binary:last(ResolvedPath) of
-                    $/ -> ResolvedPath;
-                    _ -> <<ResolvedPath/binary, "/">>
-                end
-        end,
+    SearchPath = child_prefix(ResolvedPath),
     % Use native elmdb:list function
     #{ <<"db">> := DBInstance } = find_env(Opts),
     case elmdb:list(DBInstance, SearchPath) of
         {ok, Children} -> {ok, Children};
         {error, not_found} -> {ok, []};
         not_found -> {ok, []}
+    end.
+
+read_prefix_rows(Opts, Path) ->
+    #{ <<"db">> := DBInstance } = find_env(Opts),
+    case elmdb:read_prefix(DBInstance, Path) of
+        {ok, Rows} -> {ok, Rows};
+        {error, not_found} -> not_found;
+        not_found -> not_found;
+        {error, _Type, _Description} = Error -> Error
+    end.
+
+%% Classify the first (marker) row of a bare-prefix scan. `read_prefix' returns
+%% keys in lexicographic order, so the row whose key equals `Path' — when it
+%% exists — always sorts ahead of the `Path/...' descendants and lands first.
+%% A `link:' marker chases its target, a `group' marker becomes a composite of
+%% its immediate children, and any other marker is a simple value. When no
+%% marker row is present the path is an implicit group: its descendants (if any)
+%% still resolve to a composite, otherwise the read is a miss.
+prefix_read_result(Opts, Path, [{Path, <<"link:", Link/binary>>} | _])
+        when byte_size(Link) > 0 ->
+    read_result(Opts, Link);
+prefix_read_result(_Opts, Path, [{Path, <<"raw:", Value/binary>>} | _]) ->
+    case is_data_path(Path) of
+        true -> {ok, <<"raw:", Value/binary>>};
+        false -> {ok, Value}
+    end;
+prefix_read_result(_Opts, Path, [{Path, <<"group">>} | Rows]) ->
+    {composite, immediate_children(child_prefix(Path), Rows)};
+prefix_read_result(_Opts, Path, [{Path, Value} | _]) ->
+    {ok, Value};
+prefix_read_result(_Opts, Path, Rows) ->
+    case {is_data_path(Path), immediate_children(child_prefix(Path), Rows)} of
+        {false, [_ | _] = Children} -> {composite, Children};
+        _ -> {error, not_found}
+    end.
+
+%% `elmdb:read_prefix' returns every descendant row (full key) under the prefix.
+%% Reduce that to the immediate children: strip the prefix and drop any relative
+%% key that still contains a `/' (a grandchild reached only through a subgroup,
+%% whose own `group' marker is returned as an immediate child in its own right).
+immediate_children(Prefix, Rows) ->
+    PrefixSize = byte_size(Prefix),
+    lists:filtermap(
+        fun({Key, Value}) ->
+            case Key of
+                <<Prefix:PrefixSize/binary, Child/binary>> when Child =/= <<>> ->
+                    case binary:match(Child, <<"/">>) of
+                        nomatch -> {true, {Child, Value}};
+                        _ -> false
+                    end;
+                _ ->
+                    false
+            end
+        end,
+        Rows
+    ).
+
+child_prefix(<<>>) -> <<>>;
+child_prefix(<<"/">>) -> <<>>;
+child_prefix(Path) ->
+    case binary:last(Path) of
+        $/ -> Path;
+        _ -> <<Path/binary, "/">>
     end.
 
 %% @doc Match a series of keys and values against the database. Returns 
@@ -413,22 +551,22 @@ match(Opts, MatchMap, _NodeOpts) when is_map(MatchMap) ->
     match(Opts, maps:to_list(MatchMap), #{});
 match(Opts, MatchKVs, _NodeOpts) ->
     #{ <<"db">> := DBInstance } = find_env(Opts),
-    WithPrefixes =
+    Patterns =
         lists:map(
-            fun({Key, Path}) ->
-                {Key, <<"link:", Path/binary>>}
-            end,
+            fun({Key, Value}) -> {Key, hb_util:bin(Value)} end,
             MatchKVs
         ),
     ?event_debug({elmdb_match, MatchKVs}),
-    case elmdb:match(DBInstance, WithPrefixes) of
+    match_patterns(DBInstance, Patterns).
+
+match_patterns(DBInstance, Patterns) ->
+    case elmdb:match(DBInstance, Patterns) of
         {ok, Matches} ->
             ?event_debug({elmdb_matched, Matches}),
             {ok, Matches};
         {error, not_found} -> {error, not_found};
         not_found -> {error, not_found}
     end.
-
 
 %% @doc Create a group entry that can contain other keys hierarchically.
 %%
@@ -447,7 +585,10 @@ match(Opts, MatchKVs, _NodeOpts) ->
 %% @param GroupName Binary name for the group
 %% @returns Result of the write operation
 group(Opts, #{ <<"group">> := GroupName }, _NodeOpts) ->
-    write(Opts, hb_path:to_binary(GroupName), <<"group">>).
+    case is_binary(GroupName) of
+        true -> write(Opts, GroupName, <<"group">>);
+        false -> write(Opts, hb_path:to_binary(GroupName), <<"group">>)
+    end.
 
 %% @doc Ensure all parent groups exist for a given path.
 %%
@@ -458,34 +599,45 @@ group(Opts, #{ <<"group">> := GroupName }, _NodeOpts) ->
 %% @param Opts Database configuration map
 %% @param Path The path whose parents should exist
 %% @returns ok
--spec ensure_parent_groups(map(), binary()) -> ok.
-ensure_parent_groups(Opts, Path) ->
-    PathParts = binary:split(Path, <<"/">>, [global]),
-    case PathParts of
-        [_] -> 
-            % Single segment, no parents to create
-            ok;
-        _ ->
-            % Multiple segments, create parent groups
-            ParentParts = lists:droplast(PathParts),
-            create_parent_groups(Opts, [], ParentParts)
+-spec ensure_parent_groups(map(), binary() | [binary()]) -> ok.
+ensure_parent_groups(Opts, Path) when is_binary(Path) ->
+    ensure_parent_groups(Opts, [Path]);
+ensure_parent_groups(Opts, Paths) when is_list(Paths) ->
+    % Collect the unique set of ancestor group paths across all of the given
+    % paths, then create each at most once: a single existence check and write
+    % per group for the whole batch, rather than once per path. Links that share
+    % ancestors (e.g. every key of a message under its id) thus pay for their
+    % parent groups only once.
+    Groups =
+        lists:usort(
+            lists:foldl(
+                fun(Path, Acc) -> parent_group_paths(Path, Acc) end,
+                [],
+                Paths
+            )
+        ),
+    lists:foreach(
+        fun(GroupPath) ->
+            case read_direct(Opts, GroupPath) of
+                not_found -> write(Opts, GroupPath, <<"group">>);
+                {ok, _} -> ok
+            end
+        end,
+        Groups
+    ).
+
+%% @doc Collect the ancestor group paths of a single path onto an accumulator.
+parent_group_paths(Path, Acc) ->
+    case binary:split(Path, <<"/">>, [global]) of
+        [_] -> Acc;
+        Parts -> prefix_group_paths(lists:droplast(Parts), [], Acc)
     end.
 
-%% @doc Helper function to recursively create parent groups.
-create_parent_groups(_Opts, _Current, []) ->
-    ok;
-create_parent_groups(Opts, Current, [Next | Rest]) ->
+prefix_group_paths([], _Current, Acc) ->
+    Acc;
+prefix_group_paths([Next | Rest], Current, Acc) ->
     NewCurrent = Current ++ [Next],
-    GroupPath = to_path(NewCurrent),
-    % Only create group if it doesn't already exist.
-    case read_direct(Opts, GroupPath) of
-        not_found ->
-            write(Opts, GroupPath, <<"group">>);
-        {ok, _} ->
-            % Already exists, skip
-            ok
-    end,
-    create_parent_groups(Opts, NewCurrent, Rest).
+    prefix_group_paths(Rest, NewCurrent, [to_path(NewCurrent) | Acc]).
 
 %% @doc Create a symbolic link from a new key to an existing key.
 %%
@@ -508,15 +660,22 @@ create_parent_groups(Opts, Current, [Next | Rest]) ->
 %% @param New The new key that should link to the existing key
 %% @returns Result of the write operation
 link(Opts, Req, _NodeOpts) when is_map(Req) ->
-    maps:fold(
-        fun(New, Existing, ok) ->
-            link(Opts, hb_path:to_binary(Existing), hb_path:to_binary(New));
-           (_New, _Existing, Error) ->
-            Error
-        end,
-        ok,
-        Req
-    );
+    % Resolve every link to a binary `New => "link:Existing"' value. The parent
+    % groups of all the links are created once for the whole batch (de-duplicated
+    % across links that share ancestors) rather than re-checked for every link.
+    Links =
+        maps:fold(
+            fun(New, Existing, Acc) ->
+                Acc#{
+                    hb_path:to_binary(New) =>
+                        <<"link:", (hb_path:to_binary(Existing))/binary>>
+                }
+            end,
+            #{},
+            Req
+        ),
+    ensure_parent_groups(Opts, maps:keys(Links)),
+    write(Opts, Links, #{});
 link(#{ <<"read-only">> := true }, _Existing, _New) ->
     {error, not_found};
 link(Opts, Existing, New) when is_list(Existing) ->
@@ -545,7 +704,11 @@ resolve(Opts, #{ <<"resolve">> := Path }, _NodeOpts) ->
     end.
 
 %% @doc Retrieve or create the LMDB environment handle for a database.
+find_env(Opts = #{ <<"db">> := _ }) -> Opts;
 find_env(Opts) -> hb_store:find(Opts).
+
+ensure_env(Opts = #{ <<"db">> := _ }) -> Opts;
+ensure_env(Opts) -> maps:merge(Opts, find_env(Opts)).
 
 %% Shutdown LMDB environment and cleanup resources
 stop(#{ <<"store-module">> := ?MODULE, <<"name">> := DataDir }, _Req, _Opts) ->
@@ -1065,4 +1228,39 @@ list_with_link_test() ->
     {ok, LinkChildren} = test_list(StoreOpts, <<"link-to-group">>),
     ?event_debug({link_children, LinkChildren}),
     ?assertEqual(ExpectedChildren, lists:sort(LinkChildren)),
+    test_stop(StoreOpts).
+
+read_prefix_composite_test() ->
+    StoreOpts = hb_test_utils:test_store(?MODULE),
+    test_reset(StoreOpts),
+    test_group(StoreOpts, <<"root">>),
+    test_write(StoreOpts, <<"root/a">>, <<"1">>),
+    test_group(StoreOpts, <<"root/b">>),
+    test_write(StoreOpts, <<"root/b/c">>, <<"2">>),
+    ?assertEqual(
+        {composite, [{<<"a">>, <<"1">>}, {<<"b">>, <<"group">>}]},
+        read(StoreOpts, #{ <<"read">> => <<"root">> }, #{})
+    ),
+    ?assertEqual({ok, [<<"a">>, <<"b">>]}, test_list(StoreOpts, <<"root">>)),
+    test_stop(StoreOpts).
+
+raw_value_write_test() ->
+    StoreOpts = hb_test_utils:test_store(?MODULE),
+    test_reset(StoreOpts),
+    ok = group(StoreOpts, #{ <<"group">> => <<"root">> }, #{}),
+    ok =
+        write(
+            StoreOpts,
+            #{
+                <<"data/small">> => <<"value">>,
+                <<"root/small">> => <<"raw:value">>
+            },
+            #{}
+        ),
+    ?assertEqual(
+        {composite, [{<<"small">>, <<"raw:value">>}]},
+        read(StoreOpts, #{ <<"read">> => <<"root">> }, #{})
+    ),
+    ?assertEqual({ok, <<"value">>}, test_read(StoreOpts, <<"root/small">>)),
+    ?assertEqual({ok, <<"value">>}, test_read(StoreOpts, <<"data/small">>)),
     test_stop(StoreOpts).

--- a/src/core/store/hb_store_remote_node.erl
+++ b/src/core/store/hb_store_remote_node.erl
@@ -156,7 +156,7 @@ write(Opts = #{ <<"node">> := Node }, Req, _NodeOpts) when is_map(Req) ->
     ?event({write, {node, Node}, {request, Req}}),
     maps:fold(
         fun(Destination, Value, ok) ->
-            case remote_write_value(Opts, Value) of
+            case remote_write_value(Opts, store_value(Destination, Value)) of
                 {ok, SourcePath} ->
                     remote_link(Opts, hb_path:to_binary(SourcePath), hb_path:to_binary(Destination));
                 {error, _} = Error ->
@@ -168,6 +168,20 @@ write(Opts = #{ <<"node">> := Node }, Req, _NodeOpts) when is_map(Req) ->
         ok,
         Req
     ).
+
+%% @doc The remote node re-content-addresses every written value, so a cache
+%% `raw:' inline marker -- written at a key path -- must be reduced to its
+%% logical value first. Otherwise the marker itself is hashed and stored,
+%% corrupting later reads. `data/' destinations already hold the logical value
+%% (which may itself begin with `raw:'), so they are forwarded verbatim.
+store_value(Destination, <<"raw:", Value/binary>>) when is_binary(Destination) ->
+    case Destination of
+        <<"data">> -> <<"raw:", Value/binary>>;
+        <<"data/", _/binary>> -> <<"raw:", Value/binary>>;
+        _ -> Value
+    end;
+store_value(_Destination, Value) ->
+    Value.
 
 %% @doc Link a source to a destination in the remote node.
 %%

--- a/src/core/test/hb_ao_test_vectors.erl
+++ b/src/core/test/hb_ao_test_vectors.erl
@@ -257,15 +257,18 @@ exec_dummy_device(Opts) ->
                     }
                 ]
         },
-    % Ensure that we can read the device message from the cache and that it matches
-    % the original message.
+    % Ensure that we can read the device message from the cache and that its
+    % content matches the original message.
     {ok, RawReadMsg} = hb_cache:read(ID, Opts),
     ReadMsg =
         hb_cache:ensure_all_loaded(
             hb_cache:read_all_commitments(RawReadMsg, Opts),
             Opts
         ),
-    ?assertEqual(DevMsg, ReadMsg),
+    ?assertEqual(
+        hb_maps:without([<<"commitments">>], DevMsg, Opts),
+        hb_maps:without([<<"commitments">>], ReadMsg, Opts)
+    ),
     % Create a base message with the device spec ID, then request a dummy path from
     % it.
     Req = #{ <<"path">> => <<"echo/param">>, <<"param">> => <<"example">> },

--- a/src/preloaded/codec/dev_httpsig_conv.erl
+++ b/src/preloaded/codec/dev_httpsig_conv.erl
@@ -904,14 +904,17 @@ group_maps_flat_compatible_test() ->
     ok.
 
 encode_message_with_links_test() ->
+    % hb_cache will only linkify the key if it is longer than 60 characters
     Msg = #{
         <<"immediate-key">> => <<"immediate-value">>,
-        <<"typed-key">> => 4
+        <<"long-key">> => binary:copy(<<"a">>, 61),
+        <<"short-key">> => <<"short-value">>
     },
     {ok, Path} = hb_cache:write(Msg, #{}),
     {ok, Read} = hb_cache:read(Path, #{}),
     % Ensure that the message now has a lazy link
-    ?assertMatch({link, _, _}, maps:get(<<"typed-key">>, Read, #{})),
+    ?assertMatch(<<"short-value">>, maps:get(<<"short-key">>, Read, #{})),
+    ?assertMatch({link, _, _}, maps:get(<<"long-key">>, Read, #{})),
     % Encode and decode the message as `httpsig@1.0`
     Enc = hb_message:convert(Msg, <<"httpsig@1.0">>, #{}),
     ?event({encoded, Enc}),

--- a/src/preloaded/process/dev_scheduler_cache.erl
+++ b/src/preloaded/process/dev_scheduler_cache.erl
@@ -85,7 +85,12 @@ read(ProcID, Slot, RawOpts) ->
         {ok, ResolvedPath} ->
             ?event({resolved_path, {p1, P1}, {p2, ResolvedPath}, {resolved, ResolvedPath}}),
             case hb_cache:read(ResolvedPath, Opts) of
-                {ok, Assignment} ->
+                {ok, RawAssignment} ->
+                    % `hb_cache:read' no longer normalizes commitments; the
+                    % scheduler relies on each assignment carrying its unsigned
+                    % commitment ID, so we restore it here.
+                    Assignment =
+                        hb_message:normalize_commitments(RawAssignment, Opts),
                     % If the slot key is not present, the format of the assignment is
                     % AOS2, so we need to convert it to the canonical format.
                     case hb_ao:get(<<"variant">>, Assignment, Opts) of

--- a/src/preloaded/process/dev_scheduler_formats.erl
+++ b/src/preloaded/process/dev_scheduler_formats.erl
@@ -28,20 +28,23 @@ assignments_to_bundle(ProcID, Assignments, More, TimeInfo, RawOpts) ->
         <<"block-height">> => hb_util:int(Height),
         <<"block-hash">> => hb_util:human_id(Hash),
         <<"assignments">> =>
-            hb_maps:from_list(
-                lists:map(
-                    fun(Assignment) ->
-                        {
-                            hb_ao:get(
-                                <<"slot">>,
-                                Assignment,
-                                Opts#{ <<"hashpath">> => ignore }
-                            ),
-                            Assignment
-                        }
-                    end,
-                    Assignments
-                )
+            hb_message:normalize_commitments(
+                hb_maps:from_list(
+                    lists:map(
+                        fun(Assignment) ->
+                            {
+                                hb_ao:get(
+                                    <<"slot">>,
+                                    Assignment,
+                                    Opts#{ <<"hashpath">> => ignore }
+                                ),
+                                Assignment
+                            }
+                        end,
+                        Assignments
+                    )
+                ),
+                Opts
             )
     }}.
 

--- a/src/preloaded/test/hb_codec_test_vectors.erl
+++ b/src/preloaded/test/hb_codec_test_vectors.erl
@@ -651,11 +651,12 @@ verify_nested_complex_signed_test(Codec, Opts) ->
     ?assert(MatchRes),
     ?assert(hb_message:verify(Decoded, all, Opts)),
     % % Ensure that both of the messages can be verified (and retreived).
-    FoundInner =
-        hb_message:normalize_commitments(
-            hb_maps:get(<<"body">>, Msg, not_found, Opts),
-            Opts
-        ),
+    % `hb_cache:read' no longer normalizes commitments, so `hb_maps:get' returns
+    % the inner message exactly as it was signed. Re-normalizing it here would
+    % mint an unsigned commitment for the nested `parameters' submessage -- a key
+    % the outer signature was made over in its uncommitted form -- changing the
+    % signed content and breaking verification. The faithful read needs none.
+    FoundInner = hb_maps:get(<<"body">>, Msg, not_found, Opts),
     LoadedFoundInner = hb_cache:ensure_all_loaded(FoundInner, Opts),
     % Verify that the fully loaded version of the inner message, and the one
     % gained by applying `hb_maps:get` match and verify.


### PR DESCRIPTION
Collapses LMDB message reads into one cursor seek operation followed by sequential neighbor reads, rather than one cursor seek per key read. This is dramatically faster, as LMDB can seek at around 2m ops/sec, but read sequentially at ~400m ops/sec at peak.

Before this PR our message read speed typically stood around 3,000 msgs/s. With this PR we see ~218k msgs/sec consistently. The mechanism used to optimize reads in this PR should also be a viable route for optimizing writes in a subsequent one.