### PR TITLE
fix: Allow to access path inside manifest that contains spaces

### DIFF
--- a/src/core/resolver/hb_singleton.erl
+++ b/src/core/resolver/hb_singleton.erl
@@ -339,7 +339,7 @@ parse_part(Part, Opts) ->
     case maybe_subpath(Part, Opts) of
         {resolve, Subpath} -> {resolve, Subpath};
         Part ->
-            case part([$&, $~, $+, $ , $=], Part) of
+            case part([$&, $~, $+, $=], Part) of
                 {no_match, PartKey, <<>>} when ?IS_ID(PartKey) ->
                     PartKey;
                 {no_match, PartKey, <<>>} ->

--- a/src/core/resolver/hb_singleton.erl
+++ b/src/core/resolver/hb_singleton.erl
@@ -718,6 +718,12 @@ typed_key_test() ->
     ?assertEqual(123, hb_maps:get(<<"test-key">>, Msg2, not_found)),
     ?assertEqual(not_found, hb_maps:get(<<"test-key">>, Res, not_found)).
 
+query_string_plus_value_decodes_to_space_test() ->
+    Msgs = from(<<"/a?key=8+8">>, #{}),
+    ?assertEqual(2, length(Msgs)),
+    [_, Msg] = Msgs,
+    ?assertEqual(<<"8 8">>, hb_maps:get(<<"key">>, Msg)).
+
 subpath_in_key_test() ->
     Req = #{
         <<"path">> => <<"/a/b/c">>,

--- a/src/core/resolver/hb_singleton.erl
+++ b/src/core/resolver/hb_singleton.erl
@@ -748,6 +748,12 @@ subpath_in_key_test() ->
 
 %%% Advanced path syntax tests
 
+path_with_space_test() ->
+    ?assertEqual(
+        [#{}, #{ <<"path">> => <<"foo bar">> }],
+        from(<<"/foo%20bar">>, #{})
+    ).
+
 subpath_in_path_test() ->
     Req = #{
         <<"path">> => <<"/a/(x/y/z)/z">>

--- a/src/preloaded/arweave/dev_manifest.erl
+++ b/src/preloaded/arweave/dev_manifest.erl
@@ -292,6 +292,41 @@ manifest_404_error_test_parallel() ->
     ),
     ok.
 
+manifest_path_with_spaces_test_parallel() ->
+    Opts = #{ <<"store">> => hb_opts:get(store, no_viable_store, #{}) },
+    Page = #{
+        <<"content-type">> => <<"image/png">>,
+        <<"body">> => <<"Page With Spaces">>
+    },
+    {ok, PageID} = hb_cache:write(Page, Opts),
+    IndexPage = #{
+        <<"content-type">> => <<"text/html">>,
+        <<"body">> => <<"Index Page">>
+    },
+    {ok, IndexID} = hb_cache:write(IndexPage, Opts),
+    Manifest = #{
+        <<"paths">> => #{
+            <<"ID With Spaces.png">> => #{ <<"id">> => PageID },
+            <<"index.html">> => #{ <<"id">> => IndexID }
+        },
+        <<"index">> => #{ <<"path">> => <<"index.html">> }
+    },
+    ManifestMsg = #{
+        <<"device">> => <<"manifest@1.0">>,
+        <<"body">> => hb_json:encode(Manifest)
+    },
+    {ok, ManifestID} = hb_cache:write(ManifestMsg, Opts),
+    Node = hb_http_server:start_node(Opts),
+    ?assertMatch(
+        {ok, #{ <<"body">> := <<"Page With Spaces">> }},
+        hb_http:get(
+            Node,
+            << ManifestID/binary, "/ID%20With%20Spaces.png" >>,
+            Opts
+        )
+    ),
+    ok.
+
 create_generic_manifest(Opts) ->
     IndexPage = #{
         <<"content-type">> => <<"text/html">>,


### PR DESCRIPTION
Accessing https://arweave.net/jD52P9VXPR_-o_VwLOu_zkfvc7VM1shmXZBS-MMddmo/Hora%20Bora%20cover.png returns 404 because the `Hora%20Bora%20cover.png` part gets splited to `Hora` and only then is checked in the path.