### PR TITLE
fix: header files reflected in device archive source ID

### DIFF
--- a/native/lib/Makefile
+++ b/native/lib/Makefile
@@ -19,6 +19,12 @@ SECP256K1_CMAKE_OPTIONS ?= \
 	-DSECP256K1_ENABLE_MODULE_SCHNORRSIG=OFF \
 	-DSECP256K1_APPEND_CFLAGS=-fPIC
 
+SECP256K1_SOURCE_FILES := $(shell \
+	if [ -d secp256k1/include ] && [ -d secp256k1/src ]; then \
+		find secp256k1/include secp256k1/src \
+			-type f \( -name '*.c' -o -name '*.h' \) -print; \
+	fi)
+
 GIT_SUBMODULE_OPTIONS ?= --checkout --init
 
 PHONY += all
@@ -52,7 +58,7 @@ secp256k1/build/Makefile: secp256k1/build
 	cd secp256k1/build \
 		&& cmake $(SECP256K1_CMAKE_OPTIONS) ..
 
-secp256k1/build/lib/libsecp256k1.a: secp256k1/build/Makefile
+secp256k1/build/lib/libsecp256k1.a: secp256k1/build/Makefile $(SECP256K1_SOURCE_FILES)
 	cd secp256k1/build \
 		&& cmake --build .
 

--- a/native/secp256k1/Makefile
+++ b/native/secp256k1/Makefile
@@ -71,6 +71,11 @@ LIBSECP256K1_STATIC = $(LIBSECP256K1_DIR)/build/lib/libsecp256k1.a
 # Source files
 SECP256K1_SOURCES = $(C_SRC_DIR)/secp256k1_nif.c $(BASEDIR)/native/hb_nif/hb_nif.c
 SECP256K1_OBJECTS = $(C_SRC_DIR)/secp256k1_nif.o $(BASEDIR)/native/hb_nif/hb_nif.o
+SECP256K1_HEADERS = \
+	$(BASEDIR)/native/hb_nif/hb_nif.h \
+	$(LIBSECP256K1_DIR)/include/secp256k1.h \
+	$(LIBSECP256K1_DIR)/include/secp256k1_recovery.h
+HB_NIF_HEADERS = $(BASEDIR)/native/hb_nif/hb_nif.h
 
 # Build up SECP256K1 flags (matching Arweave's pattern)
 SECP256K1_CFLAGS += $(CFLAGS)
@@ -108,10 +113,10 @@ else
 	$(link_verbose) $(CC) $(SECP256K1_OBJECTS) $(LIBSECP256K1_STATIC) -shared $(SECP256K1_LDLIBS) -o $(SECP256K1_OUTPUT)
 endif
 
-%secp256k1_nif.o: %secp256k1_nif.c
+$(C_SRC_DIR)/secp256k1_nif.o: $(C_SRC_DIR)/secp256k1_nif.c $(SECP256K1_HEADERS)
 	$(c_verbose) $(CC) $(SECP256K1_CFLAGS) -c $(OUTPUT_OPTION) $<
 
-%hb_nif.o: %hb_nif.c
+$(BASEDIR)/native/hb_nif/hb_nif.o: $(BASEDIR)/native/hb_nif/hb_nif.c $(HB_NIF_HEADERS)
 	$(c_verbose) $(CC) $(SECP256K1_CFLAGS) -c $(OUTPUT_OPTION) $<
 
 %.o: %.c

--- a/src/forge/hb_packager.erl
+++ b/src/forge/hb_packager.erl
@@ -293,11 +293,16 @@ package_all(Groups, Opts) ->
 package(#{ root := Root, root_file := RootFile, helpers := Helpers,
     files := Files } = Group, Opts) ->
     Libraries = maps:get(libraries, Group, []),
+    Entries = [{Root, RootFile} | Helpers ++ Libraries],
     {_RootForms, RootAttrs} = parse_module(RootFile),
     Implements = derived_or_declared_implements(Root, RootAttrs),
     {SpecBody, SpecContentType} = derive_spec(RootFile, RootAttrs, Opts),
     PrivFiles = priv_files(Root, RootFile),
-    SourceID = source_id(maps:merge(Files, PrivFiles), Opts),
+    SourceID =
+        source_id(
+            maps:merge(maps:merge(Files, PrivFiles), include_source_files(Entries)),
+            Opts
+        ),
     ModName =
         hb_device_name:generated(Implements, source_id_to_hash(SourceID)),
     ?event(
@@ -660,20 +665,31 @@ generated_constituent_module_name(RootMod, Root, Mod) ->
 
 %% @doc Return include dirs needed to compile package sources.
 include_dirs(Entries) ->
+    lists:usort([Dir || {_DirKey, Dir} <- include_dir_entries(Entries)]).
+
+include_dir_entries(Entries) ->
     lists:usort(
         [
-            <<"src">>,
-            hb_util:bin(filename:absname("src")),
-            <<"src/core">>,
-            hb_util:bin(filename:absname("src/core"))
+            {<<"src">>, <<"src">>},
+            {<<"src">>, hb_util:bin(filename:absname("src"))},
+            {<<"src-core">>, <<"src/core">>},
+            {<<"src-core">>, hb_util:bin(filename:absname("src/core"))}
         ]
         ++ [
-            hb_util:bin(filename:dirname(hb_util:list(Path)))
+            {
+                <<"module/", (atom_to_binary(Mod, utf8))/binary>>,
+                hb_util:bin(filename:dirname(hb_util:list(Path)))
+            }
          ||
-            {_Mod, Path} <- Entries
+            {Mod, Path} <- Entries
         ]
         ++ lists:filtermap(
-            fun({_Mod, Path}) -> source_core_dir(Path) end,
+            fun({_Mod, Path}) ->
+                case source_core_dir(Path) of
+                    false -> false;
+                    {true, Dir} -> {true, {<<"src-core">>, hb_util:bin(Dir)}}
+                end
+            end,
             Entries
         )
     ).
@@ -690,6 +706,30 @@ source_core_dir(Source) ->
                 )
             }
     end.
+
+%% @doc Return local header files that can affect the compiled package forms.
+include_source_files(Entries) ->
+    Files =
+        [
+            {
+                hb_util:bin(
+                    filename:join(hb_util:list(DirKey), relative_path(Dir, Path))
+                ),
+                filename:absname(Path)
+            }
+         ||
+            {DirKey, Dir} <- include_dir_entries(Entries),
+            Pattern <- ["*.hrl", "include/*.hrl"],
+            Path <- filelib:wildcard(filename:join(hb_util:list(Dir), Pattern)),
+            is_regular_file(Path)
+        ],
+    maps:from_list(
+        [
+            {Key, read_file(Path)}
+         ||
+            {Key, Path} <- lists:usort(Files)
+        ]
+    ).
 
 %% @doc Add test-only compile flags when packaging for `device test'.
 test_compile_opts(Opts) ->

--- a/src/forge/hb_packager.erl
+++ b/src/forge/hb_packager.erl
@@ -672,8 +672,8 @@ include_dir_entries(Entries) ->
         [
             {<<"src">>, <<"src">>},
             {<<"src">>, hb_util:bin(filename:absname("src"))},
-            {<<"src-core">>, <<"src/core">>},
-            {<<"src-core">>, hb_util:bin(filename:absname("src/core"))}
+            {<<"src/core">>, <<"src/core">>},
+            {<<"src/core">>, hb_util:bin(filename:absname("src/core"))}
         ]
         ++ [
             {
@@ -687,7 +687,7 @@ include_dir_entries(Entries) ->
             fun({_Mod, Path}) ->
                 case source_core_dir(Path) of
                     false -> false;
-                    {true, Dir} -> {true, {<<"src-core">>, hb_util:bin(Dir)}}
+                    {true, Dir} -> {true, {<<"src/core">>, hb_util:bin(Dir)}}
                 end
             end,
             Entries

--- a/src/forge/hb_packager_test_vectors.erl
+++ b/src/forge/hb_packager_test_vectors.erl
@@ -370,6 +370,37 @@ source_id_changes_with_content_test() ->
     ?assert(?IS_ID(ID2)),
     ?assertNotEqual(ID1, ID2).
 
+source_id_changes_with_include_content_test() ->
+    Dir = test_fixture_dir(),
+    RootPath = filename:join(Dir, <<"dev_test_pkg.erl">>),
+    HeaderPath = filename:join(Dir, <<"fixture.hrl">>),
+    ok =
+        file:write_file(
+            HeaderPath,
+            <<"-define(HB_PACKAGER_TEST_HEADER, <<\"one\">>).\n">>
+        ),
+    {ok, Root} = file:read_file(RootPath),
+    ok =
+        file:write_file(
+            RootPath,
+            binary:replace(
+                Root,
+                <<"-module(dev_test_pkg).\n">>,
+                <<"-module(dev_test_pkg).\n-include(\"fixture.hrl\").\n">>
+            )
+        ),
+    [Group] = hb_packager:scan([Dir], #{}),
+    Pkg1 = package_for_test(Group),
+    ok =
+        file:write_file(
+            HeaderPath,
+            <<"-define(HB_PACKAGER_TEST_HEADER, <<\"two\">>).\n">>
+        ),
+    [Group2] = hb_packager:scan([Dir], #{}),
+    Pkg2 = package_for_test(Group2),
+    ?assertNotEqual(maps:get(source_id, Pkg1), maps:get(source_id, Pkg2)),
+    ?assertNotEqual(maps:get(module_name, Pkg1), maps:get(module_name, Pkg2)).
+
 %% The cryptographic anchor: the generated module name embeds the
 %% lowercase-base32 of the source ID's native bytes, so the loaded
 %% module is provably bound to the exact source it was built from.


### PR DESCRIPTION
Improves the reliability of package builds and source ID generation by correctly tracking header file dependencies.

Previously, modifications to C/C++ header files for native code or Erlang header files (`.hrl`) for packaged Erlang applications did not always trigger necessary rebuilds or invalidate the `source-id` of the resulting package. This could lead to stale build artifacts or inconsistent package identities.

This update addresses these issues by:
*   Updating Makefiles to include all C/C++ source and header files in the dependency list for the `libsecp256k1` static library and NIF object files. This ensures that changes to native headers correctly trigger recompilations.
*   Modifying the Erlang packager to systematically identify and include the content of relevant Erlang header files (`.hrl`) when calculating a package's `source_id`. This guarantees that any change within a header file dependency results in a unique `source-id` and, consequently, a new module name for the package, preventing caching issues and ensuring package integrity.

A new test confirms that changes to an included Erlang header file successfully invalidate the package's `source_id` and module name.