### PR TITLE
fix: Ref name-id collusion

### DIFF
--- a/src/core/device/hb_device_load.erl
+++ b/src/core/device/hb_device_load.erl
@@ -150,8 +150,15 @@ from_preloaded(Ref, Opts) ->
             end
     end.
 
-preloaded_spec(Ref, _Store, _Opts) when ?IS_ID(Ref) ->
-    {ok, Ref};
+%% Versioned device names can be 32 bytes and satisfy `?IS_ID' by length.
+%% Names include `@', so keep those on the preloaded index lookup path.
+preloaded_spec(Ref, Store, Opts) when ?IS_ID(Ref) ->
+    case binary:match(Ref, <<"@">>) of
+        nomatch ->
+            {ok, Ref};
+        _ ->
+            hb_store:read(Store, <<?PRELOADED_INDEX_KEY/binary, "/", Ref/binary>>, Opts)
+    end;
 preloaded_spec(Ref, Store, Opts) ->
     hb_store:read(Store, <<?PRELOADED_INDEX_KEY/binary, "/", Ref/binary>>, Opts).
 


### PR DESCRIPTION
i hit this edge case when i tried to run `rebar3 device test` on a device package named `<<"recharger-ledger-ao-balance@1.0">>`

so this fix treats ID-shaped ref containing `@` as a device name (versioning is always part of the name (?)) and look it up in the preloaded index.

edge case affects `rebar3 device test` / `rebar3 device preload` when name is the 32/42/43 byte but not a real ID

rebar3 eunit --module=hb_packager_test_vectors all tests pass

```
  [done in 6.301 s]
=======================================================
  All 15 tests passed.
  ```