### PR TITLE
Uses local node to fetch transaction data

### DIFF
--- a/src/core/store/hb_store_arweave.erl
+++ b/src/core/store/hb_store_arweave.erl
@@ -96,7 +96,7 @@ read_offset(_, _, _) -> not_found.
 
 %% @doc Read the data at the given key, reading the `local-store' first if
 %% available.
-read(StoreOpts, #{ <<"read">> := ID }, _NodeOpts) when ?IS_ID(ID) ->
+read(StoreOpts, #{ <<"read">> := ID }, NodeOpts) when ?IS_ID(ID) ->
     case hb_store_remote_node:read_local_cache(StoreOpts, ID, StoreOpts) of
         {ok, Message} ->
             ?event(
@@ -105,7 +105,7 @@ read(StoreOpts, #{ <<"read">> := ID }, _NodeOpts) when ?IS_ID(ID) ->
             ),
             {ok, Message};
         _ ->
-            case do_read(StoreOpts, ID, StoreOpts) of
+            case do_read(StoreOpts, ID, NodeOpts) of
                 not_found -> {error, not_found};
                 Result -> Result
             end

--- a/src/preloaded/arweave/dev_arweave.erl
+++ b/src/preloaded/arweave/dev_arweave.erl
@@ -12,6 +12,8 @@
 -export([post_tx_header/2, post_tx/3, post_tx/4, post_chunk/2]).
 %%% Helper functions
 -export([get_chunk/2]).
+%%% Test only 
+-export([setup_arweave_index_opts/1]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -1024,7 +1026,12 @@ to_tx_message(Type, ID, Path, {ok, #{ <<"body">> := Body }}, LogExtra, Opts) ->
                 DataRes =
                     case Type of
                         tx ->
-                            request(<<"GET">>, <<"/raw/", ID/binary>>, Opts);
+                            case hb_ao:resolve(<<"~arweave@2.9/raw=", ID/binary>>, Opts) of
+                                {ok, #{<<"body">> := RawBody}} ->
+                                    {ok, RawBody};
+                                Resp ->
+                                    Resp
+                            end;
                         pending ->
                             get_chunk_range_relative(
                                 0,
@@ -1036,7 +1043,7 @@ to_tx_message(Type, ID, Path, {ok, #{ <<"body">> := Body }}, LogExtra, Opts) ->
                 case DataRes of
                     {ok, RawData} -> {ok, RawData};
                     {error, not_found} -> {ok, ?DEFAULT_DATA};
-                    Error -> Error    
+                    Error -> Error
                 end
         end,
     {
@@ -1375,17 +1382,19 @@ tx_index_block(<<"4FnBmvgWmqXWEEprjVqBsV5aRpAgF6_yJX_GTGsSZjY">>) -> 753012;
 tx_index_block(<<"YR9m4c3CrlljCRYEWBLeoKekbAyYZRMo2Kpz61IeNp8">>) -> 1233918.
 
 get_tx_basic_data_test_parallel() ->
+    TXID = <<"ptBC0UwDmrUTBQX3MqZ1lB57ex20ygwzkjjCrQjIx3o">>,
+    Opts = setup_arweave_index_opts([TXID]),
     {ok, Structured} = hb_ao:resolve(
         #{ <<"device">> => <<"arweave@2.9">> },
         #{
             <<"path">> => <<"tx">>,
-            <<"tx">> => <<"ptBC0UwDmrUTBQX3MqZ1lB57ex20ygwzkjjCrQjIx3o">>,
+            <<"tx">> => TXID,
             <<"exclude-data">> => false
         },
-        #{}
+        Opts
     ),
     ?event(debug_test, {structured_tx, Structured}),
-    ?assert(hb_message:verify(Structured, all, #{})),
+    ?assert(hb_message:verify(Structured, all, Opts)),
     % Hash the data to make it easier to match
     StructuredWithHash = Structured#{
         <<"data">> => hb_util:encode(
@@ -1403,16 +1412,18 @@ get_tx_basic_data_test_parallel() ->
 
 %% @doc The data for this transaction ends with two smaller chunks.
 get_tx_split_chunk_test_parallel() ->
+    TXID = <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>,
+    Opts = setup_arweave_index_opts([TXID]),
     {ok, Structured} = hb_ao:resolve(
         #{ <<"device">> => <<"arweave@2.9">> },
         #{
             <<"path">> => <<"tx">>,
-            <<"tx">> => <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>,
+            <<"tx">> => TXID,
             <<"exclude-data">> => false
         },
-        #{}
+        Opts
     ),
-    ?assert(hb_message:verify(Structured, all, #{})),
+    ?assert(hb_message:verify(Structured, all, Opts)),
     ?assertEqual(
         <<"T2pluNnaavL7-S2GkO_m3pASLUqMH_XQ9IiIhZKfySs">>,
         hb_message:id(Structured, signed)),
@@ -1422,9 +1433,8 @@ get_tx_split_chunk_test_parallel() ->
         <<"Contract">> => <<"KTzTXT_ANmF84fWEKHzWURD1LWd9QaFR9yfYUwH2Lxw">>
     },
     ?assert(hb_message:match(ExpectedMsg, Structured, only_present)),
-
     Child = hb_ao:get(<<"1/2">>, Structured),
-    ?assert(hb_message:verify(Child, all, #{})),
+    ?assert(hb_message:verify(Child, all, Opts)),
     ?event(debug_test, {child, {explicit, hb_message:id(Child, signed)}}),
     ?assertEqual(
         <<"8aJrRWtHcJvJ61qsH6agGkemzrtLw3W22xFrpCGAnTM">>,
@@ -1666,20 +1676,22 @@ get_raw_range_ans104_test_parallel() ->
     ).
 
 get_tx_rsa_nested_bundle_test_parallel() ->
-    Node = hb_http_server:start_node(),
-    Path = <<"/~arweave@2.9/tx=bndIwac23-s0K11TLC1N7z472sLGAkiOdhds87ZywoE">>,
-    {ok, Root} = hb_http:get(Node, Path, #{}),
+    TXID = <<"bndIwac23-s0K11TLC1N7z472sLGAkiOdhds87ZywoE">>,
+    Opts = setup_arweave_index_opts([TXID]),
+    Node = hb_http_server:start_node(Opts),
+    Path = <<"/~arweave@2.9/tx=", TXID/binary>>,
+    {ok, Root} = hb_http:get(Node, Path, Opts),
     ?event(debug_test, {root, Root}),
-    ?assert(hb_message:verify(Root, all, #{})),
+    ?assert(hb_message:verify(Root, all, Opts)),
     ChildPath = <<Path/binary, "/1/2">>,
-    {ok, Child} = hb_http:get(Node, ChildPath, #{}),
+    {ok, Child} = hb_http:get(Node, ChildPath, Opts),
     ?event(debug_test, {child, Child}),
-    ?assert(hb_message:verify(Child, all, #{})),
+    ?assert(hb_message:verify(Child, all, Opts)),
     {ok, ExpectedChild} =
         hb_ao:resolve(
             Root,
             <<"1/2">>,
-            #{}
+            Opts
         ),
     ?assert(hb_message:match(ExpectedChild, Child, only_present)),
     ManualChild = #{

--- a/src/preloaded/arweave/dev_arweave.erl
+++ b/src/preloaded/arweave/dev_arweave.erl
@@ -1765,21 +1765,20 @@ pending_offset_handling_test() ->
             <<"stop-after">> => true
         }
     ],
-    IndexStore =
+    ArweaveStore =
         #{
-            <<"index-store">> => [hb_test_utils:test_store()],
-            <<"routes">> => Routes
+            <<"index-store">> => [hb_test_utils:test_store()]
         },
     try
         ok = hb_store_arweave:write_offset(
-            IndexStore,
+            ArweaveStore,
             TXID,
             <<"tx@1.0">>,
             relative,
             PendingLength
         ),
         {ok, StoreTX} =
-            hb_store_arweave:read(IndexStore, #{ <<"read">> => TXID }, ClientOpts),
+            hb_store_arweave:read(ArweaveStore, #{ <<"read">> => TXID }, ClientOpts#{<<"routes">> => Routes}),
         ?assertEqual(TXID, hb_message:id(StoreTX, signed, ClientOpts)),
         ?assertEqual(PendingData, maps:get(<<"data">>, StoreTX))
     after

--- a/src/preloaded/arweave/dev_arweave_offset.erl
+++ b/src/preloaded/arweave/dev_arweave_offset.erl
@@ -382,9 +382,9 @@ offset_item_cases_test() ->
     ok.
 
 offset_nested_item_test() ->
-    Opts = #{},
     TXID = <<"bndIwac23-s0K11TLC1N7z472sLGAkiOdhds87ZywoE">>,
-    Node = hb_http_server:start_node(),
+    Opts = dev_arweave:setup_arweave_index_opts([TXID]),
+    Node = hb_http_server:start_node(Opts),
     {ok, Expected} =
         hb_http:get(
             Node,


### PR DESCRIPTION
Instead of using the `arweave.net/raw` endpoint to fetch transaction data (which can be a loop if set up incorrectly), it uses the arweave node directly. The only thing we need to make sure of is that we already have the TX indexed (i.e., the block that has it).

```
 All 3476 tests passed.
```