### PR TITLE
impr: batched cache writes

### DIFF
--- a/src/core/resolver/hb_cache.erl
+++ b/src/core/resolver/hb_cache.erl
@@ -111,13 +111,6 @@ ensure_loaded(Ref,
         {error, not_found} ->
             report_ensure_loaded_not_found(Ref, Lk, Opts)
     end;
-ensure_loaded(_Ref, {link, _ID, LinkOpts = #{ <<"value">> := DirectValue }}, Opts) ->
-    % The composite read already supplied this value inline, so resolve it
-    % without a further store read, applying the `ao-type' if one is present.
-    case hb_maps:get(<<"type">>, LinkOpts, undefined, Opts) of
-        undefined -> DirectValue;
-        Type -> hb_util:decode(Type, DirectValue)
-    end;
 ensure_loaded(Ref, Link = {link, ID, LinkOpts = #{ <<"lazy">> := true }}, RawOpts) ->
     % If the user provided their own options, we merge them and _overwrite_
     % the options that are already set in the link.
@@ -244,7 +237,7 @@ normalize_match_spec(MatchSpec, _ReadMode, Opts) ->
 store_match(NormalizedSpec, Opts) ->
     ConvertedMatchSpec =
         maps:map(
-            fun(_, Value) -> store_match_value(Value, Opts) end,
+            fun(Key, Value) -> store_match_value(Key, Value, Opts) end,
             NormalizedSpec
         ),
     case hb_store:match(
@@ -275,19 +268,12 @@ generate_binary_path(Bin, Opts) ->
 write(RawMsg, Opts) when is_map(RawMsg) ->
     hb_message:paranoid_verify(cache_write, RawMsg, Opts),
     {ok, Msg} = hb_message:with_only_committed(RawMsg, Opts),
-    Store = hb_opts:get(store, no_viable_store, Opts),
-    TABM =
-        hb_message:convert(
-            Msg,
-            tabm,
-            <<"structured@1.0">>,
-            Opts
-        ),
+    TABM = hb_message:convert(Msg, tabm, <<"structured@1.0">>, Opts),
     ?event_debug(debug_cache, {writing_full_message, {msg, TABM}}),
     try
         do_write_message(
             TABM,
-            Store,
+            hb_opts:get(store, no_viable_store, Opts),
             Opts
         )
     catch
@@ -320,188 +306,10 @@ do_write_message(List, Store, Opts) when is_list(List) ->
         Store,
         Opts
     );
-do_write_message(Msg, Store = #{ <<"store-module">> := hb_store_lmdb }, Opts)
-        when is_map(Msg) ->
-    InitialIndexEntries =
-        case hb_opts:get(match_index, false, Opts) of
-            false -> skip;
-            _ -> []
-        end,
-    {UncommittedID, Writes, Links, IndexEntries} =
-        prepare_message(Msg, Opts, #{}, #{}, InitialIndexEntries),
-    WriteMap = link_write_ops(Links, Writes),
-    case match_index_ops(IndexEntries, Opts) of
-        {Store, MatchWrites} ->
-            write_ops(Store, maps:merge(WriteMap, MatchWrites), Opts);
-        {MatchStore, MatchWrites} ->
-            write_ops(Store, WriteMap, Opts),
-            write_ops(MatchStore, MatchWrites, Opts);
-        legacy ->
-            write_ops(Store, WriteMap, Opts),
-            write_match_indexes(IndexEntries, Opts);
-        skip ->
-            write_ops(Store, WriteMap, Opts)
-    end,
-    {ok, UncommittedID};
 do_write_message(Msg, Store, Opts) when is_map(Msg) ->
     {ok, UncommittedID, Ops} = write_message_ops(Msg, Opts),
     run_write_ops(Store, Ops, Opts),
     {ok, UncommittedID}.
-
-prepare_message(Msg, Opts, Writes, Links, IndexEntries) ->
-    ?event_debug(debug_cache, {writing_message, Msg}),
-    UncommittedID =
-        hb_message:id(Msg, none, Opts#{ <<"linkify-mode">> => discard }),
-    AllIDs = calculate_all_ids(Msg, UncommittedID, Opts),
-    AltIDs = AllIDs -- [UncommittedID],
-    ?event_debug(debug_cache,
-        {writing_message,
-            {id, UncommittedID},
-            {alt_ids, AltIDs},
-            {original, Msg}
-        }
-    ),
-    {PreparedWrites, PreparedLinks, PreparedIndexEntries} =
-        maps:fold(
-            fun(Key, Value, Acc) ->
-                prepare_key(UncommittedID, Key, Value, Opts, Acc)
-            end,
-            {Writes#{ UncommittedID => <<"group">> }, Links, IndexEntries},
-            maps:without([<<"priv">>], Msg)
-        ),
-    {
-        UncommittedID,
-        PreparedWrites,
-        add_alt_links(UncommittedID, AltIDs, PreparedLinks),
-        add_index_entry(AllIDs, Msg, PreparedIndexEntries)
-    }.
-
-prepare_value(Bin, Opts, Writes, Links, IndexEntries) when is_binary(Bin) ->
-    Path = generate_binary_path(Bin, Opts),
-    {Path, Writes#{ Path => Bin }, Links, IndexEntries};
-prepare_value(List, Opts, Writes, Links, IndexEntries) when is_list(List) ->
-    prepare_value(
-        hb_message:convert(List, tabm, <<"structured@1.0">>, Opts),
-        Opts,
-        Writes,
-        Links,
-        IndexEntries
-    );
-prepare_value(Msg, Opts, Writes, Links, IndexEntries) when is_map(Msg) ->
-    prepare_message(Msg, Opts, Writes, Links, IndexEntries).
-
-add_alt_links(UncommittedID, AltIDs, Links) ->
-    lists:foldl(
-        fun(AltID, Acc) ->
-            ?event_debug(debug_cache,
-                {linking_commitment,
-                    {uncommitted_id, UncommittedID},
-                    {committed_id, AltID}
-            }),
-            Acc#{ AltID => UncommittedID }
-        end,
-        Links,
-        AltIDs
-    ).
-
-link_write_ops(Links, Writes) when map_size(Links) =:= 0 ->
-    Writes;
-link_write_ops(Links, Writes) ->
-    maps:fold(
-        fun(New, Existing, Acc) ->
-            ExistingBin =
-                case is_binary(Existing) of
-                    true -> Existing;
-                    false -> hb_path:to_binary(Existing)
-                end,
-            Acc#{ New => <<"link:", ExistingBin/binary>> }
-        end,
-        Writes,
-        Links
-    ).
-
-add_index_entry(_AllIDs, _Msg, skip) ->
-    skip;
-add_index_entry(AllIDs, Msg, IndexEntries) ->
-    [{AllIDs, Msg} | IndexEntries].
-
-write_ops(_Store, Ops, _Opts) when map_size(Ops) =:= 0 ->
-    ok;
-write_ops(Store, Ops, Opts) ->
-    hb_store:write(Store, Ops, Opts).
-
-%% @doc Prepare a single key for an LMDB message write.
-prepare_key(Base, <<"commitments">>, RawCommitments, Opts,
-        {Writes, Links, IndexEntries}) ->
-    Commitments = prepare_commitments(RawCommitments, Opts),
-    CommitmentsBase = commitment_path(Base, Opts),
-    ?event(
-        {writing_commitments,
-            {base, Base},
-            {commitments_message, Commitments},
-            {commitments_base, CommitmentsBase}
-        }
-    ),
-    {PreparedWrites, PreparedLinks, PreparedIndexEntries} =
-        maps:fold(
-            fun(BaseCommID, Commitment, {WriteAcc, LinkAcc, IndexAcc}) ->
-                ?event_debug(debug_cache, {writing_commitment, {commitment, Commitment}}),
-                {CommMsgID, NewWrites, NewLinks, NewIndexEntries} =
-                    prepare_value(
-                        Commitment,
-                        Opts,
-                        WriteAcc,
-                        LinkAcc,
-                        IndexAcc
-                    ),
-                {
-                    NewWrites,
-                    NewLinks#{
-                        <<CommitmentsBase/binary, "/", BaseCommID/binary>> =>
-                            CommMsgID
-                    },
-                    NewIndexEntries
-                }
-            end,
-            {Writes#{ CommitmentsBase => <<"group">> }, Links, IndexEntries},
-            Commitments
-        ),
-    {
-        PreparedWrites,
-        PreparedLinks#{ <<Base/binary, "/commitments">> => CommitmentsBase },
-        PreparedIndexEntries
-    };
-prepare_key(Base, Key, Value, Opts, {Writes, Links, IndexEntries}) ->
-    KeyPath = message_key_path(Base, Key),
-    case direct_cache_value(Key, Value) of
-        true ->
-            {
-                Writes#{ KeyPath => <<"raw:", Value/binary>> },
-                Links,
-                IndexEntries
-            };
-        false ->
-            {Path, PreparedWrites, PreparedLinks, PreparedIndexEntries} =
-                prepare_value(Value, Opts, Writes, Links, IndexEntries),
-            {
-                PreparedWrites,
-                PreparedLinks#{ KeyPath => Path },
-                PreparedIndexEntries
-            }
-    end.
-
-message_key_path(Base, Key) when is_binary(Key) ->
-    <<Base/binary, "/", Key/binary>>;
-message_key_path(Base, Key) ->
-    KeyBin = hb_path:to_binary(Key),
-    <<Base/binary, "/", KeyBin/binary>>.
-
-direct_cache_value(<<"ao-types">>, Value) when is_binary(Value) ->
-    true;
-direct_cache_value(Key, Value) ->
-    is_binary(Value) andalso
-        byte_size(Value) < ?DIRECT_VALUE_LENGTH andalso
-        not hb_link:is_link_key(Key).
 
 write_message_ops(Bin, Opts) when is_binary(Bin) ->
     Path = generate_binary_path(Bin, Opts),
@@ -534,8 +342,8 @@ write_message_ops(Msg, Opts) when is_map(Msg) ->
             maps:without([<<"priv">>], Msg)
         ),
     MatchOps =
-        case hb_opts:get(match_index, false, Opts) of
-            false -> KeyOps;
+        case match_store(Opts) of
+            [] -> KeyOps;
             _ -> [{match, AllIDs, Msg} | KeyOps]
         end,
     Ops =
@@ -587,17 +395,65 @@ write_key_ops(Base, Key, HPAlg, Value, Opts, Acc) ->
             HPAlg,
             Opts
         ),
-    {ok, Path, ValueOps} = write_message_ops(Value, Opts),
-    [
-        write_key_op(KeyHashPath, Value, Path)
-        | prepend_reversed(ValueOps, Acc)
-    ].
+    case is_immediate_value(Key, Value) of
+        true ->
+            [{write, KeyHashPath, encode_immediate_value(Value)} | Acc];
+        false ->
+            {ok, Path, ValueOps} = write_message_ops(Value, Opts),
+            [
+                {link, KeyHashPath, Path}
+                | prepend_reversed(ValueOps, Acc)
+            ]
+    end.
 
-write_key_op(KeyHashPath, Value, _Path)
-        when is_binary(Value), byte_size(Value) < ?DIRECT_VALUE_LENGTH ->
-    {write, KeyHashPath, <<"raw:", Value/binary>>};
-write_key_op(KeyHashPath, _Value, Path) ->
-    {link, KeyHashPath, Path}.
+%% @doc True when `Value' should be stored at `Key''s path instead of linked
+%% through `data/'.
+is_immediate_value(Key, Value) ->
+    is_binary(Value) andalso
+        byte_size(Value) < ?DIRECT_VALUE_LENGTH andalso
+        not hb_link:is_link_key(Key).
+
+%% @doc Encode an immediate value so it cannot be confused with cache markers.
+%% Most values are stored unchanged. Literal marker-looking values get a single
+%% `raw:' prefix, so decoding removes exactly one layer and preserves literal
+%% values that start with `link:' or `raw:'.
+encode_immediate_value(<<"group">>) -> <<"raw:group">>;
+encode_immediate_value(<<"link:", _/binary>> = Value) -> <<"raw:", Value/binary>>;
+encode_immediate_value(<<"raw:", _/binary>> = Value) -> <<"raw:", Value/binary>>;
+encode_immediate_value(Value) -> Value.
+
+%% @doc Decode a value read from a message key path. Linked payloads under
+%% `data/' are not immediate values, so leave them byte-for-byte intact.
+decode_immediate_value(<<"data/", _/binary>>, Value) -> Value;
+decode_immediate_value(_Path, <<"raw:", Value/binary>>) -> Value;
+decode_immediate_value(_Path, Value) -> Value.
+
+store_match_value(Key, Bin, Opts) when is_binary(Bin) ->
+    case is_immediate_value(Key, Bin) of
+        true -> encode_immediate_value(Bin);
+        false -> <<"link:", (generate_binary_path(Bin, Opts))/binary>>
+    end;
+store_match_value(_Key, Map, Opts) when is_map(Map) ->
+    <<"link:",
+        (hb_message:id(
+            Map,
+            none,
+            Opts#{ <<"linkify-mode">> => discard }
+        ))/binary
+    >>;
+store_match_value(Key, List, Opts) when is_list(List) ->
+    case io_lib:printable_unicode_list(List) of
+        true ->
+            store_match_value(Key, iolist_to_binary(List), Opts);
+        false ->
+            store_match_value(
+                Key,
+                hb_message:convert(List, tabm, <<"structured@1.0">>, Opts),
+                Opts
+            )
+    end;
+store_match_value(Key, Other, Opts) ->
+    store_match_value(Key, hb_path:to_binary(Other), Opts).
 
 prepend_reversed(Ops, Acc) ->
     lists:foldl(fun(Op, InnerAcc) -> [Op | InnerAcc] end, Acc, Ops).
@@ -651,81 +507,6 @@ apply_write_ops(Store, Ops, Opts) ->
     ok.
 
 %% @doc Write all message keys to the optional match index.
-match_index_ops(skip, _Opts) ->
-    skip;
-match_index_ops(IndexEntries, Opts) ->
-    case hb_opts:get(match_index, false, Opts) of
-        false ->
-            skip;
-        _ ->
-            case match_store(Opts) of
-                [] ->
-                    skip;
-                [Store = #{ <<"store-module">> := hb_store_lmdb }] ->
-                    {Store, match_index_rows(IndexEntries, Opts)};
-                Store = #{ <<"store-module">> := hb_store_lmdb } ->
-                    {Store, match_index_rows(IndexEntries, Opts)};
-                _ ->
-                    legacy
-            end
-    end.
-
-write_match_indexes(IndexEntries, Opts) ->
-    case match_store(Opts) of
-        [] ->
-            {skip, <<"No store configured for match index.">>};
-        _ ->
-            lists:foreach(
-                fun({IDs, IndexedMsg}) ->
-                    write_match_index(IDs, IndexedMsg, Opts)
-                end,
-                IndexEntries
-            )
-    end.
-
-match_index_rows(IndexEntries, Opts) ->
-    lists:foldl(
-        fun({IDs, Base}, Acc) ->
-            IndexBase =
-                maps:without(
-                    [<<"ao-types">>],
-                    hb_message:uncommitted(hb_private:reset(Base))
-                ),
-            hb_maps:fold(
-                fun(RawKey, Value, KeyAcc) ->
-                    {Key, ValuePath} =
-                        match_index_key_value(RawKey, Value, Opts),
-                    MatchAddress = match_address(Key, ValuePath),
-                    lists:foldl(
-                        fun(ID, IDAcc) ->
-                            Address = match_address_id(MatchAddress, ID),
-                            ?event_debug(
-                                debug_match,
-                                {writing_reverse_index, {address, Address}},
-                                Opts
-                            ),
-                            IDAcc#{ Address => <<>> }
-                        end,
-                        KeyAcc#{ MatchAddress => <<"group">> },
-                        IDs
-                    )
-                end,
-                Acc,
-                IndexBase
-            )
-        end,
-        #{},
-        IndexEntries
-    ).
-
-match_index_key_value(RawKey, Value, Opts)
-        when is_map(Value) orelse is_list(Value) ->
-    Key = hb_ao:normalize_key(RawKey),
-    LinkID = hb_message:id(Value, none, Opts#{ <<"linkify-mode">> => discard }),
-    {<<Key/binary, "+link">>, match_value_path(LinkID, Opts)};
-match_index_key_value(RawKey, Value, Opts) ->
-    {hb_ao:normalize_key(RawKey), match_value_path(Value, Opts)}.
-
 write_match_index(IDs, Base, Opts) ->
     case match_store(Opts) of
         [] -> {skip, <<"No store configured for match index.">>};
@@ -765,6 +546,10 @@ match_store(Opts) ->
     GlobalMatchIndex = hb_opts:get(match_index, false, #{ <<"only">> => global }),
     MatchIndexStore =
         case {LocalMatchIndex, LocalStore} of
+            {false, _} ->
+                false;
+            {[], _} ->
+                [];
             {undefined, undefined} ->
                 GlobalMatchIndex;
             {undefined, _} ->
@@ -821,35 +606,6 @@ match_value_path(List, Opts) when is_list(List) ->
     end;
 match_value_path(Other, Opts) ->
     match_value_path(hb_path:to_binary(Other), Opts).
-
-store_match_value(Bin, Opts) when is_binary(Bin) ->
-    cache_link_value(Bin, generate_binary_path(Bin, Opts));
-store_match_value(Map, Opts) when is_map(Map) ->
-    <<"link:",
-        (hb_message:id(
-            Map,
-            none,
-            Opts#{ <<"linkify-mode">> => discard }
-        ))/binary
-    >>;
-store_match_value(List, Opts) when is_list(List) ->
-    case io_lib:printable_unicode_list(List) of
-        true ->
-            store_match_value(iolist_to_binary(List), Opts);
-        false ->
-            store_match_value(
-                hb_message:convert(List, tabm, <<"structured@1.0">>, Opts),
-                Opts
-            )
-    end;
-store_match_value(Other, Opts) ->
-    store_match_value(hb_path:to_binary(Other), Opts).
-
-cache_link_value(Value, _Path)
-        when is_binary(Value), byte_size(Value) < ?DIRECT_VALUE_LENGTH ->
-    <<"raw:", Value/binary>>;
-cache_link_value(_Value, Path) ->
-    <<"link:", Path/binary>>.
 
 %% @doc The `structured@1.0` encoder does not typically encode `commitments`,
 %% subsequently, when we encounter a commitments message we prepare its contents
@@ -1000,16 +756,14 @@ store_read(Target, Path, Store, Opts) ->
     end.
 
 %% @doc Read a path whose intermediate links are already resolved, skipping the
-%% redundant per-segment `hb_store:resolve' round-trip. Used for content-
-%% addressed `data' leaves, where re-resolving a path the store maps to itself
-%% is pure overhead.
+%% redundant per-segment `hb_store:resolve' round-trip.
 read_resolved_path(_Target, _Path, no_viable_store, _) ->
     {error, not_found};
 read_resolved_path(Target, ResolvedFullPath, Store, Opts) ->
     case hb_store:read(Store, ResolvedFullPath, Opts) of
         {ok, Bin} ->
             ?event_debug({reading_data, ResolvedFullPath}),
-            {ok, cache_row_value(ResolvedFullPath, Bin)};
+            {ok, decode_immediate_value(ResolvedFullPath, Bin)};
         {composite, Children} ->
             ?event_debug({reading_composite, ResolvedFullPath}),
             Subpaths =
@@ -1075,13 +829,8 @@ read_resolved_path(Target, ResolvedFullPath, Store, Opts) ->
 child_name({Subpath, _Value}) -> Subpath;
 child_name(Subpath) -> Subpath.
 
-cache_row_value(<<"data/", _/binary>>, Value) -> Value;
-cache_row_value(_Path, <<"raw:", Value/binary>>) -> Value;
-cache_row_value(_Path, Value) -> Value.
-
-%% @doc Prepare typed values using `ao-types'. Small values supplied inline by
-%% the prefix read are decoded directly; larger values and nested messages are
-%% returned as lazy links to their subpaths.
+%% @doc Prepare child values using `ao-types' where present. Immediate values
+%% are returned directly; linked values remain lazy.
 prepare_typed_values(Target, RootPath, Subpaths, Values, Store, Opts) ->
     {ok, Implicit, Types} = read_ao_types(RootPath, Subpaths, Values, Store, Opts),
     Res =
@@ -1170,15 +919,12 @@ prepare_typed_values(Target, RootPath, Subpaths, Values, Store, Opts) ->
                                 end)#{ <<"store">> => Store },
                             PreparedValue =
                                 case maps:get(Subpath, Values, none) of
-                                    <<"raw:", DirectValue/binary>> ->
-                                        case LinkOpts of
-                                            #{ <<"type">> := DirectType } ->
-                                                hb_util:decode(DirectType, DirectValue);
-                                            _ ->
-                                                DirectValue
-                                        end;
+                                    <<"raw:", ImmediateValue/binary>> ->
+                                        apply_type_to_immediate(ImmediateValue, LinkOpts);
                                     <<"link:", Path/binary>> ->
                                         {link, Path, LinkOpts};
+                                    ImmediateValue when is_binary(ImmediateValue) ->
+                                        apply_type_to_immediate(ImmediateValue, LinkOpts);
                                     _ ->
                                         {link, SubkeyPath, LinkOpts}
                                 end,
@@ -1216,26 +962,30 @@ prepare_typed_values(Target, RootPath, Subpaths, Values, Store, Opts) ->
             end
     end.
 
+apply_type_to_immediate(Value, #{ <<"type">> := Type }) ->
+    hb_util:decode(Type, Value);
+apply_type_to_immediate(Value, _LinkOpts) ->
+    Value.
+
 %% @doc Read and parse the ao-types for a given path if it is in the supplied
-%% list of subpaths, returning a map of keys and their types. The composite
-%% read already returns the `ao-types' value alongside every other child, so we
-%% reuse it from `Values' when present and only fall back to a dedicated store
-%% read for the per-key (non-prefix) path.
+%% list of subpaths, returning a map of keys and their types. Prefix reads
+%% already return small inline `ao-types' values, so reuse them when present.
 read_ao_types(Path, Subpaths, Values, Store, Opts) ->
     ?event_debug({reading_ao_types, {path, Path}, {subpaths, {explicit, Subpaths}}}),
     case lists:member(<<"ao-types">>, Subpaths) of
         true ->
+            TypesPath = hb_path:to_binary([Path, <<"ao-types">>]),
             TypesBin =
                 case Values of
-                    #{ <<"ao-types">> := <<"raw:", Direct/binary>> } ->
-                        % The composite read already supplied the small inline
-                        % value, so we use it directly. Larger (`link:') values
-                        % fall through to a dedicated read that follows the link.
+                    #{ <<"ao-types">> := <<"raw:", Direct/binary>> } -> Direct;
+                    #{ <<"ao-types">> := <<"link:", _/binary>> } ->
+                        {ok, Bin} = hb_store:read(Store, TypesPath, Opts),
+                        decode_immediate_value(TypesPath, Bin);
+                    #{ <<"ao-types">> := Direct } when is_binary(Direct) ->
                         Direct;
                     _ ->
-                        TypesPath = hb_path:to_binary([Path, <<"ao-types">>]),
                         {ok, Bin} = hb_store:read(Store, TypesPath, Opts),
-                        cache_row_value(TypesPath, Bin)
+                        decode_immediate_value(TypesPath, Bin)
                 end,
             Types = structured_decode_types(TypesBin, Opts),
             ?event_debug({parsed_ao_types, {types, Types}}),
@@ -1664,6 +1414,32 @@ test_raw_match_read(Store) ->
         hb_maps:get(<<"body">>, RawMsg, undefined, RawOpts)
     ).
 
+test_immediate_marker_values(Store) ->
+    hb_store:reset(Store),
+    Opts = #{ <<"store">> => Store },
+    Msg = #{
+        <<"groupish">> => <<"group">>,
+        <<"linkish">> => <<"link:literal">>,
+        <<"rawish">> => <<"raw:literal">>
+    },
+    {ok, ID} = write(Msg, Opts),
+    {ok, Read} = read(ID, Opts),
+    ?assertEqual(<<"group">>, hb_maps:get(<<"groupish">>, Read, Opts)),
+    ?assertEqual(<<"link:literal">>, hb_maps:get(<<"linkish">>, Read, Opts)),
+    ?assertEqual(<<"raw:literal">>, hb_maps:get(<<"rawish">>, Read, Opts)),
+    case map_get(<<"store-module">>, Store) of
+        hb_store_lmdb ->
+            ?assertEqual({ok, [ID]}, match(#{ <<"rawish">> => <<"raw:literal">> }, Opts));
+        _ ->
+            ok
+    end.
+
+match_store_control_test() ->
+    Store = hb_test_utils:test_store(hb_store_volatile, <<"match-control">>),
+    ?assertEqual([Store], match_store(#{ <<"store">> => Store })),
+    ?assertEqual([], match_store(#{ <<"store">> => Store, <<"match-index">> => false })),
+    ?assertEqual([], match_store(#{ <<"store">> => Store, <<"match-index">> => [] })).
+
 cache_suite_test_() ->
     hb_store:generate_test_suite([
         {"store unsigned empty message",
@@ -1678,7 +1454,8 @@ cache_suite_test_() ->
         {"match message", fun test_match_message/1},
         {"match linked message", fun test_match_linked_message/1},
         {"match typed message", fun test_match_typed_message/1},
-        {"raw match read", fun test_raw_match_read/1}
+        {"raw match read", fun test_raw_match_read/1},
+        {"immediate marker values", fun test_immediate_marker_values/1}
     ]).
 
 %% @doc Test that message whose device is `#{}' cannot be written. If it were to

--- a/src/core/resolver/hb_cache.erl
+++ b/src/core/resolver/hb_cache.erl
@@ -275,12 +275,19 @@ generate_binary_path(Bin, Opts) ->
 write(RawMsg, Opts) when is_map(RawMsg) ->
     hb_message:paranoid_verify(cache_write, RawMsg, Opts),
     {ok, Msg} = hb_message:with_only_committed(RawMsg, Opts),
-    TABM = hb_message:convert(Msg, tabm, <<"structured@1.0">>, Opts),
+    Store = hb_opts:get(store, no_viable_store, Opts),
+    TABM =
+        hb_message:convert(
+            Msg,
+            tabm,
+            <<"structured@1.0">>,
+            Opts
+        ),
     ?event_debug(debug_cache, {writing_full_message, {msg, TABM}}),
     try
         do_write_message(
             TABM,
-            hb_opts:get(store, no_viable_store, Opts),
+            Store,
             Opts
         )
     catch
@@ -322,18 +329,18 @@ do_write_message(Msg, Store = #{ <<"store-module">> := hb_store_lmdb }, Opts)
         end,
     {UncommittedID, Writes, Links, IndexEntries} =
         prepare_message(Msg, Opts, #{}, #{}, InitialIndexEntries),
-    LinkWrites = link_write_ops(Links),
+    WriteMap = link_write_ops(Links, Writes),
     case match_index_ops(IndexEntries, Opts) of
         {Store, MatchWrites} ->
-            write_ops(Store, maps:merge(maps:merge(Writes, LinkWrites), MatchWrites), Opts);
+            write_ops(Store, maps:merge(WriteMap, MatchWrites), Opts);
         {MatchStore, MatchWrites} ->
-            write_ops(Store, maps:merge(Writes, LinkWrites), Opts),
+            write_ops(Store, WriteMap, Opts),
             write_ops(MatchStore, MatchWrites, Opts);
         legacy ->
-            write_ops(Store, maps:merge(Writes, LinkWrites), Opts),
+            write_ops(Store, WriteMap, Opts),
             write_match_indexes(IndexEntries, Opts);
         skip ->
-            write_ops(Store, maps:merge(Writes, LinkWrites), Opts)
+            write_ops(Store, WriteMap, Opts)
     end,
     {ok, UncommittedID};
 do_write_message(Msg, Store, Opts) when is_map(Msg) ->
@@ -397,7 +404,9 @@ add_alt_links(UncommittedID, AltIDs, Links) ->
         AltIDs
     ).
 
-link_write_ops(Links) ->
+link_write_ops(Links, Writes) when map_size(Links) =:= 0 ->
+    Writes;
+link_write_ops(Links, Writes) ->
     maps:fold(
         fun(New, Existing, Acc) ->
             ExistingBin =
@@ -407,7 +416,7 @@ link_write_ops(Links) ->
                 end,
             Acc#{ New => <<"link:", ExistingBin/binary>> }
         end,
-        #{},
+        Writes,
         Links
     ).
 

--- a/src/core/resolver/hb_cache.erl
+++ b/src/core/resolver/hb_cache.erl
@@ -313,10 +313,186 @@ do_write_message(List, Store, Opts) when is_list(List) ->
         Store,
         Opts
     );
+do_write_message(Msg, Store = #{ <<"store-module">> := hb_store_lmdb }, Opts)
+        when is_map(Msg) ->
+    InitialIndexEntries =
+        case hb_opts:get(match_index, false, Opts) of
+            false -> skip;
+            _ -> []
+        end,
+    {UncommittedID, Writes, Links, IndexEntries} =
+        prepare_message(Msg, Opts, #{}, #{}, InitialIndexEntries),
+    LinkWrites = link_write_ops(Links),
+    case match_index_ops(IndexEntries, Opts) of
+        {Store, MatchWrites} ->
+            write_ops(Store, maps:merge(maps:merge(Writes, LinkWrites), MatchWrites), Opts);
+        {MatchStore, MatchWrites} ->
+            write_ops(Store, maps:merge(Writes, LinkWrites), Opts),
+            write_ops(MatchStore, MatchWrites, Opts);
+        legacy ->
+            write_ops(Store, maps:merge(Writes, LinkWrites), Opts),
+            write_match_indexes(IndexEntries, Opts);
+        skip ->
+            write_ops(Store, maps:merge(Writes, LinkWrites), Opts)
+    end,
+    {ok, UncommittedID};
 do_write_message(Msg, Store, Opts) when is_map(Msg) ->
     {ok, UncommittedID, Ops} = write_message_ops(Msg, Opts),
     run_write_ops(Store, Ops, Opts),
     {ok, UncommittedID}.
+
+prepare_message(Msg, Opts, Writes, Links, IndexEntries) ->
+    ?event_debug(debug_cache, {writing_message, Msg}),
+    UncommittedID =
+        hb_message:id(Msg, none, Opts#{ <<"linkify-mode">> => discard }),
+    AllIDs = calculate_all_ids(Msg, UncommittedID, Opts),
+    AltIDs = AllIDs -- [UncommittedID],
+    ?event_debug(debug_cache,
+        {writing_message,
+            {id, UncommittedID},
+            {alt_ids, AltIDs},
+            {original, Msg}
+        }
+    ),
+    {PreparedWrites, PreparedLinks, PreparedIndexEntries} =
+        maps:fold(
+            fun(Key, Value, Acc) ->
+                prepare_key(UncommittedID, Key, Value, Opts, Acc)
+            end,
+            {Writes#{ UncommittedID => <<"group">> }, Links, IndexEntries},
+            maps:without([<<"priv">>], Msg)
+        ),
+    {
+        UncommittedID,
+        PreparedWrites,
+        add_alt_links(UncommittedID, AltIDs, PreparedLinks),
+        add_index_entry(AllIDs, Msg, PreparedIndexEntries)
+    }.
+
+prepare_value(Bin, Opts, Writes, Links, IndexEntries) when is_binary(Bin) ->
+    Path = generate_binary_path(Bin, Opts),
+    {Path, Writes#{ Path => Bin }, Links, IndexEntries};
+prepare_value(List, Opts, Writes, Links, IndexEntries) when is_list(List) ->
+    prepare_value(
+        hb_message:convert(List, tabm, <<"structured@1.0">>, Opts),
+        Opts,
+        Writes,
+        Links,
+        IndexEntries
+    );
+prepare_value(Msg, Opts, Writes, Links, IndexEntries) when is_map(Msg) ->
+    prepare_message(Msg, Opts, Writes, Links, IndexEntries).
+
+add_alt_links(UncommittedID, AltIDs, Links) ->
+    lists:foldl(
+        fun(AltID, Acc) ->
+            ?event_debug(debug_cache,
+                {linking_commitment,
+                    {uncommitted_id, UncommittedID},
+                    {committed_id, AltID}
+            }),
+            Acc#{ AltID => UncommittedID }
+        end,
+        Links,
+        AltIDs
+    ).
+
+link_write_ops(Links) ->
+    maps:fold(
+        fun(New, Existing, Acc) ->
+            ExistingBin =
+                case is_binary(Existing) of
+                    true -> Existing;
+                    false -> hb_path:to_binary(Existing)
+                end,
+            Acc#{ New => <<"link:", ExistingBin/binary>> }
+        end,
+        #{},
+        Links
+    ).
+
+add_index_entry(_AllIDs, _Msg, skip) ->
+    skip;
+add_index_entry(AllIDs, Msg, IndexEntries) ->
+    [{AllIDs, Msg} | IndexEntries].
+
+write_ops(_Store, Ops, _Opts) when map_size(Ops) =:= 0 ->
+    ok;
+write_ops(Store, Ops, Opts) ->
+    hb_store:write(Store, Ops, Opts).
+
+%% @doc Prepare a single key for an LMDB message write.
+prepare_key(Base, <<"commitments">>, RawCommitments, Opts,
+        {Writes, Links, IndexEntries}) ->
+    Commitments = prepare_commitments(RawCommitments, Opts),
+    CommitmentsBase = commitment_path(Base, Opts),
+    ?event(
+        {writing_commitments,
+            {base, Base},
+            {commitments_message, Commitments},
+            {commitments_base, CommitmentsBase}
+        }
+    ),
+    {PreparedWrites, PreparedLinks, PreparedIndexEntries} =
+        maps:fold(
+            fun(BaseCommID, Commitment, {WriteAcc, LinkAcc, IndexAcc}) ->
+                ?event_debug(debug_cache, {writing_commitment, {commitment, Commitment}}),
+                {CommMsgID, NewWrites, NewLinks, NewIndexEntries} =
+                    prepare_value(
+                        Commitment,
+                        Opts,
+                        WriteAcc,
+                        LinkAcc,
+                        IndexAcc
+                    ),
+                {
+                    NewWrites,
+                    NewLinks#{
+                        <<CommitmentsBase/binary, "/", BaseCommID/binary>> =>
+                            CommMsgID
+                    },
+                    NewIndexEntries
+                }
+            end,
+            {Writes#{ CommitmentsBase => <<"group">> }, Links, IndexEntries},
+            Commitments
+        ),
+    {
+        PreparedWrites,
+        PreparedLinks#{ <<Base/binary, "/commitments">> => CommitmentsBase },
+        PreparedIndexEntries
+    };
+prepare_key(Base, Key, Value, Opts, {Writes, Links, IndexEntries}) ->
+    KeyPath = message_key_path(Base, Key),
+    case direct_cache_value(Key, Value) of
+        true ->
+            {
+                Writes#{ KeyPath => <<"raw:", Value/binary>> },
+                Links,
+                IndexEntries
+            };
+        false ->
+            {Path, PreparedWrites, PreparedLinks, PreparedIndexEntries} =
+                prepare_value(Value, Opts, Writes, Links, IndexEntries),
+            {
+                PreparedWrites,
+                PreparedLinks#{ KeyPath => Path },
+                PreparedIndexEntries
+            }
+    end.
+
+message_key_path(Base, Key) when is_binary(Key) ->
+    <<Base/binary, "/", Key/binary>>;
+message_key_path(Base, Key) ->
+    KeyBin = hb_path:to_binary(Key),
+    <<Base/binary, "/", KeyBin/binary>>.
+
+direct_cache_value(<<"ao-types">>, Value) when is_binary(Value) ->
+    true;
+direct_cache_value(Key, Value) ->
+    is_binary(Value) andalso
+        byte_size(Value) < ?DIRECT_VALUE_LENGTH andalso
+        not hb_link:is_link_key(Key).
 
 write_message_ops(Bin, Opts) when is_binary(Bin) ->
     Path = generate_binary_path(Bin, Opts),
@@ -466,6 +642,81 @@ apply_write_ops(Store, Ops, Opts) ->
     ok.
 
 %% @doc Write all message keys to the optional match index.
+match_index_ops(skip, _Opts) ->
+    skip;
+match_index_ops(IndexEntries, Opts) ->
+    case hb_opts:get(match_index, false, Opts) of
+        false ->
+            skip;
+        _ ->
+            case match_store(Opts) of
+                [] ->
+                    skip;
+                [Store = #{ <<"store-module">> := hb_store_lmdb }] ->
+                    {Store, match_index_rows(IndexEntries, Opts)};
+                Store = #{ <<"store-module">> := hb_store_lmdb } ->
+                    {Store, match_index_rows(IndexEntries, Opts)};
+                _ ->
+                    legacy
+            end
+    end.
+
+write_match_indexes(IndexEntries, Opts) ->
+    case match_store(Opts) of
+        [] ->
+            {skip, <<"No store configured for match index.">>};
+        _ ->
+            lists:foreach(
+                fun({IDs, IndexedMsg}) ->
+                    write_match_index(IDs, IndexedMsg, Opts)
+                end,
+                IndexEntries
+            )
+    end.
+
+match_index_rows(IndexEntries, Opts) ->
+    lists:foldl(
+        fun({IDs, Base}, Acc) ->
+            IndexBase =
+                maps:without(
+                    [<<"ao-types">>],
+                    hb_message:uncommitted(hb_private:reset(Base))
+                ),
+            hb_maps:fold(
+                fun(RawKey, Value, KeyAcc) ->
+                    {Key, ValuePath} =
+                        match_index_key_value(RawKey, Value, Opts),
+                    MatchAddress = match_address(Key, ValuePath),
+                    lists:foldl(
+                        fun(ID, IDAcc) ->
+                            Address = match_address_id(MatchAddress, ID),
+                            ?event_debug(
+                                debug_match,
+                                {writing_reverse_index, {address, Address}},
+                                Opts
+                            ),
+                            IDAcc#{ Address => <<>> }
+                        end,
+                        KeyAcc#{ MatchAddress => <<"group">> },
+                        IDs
+                    )
+                end,
+                Acc,
+                IndexBase
+            )
+        end,
+        #{},
+        IndexEntries
+    ).
+
+match_index_key_value(RawKey, Value, Opts)
+        when is_map(Value) orelse is_list(Value) ->
+    Key = hb_ao:normalize_key(RawKey),
+    LinkID = hb_message:id(Value, none, Opts#{ <<"linkify-mode">> => discard }),
+    {<<Key/binary, "+link">>, match_value_path(LinkID, Opts)};
+match_index_key_value(RawKey, Value, Opts) ->
+    {hb_ao:normalize_key(RawKey), match_value_path(Value, Opts)}.
+
 write_match_index(IDs, Base, Opts) ->
     case match_store(Opts) of
         [] -> {skip, <<"No store configured for match index.">>};
@@ -500,13 +751,27 @@ write_match_index(IDs, Base, Opts) ->
 %% `false' disables index writes, `true' uses the normal configured
 %% store, and a store definition/list writes the index there.
 match_store(Opts) ->
-    Global = hb_opts:get(match_index, false, #{ <<"only">> => global }),
-    LocalStore = hb_opts:get(store, Global, Opts#{ <<"only">> => local }),
-    case hb_opts:get(match_index, LocalStore, Opts#{ <<"only">> => local }) of
+    LocalMatchIndex = maps:get(<<"match-index">>, Opts, undefined),
+    LocalStore = maps:get(<<"store">>, Opts, undefined),
+    GlobalMatchIndex = hb_opts:get(match_index, false, #{ <<"only">> => global }),
+    MatchIndexStore =
+        case {LocalMatchIndex, LocalStore} of
+            {undefined, undefined} ->
+                GlobalMatchIndex;
+            {undefined, _} ->
+                LocalStore;
+            {Local, Store}
+                    when Store =/= undefined andalso
+                        Local =:= GlobalMatchIndex ->
+                Store;
+            {Local, _} ->
+                Local
+        end,
+    case MatchIndexStore of
         false -> [];
         true -> hb_opts:get(store, [], Opts);
-        Store when is_list(Store) -> Store;
-        Store -> [Store]
+        ResolvedStore when is_list(ResolvedStore) -> ResolvedStore;
+        ResolvedStore -> [ResolvedStore]
     end.
 
 %% @doc Calculate the address of a key-value pair in the match index.

--- a/src/core/resolver/hb_opts.erl
+++ b/src/core/resolver/hb_opts.erl
@@ -289,7 +289,7 @@ raw_default_message() ->
         % Every modification to `Opts' called directly by the node operator
         % should be recorded here.
         <<"node-history">> => [],
-        <<"debug-stack-depth">> => 40,
+        <<"debug-stack-depth">> => 8,
         <<"debug-print">> => false,
         <<"debug-log">> => false,
         <<"log-dir">> => <<"logs">>,

--- a/src/core/store/hb_store.erl
+++ b/src/core/store/hb_store.erl
@@ -80,7 +80,7 @@
 -define(STORE_BENCH_LIST_OPS, 20_000).
 -define(BENCH_MSG_WRITE_OPS, 50_000).
 -define(BENCH_MSG_READ_OPS, 50_000).
--define(BENCH_MSG_DATA_SIZE, 1024).
+-define(BENCH_MSG_DATA_SIZE, 32).
 
 behavior_info(callbacks) ->
     [
@@ -1032,7 +1032,10 @@ benchmark_message_read_write(Store, Shape) ->
     ).
 benchmark_message_read_write(Store, WriteOps, ReadOps, Shape) ->
     start(Store),
-    Opts = #{ <<"store">> => Store, <<"priv-wallet">> => hb:wallet() },
+    Opts = #{ 
+        <<"store">> => Store, 
+        <<"priv-wallet">> => hb:wallet()
+    },
     TestDataSize = ?BENCH_MSG_DATA_SIZE * 8, % in _bits_
     timer:sleep(100),
     ?event(
@@ -1113,9 +1116,9 @@ benchmark_message_read_write(Store, WriteOps, ReadOps, Shape) ->
     ),
     ?assertEqual(0, NotFoundCount, "Written keys not found in store.").
 
-benchmark_message(flat, N, _TestDataSize) ->
+benchmark_message(flat, N, TestDataSize) ->
     #{
-        <<"process">> => hb_util:human_id(crypto:strong_rand_bytes(32)),
+        <<"process">> => <<0:TestDataSize, N:32>>,
         <<"slot">> => N
     };
 benchmark_message(nested, N, TestDataSize) ->

--- a/src/core/store/hb_store.erl
+++ b/src/core/store/hb_store.erl
@@ -78,8 +78,8 @@
 -define(STORE_BENCH_LIST_KEYS, 100_000).
 -define(STORE_BENCH_LIST_GROUP_SIZE, 10).
 -define(STORE_BENCH_LIST_OPS, 20_000).
--define(BENCH_MSG_WRITE_OPS, 250).
--define(BENCH_MSG_READ_OPS, 100_000).
+-define(BENCH_MSG_WRITE_OPS, 50_000).
+-define(BENCH_MSG_READ_OPS, 50_000).
 -define(BENCH_MSG_DATA_SIZE, 1024).
 
 behavior_info(callbacks) ->
@@ -654,13 +654,13 @@ strongest_error(Current, _Error) -> Current.
 test_stores() ->
     [
         (hb_test_utils:test_store(hb_store_fs))#{
-            <<"benchmark-scale">> => 0.001
+            <<"benchmark-scale">> => 0.0001
         },
         (hb_test_utils:test_store(hb_store_lmdb))#{
             <<"benchmark-scale">> => 0.5
         },
         (hb_test_utils:test_store(hb_store_volatile))#{
-            <<"benchmark-scale">> => 0.01
+            <<"benchmark-scale">> => 0.001
         }
     ] ++ rocks_stores().
 
@@ -757,7 +757,8 @@ benchmark_suite_test_() ->
     generate_test_suite([
         {"benchmark key read write", fun benchmark_key_read_write/1},
         {"benchmark list", fun benchmark_list/1},
-        {"benchmark message read write", fun benchmark_message_read_write/1}
+        {"benchmark flat message read write", fun benchmark_flat_message_read_write/1},
+        {"benchmark nested message read write", fun benchmark_nested_message_read_write/1}
     ]).
 
 %% @doc Benchmark a store. By default, we write 10,000 keys and read 10,000
@@ -1009,15 +1010,27 @@ benchmark_list(Store, WriteOps, ListOps, GroupSize) ->
     ),
     ?assertEqual(0, NotFoundCount, "Groups listed in correctly.").
 
-benchmark_message_read_write(Store = #{ <<"benchmark-scale">> := Scale }) ->
+benchmark_flat_message_read_write(Store) ->
+    benchmark_message_read_write(Store, flat).
+
+benchmark_nested_message_read_write(Store) ->
+    benchmark_message_read_write(Store, nested).
+
+benchmark_message_read_write(Store = #{ <<"benchmark-scale">> := Scale }, Shape) ->
     benchmark_message_read_write(
         Store,
         erlang:ceil(Scale * ?BENCH_MSG_WRITE_OPS),
-        erlang:ceil(Scale * ?BENCH_MSG_READ_OPS)
+        erlang:ceil(Scale * ?BENCH_MSG_READ_OPS),
+        Shape
     );
-benchmark_message_read_write(Store) ->
-    benchmark_message_read_write(Store, ?BENCH_MSG_WRITE_OPS, ?BENCH_MSG_READ_OPS).
-benchmark_message_read_write(Store, WriteOps, ReadOps) ->
+benchmark_message_read_write(Store, Shape) ->
+    benchmark_message_read_write(
+        Store,
+        ?BENCH_MSG_WRITE_OPS,
+        ?BENCH_MSG_READ_OPS,
+        Shape
+    ).
+benchmark_message_read_write(Store, WriteOps, ReadOps, Shape) ->
     start(Store),
     Opts = #{ <<"store">> => Store, <<"priv-wallet">> => hb:wallet() },
     TestDataSize = ?BENCH_MSG_DATA_SIZE * 8, % in _bits_
@@ -1025,34 +1038,28 @@ benchmark_message_read_write(Store, WriteOps, ReadOps) ->
     ?event(
         {benchmarking,
             {store, Store},
+            {shape, Shape},
             {write_ops, WriteOps},
             {read_ops, ReadOps}
         }
     ),
     % Generate a random message to write and the keys to read ahead of time.
-    Msgs =
-        lists:map(
-            fun(N) ->
-                #{
-                    <<"process">> => hb_util:human_id(crypto:strong_rand_bytes(32)),
-                    <<"slot">> => N,
-                    <<"message">> =>
-                        hb_message:commit(
-                            #{
-                                <<"body">> => <<"test", 0:TestDataSize, N:32>>
-                            },
-                            Opts
-                        )
-                }
-            end,
-            lists:seq(1, WriteOps)
+    {GenerateTime, Msgs} =
+        timer:tc(
+            fun() ->
+                lists:map(
+                    fun(N) ->
+                        benchmark_message(Shape, N, TestDataSize)
+                    end,
+                    lists:seq(1, WriteOps)
+                )
+            end
         ),
-    hb_format:eunit_print(
-        "Generated ~s messages (size ~s bits)",
-        [
-            hb_util:human_int(WriteOps),
-            hb_util:human_int(TestDataSize)
-        ]
+    hb_test_utils:benchmark_print(
+        <<"Generated">>,
+        <<"messages">>,
+        WriteOps,
+        GenerateTime / 1_000_000
     ),
     {WriteTime, MsgPairs} =
         timer:tc(
@@ -1105,6 +1112,19 @@ benchmark_message_read_write(Store, WriteOps, ReadOps) ->
         ReadTime / 1_000_000
     ),
     ?assertEqual(0, NotFoundCount, "Written keys not found in store.").
+
+benchmark_message(flat, N, _TestDataSize) ->
+    #{
+        <<"process">> => hb_util:human_id(crypto:strong_rand_bytes(32)),
+        <<"slot">> => N
+    };
+benchmark_message(nested, N, TestDataSize) ->
+    (benchmark_message(flat, N, TestDataSize))#{
+        <<"message">> =>
+            #{
+                <<"body">> => <<"test", 0:TestDataSize, N:32>>
+            }
+    }.
 
 %%% Access Control Tests
 

--- a/src/core/store/hb_store_lmdb.erl
+++ b/src/core/store/hb_store_lmdb.erl
@@ -360,15 +360,6 @@ read_direct(DBInstance, Name, Path) ->
 %% This is the internal implementation that handles actual database reads.
 read_with_links(Opts, Path) ->
     case read_direct(Opts, Path) of
-        {ok, <<"raw:", Value/binary>>} ->
-            case is_data_path(Path) of
-                true -> {ok, Path, <<"raw:", Value/binary>>};
-                false -> {ok, Path, Value}
-            end;
-        {ok, <<"link:data">>} ->
-            read_with_links(Opts, <<"data">>);
-        {ok, <<"link:data/", Link/binary>>} ->
-            read_with_links(Opts, <<"data/", Link/binary>>);
         {ok, Value} ->
             case is_link(Value) of
                 {true, Link} -> 
@@ -513,11 +504,6 @@ read_prefix_rows(Opts, Path) ->
 prefix_read_result(Opts, Path, [{Path, <<"link:", Link/binary>>} | _])
         when byte_size(Link) > 0 ->
     read_result(Opts, Link);
-prefix_read_result(_Opts, Path, [{Path, <<"raw:", Value/binary>>} | _]) ->
-    case is_data_path(Path) of
-        true -> {ok, <<"raw:", Value/binary>>};
-        false -> {ok, Value}
-    end;
 prefix_read_result(_Opts, Path, [{Path, <<"group">>} | Rows]) ->
     {composite, immediate_children(child_prefix(Path), Rows)};
 prefix_read_result(_Opts, Path, [{Path, Value} | _]) ->
@@ -1257,25 +1243,4 @@ read_prefix_composite_test() ->
         read(StoreOpts, #{ <<"read">> => <<"root">> }, #{})
     ),
     ?assertEqual({ok, [<<"a">>, <<"b">>]}, test_list(StoreOpts, <<"root">>)),
-    test_stop(StoreOpts).
-
-raw_value_write_test() ->
-    StoreOpts = hb_test_utils:test_store(?MODULE),
-    test_reset(StoreOpts),
-    ok = group(StoreOpts, #{ <<"group">> => <<"root">> }, #{}),
-    ok =
-        write(
-            StoreOpts,
-            #{
-                <<"data/small">> => <<"value">>,
-                <<"root/small">> => <<"raw:value">>
-            },
-            #{}
-        ),
-    ?assertEqual(
-        {composite, [{<<"small">>, <<"raw:value">>}]},
-        read(StoreOpts, #{ <<"read">> => <<"root">> }, #{})
-    ),
-    ?assertEqual({ok, <<"value">>}, test_read(StoreOpts, <<"root/small">>)),
-    ?assertEqual({ok, <<"value">>}, test_read(StoreOpts, <<"data/small">>)),
     test_stop(StoreOpts).

--- a/src/core/store/hb_store_remote_node.erl
+++ b/src/core/store/hb_store_remote_node.erl
@@ -156,7 +156,7 @@ write(Opts = #{ <<"node">> := Node }, Req, _NodeOpts) when is_map(Req) ->
     ?event({write, {node, Node}, {request, Req}}),
     maps:fold(
         fun(Destination, Value, ok) ->
-            case remote_write_value(Opts, store_value(Destination, Value)) of
+            case remote_write_value(Opts, Value) of
                 {ok, SourcePath} ->
                     remote_link(Opts, hb_path:to_binary(SourcePath), hb_path:to_binary(Destination));
                 {error, _} = Error ->
@@ -168,20 +168,6 @@ write(Opts = #{ <<"node">> := Node }, Req, _NodeOpts) when is_map(Req) ->
         ok,
         Req
     ).
-
-%% @doc The remote node re-content-addresses every written value, so a cache
-%% `raw:' inline marker -- written at a key path -- must be reduced to its
-%% logical value first. Otherwise the marker itself is hashed and stored,
-%% corrupting later reads. `data/' destinations already hold the logical value
-%% (which may itself begin with `raw:'), so they are forwarded verbatim.
-store_value(Destination, <<"raw:", Value/binary>>) when is_binary(Destination) ->
-    case Destination of
-        <<"data">> -> <<"raw:", Value/binary>>;
-        <<"data/", _/binary>> -> <<"raw:", Value/binary>>;
-        _ -> Value
-    end;
-store_value(_Destination, Value) ->
-    Value.
 
 %% @doc Link a source to a destination in the remote node.
 %%

--- a/src/preloaded/codec/dev_httpsig_conv.erl
+++ b/src/preloaded/codec/dev_httpsig_conv.erl
@@ -908,12 +908,14 @@ encode_message_with_links_test() ->
     Msg = #{
         <<"immediate-key">> => <<"immediate-value">>,
         <<"long-key">> => binary:copy(<<"a">>, 61),
-        <<"short-key">> => <<"short-value">>
+        <<"short-key">> => <<"short-value">>,
+        <<"typed-key">> => 4
     },
     {ok, Path} = hb_cache:write(Msg, #{}),
     {ok, Read} = hb_cache:read(Path, #{}),
     % Ensure that the message now has a lazy link
     ?assertMatch(<<"short-value">>, maps:get(<<"short-key">>, Read, #{})),
+    ?assertEqual(4, maps:get(<<"typed-key">>, Read, #{})),
     ?assertMatch({link, _, _}, maps:get(<<"long-key">>, Read, #{})),
     % Encode and decode the message as `httpsig@1.0`
     Enc = hb_message:convert(Msg, <<"httpsig@1.0">>, #{}),

--- a/src/preloaded/codec/dev_httpsig_conv.erl
+++ b/src/preloaded/codec/dev_httpsig_conv.erl
@@ -904,7 +904,6 @@ group_maps_flat_compatible_test() ->
     ok.
 
 encode_message_with_links_test() ->
-    % hb_cache will only linkify the key if it is longer than 60 characters
     Msg = #{
         <<"immediate-key">> => <<"immediate-value">>,
         <<"long-key">> => binary:copy(<<"a">>, 61),
@@ -913,10 +912,12 @@ encode_message_with_links_test() ->
     },
     {ok, Path} = hb_cache:write(Msg, #{}),
     {ok, Read} = hb_cache:read(Path, #{}),
-    % Ensure that the message now has a lazy link
-    ?assertMatch(<<"short-value">>, maps:get(<<"short-key">>, Read, #{})),
+    % Ensure that small values are materialized directly while larger values
+    % stay lazy.
+    ?assertEqual(<<"short-value">>, maps:get(<<"short-key">>, Read, #{})),
     ?assertEqual(4, maps:get(<<"typed-key">>, Read, #{})),
     ?assertMatch({link, _, _}, maps:get(<<"long-key">>, Read, #{})),
+    ?assertEqual(Msg, hb_cache:ensure_all_loaded(Read, #{})),
     % Encode and decode the message as `httpsig@1.0`
     Enc = hb_message:convert(Msg, <<"httpsig@1.0">>, #{}),
     ?event({encoded, Enc}),

--- a/src/preloaded/codec/dev_structured.erl
+++ b/src/preloaded/codec/dev_structured.erl
@@ -205,13 +205,28 @@ apply_bundle_hint(Msg, Req, Opts) ->
     case hb_maps:get(<<"hint-device">>, Req, undefined, Opts) of
         undefined -> Req;
         DeviceBin ->
-            % May add a `bundle` key to the request
-            try hb_util:ok(
-                hb_ao:raw(DeviceBin, <<"to-hint">>, Msg, Req, Opts)
-            )
-            catch _:_ ->
-                Req
+            case hint_device_exports_to_hint(DeviceBin, Opts) of
+                true ->
+                    % May add a `bundle` key to the request
+                    try hb_util:ok(
+                        hb_ao:raw(DeviceBin, <<"to-hint">>, Msg, Req, Opts)
+                    )
+                    catch _:_ ->
+                        Req
+                    end;
+                false ->
+                    Req
             end
+    end.
+
+hint_device_exports_to_hint(DeviceBin, Opts) ->
+    try hb_device:message_to_device(#{ <<"device">> => DeviceBin }, Opts) of
+        DeviceMod when is_atom(DeviceMod) ->
+            erlang:function_exported(DeviceMod, to_hint, 3);
+        _ ->
+            true
+    catch _:_ ->
+        false
     end.
 
 %% @doc Discern the linkify mode from the request and the options.

--- a/src/preloaded/codec/dev_structured.erl
+++ b/src/preloaded/codec/dev_structured.erl
@@ -81,7 +81,12 @@ from(List, Req, Opts) when is_list(List) ->
     end;
 from(Msg, Req, Opts) when is_map(Msg) ->
     HintedReq = apply_bundle_hint(Msg, Req, Opts),
-    NormLinks = hb_link:normalize(Msg, linkify_mode(HintedReq, Opts), Opts),
+    NormLinks =
+        hb_link:normalize(
+            encode_map_ao_types(Msg, Opts),
+            linkify_mode(HintedReq, Opts),
+            Opts
+        ),
     NormKeysMap = hb_ao:normalize_keys(NormLinks, Opts),
     EncodeTypes = find_encode_types(HintedReq, Opts),
     {Types, Values} = lists:foldl(
@@ -176,6 +181,14 @@ from(Other, _Req, _Opts) -> {ok, hb_path:to_binary(Other)}.
 %% @doc Find the types that should be encoded from the request and options.
 find_encode_types(Req, Opts) ->
     hb_maps:get(<<"encode-types">>, Req, ?SUPPORTED_TYPES, Opts).
+
+%% @doc Encode map-valued `ao-types' before link normalization. `ao-types'
+%% describes the current message, so it must remain inline rather than being
+%% treated as a child message and offloaded as `ao-types+link'.
+encode_map_ao_types(Msg = #{ <<"ao-types">> := Types }, Opts) when is_map(Types) ->
+    Msg#{ <<"ao-types">> := encode_ao_types(Types, Opts) };
+encode_map_ao_types(Msg, _Opts) ->
+    Msg.
 
 %% @doc Determine the type for a value.
 type(Int) when is_integer(Int) -> <<"integer">>;

--- a/src/preloaded/codec/dev_structured.erl
+++ b/src/preloaded/codec/dev_structured.erl
@@ -205,28 +205,13 @@ apply_bundle_hint(Msg, Req, Opts) ->
     case hb_maps:get(<<"hint-device">>, Req, undefined, Opts) of
         undefined -> Req;
         DeviceBin ->
-            case hint_device_exports_to_hint(DeviceBin, Opts) of
-                true ->
+            case hb_ao:raw(DeviceBin, <<"to-hint">>, Msg, Req, Opts) of
+                {ok, HintedReq} ->
                     % May add a `bundle` key to the request
-                    try hb_util:ok(
-                        hb_ao:raw(DeviceBin, <<"to-hint">>, Msg, Req, Opts)
-                    )
-                    catch _:_ ->
-                        Req
-                    end;
-                false ->
+                    HintedReq;
+                _ ->
                     Req
             end
-    end.
-
-hint_device_exports_to_hint(DeviceBin, Opts) ->
-    try hb_device:message_to_device(#{ <<"device">> => DeviceBin }, Opts) of
-        DeviceMod when is_atom(DeviceMod) ->
-            erlang:function_exported(DeviceMod, to_hint, 3);
-        _ ->
-            true
-    catch _:_ ->
-        false
     end.
 
 %% @doc Discern the linkify mode from the request and the options.

--- a/src/preloaded/codec/dev_structured.erl
+++ b/src/preloaded/codec/dev_structured.erl
@@ -81,12 +81,7 @@ from(List, Req, Opts) when is_list(List) ->
     end;
 from(Msg, Req, Opts) when is_map(Msg) ->
     HintedReq = apply_bundle_hint(Msg, Req, Opts),
-    NormLinks =
-        hb_link:normalize(
-            encode_map_ao_types(Msg, Opts),
-            linkify_mode(HintedReq, Opts),
-            Opts
-        ),
+    NormLinks = hb_link:normalize(Msg, linkify_mode(HintedReq, Opts), Opts),
     NormKeysMap = hb_ao:normalize_keys(NormLinks, Opts),
     EncodeTypes = find_encode_types(HintedReq, Opts),
     {Types, Values} = lists:foldl(
@@ -181,14 +176,6 @@ from(Other, _Req, _Opts) -> {ok, hb_path:to_binary(Other)}.
 %% @doc Find the types that should be encoded from the request and options.
 find_encode_types(Req, Opts) ->
     hb_maps:get(<<"encode-types">>, Req, ?SUPPORTED_TYPES, Opts).
-
-%% @doc Encode map-valued `ao-types' before link normalization. `ao-types'
-%% describes the current message, so it must remain inline rather than being
-%% treated as a child message and offloaded as `ao-types+link'.
-encode_map_ao_types(Msg = #{ <<"ao-types">> := Types }, Opts) when is_map(Types) ->
-    Msg#{ <<"ao-types">> := encode_ao_types(Types, Opts) };
-encode_map_ao_types(Msg, _Opts) ->
-    Msg.
 
 %% @doc Determine the type for a value.
 type(Int) when is_integer(Int) -> <<"integer">>;


### PR DESCRIPTION
Matching the earlier work in #981, this PR introduces bulk write operations for HyperBEAM stores when committing a message for persistence.

Flat messages read/write (LMDB): `45.4k/243k msg/s`
Nested messages: `19.8k/193k msg/s`

Pure `~lua@5.3a` process execution: `455 slots/s`
HyperAOS process execution: `182 slots/s`