### PR TITLE
impr: Allow to return arweave node response without process it

### DIFF
--- a/src/preloaded/arweave/dev_arweave.erl
+++ b/src/preloaded/arweave/dev_arweave.erl
@@ -7,7 +7,7 @@
 -implements(<<"arweave@2.9">>).
 -device_libraries([lib_arweave_common]).
 -export([info/0]).
--export([tx/3, raw/3, chunk/3, block/3, current/3, status/3, price/3, tx_anchor/3]).
+-export([tx/3, raw/3, chunk/3, block/3, current/3, status/3, price/3, tx_anchor/3, height/3]).
 -export([pending/3]).
 -export([post_tx_header/2, post_tx/3, post_tx/4, post_chunk/2]).
 %%% Helper functions
@@ -26,8 +26,8 @@ info() ->
     }.
 
 %% @doc Proxy the `/info' endpoint from the Arweave node.
-status(_Base, _Request, Opts) ->
-    request(<<"GET">>, <<"/info">>, Opts).
+status(_Base, Request, Opts) ->
+    request(<<"GET">>, <<"/info">>, Request, Opts).
 
 %% @doc Returns the given transaction as an AO-Core message. By default, this
 %% embeds the `/raw` payload. Set `exclude-data` to true to return just the
@@ -128,6 +128,7 @@ post_tx_header(TX, Opts) ->
         <<"/tx">>,
         #{ <<"body">> => Serialized },
         LogExtra,
+        #{},
         Opts
     ).
 
@@ -141,6 +142,7 @@ get_tx(Base, Request, Opts) ->
             request(
                 <<"GET">>,
                 <<"/tx/", TXID/binary>>,
+                Request,
                 Opts#{
                     <<"exclude-data">> =>
                         hb_util:bool(
@@ -712,7 +714,7 @@ get_chunk(Offset, Opts) ->
     % leaeve the header out and continue to search for a case where it is
     % needed.
     Path = <<"/chunk/", (hb_util:bin(Offset))/binary>>,
-    request(<<"GET">>, Path, #{ <<"route-by">> => Offset }, Opts).
+    request(<<"GET">>, Path, #{ <<"route-by">> => Offset }, #{}, Opts).
 
 %% @doc Retrieve (and cache) block information from Arweave. If the `block' key
 %% is present, it is used to look up the associated block. If it is of Arweave
@@ -754,10 +756,10 @@ block({id, ID}, Req, Opts) ->
         {error, not_found} when is_map(Req) ->
             case only_if_cached(Req, Opts) of
                 true -> {error, not_found};
-                false -> request(<<"GET">>, <<"/block/hash/", ID/binary>>, Opts)
+                false -> request(<<"GET">>, <<"/block/hash/", ID/binary>>, Req, Opts)
             end;
         {error, not_found} ->
-            request(<<"GET">>, <<"/block/hash/", ID/binary>>, Opts)
+            request(<<"GET">>, <<"/block/hash/", ID/binary>>, Req, Opts)
     end;
 block({height, Height}, Req, Opts) ->
     case dev_arweave_block_cache:read(Height, Opts) of
@@ -775,6 +777,7 @@ block({height, Height}, Req, Opts) ->
                         <<"/block/height/",
                             (hb_util:bin(Height))/binary>>,
                         #{ <<"route-by">> => Height },
+                        Req,
                         Opts
                     )
             end;
@@ -784,6 +787,7 @@ block({height, Height}, Req, Opts) ->
                 <<"/block/height/",
                     (hb_util:bin(Height))/binary>>,
                 #{ <<"route-by">> => Height },
+                Req,
                 Opts
             )
     end.
@@ -796,8 +800,11 @@ only_if_cached(Req, Opts) ->
     ).
 
 %% @doc Retrieve the current block information from Arweave.
-current(_Base, _Request, Opts) ->
-    request(<<"GET">>, <<"/block/current">>, Opts).
+current(_Base, Request, Opts) ->
+    request(<<"GET">>, <<"/block/current">>, Request, Opts).
+
+height(_Base, Request, Opts) ->
+    request(<<"GET">>, <<"/height">>, Request, Opts).
 
 price(Base, Request, Opts) ->
     Size =
@@ -813,17 +820,17 @@ price(Base, Request, Opts) ->
         not_found ->
             {error, not_found};
         _ ->
-            request(<<"GET">>, <<"/price/", (hb_util:bin(Size))/binary>>, Opts)
+            request(<<"GET">>, <<"/price/", (hb_util:bin(Size))/binary>>, Request, Opts)
     end.
 
-tx_anchor(_Base, _Request, Opts) ->
-    request(<<"GET">>, <<"/tx_anchor">>, Opts).
+tx_anchor(_Base, Request, Opts) ->
+    request(<<"GET">>, <<"/tx_anchor">>, Request, Opts).
 
 %% @doc Retrieve either a list of the pending TXIDs on the configured Arweave
 %% nodes, or a specific unconfirmed transaction header by its TXID.
 pending(Base, Request, Opts) ->
     case find_key(<<"pending">>, Base, Request, Opts) of
-        not_found -> request(<<"GET">>, <<"/tx/pending">>, Opts);
+        not_found -> request(<<"GET">>, <<"/tx/pending">>, Request, Opts);
         TXID ->
             case hb_maps:find(<<"offset">>, Request, Opts) of
                 error ->
@@ -834,6 +841,7 @@ pending(Base, Request, Opts) ->
                     request(
                         <<"GET">>,
                         <<"/unconfirmed_tx/", TXID/binary>>,
+                        Request,
                         Opts#{ <<"exclude-data">> => ExcludeData }
                     );
                 {ok, RawOffset} ->
@@ -847,6 +855,7 @@ pending(Base, Request, Opts) ->
                             "/",
                             (hb_util:bin(Offset))/binary
                         >>,
+                        Request,
                         Opts
                     )
             end
@@ -868,11 +877,11 @@ find_key(Key, Base, Request, Opts) ->
 %% AO-Core message. Most Arweave API responses are in JSON format, but without
 %% a `content-type' header. Subsequently, we parse the response manually and
 %% pass it back as a message.
-request(Method, Path, Opts) ->
-    request(Method, Path, #{}, [], Opts).
-request(Method, Path, Extra, Opts) ->
-    request(Method, Path, Extra, [], Opts).
-request(Method, Path, Extra, LogExtra, Opts) ->
+request(Method, Path, Request, Opts) ->
+    request(Method, Path, #{}, [], Request, Opts).
+request(Method, Path, Extra, Request, Opts) ->
+    request(Method, Path, Extra, [], Request, Opts).
+request(Method, Path, Extra, LogExtra, Request, Opts) ->
     ?event(debug_arweave, {request,
         {method, Method}, {path, {explicit, Path}}, {log_extra, LogExtra}}),
     Res =
@@ -885,7 +894,20 @@ request(Method, Path, Extra, LogExtra, Opts) ->
                 <<"cache-control">> => [<<"no-cache">>, <<"no-store">>]
             }
         ),
-    to_message(Path, Method, best_response(Res), LogExtra, Opts).
+    ?event(error, {res, Res}),
+    % To keep the same response structure from Arweave Node, we skip
+    % the processing of the results. Useful to provide same strcture
+    % as we had before HyperBEAM.
+    case should_process_message(Request, true) of
+        true -> to_message(Path, Method, best_response(Res), LogExtra, Opts);
+        false -> Res
+    end.
+
+should_process_message(#{<<"process-message">> := Value}, _Default) ->
+    ?event(error, {process_message, hb_util:bool(Value)}),
+    hb_util:bool(Value);
+should_process_message(_Req, Default) ->
+    Default.
 
 %% @doc Select the best response from a list of responses by sorting them
 %% ascending by HTTP status code. Returns the first (best) response tuple.
@@ -1018,13 +1040,13 @@ to_tx_message(Type, ID, Path, {ok, #{ <<"body">> := Body }}, LogExtra, Opts) ->
         }
     ),
     {ok, Data} =
-        case hb_opts:get(exclude_data, false, Opts) of
+        case hb_opts:get(exclude_data, false, Opts) orelse TXHeader#tx.data_size == 0 of
             true -> {ok, ?DEFAULT_DATA};
             false ->
                 DataRes =
                     case Type of
                         tx ->
-                            request(<<"GET">>, <<"/raw/", ID/binary>>, Opts);
+                            request(<<"GET">>, <<"/raw/", ID/binary>>, #{}, Opts);
                         pending ->
                             get_chunk_range_relative(
                                 0,
@@ -2268,3 +2290,17 @@ get_post_split_mid_chunk_large_module_test_parallel() ->
         #{}
     ),
     ?assertEqual(ExpectedLength, byte_size(Data)).
+
+replicate_arweave_node_response_test_parallel() ->
+    Server = hb_http_server:start_node(),
+    Args =
+        #{
+             peer => <<"http://chain-1.arweave.xyz:1984">>,
+             path => <<"/height">>,
+             method => <<"GET">>,
+             headers => #{},
+             body => <<>>
+        },
+    {ok, 200, _ResponseHeaders, Body1} = hb_http_client:request(Args, #{}),
+    {ok, #{<<"body">> := Body2}} = hb_http:get(Server, <<"/~arweave@2.9/height?process-message=false">>, #{}),
+    ?assertEqual(Body1, Body2).

--- a/src/preloaded/arweave/dev_arweave.erl
+++ b/src/preloaded/arweave/dev_arweave.erl
@@ -7,8 +7,9 @@
 -implements(<<"arweave@2.9">>).
 -device_libraries([lib_arweave_common]).
 -export([info/0]).
--export([tx/3, raw/3, chunk/3, block/3, current/3, status/3, price/3, tx_anchor/3, height/3]).
--export([pending/3]).
+-export([tx/3, raw/3, chunk/3, block/3, current/3, status/3, price/3, price2/3, tx_anchor/3, height/3]).
+-export([pending/3, chunk_bare/3]).
+-export([wallet_balance/3, wallet_last_tx/3, wallet_list/3, total_suply/3]).
 -export([post_tx_header/2, post_tx/3, post_tx/4, post_chunk/2]).
 %%% Helper functions
 -export([get_chunk/2]).
@@ -431,6 +432,7 @@ get_chunk(_Base, Request, Opts) ->
     Offset = hb_util:int(hb_maps:get(<<"offset">>, Request, 0, Opts)),
     Length = hb_util:int(hb_maps:get(<<"length">>, Request, 1, Opts)),
     MaybeRelativeTXID = hb_maps:get(<<"pending">>, Request, undefined, Opts),
+    ?event(error, {get_chunk, {offset, Offset}, {length, Length}}),
     case fetch_chunk_range(Offset, Length, MaybeRelativeTXID, Opts) of
         {ok, Chunks} ->
             Data = iolist_to_binary(Chunks),
@@ -722,6 +724,7 @@ get_chunk(Offset, Opts) ->
 %% an integer, it is used as a block height. If it is not present, the current
 %% block is used.
 block(Base, Request, Opts) when is_map(Base) ->
+    ?event(error, {block, {request, Request}}),
     Block =
         hb_ao:get_first(
             [
@@ -823,6 +826,23 @@ price(Base, Request, Opts) ->
             request(<<"GET">>, <<"/price/", (hb_util:bin(Size))/binary>>, Request, Opts)
     end.
 
+price2(Base, Request, Opts) ->
+    Size =
+        hb_ao:get_first(
+            [
+                {Request, <<"size">>},
+                {Base, <<"size">>}
+            ],
+            not_found,
+            Opts
+        ),
+    case Size of
+        not_found ->
+            {error, not_found};
+        _ ->
+            request(<<"GET">>, <<"/price2/", (hb_util:bin(Size))/binary>>, Request, Opts)
+    end.
+
 tx_anchor(_Base, Request, Opts) ->
     request(<<"GET">>, <<"/tx_anchor">>, Request, Opts).
 
@@ -861,6 +881,114 @@ pending(Base, Request, Opts) ->
             end
     end.
 
+%% @doc Request `/chunk` and `/chunk2` endpoints from Arweave Nodes by using 
+%% route-by strategy using offset.
+chunk_bare(Base, Request, Opts) ->
+    Offset =
+        hb_ao:get_first(
+            [
+                {Request, <<"offset">>},
+                {Base, <<"offset">>}
+            ],
+            not_found,
+            Opts
+        ),
+    Type = 
+            hb_ao:get_first(
+            [
+                {Request, <<"type">>},
+                {Base, <<"type">>}
+            ],
+            not_found,
+            Opts
+        ),
+    Path = 
+        case Type of 
+            <<"binary">> -> <<"/chunk2">>;
+            _ -> <<"/chunk">>
+        end,
+    case Offset of
+        not_found ->
+            {error, not_found};
+        _ ->
+            request(
+              <<"GET">>,
+              <<Path/binary, "/", (hb_util:bin(Offset))/binary>>,
+              #{ <<"route-by">> => hb_util:int(Offset) },
+              Request,
+              Opts)
+    end.
+
+wallet_balance(Base, Request, Opts) -> 
+    Wallet =
+        hb_ao:get_first(
+            [
+                {Request, <<"wallet">>},
+                {Base, <<"wallet">>}
+            ],
+            not_found,
+            Opts
+        ),
+    case Wallet of
+        not_found ->
+            {error, not_found};
+        _ ->
+            request(
+              <<"GET">>,
+              <<"/wallet/", (hb_util:bin(Wallet))/binary, "/balance">>,
+              Request,
+              Opts)
+    end.
+
+wallet_last_tx(Base, Request, Opts) ->
+    Wallet =
+        hb_ao:get_first(
+            [
+                {Request, <<"wallet">>},
+                {Base, <<"wallet">>}
+            ],
+            not_found,
+            Opts
+        ),
+    case Wallet of
+        not_found ->
+            {error, not_found};
+        _ ->
+            request(
+              <<"GET">>,
+              <<"/wallet/", (hb_util:bin(Wallet))/binary, "/last_tx">>,
+              Request,
+              Opts)
+    end.
+
+wallet_list(Base, Request, Opts) -> 
+    WalletRoot =
+        hb_ao:get_first(
+            [
+                {Request, <<"wallet-root">>},
+                {Base, <<"wallet-root">>}
+            ],
+            not_found,
+            Opts
+        ),
+    case WalletRoot of
+        not_found ->
+            {error, not_found};
+        _ ->
+            request(
+              <<"GET">>,
+              <<"/wallet_list/", (hb_util:bin(WalletRoot))/binary>>,
+              Request,
+              Opts)
+    end.
+
+%% @doc Return the sum of all the existing accounts in the latest state, in Winston.
+total_suply(_Base, Request, Opts) -> 
+    request(<<"GET">>, <<"/total_suply">>, Request, Opts).
+
+peers(_Base, Request, Opts) ->
+    request(<<"GET">>, <<"/peers">>, Request, Opts).
+
 %%% Internal Functions
 
 %% @doc Find the transaction ID to retrieve from Arweave based on the request or
@@ -894,7 +1022,6 @@ request(Method, Path, Extra, LogExtra, Request, Opts) ->
                 <<"cache-control">> => [<<"no-cache">>, <<"no-store">>]
             }
         ),
-    ?event(error, {res, Res}),
     % To keep the same response structure from Arweave Node, we skip
     % the processing of the results. Useful to provide same strcture
     % as we had before HyperBEAM.


### PR DESCRIPTION
This PR allows returning information for the Arweave node like `/height`, `/tx/TXID`, etc, similar to arweave.net using the dev_arweave. This is done by setting `process-message` to `false`.

```
All 3477 tests passed.
```

## Todo
- [x] Check if there is more endpoints that need to connect to arweave nodes.