### PR TITLE
chore: bump b64veryfast dep

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -187,7 +187,7 @@
     %% the LMDB composite reads below (edge's 06ccf937 + the read_prefix NIF
     %% commits). Repin to the default branch once read_prefix lands there.
     {elmdb, {git, "https://github.com/permaweb/elmdb-rs.git", {ref, "faa762323be6bad2db26abfa1d4243863a877f0f"}}},
-    {b64veryfast, {git, "https://github.com/permaweb/b64veryfast.git", {ref, "673388c8d46968f90e1da902146a8367d63226d2"}}},
+    {b64veryfast, {git, "https://github.com/permaweb/b64veryfast.git", {ref, "20ea7c4b5420501c9a4d5f19d8f043a2e96f3271"}}},
     {base32, "1.0.0"},
     {cowlib, "2.16.0"},
 	{cowboy, "2.14.0"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -2,7 +2,7 @@
 [{<<"accept">>,{pkg,<<"accept">>,<<"0.3.7">>},1},
  {<<"b64veryfast">>,
   {git,"https://github.com/permaweb/b64veryfast.git",
-       {ref,"673388c8d46968f90e1da902146a8367d63226d2"}},
+       {ref,"20ea7c4b5420501c9a4d5f19d8f043a2e96f3271"}},
   0},
  {<<"base32">>,{pkg,<<"base32">>,<<"1.0.0">>},0},
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.15.0">>},1},


### PR DESCRIPTION
bumps to https://github.com/permaweb/b64veryfast/pull/1 