### PR TITLE
feat: add push_result and http_result paranoid-verify topics

### DIFF
--- a/src/core/http/hb_http.erl
+++ b/src/core/http/hb_http.erl
@@ -625,6 +625,9 @@ add_cors_headers(Msg, ReqHdr, Opts) ->
 
 %% @doc Generate the headers and body for a HTTP response message.
 encode_reply(Status, TABMReq, Message, Opts) ->
+    % Verify the result while it is still in `structured@1.0' form, before it is
+    % converted to the target wire codec, if paranoid mode enables http_result.
+    hb_message:paranoid_verify(http_result, Message, Opts),
     Codec = accept_to_codec(TABMReq, Message, Opts),
     ?event(debug_http, {encoding_reply, {codec, Codec}, {message, Message}}),
     BaseHdrs =
@@ -1200,6 +1203,22 @@ simple_ao_resolve_signed_test() ->
             test_opts()
         ),
     ?assertEqual(<<"Value1">>, Res).
+
+paranoid_http_result_test() ->
+    % The `http_result' topic verifies each response at the reply boundary (in
+    % `encode_reply', before wire conversion): a validly committed result
+    % encodes cleanly, while corrupting its committed body is caught.
+    Opts =
+        (test_opts())#{
+            <<"paranoid-verify">> => [http_result],
+            <<"debug-print">> => []
+        },
+    Valid = hb_message:commit(#{ <<"body">> => <<"ok">> }, Opts),
+    ?assertMatch({_, _, _}, encode_reply(200, #{}, Valid, Opts)),
+    ?assertThrow(
+        {paranoid_verification_failure, http_result, _, _, _},
+        encode_reply(200, #{}, Valid#{ <<"body">> => <<"mangled">> }, Opts)
+    ).
 
 nested_ao_resolve_test() ->
     URL = hb_http_server:start_node(),

--- a/src/core/resolver/hb_opts.erl
+++ b/src/core/resolver/hb_opts.erl
@@ -84,8 +84,10 @@
         %   false - No paranoid verification
         %   true - Verify all messages in all contexts
         %   [http_request] - Verify messages in outbound HTTP requests only
+        %   [http_result] - Verify outbound HTTP results before wire encoding
         %   [cache_write] - Verify messages only when writing to cache
         %   [cache_read] - Verify messages only when reading from cache
+        %   [push_result] - Verify process push results before signing
         %   [http_request, cache_write] - Verify in both contexts
         <<"debug-print">> =>
             {

--- a/src/preloaded/process/dev_push.erl
+++ b/src/preloaded/process/dev_push.erl
@@ -679,6 +679,10 @@ augment_message(Origin, ToSched, Opts) ->
 %% - `authority': A single committer, or list of comma separated committers.
 %% - (Default: Signs with default wallet)
 apply_security(Msg, TargetProcess, Codec, Opts) ->
+    % Verify the result before it is signed for POSTing, if paranoid mode
+    % enables push_result. `commit_result' signs `uncommitted(Msg)', so we
+    % verify exactly that content here, before any signature is applied.
+    hb_message:paranoid_verify(push_result, hb_message:uncommitted(Msg), Opts),
     apply_security(policy, Msg, TargetProcess, Codec, Opts).
 apply_security(policy, Msg, TargetProcess, Codec, Opts) ->
     case hb_ao:get(<<"policy">>, TargetProcess, not_found, Opts) of
@@ -862,8 +866,30 @@ max_depth_test_cases() ->
         {timeout, 30, fun test_max_depth_zero_schedules_only/0},
         {timeout, 30, fun test_max_depth_one_walks_one_hop/0},
         {timeout, 30, fun test_compute_push_hook_idempotent/0},
+        fun test_paranoid_push_result/0,
         fun test_parse_max_depth/0
     ].
+
+test_paranoid_push_result() ->
+    % The `push_result' topic verifies the result before it is signed for
+    % POSTing (at the `apply_security' entry): corrupting a committed
+    % sub-message is caught before any signature is applied.
+    Opts =
+        #{
+            <<"priv-wallet">> => hb:wallet(),
+            <<"paranoid-verify">> => [push_result],
+            <<"debug-print">> => []
+        },
+    Nested = hb_message:commit(#{ <<"body">> => <<"ok">> }, Opts),
+    ?assertThrow(
+        {paranoid_verification_failure, push_result, _, _, _},
+        apply_security(
+            #{ <<"body">> => Nested#{ <<"body">> => <<"mangled">> } },
+            #{},
+            <<"httpsig@1.0">>,
+            Opts
+        )
+    ).
 
 -ifdef(ENABLE_GENESIS_WASM).
 genesis_wasm_tests() -> [{timeout, 30, fun test_nested_push_prompts_encoding_change/0}].
@@ -876,7 +902,9 @@ test_full_push() ->
     Opts = #{
         <<"priv-wallet">> => hb:wallet(),
         <<"cache-control">> => <<"always">>,
-        <<"store">> => [hb_test_utils:test_store(hb_store_lmdb)]
+        <<"store">> => [hb_test_utils:test_store(hb_store_lmdb)],
+        % Exercise the `push_result' paranoid check against a real signed push.
+        <<"paranoid-verify">> => [push_result]
     },
     Base = hb_process_test_vectors:aos_process(Opts),
     hb_cache:write(Base, Opts),


### PR DESCRIPTION
Extend the opt-in `HB_PARANOID `mechanism (alongside cache_read, cache_write
and http_request) with two topics that verify committed outbound messages
at their last critical boundary:

- http_result: at the top of hb_http:encode_reply, verifying the response
  while it is still in structured@1.0 form, before conversion to the target
  wire codec.
- push_result: at the dev_push:apply_security entry, verifying the result
  before it is signed for POSTing. commit_result signs uncommitted(Msg), so
  that is exactly what is verified.

Both are no-ops unless enabled (e.g. HB_PARANOID=push_result,http_result).
Each call site has a throw-on-corruption test, and the happy path is
exercised end-to-end (a valid encoded reply and the full ping-pong push).