### PR TITLE
fix: tilde parser in hb_format not escaped

### DIFF
--- a/src/core/util/hb_format.erl
+++ b/src/core/util/hb_format.erl
@@ -401,14 +401,18 @@ removing_trailing_noise(BinList, Noise) when is_list(BinList) ->
 %% @doc Format a string with an indentation level.
 indent(Str, Indent) -> indent(Str, #{}, Indent).
 indent(Str, Opts, Indent) -> indent(Str, [], Opts, Indent).
+indent(FmtStr, [], Opts, Ind) ->
+    do_indent(escape_format(FmtStr), [], Opts, Ind);
 indent(FmtStr, Terms, Opts, Ind) ->
+    do_indent(FmtStr, Terms, Opts, Ind).
+
+do_indent(FmtStr, Terms, Opts, Ind) ->
     IndentSpaces = hb_opts:get(debug_print_indent, Opts),
-    EscapedFmt = escape_format(FmtStr),
     lists:droplast(
         lists:flatten(
             io_lib:format(
                 [$\s || _ <- lists:seq(1, Ind * IndentSpaces)] ++
-                    lists:flatten(hb_util:list(EscapedFmt)) ++ "\n",
+                    lists:flatten(hb_util:list(FmtStr)) ++ "\n",
                 Terms
             )
         )
@@ -416,12 +420,18 @@ indent(FmtStr, Terms, Opts, Ind) ->
 
 %% @doc Escape a string for use as an io_lib:format specifier.
 escape_format(Str) when is_list(Str) ->
-    re:replace(
-        Str,
-        "~([a-z\\-_]+@[0-9]+\\.[0-9]+)", "~~\\1",
-        [global, {return, list}]
-    );
-escape_format(Else) -> Else.
+    escape_format_list(Str);
+escape_format(Bin) when is_binary(Bin) ->
+    escape_format_list(binary_to_list(Bin));
+escape_format(Else) ->
+    Else.
+
+escape_format_list([$~|Rest]) ->
+    [$~, $~|escape_format_list(Rest)];
+escape_format_list([Char|Rest]) ->
+    [Char|escape_format_list(Rest)];
+escape_format_list([]) ->
+    [].
 
 %% @doc Format an error message as a string.
 error(ErrorMsg, Opts) ->
@@ -1130,3 +1140,9 @@ truncate_with_truncation_test() ->
 
 truncate_empty_test() ->
     ?assertEqual(<<>>, truncate(<<>>, 5)).
+
+indent_literal_device_path_test() ->
+    ?assertEqual(
+        "  <<\"^/~bundler@1\\\\.0/tx$\">>}",
+        indent(<<"<<\"^/~bundler@1\\\\.0/tx$\">>}">>, #{}, 1)
+    ).


### PR DESCRIPTION
When trying to parse the error message (500) it doesn't escape properly the `~b` from `/~bundler` route definition (opts).

```
All 3471 tests passed.
```

## Clanker Description

That crash is from HyperBEAM’s error formatter, not directly from your route. It was passing a literal route string containing ~bundler@1\\.0 into io_lib:format/2; ~b was treated as a format directive, causing badarg.

I patched src/core/util/hb_format.erl:401 so no-argument indentation treats strings as literals and escapes all ~ characters before calling io_lib:format/2. I also added a regression test for the exact ^/~bundler@1\\.0/tx$ shape.