### PR TITLE
Use checked base64 URL decoder for safety(e.g. %% RSA wallet moduli)

### DIFF
--- a/src/core/util/hb_util.erl
+++ b/src/core/util/hb_util.erl
@@ -304,13 +304,14 @@ encode(_) ->
     error(badarg).
 
 %% @doc Decode a URL safe base64 binary or iolist into a binary. Uses the
-%% unchecked decoder: the input is assumed to be valid base64url (as produced
-%% by `encode/1'), so malformed input yields garbage rather than reliably
-%% raising.
+%% checked decoder: the unchecked variant (`decode64_url_unchecked/1') has a
+%% bug in its vectorized path that corrupts inputs longer than ~33 bytes (e.g.
+%% RSA wallet moduli), so the node would derive the wrong address. The checked
+%% decoder round-trips correctly at all lengths.
 decode(Bin) when is_binary(Bin) ->
-    b64veryfast:decode64_url_unchecked(Bin);
+    b64veryfast:decode64_url(Bin);
 decode(List) when is_list(List) ->
-    b64veryfast:decode64_url_unchecked(iolist_to_binary(List));
+    b64veryfast:decode64_url(iolist_to_binary(List));
 decode(_) ->
     error(badarg).
 


### PR DESCRIPTION
Replaced unchecked base64 URL decoder with checked variant to prevent corruption of long inputs.(e.g.%% RSA wallet moduli)