### PR TITLE
perf: Optimize codec ID generation hot paths

### DIFF
--- a/src/core/http/hb_structured_fields.erl
+++ b/src/core/http/hb_structured_fields.erl
@@ -558,7 +558,7 @@ inner_list({list, List, Params}) ->
     [$(, lists:join($\s, [item(Value) || Value <- List]), $), params(Params)].
 
 bare_item({string, String}) ->
-    [$", escape_string(String, <<>>), $"];
+    [$", escape_string(String), $"];
 %% @todo Must fail if Token has invalid characters.
 bare_item({token, Token}) ->
     Token;
@@ -638,10 +638,22 @@ bare_item(false) ->
 exp_div(0) -> 1;
 exp_div(N) -> 10 * exp_div(N + 1).
 
-escape_string(<<>>, Acc) -> Acc;
-escape_string(<<$\\, R/bits>>, Acc) -> escape_string(R, <<Acc/binary, $\\, $\\>>);
-escape_string(<<$", R/bits>>, Acc) -> escape_string(R, <<Acc/binary, $\\, $">>);
-escape_string(<<C, R/bits>>, Acc) -> escape_string(R, <<Acc/binary, C>>).
+escape_string(Bin) ->
+    escape_string(Bin, Bin).
+
+escape_string(<<>>, Original) ->
+    Original;
+escape_string(<<$\\, _/binary>>, Original) ->
+    escape_chars(Original, []);
+escape_string(<<$", _/binary>>, Original) ->
+    escape_chars(Original, []);
+escape_string(<<_C, Rest/binary>>, Original) ->
+    escape_string(Rest, Original).
+
+escape_chars(<<>>, Acc) -> lists:reverse(Acc);
+escape_chars(<<$\\, R/bits>>, Acc) -> escape_chars(R, [$\\, $\\ | Acc]);
+escape_chars(<<$", R/bits>>, Acc) -> escape_chars(R, [$", $\\ | Acc]);
+escape_chars(<<C, R/bits>>, Acc) -> escape_chars(R, [C | Acc]).
 
 params(Params) ->
     [

--- a/src/core/util/hb_escape.erl
+++ b/src/core/util/hb_escape.erl
@@ -16,11 +16,20 @@
 
 %% @doc Encode a binary as a URI-encoded string.
 encode(Bin) when is_binary(Bin) ->
-    list_to_binary(percent_escape(binary_to_list(Bin))).
+    case uri_safe(Bin) of
+        true -> Bin;
+        false -> iolist_to_binary(lists:reverse(percent_escape(Bin, [])))
+    end.
 
 %% @doc Decode a URI-encoded string back to a binary.
 decode(Bin) when is_binary(Bin) ->
-    list_to_binary(percent_unescape(binary_to_list(Bin))).
+    decode(Bin, Bin).
+decode(<<>>, Original) ->
+    Original;
+decode(<<$%, _/binary>>, Original) ->
+    iolist_to_binary(lists:reverse(percent_unescape(Original, [])));
+decode(<<_C, Rest/binary>>, Original) ->
+    decode(Rest, Original).
 
 %% @doc Encode a string with escaped quotes.
 encode_quotes(String) when is_binary(String) ->
@@ -64,15 +73,30 @@ encode_keys(Msg, Opts) when is_map(Msg) ->
     );
 encode_keys(Other, _Opts) -> Other.
 
-%% @doc Escape a list of characters as a URI-encoded string.
-percent_escape([]) -> [];
-percent_escape([C | Cs]) when C >= $a, C =< $z -> [C | percent_escape(Cs)];
-percent_escape([C | Cs]) when C >= $0, C =< $9 -> [C | percent_escape(Cs)];
-percent_escape([C | Cs]) when
+%% @doc Escape a binary as a URI-encoded string.
+uri_safe(<<>>) -> true;
+uri_safe(<<C, Rest/binary>>) when C >= $a, C =< $z ->
+    uri_safe(Rest);
+uri_safe(<<C, Rest/binary>>) when C >= $0, C =< $9 ->
+    uri_safe(Rest);
+uri_safe(<<C, Rest/binary>>) when
         C == $.; C == $-; C == $_; C == $/;
         C == $?; C == $& ->
-    [C | percent_escape(Cs)];
-percent_escape([C | Cs]) -> [escape_byte(C) | percent_escape(Cs)].
+    uri_safe(Rest);
+uri_safe(_) ->
+    false.
+
+percent_escape(<<>>, Acc) -> Acc;
+percent_escape(<<C, Rest/binary>>, Acc) when C >= $a, C =< $z ->
+    percent_escape(Rest, [C | Acc]);
+percent_escape(<<C, Rest/binary>>, Acc) when C >= $0, C =< $9 ->
+    percent_escape(Rest, [C | Acc]);
+percent_escape(<<C, Rest/binary>>, Acc) when
+        C == $.; C == $-; C == $_; C == $/;
+        C == $?; C == $& ->
+    percent_escape(Rest, [C | Acc]);
+percent_escape(<<C, Rest/binary>>, Acc) ->
+    percent_escape(Rest, [escape_byte(C) | Acc]).
 
 %% @doc Escape a single byte as a URI-encoded string.
 escape_byte(C) when C >= 0, C =< 255 ->
@@ -84,13 +108,13 @@ hex_digit(N) when N > 9, N =< 15 ->
     N + $a - 10.
 
 %% @doc Unescape a URI-encoded string.
-percent_unescape([$%, H1, H2 | Cs]) ->
+percent_unescape(<<$%, H1, H2, Rest/binary>>, Acc) ->
     Byte = (hex_value(H1) bsl 4) + hex_value(H2),
-    [Byte | percent_unescape(Cs)];
-percent_unescape([C | Cs]) ->
-    [C | percent_unescape(Cs)];
-percent_unescape([]) ->
-    [].
+    percent_unescape(Rest, [Byte | Acc]);
+percent_unescape(<<C, Rest/binary>>, Acc) ->
+    percent_unescape(Rest, [C | Acc]);
+percent_unescape(<<>>, Acc) ->
+    Acc.
 
 hex_value(C) when C >= $0, C =< $9 ->
     C - $0;

--- a/src/core/util/hb_util.erl
+++ b/src/core/util/hb_util.erl
@@ -39,7 +39,7 @@
 
 %% @doc Coerce a string to an integer.
 int(Str) when is_binary(Str) ->
-    list_to_integer(binary_to_list(Str));
+    binary_to_integer(Str);
 int(Str) when is_list(Str) ->
     list_to_integer(Str);
 int(Int) when is_integer(Int) ->
@@ -318,7 +318,7 @@ decode(_) ->
 decode(Type, Value) when is_list(Type) ->
     decode(list_to_binary(Type), Value);
 decode(Type, Value) when is_binary(Type) ->
-    ?event({decoding, {type, Type}, {value, {explicit, Value}}}),
+    ?event_debug({decoding, {type, Type}, {value, {explicit, Value}}}),
     decode(
         binary_to_existing_atom(to_lower(Type), latin1),
         Value
@@ -496,10 +496,12 @@ template_message_match(ToMatch, TemplateWithoutPath, Opts) ->
 
 %% @doc Label a list of elements with a number.
 number(List) ->
-    lists:map(
-        fun({N, Item}) -> {integer_to_binary(N), Item} end,
-        lists:zip(lists:seq(1, length(List)), List)
-    ).
+    number(List, 1, []).
+
+number([], _N, Acc) ->
+    lists:reverse(Acc);
+number([Item|Rest], N, Acc) ->
+    number(Rest, N + 1, [{integer_to_binary(N), Item}|Acc]).
 
 %% @doc Convert a list of elements to a map with numbered keys.
 list_to_numbered_message(Msg) when is_map(Msg) ->
@@ -514,21 +516,32 @@ list_to_numbered_message(List) ->
 %% @doc Determine if the message given is an ordered list, starting from 1.
 is_ordered_list(Msg, _Opts) when is_list(Msg) -> true;
 is_ordered_list(Msg, Opts) ->
-    is_ordered_list(1, hb_ao:normalize_keys(Msg, Opts), Opts).
-is_ordered_list(N, Msg, _Opts) ->
-    case maps:get(NormKey = hb_ao:normalize_key(N), Msg, not_found) of
-        not_found ->
-            WithoutPriv = hb_private:reset(Msg),
-            case maps:without([<<"commitments">>, <<"ao-types">>], WithoutPriv) of
-                EmptyMsg when map_size(EmptyMsg) == 0 -> true;
-                _ -> false
-            end;
-        _ ->
-            is_ordered_list(
-                N + 1,
-                maps:without([NormKey], Msg),
-				_Opts
-            )
+    is_ordered_list(maps:next(maps:iterator(hb_ao:normalize_keys(Msg, Opts))), 0, 0).
+is_ordered_list(none, Count, Max) ->
+    Count == Max;
+is_ordered_list({Key, _Val, Iter}, Count, Max) ->
+    case is_ordered_list_key(Key) of
+        skip -> is_ordered_list(maps:next(Iter), Count, Max);
+        false -> false;
+        N -> is_ordered_list(maps:next(Iter), Count + 1, max(N, Max))
+    end.
+
+is_ordered_list_key(<<"commitments">>) -> skip;
+is_ordered_list_key(<<"ao-types">>) -> skip;
+is_ordered_list_key(Key) ->
+    case hb_private:is_private(Key) of
+        true -> skip;
+        false ->
+            try binary_to_integer(Key) of
+                N when N >= 1 ->
+                    case integer_to_binary(N) of
+                        Key -> N;
+                        _ -> false
+                    end;
+                _ ->
+                    false
+            catch _:_ -> false
+            end
     end.
 
 %% @doc Replace a key in a list with a new value.
@@ -580,39 +593,65 @@ message_to_ordered_list(List, _Opts) when is_list(List) ->
     List;
 message_to_ordered_list(Message, Opts) ->
     NormMessage = hb_ao:normalize_keys(Message, Opts),
-    Keys = hb_maps:keys(NormMessage, Opts) -- [<<"priv">>, <<"commitments">>],
-    SortedKeys =
-        lists:map(
-            fun hb_ao:normalize_key/1,
-            lists:sort(lists:map(fun int/1, Keys))
-        ),
-    message_to_ordered_list(NormMessage, SortedKeys, erlang:hd(SortedKeys), Opts).
-message_to_ordered_list(_Message, [], _Key, _Opts) ->
+    Pairs = message_to_ordered_pairs(maps:next(maps:iterator(NormMessage)), []),
+    message_to_ordered_list(NormMessage, lists:sort(Pairs), Opts).
+message_to_ordered_list(_Message, [], _Opts) ->
     [];
-message_to_ordered_list(Message, [Key|Keys], Key, Opts) ->
+message_to_ordered_list(Message, [{N, Key, MaybeValue}|Rest], Opts) ->
+    message_to_ordered_list(Message, Rest, N, Key, MaybeValue, Opts, []).
+
+message_to_ordered_pairs(none, Acc) ->
+    Acc;
+message_to_ordered_pairs({Key, Val, Iter}, Acc) ->
+    Next = maps:next(Iter),
+    case message_to_ordered_key(Key) of
+        skip ->
+            message_to_ordered_pairs(Next, Acc);
+        N ->
+            CanonicalKey = integer_to_binary(N),
+            MaybeValue =
+                case Key of
+                    CanonicalKey -> Val;
+                    _ -> lookup
+                end,
+            message_to_ordered_pairs(Next, [{N, CanonicalKey, MaybeValue}|Acc])
+    end.
+
+message_to_ordered_key(<<"commitments">>) -> skip;
+message_to_ordered_key(<<"ao-types">>) -> skip;
+message_to_ordered_key(<<"priv", _/binary>>) -> skip;
+message_to_ordered_key(Key) -> int(Key).
+
+message_to_ordered_list(Message, [{Next, NextKey, NextVal}|Rest], N, Key, MaybeValue, Opts, Acc)
+        when Next == N + 1 ->
+    Value = ordered_list_value(Key, MaybeValue, Message, Opts),
+    message_to_ordered_list(Message, Rest, Next, NextKey, NextVal, Opts, [Value|Acc]);
+message_to_ordered_list(Message, [{Next, NextKey, _NextVal}|_Rest], N, Key, MaybeValue, Opts, _Acc)
+        when Next =/= N + 1 ->
+    _ = ordered_list_value(Key, MaybeValue, Message, Opts),
+    ExpectedKey = integer_to_binary(N + 1),
+    throw({missing_key, {expected, ExpectedKey, {next, NextKey}, {message, Message}}});
+message_to_ordered_list(Message, [], _N, Key, MaybeValue, Opts, Acc) ->
+    Value = ordered_list_value(Key, MaybeValue, Message, Opts),
+    lists:reverse([Value|Acc]).
+
+ordered_list_value(Key, lookup, Message, Opts) ->
     case hb_maps:get(Key, Message, undefined, Opts#{ <<"hashpath">> => ignore }) of
         undefined ->
             throw(
                 {missing_key,
                     {key, Key},
-                    {remaining_keys, Keys},
                     {message, Message}
                 }
             );
-        Value ->
-            [
-                Value
-            |
-                message_to_ordered_list(
-                    Message,
-                    Keys,
-                    hb_ao:normalize_key(int(Key) + 1),
-                    Opts
-                )
-            ]
+        Value -> Value
     end;
-message_to_ordered_list(Message, [Key|_Keys], ExpectedKey, _Opts) ->
-    throw({missing_key, {expected, ExpectedKey, {next, Key}, {message, Message}}}).
+ordered_list_value(Key, undefined, Message, _Opts) ->
+    throw({missing_key, {key, Key}, {message, Message}});
+ordered_list_value(_Key, Value, _Message, Opts) when ?IS_LINK(Value) ->
+    hb_cache:ensure_loaded(Value, Opts#{ <<"hashpath">> => ignore });
+ordered_list_value(_Key, Value, _Message, _Opts) ->
+    Value.
 
 %% @doc Convert a message with numbered keys and others to a sorted list with only
 %% the numbered values.
@@ -941,6 +980,16 @@ atom_to_dashed_binary(Key) when is_atom(Key) ->
 
 atom_to_dashed_binary_test_parallel() ->
     ?assertEqual(atom_to_dashed_binary(atom_1), <<"atom-1">>).
+
+message_to_ordered_list_metadata_test() ->
+    Msg = #{
+        <<"1">> => one,
+        <<"2">> => two,
+        <<"ao-types">> => #{},
+        <<"commitments">> => #{},
+        <<"priv">> => #{ <<"state">> => ignored }
+    },
+    ?assertEqual([one, two], message_to_ordered_list(Msg)).
 
 %% `to_lower/1' must remain byte-for-byte equivalent to `string:lowercase',
 %% including the `badarg' throw on invalid UTF-8 that `ar_tx' tag parsing

--- a/src/preloaded/codec/dev_httpsig.erl
+++ b/src/preloaded/codec/dev_httpsig.erl
@@ -251,7 +251,7 @@ commit(BaseMsg, Req = #{ <<"type">> := <<"hmac-sha256">> }, RawOpts) ->
         normalize_for_encoding(Msg, UnauthedCommitment, Opts),
     SigBase = signature_base(EncMsg, EncComm, Opts),    
     HMac = hb_util:human_id(crypto:mac(hmac, sha256, Key, SigBase)),
-    ?event(
+    ?event_debug(
         debug_commitments,
         {hmac_commit,
             {type, <<"hmac-sha256">>},
@@ -295,25 +295,33 @@ keys_to_commit(_Base, #{ <<"committed">> := Explicit}, _Opts) ->
     % Add `+link` specifiers to the user given list as necessary, in order for
     % their given keys to match the HTTPSig encoded TABM form.
     hb_util:list_to_numbered_message(Explicit);
+keys_to_commit(Base = #{ <<"commitments">> := Commitments }, _Req, Opts)
+        when ?IS_EMPTY_MESSAGE(Commitments) ->
+    default_keys_to_commit(Base, Opts);
+keys_to_commit(Base, _Req, Opts) when not is_map_key(<<"commitments">>, Base) ->
+    default_keys_to_commit(Base, Opts);
 keys_to_commit(Base, _Req, Opts) ->
     % Extract the set of committed keys from the message.
     case hb_message:committed(Base, #{ <<"committers">> => <<"all">> }, opts(Opts)) of
         [] ->
             % Case 3: Default to all keys in the TABM-encoded message, aside
             % metadata.
-            hb_util:list_to_numbered_message(
-                lists:map(
-                    fun hb_link:remove_link_specifier/1,
-                    hb_util:to_sorted_keys(Base, Opts)
-                        -- [<<"commitments">>, <<"priv">>]
-                )
-            );
+            default_keys_to_commit(Base, Opts);
         Keys ->
             % Case 2: Replicate the raw keys that the existing commitments have
             % used. This leads to a message whose commitments can be 'stacked'
             % and represented together in HTTPSig format.
             hb_util:list_to_numbered_message(Keys)
     end.
+
+default_keys_to_commit(Base, Opts) ->
+    hb_util:list_to_numbered_message(
+        lists:map(
+            fun hb_link:remove_link_specifier/1,
+            hb_util:to_sorted_keys(Base, Opts)
+                -- [<<"commitments">>, <<"priv">>]
+        )
+    ).
 
 %% @doc If the `body' key is present and a binary, replace it with a
 %% content-digest.
@@ -409,13 +417,10 @@ normalize_for_encoding(Msg, Commitment, Opts) ->
             RawInputs
         ),
     KeysForCommitment =
-        decode_committed_keys(
-            dev_httpsig_siginfo:from_siginfo_keys(
-                EncodedWithSigInfo,
-                BodyKeys,
-                KeysForEncoding
-            ),
-            Opts
+        dev_httpsig_siginfo:from_siginfo_keys(
+            EncodedWithSigInfo,
+            BodyKeys,
+            KeysForEncoding
         ),
     ?event_debug(debug_httpsig,
         {normalized_for_encoding,
@@ -431,11 +436,6 @@ normalize_for_encoding(Msg, Commitment, Opts) ->
         Commitment#{ <<"committed">> => KeysForEncoding },
         KeysForCommitment
     }.
-
-%% @doc Decode the committed keys from their percent-encoded form, for use in
-%% the `committed` key of the commitment.
-decode_committed_keys(ModCommittedKeys, _Opts) when is_list(ModCommittedKeys) ->
-    lists:map(fun hb_escape:decode/1, ModCommittedKeys).
 
 %% @doc Calculate if a key or its `+link' TABM variant is present in a message.
 key_present(Key, Keys) -> key_present(true, Key, Keys).
@@ -502,12 +502,7 @@ signature_components_line(Req, Commitment, _Opts) ->
 %%
 %% See https://datatracker.ietf.org/doc/html/rfc9421#section-2.5-7.3.2.4
 signature_params_line(RawCommitment, Opts) ->
-    Commitment =
-        maps:without(
-            [<<"signature">>, <<"signature-input">>],
-            RawCommitment
-        ),
-    ?event_debug(debug_enc, {signature_params_line, {commitment, Commitment}}),
+    ?event_debug(debug_enc, {signature_params_line, {commitment, RawCommitment}}),
 	hb_util:bin(
         hb_structured_fields:list(
             [
@@ -517,38 +512,41 @@ signature_params_line(RawCommitment, Opts) ->
                         fun(Key) -> {item, {string, Key}, []} end,
                         dev_httpsig_siginfo:add_derived_specifiers(
                             hb_util:message_to_ordered_list(
-                                maps:get(<<"committed">>, Commitment),
+                                maps:get(<<"committed">>, RawCommitment),
                                 Opts
                             )
                         )
                     ),
-                    lists:map(
-                        fun ({<<"alg">>, Param}) when is_binary(Param) ->
-                            {<<"alg">>, {string, Param}};
-                        ({Name, Param}) when is_binary(Param) ->
-                            {Name, {string, Param}};
-                        ({Name, Param}) when is_integer(Param) ->
-                            {Name, Param}
-                        end,
-                        lists:sort(maps:to_list(
-                            maps:with(
-                                [
-                                    <<"created">>,
-                                    <<"expires">>,
-                                    <<"nonce">>,
-                                    <<"alg">>,
-                                    <<"keyid">>,
-                                    <<"tag">>,
-                                    <<"bundle">>
-                                ],
-                                Commitment#{ <<"alg">> => maps:get(<<"type">>, Commitment) }
-                            )
-                        ))
-                    )
+                    signature_params(RawCommitment)
                 }
             ]
         )
     ).
+
+signature_params(Commitment) ->
+    lists:filtermap(
+        fun(Name) ->
+            case signature_param(Name, Commitment) of
+                undefined -> false;
+                Param when is_binary(Param) -> {true, {Name, {string, Param}}};
+                Param when is_integer(Param) -> {true, {Name, Param}}
+            end
+        end,
+        [
+            <<"alg">>,
+            <<"bundle">>,
+            <<"created">>,
+            <<"expires">>,
+            <<"keyid">>,
+            <<"nonce">>,
+            <<"tag">>
+        ]
+    ).
+
+signature_param(<<"alg">>, Commitment) ->
+    maps:get(<<"type">>, Commitment);
+signature_param(Name, Commitment) ->
+    maps:get(Name, Commitment, undefined).
 
 %%%
 %%% TESTS

--- a/src/preloaded/codec/dev_httpsig_conv.erl
+++ b/src/preloaded/codec/dev_httpsig_conv.erl
@@ -72,7 +72,7 @@ from(HTTP, _Req, Opts) ->
             false -> MsgWithoutSigs#{ <<"commitments">> => Commitments };
             true -> MsgWithoutSigs
         end,
-    ?event({message_with_commitments, MsgWithSigs}),
+    ?event_debug({message_with_commitments, MsgWithSigs}),
     Res =
         hb_maps:without(
             Removed =
@@ -89,7 +89,7 @@ from(HTTP, _Req, Opts) ->
             MsgWithSigs,
             Opts
         ),
-    ?event({message_without_commitments, Res, Removed}),
+    ?event_debug({message_without_commitments, Res, Removed}),
     {ok, Res}.
 
 %% @doc Generate the body TABM from the `body' key of the encoded message.
@@ -98,7 +98,7 @@ body_to_tabm(HTTP, Opts) ->
     Body = hb_maps:get(<<"body">>, HTTP, no_body, Opts),
     ContentType = hb_maps:get(<<"content-type">>, HTTP, undefined, Opts),
     {_, InlinedKey} = inline_key(HTTP),
-    ?event({inlined_body_key, InlinedKey}),
+    ?event_debug({inlined_body_key, InlinedKey}),
     % Parse the body into a TABM.
     {OrderedBodyKeys, BodyTABM} =
         case body_to_parts(ContentType, Body, Opts) of
@@ -148,7 +148,7 @@ body_to_tabm(HTTP, Opts) ->
 %% @doc Split the body into parts, if it is a multipart.
 body_to_parts(_ContentType, no_body, _Opts) -> no_body;
 body_to_parts(ContentType, Body, _Opts) ->
-    ?event(
+    ?event_debug(
         {from_body,
             {content_type, {explicit, ContentType}},
             {body, Body}
@@ -433,7 +433,7 @@ to(TABM, Req, FormatOpts, Opts) when is_map(TABM) ->
             Commitments ->
                 Commitments
         end,
-    ?event({converting_commitments_to_siginfo, Msg}),
+    ?event_debug({converting_commitments_to_siginfo, Msg}),
     {ok,
         maps:merge(
             Intermediate,
@@ -471,7 +471,7 @@ do_to(TABM, FormatOpts, Opts) when is_map(TABM) ->
             end,
             maps:without([<<"priv">>], TABM)
         ),
-    ?event({prepared_body_map, {msg, Enc0}}),
+    ?event_debug({prepared_body_map, {msg, Enc0}}),
     BodyMap = maps:get(<<"body">>, Enc0, #{}),
     GroupedBodyMap = group_maps(BodyMap, <<>>, #{}, Opts),
     Enc1 =
@@ -479,7 +479,7 @@ do_to(TABM, FormatOpts, Opts) when is_map(TABM) ->
             EmptyBody when map_size(EmptyBody) =:= 0 ->
                 % If the body map is empty, then simply set the body to be a 
                 % corresponding empty binary.
-                ?event({encoding_empty_body, {msg, Enc0}}),
+                ?event_debug({encoding_empty_body, {msg, Enc0}}),
                 Enc0;
             #{ InlineKey := UserBody }
                     when map_size(GroupedBodyMap) =:= 1 andalso is_binary(UserBody) ->
@@ -493,12 +493,12 @@ do_to(TABM, FormatOpts, Opts) when is_map(TABM) ->
                 % 
                 % In all other cases, the mapping fallsthrough to the case below 
                 % that properly encodes a nested body within a sub-part
-                ?event({encoding_single_body, {body, UserBody}, {http, Enc0}}),
+                ?event_debug({encoding_single_body, {body, UserBody}, {http, Enc0}}),
                 hb_maps:put(<<"body">>, UserBody, Enc0, Opts);
             _ ->
                 % Otherwise, we need to encode the body map as the
                 % multipart body of the HTTP message
-                ?event({encoding_multipart, {bodymap, {explicit, GroupedBodyMap}}}),
+                ?event_debug({encoding_multipart, {bodymap, {explicit, GroupedBodyMap}}}),
                 PartList = hb_util:to_sorted_list(
                     hb_maps:map(
                         fun(Key, M = #{ <<"body">> := _ }) when map_size(M) =:= 1 ->
@@ -554,14 +554,14 @@ do_to(TABM, FormatOpts, Opts) when is_map(TABM) ->
     Enc2 = case hb_maps:get(<<"body">>, Enc1, <<>>, Opts) of
         <<>> -> Enc1;
         _ ->
-            ?event({adding_content_digest, {msg, Enc1}}),
+            ?event_debug({adding_content_digest, {msg, Enc1}}),
             hb_maps:merge(
                 Enc1,
                 dev_httpsig:add_content_digest(Enc1, Opts),
                 Opts
             )
     end,
-    ?event({final_body_map, {msg, Enc2}}),
+    ?event_debug({final_body_map, {msg, Enc2}}),
     Enc2.
 
 %% @doc Transform all ID fields into their percent-encoded form.
@@ -589,10 +589,10 @@ decode_ids(Msg, _Opts) ->
 group_maps(Map) ->
     group_maps(Map, <<>>, #{}, #{}).
 group_maps(Map, Parent, Top, Opts) when is_map(Map) ->
-    ?event({group_maps, {map, Map}, {parent, Parent}, {top, Top}}),
+    ?event_debug({group_maps, {map, Map}, {parent, Parent}, {top, Top}}),
     {Flattened, NewTop} = hb_maps:fold(
         fun(Key, Value, {CurMap, CurTop}) ->
-            ?event({group_maps, {key, Key}, {value, Value}}),
+            ?event_debug({group_maps, {key, Key}, {value, Value}}),
             NormKey = hb_ao:normalize_key(Key),
             FlatK =
                 case Parent of
@@ -628,7 +628,7 @@ group_maps(Map, Parent, Top, Opts) when is_map(Map) ->
                             {CurMap, NewTop}
                     end;
                 _ ->
-                    ?event({group_maps, {norm_key, NormKey}, {value, Value}}),
+                    ?event_debug({group_maps, {norm_key, NormKey}, {value, Value}}),
                     case byte_size(Value) > ?MAX_HEADER_LENGTH of
                         % the value is too large to be encoded as a header
                         % within a part, so instead lift it to be a top level
@@ -653,7 +653,7 @@ group_maps(Map, Parent, Top, Opts) when is_map(Map) ->
             <<>> -> hb_maps:merge(NewTop, Flattened, Opts);
             _ ->
                 Res = NewTop#{ Parent => Flattened },
-                ?event({returning_res, {res, Res}}),
+                ?event_debug({returning_res, {res, Res}}),
                 Res
         end
     end.
@@ -731,7 +731,7 @@ inline_key(Msg, Opts) ->
     % inline part. Otherwise, the Msg <<"body">> is used. If not present, the
     % Msg <<"data">> is used.
     InlineBodyKey = hb_maps:get(<<"ao-body-key">>, Msg, false, Opts),
-    ?event({inlined, InlineBodyKey}),
+    ?event_debug({inlined, InlineBodyKey}),
     case {
         InlineBodyKey,
         hb_maps:is_key(<<"body">>, Msg, Opts)
@@ -768,7 +768,7 @@ encode_http_flat_msg(Httpsig, Opts) ->
         lists:foldl(
             fun ({HeaderName, RawHeaderVal}, Acc) ->
                 HVal = hb_cache:ensure_loaded(RawHeaderVal, Opts),
-                ?event({encoding_http_header, {header, HeaderName}, {value, HVal}}),
+                ?event_debug({encoding_http_header, {header, HeaderName}, {value, HVal}}),
                 [<<HeaderName/binary, ": ", HVal/binary>> | Acc]
             end,
             [],
@@ -918,8 +918,8 @@ encode_message_with_links_test() ->
     ?assertEqual(4, maps:get(<<"typed-key">>, Read, #{})),
     ?assertMatch({link, _, _}, maps:get(<<"long-key">>, Read, #{})),
     ?assertEqual(Msg, hb_cache:ensure_all_loaded(Read, #{})),
-    % Encode and decode the message as `httpsig@1.0`
-    Enc = hb_message:convert(Msg, <<"httpsig@1.0">>, #{}),
+    % Encode and decode the cached message as `httpsig@1.0`.
+    Enc = hb_message:convert(Read, <<"httpsig@1.0">>, #{}),
     ?event({encoded, Enc}),
     Dec = hb_message:convert(Enc, <<"structured@1.0">>, <<"httpsig@1.0">>, #{}),
     % Ensure that the result is the same as the original message

--- a/src/preloaded/codec/dev_httpsig_keyid.erl
+++ b/src/preloaded/codec/dev_httpsig_keyid.erl
@@ -25,25 +25,28 @@
 %% @doc Extract the key and keyid from a request, returning
 %% `{ok, Scheme, Key, KeyID}' or `{error, Reason}'.
 req_to_key_material(Req, Opts) ->
-    ?event({req_to_key_material, {priv_req, Req}}),
+    ?event_debug({req_to_key_material, {priv_req, Req}}),
     KeyID = maps:get(<<"keyid">>, Req, undefined),
-    ?event({keyid_to_key_material, {keyid, KeyID}}),
+    ?event_debug({keyid_to_key_material, {keyid, KeyID}}),
     case find_scheme(KeyID, Req, Opts) of
         {ok, Scheme} ->
-            ?event({scheme_found, {scheme, Scheme}}),
-            ApplyRes = apply_scheme(Scheme, KeyID, Req),
-            ?event({apply_scheme_result, {priv_apply_res, ApplyRes}}),
-            case ApplyRes of
-                {ok, _, CalcKeyID} when KeyID /= undefined, CalcKeyID /= KeyID ->
-                    {error, key_mismatch};
-                {ok, Key, CalcKeyID} ->
-                    {ok, Scheme, Key, CalcKeyID};
-                {error, Reason} ->
-                    {error, Reason}
-            end;
+            ?event_debug({scheme_found, {scheme, Scheme}}),
+            apply_key_scheme(Scheme, KeyID, Req);
         {error, undefined_scheme} ->
             {ok, DefaultScheme} = req_to_default_scheme(Req, Opts),
-            req_to_key_material(Req#{ <<"scheme">> => DefaultScheme }, Opts);
+            apply_key_scheme(DefaultScheme, KeyID, Req);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+apply_key_scheme(Scheme, KeyID, Req) ->
+    ApplyRes = apply_scheme(Scheme, KeyID, Req),
+    ?event_debug({apply_scheme_result, {priv_apply_res, ApplyRes}}),
+    case ApplyRes of
+        {ok, _, CalcKeyID} when KeyID /= undefined, CalcKeyID /= KeyID ->
+            {error, key_mismatch};
+        {ok, Key, CalcKeyID} ->
+            {ok, Scheme, Key, CalcKeyID};
         {error, Reason} ->
             {error, Reason}
     end.

--- a/src/preloaded/codec/dev_httpsig_siginfo.erl
+++ b/src/preloaded/codec/dev_httpsig_siginfo.erl
@@ -64,7 +64,7 @@ commitment_to_sf_siginfo(Msg, CommID, Commitment, Opts) ->
     Signature = hb_util:decode(maps:get(<<"signature">>, Commitment)),
     % Extract the keys present in the commitment.
     CommittedKeys = to_siginfo_keys(Msg, Commitment, Opts),
-    ?event({normalized_for_enc, CommittedKeys, {commitment, Commitment}}),
+    ?event_debug({normalized_for_enc, CommittedKeys, {commitment, Commitment}}),
     % Extract the hashpath, used as a tag, from the commitment.
     Tag = maps:get(<<"tag">>, Commitment, undefined),
     % Extract other permissible values, if present.
@@ -119,7 +119,7 @@ commitment_to_sf_siginfo(Msg, CommID, Commitment, Opts) ->
             ],
             Params
         },
-    ?event(
+    ?event_debug(
         {sig_input,
             {string,
                 hb_util:bin(
@@ -356,15 +356,17 @@ from_siginfo_keys(HTTPEncMsg, BodyKeys, SigInfoCommitted) ->
     % 1. Remove specifiers from the list and decode percent-encoded keys.
     BaseCommitted =
         lists:map(
-            fun hb_escape:decode/1,
-            remove_derived_specifiers(SigInfoCommitted)
+            fun(<<"@", Key/binary>>) -> hb_escape:decode(Key);
+               (Key) -> hb_escape:decode(Key)
+            end,
+            SigInfoCommitted
         ),
     % 2. Replace the `content-digest' key with the `body' key, if present.
     WithBody =
         hb_util:list_replace(BaseCommitted, <<"content-digest">>, BodyKeys),
     % 3. Replace the `body' key again with the value of the `ao-body-key' key,
     %    if present.
-    ?event(
+    ?event_debug(
         {from_siginfo_keys,
             {body_keys, BodyKeys},
             {raw_committed, SigInfoCommitted},
@@ -380,7 +382,7 @@ from_siginfo_keys(HTTPEncMsg, BodyKeys, SigInfoCommitted) ->
                         <<"body">>,
                         maps:get(<<"ao-body-key">>, HTTPEncMsg)
                     ),
-                ?event({with_orig_body_key, WithOrigBodyKey}),
+                ?event_debug({with_orig_body_key, WithOrigBodyKey}),
                 WithOrigBodyKey -- [<<"ao-body-key">>];
             false ->
                 WithBody
@@ -401,7 +403,7 @@ from_siginfo_keys(HTTPEncMsg, BodyKeys, SigInfoCommitted) ->
             )
         ),
     List = hb_util:message_to_ordered_list(Normalized),
-    ?event({from_siginfo_keys, {list, List}}),
+    ?event_debug({from_siginfo_keys, {list, List}}),
     List.
 
 %% @doc Convert committed keys to their siginfo format. This involves removing

--- a/src/preloaded/codec/dev_structured.erl
+++ b/src/preloaded/codec/dev_structured.erl
@@ -81,7 +81,17 @@ from(List, Req, Opts) when is_list(List) ->
     end;
 from(Msg, Req, Opts) when is_map(Msg) ->
     HintedReq = apply_bundle_hint(Msg, Req, Opts),
-    NormLinks = hb_link:normalize(Msg, linkify_mode(HintedReq, Opts), Opts),
+    NormLinks =
+        hb_link:normalize(
+            case Msg of
+                #{ <<"ao-types">> := AOTypeMap } when is_map(AOTypeMap) ->
+                    Msg#{ <<"ao-types">> := encode_ao_types(AOTypeMap, Opts) };
+                _ ->
+                    Msg
+            end,
+            linkify_mode(HintedReq, Opts),
+            Opts
+        ),
     NormKeysMap = hb_ao:normalize_keys(NormLinks, Opts),
     EncodeTypes = find_encode_types(HintedReq, Opts),
     {Types, Values} = lists:foldl(
@@ -90,7 +100,7 @@ from(Msg, Req, Opts) when is_map(Msg) ->
                 {ok, Value} when is_binary(Value) ->
                     {Types, [{Key, Value} | Values]};
                 {ok, Nested} when is_map(Nested) orelse is_list(Nested) ->
-                    ?event({from_recursing, {nested, Nested}}),
+                    ?event_debug({from_recursing, {nested, Nested}}),
                     % We pass the HintedReq to the recursive call rather than
                     % Req so that this message's bundle status serves as the
                     % default for any children that don't explicitly set the
@@ -105,7 +115,7 @@ from(Msg, Req, Opts) when is_map(Msg) ->
                         orelse is_integer(Value)
                         orelse is_float(Value) ->
                     BinKey = hb_ao:normalize_key(Key),
-                    ?event({encode_value, Value}),
+                    ?event_debug({encode_value, Value}),
                     case maybe_encode_value(Value, EncodeTypes) of
                         {Type, BinValue} ->
                             {
@@ -210,7 +220,7 @@ linkify_mode(Req, Opts) ->
         _ ->
             % The request is either asking for a flat message or has not
             % specified. In both cases we should linkify.
-            hb_opts:get(linkify_mode, offload, Opts)
+            hb_opts:get(<<"linkify-mode">>, offload, Opts)
     end.
 
 %% @doc Convert a TABM into a native HyperBEAM message.


### PR DESCRIPTION
Improves HTTPSig unsigned ID generation ~48-51% through optimizations of a variety of string manipulation methods.

Results for various commitment types:
Case | **edge** avg | **This branch** avg | Delta
-- | -- | -- | --
Unsigned flat | 71,049/s | 107,802/s | +51.7%
Unsigned nested | 27,011/s | 40,020/s | +48.2%
Signed flat | 1,013,884/s | 970,161/s | -4.3%
Signed nested | 1,006,217/s | 976,507/s | -3.0%
Normalized unsigned flat | 1,151,868/s | 1,134,977/s | -1.5%
Normalized unsigned nested | 1,151,777/s | 1,142,017/s | -0.8%
Normalized signed flat | 1,005,278/s | 1,003,890/s | -0.1%
Normalized signed nested | 1,006,208/s | 998,050/s | -0.8%
