### PR TITLE
fix: preserve provenance, policy and hint-strip on push 307 redirects

### DIFF
--- a/src/preloaded/process/dev_push.erl
+++ b/src/preloaded/process/dev_push.erl
@@ -623,8 +623,12 @@ schedule_result(TargetProcess, MsgToPush, Codec, Origin, Opts) ->
         {ok, 307} ->
             Location = hb_ao:get(<<"location">>, Res, Opts),
             ?event(push, {redirect, {location, {explicit, Location}}}),
-            NormMsg = normalize_message(MsgToPush, Opts),
-            SignedNormMsg = hb_message:commit(NormMsg, Opts),
+            % Strip the now-resolved hint from the target and re-sign the
+            % already-augmented message to the target's policy -- preserving the
+            % `from-*' provenance and honoring the policy, rather than
+            % re-committing the raw message with the default wallet.
+            NormMsg = normalize_message(AugmentedMsg, Opts),
+            SignedNormMsg = apply_security(NormMsg, TargetProcess, Codec, Opts),
             remote_schedule_result(Location, SignedNormMsg, Opts);
         {error, 422} ->
             ?event(push, {wrong_format, {422, Res}, {codec, Codec}}, Opts),


### PR DESCRIPTION
When the local scheduler returned a 307 (target on another node),
schedule_result rebuilt the outbound message from the raw `MsgToPush` and
re-signed it with the default wallet -- dropping the `from-*` provenance
`augment_message` adds and ignoring the target's security policy. The
remote received a default-signed message with no provenance (and, for an
authority-gated target, a message signed by the wrong identity), rendering it useless.

Normalize and re-sign the already-augmented message instead: strip the
now-resolved hint from the target (so the remote scheduler resolves a
bare id) and sign via apply_security, preserving the from-* keys and the
target's policy. The hint-strip is retained -- it is load-bearing, since
the remote's find_target_id resolves the target via human_id, which has
no clause for a hinted binary.