### PR TITLE
impr: Allow to receive multiple /block/current requests and use highest height.

### DIFF
--- a/src/core/resolver/hb_opts.erl
+++ b/src/core/resolver/hb_opts.erl
@@ -426,9 +426,17 @@ raw_default_message() ->
                         <<"opts">> => ?DEFAULT_HTTP_OPTS
                     }
             },
-            % Wait for 2 node responses when fetching current block information
+            % Wait for 2 node responses when fetching current block or height information
             #{
                 <<"template">> => <<"^/arweave/block/current">>,
+                <<"nodes">> => add_opts(?ARWEAVE_BOOTSTRAP_CHAIN_NODES),
+                <<"parallel">> => true,
+                <<"responses">> => 2,
+                <<"stop-after">> => true,
+                <<"admissible-status">> => 200
+            },
+            #{
+                <<"template">> => <<"^/arweave/height">>,
                 <<"nodes">> => add_opts(?ARWEAVE_BOOTSTRAP_CHAIN_NODES),
                 <<"parallel">> => true,
                 <<"responses">> => 2,

--- a/src/core/resolver/hb_opts.erl
+++ b/src/core/resolver/hb_opts.erl
@@ -426,6 +426,15 @@ raw_default_message() ->
                         <<"opts">> => ?DEFAULT_HTTP_OPTS
                     }
             },
+            % Wait for 2 node responses when fetching current block information
+            #{
+                <<"template">> => <<"^/arweave/block/current">>,
+                <<"nodes">> => add_opts(?ARWEAVE_BOOTSTRAP_CHAIN_NODES),
+                <<"parallel">> => true,
+                <<"responses">> => 2,
+                <<"stop-after">> => true,
+                <<"admissible-status">> => 200
+            },
             % General Arweave requests: race all chain nodes, take
             % the first 200.
             #{

--- a/src/preloaded/arweave/dev_arweave.erl
+++ b/src/preloaded/arweave/dev_arweave.erl
@@ -892,9 +892,9 @@ request(Method, Path, Extra, LogExtra, Opts) ->
 best_response(Path, {error, {no_viable_responses, Responses}}) ->
     best_response(Path, Responses);
 best_response(<<"/height">>, Responses) when is_list(Responses) ->
-    current_height_best_response(Responses);
+    current_height_best_response(current_height_responses(Responses));
 best_response(<<"/block/current">>, Responses) when is_list(Responses) ->
-    current_height_best_response(Responses);
+    current_height_best_response(current_height_responses(Responses));
 best_response(_Path, Response) ->
     best_response(Response).
 
@@ -922,42 +922,44 @@ response_status(_Response) ->
 
 %% @doc Parse responses that contains block height to return the one with the
 %% highest value. This helps when one node lags behind.
-current_height_best_response(Responses) ->
-    Best = lists:foldl(
+current_height_responses(Responses) ->
+    lists:filtermap(
         fun
-            ({ok, #{ <<"body">> := Body }} = Response, CurrentBest) ->
-                Height = try hb_json:decode(Body) of
-                    #{ <<"height">> := DecodedHeight } ->
-                        hb_util:int(DecodedHeight);
-                    DecodedHeight when is_integer(DecodedHeight) ->
-                        DecodedHeight;
+            ({ok, #{ <<"body">> := Body }} = Response) ->
+                try hb_json:decode(Body) of
+                    #{ <<"height">> := Height } ->
+                        {true, {hb_util:int(Height), Response}};
+                    Height when is_integer(Height) ->
+                        {true, {Height, Response}};
                     _ ->
-                        undefined
+                        false
                 catch _:_ ->
                     case hb_util:safe_int(Body) of
-                        {ok, ParsedHeight} -> ParsedHeight;
-                        {error, invalid} -> undefined
+                        {ok, Height} -> {true, {Height, Response}};
+                        {error, invalid} -> false
                     end
-                end,
-                case CurrentBest of
-                    undefined when is_integer(Height) -> {Height, Response};
-                    {BestHeight, _}
-                            when is_integer(Height), Height > BestHeight ->
-                        {Height, Response};
-                    _ -> CurrentBest
                 end;
-            (_, CurrentBest) ->
-                CurrentBest
+            (_) ->
+                false
         end,
-        undefined,
         Responses
-    ),
-    case Best of
-        undefined ->
-            {error, no_viable_responses};
-        {_Height, BestResponse} ->
-            BestResponse
-    end.
+    ).
+
+current_height_best_response([]) ->
+    {error, no_viable_responses};
+current_height_best_response([{Height, Response} | Rest]) ->
+    {_, BestResponse} =
+        lists:foldl(
+            fun({NextHeight, NextResponse}, {BestHeight, Best}) ->
+                case NextHeight > BestHeight of
+                    true -> {NextHeight, NextResponse};
+                    false -> {BestHeight, Best}
+                end
+            end,
+            {Height, Response},
+            Rest
+        ),
+    BestResponse.
 
 %% @doc Transform a response from the Arweave node into an AO-Core message.
 to_message(Path, Method, {error, #{ <<"status">> := 404 }}, LogExtra, _Opts) ->

--- a/src/preloaded/arweave/dev_arweave.erl
+++ b/src/preloaded/arweave/dev_arweave.erl
@@ -891,11 +891,10 @@ request(Method, Path, Extra, LogExtra, Opts) ->
 %% ascending by HTTP status code. Returns the first (best) response tuple.
 best_response(Path, {error, {no_viable_responses, Responses}}) ->
     best_response(Path, Responses);
+best_response(<<"/height">>, Responses) when is_list(Responses) ->
+    current_height_best_response(Responses);
 best_response(<<"/block/current">>, Responses) when is_list(Responses) ->
-    case current_height_responses(Responses) of
-        [] -> best_response(Responses);
-        Heights -> current_height_best_response(Heights)
-    end;
+    current_height_best_response(Responses);
 best_response(_Path, Response) ->
     best_response(Response).
 
@@ -921,37 +920,47 @@ response_status(Response) when is_map(Response) ->
 response_status(_Response) ->
     999.
 
-current_height_responses(Responses) ->
-    lists:filtermap(
+%% @doc Parse responses that contains block height to return the one with the
+%% highest value. This helps when one node lags behind.
+current_height_best_response(Responses) ->
+    FilteredResponsesHeight = lists:filtermap(
         fun
             ({ok, #{ <<"body">> := Body }} = Response) ->
                 try hb_json:decode(Body) of
                     #{ <<"height">> := Height } ->
                         {true, {hb_util:int(Height), Response}};
+                    Height when is_integer(Height) ->
+                        {true, {Height, Response}};
                     _ ->
                         false
                 catch _:_ ->
-                    false
+                    case hb_util:safe_int(Body) of
+                        {ok, Height} -> {true, {Height, Response}};
+                        {error, invalid} -> false
+                    end
                 end;
             (_) ->
                 false
         end,
         Responses
-    ).
-
-current_height_best_response([{Height, Response} | Rest]) ->
-    {_, BestResponse} =
-        lists:foldl(
-            fun({NextHeight, NextResponse}, {BestHeight, Best}) ->
-                case NextHeight > BestHeight of
-                    true -> {NextHeight, NextResponse};
-                    false -> {BestHeight, Best}
-                end
-            end,
-            {Height, Response},
-            Rest
-        ),
-    BestResponse.
+    ),
+    case FilteredResponsesHeight of
+        [] ->
+            {error, no_viable_responses};
+        [{Height, Response} | Rest] ->
+            {_, BestResponse} =
+                lists:foldl(
+                    fun({NextHeight, NextResponse}, {BestHeight, Best}) ->
+                        case NextHeight > BestHeight of
+                            true -> {NextHeight, NextResponse};
+                            false -> {BestHeight, Best}
+                        end
+                    end,
+                    {Height, Response},
+                    Rest
+                ),
+            BestResponse
+    end.
 
 %% @doc Transform a response from the Arweave node into an AO-Core message.
 to_message(Path, Method, {error, #{ <<"status">> := 404 }}, LogExtra, _Opts) ->
@@ -1249,6 +1258,16 @@ best_response_handles_failed_connect_entries_test_parallel() ->
     ?assertEqual(
         {ok, #{ <<"status">> => 200, <<"body">> => <<"OK-2">> }},
         best_response(Responses)
+    ).
+
+best_response_height_integer_body_test_parallel() ->
+    Responses = [
+        {ok, #{ <<"status">> => 200, <<"body">> => <<"5">> }},
+        {ok, #{ <<"status">> => 200, <<"body">> => <<"8">> }}
+    ],
+    ?assertEqual(
+        {ok, #{ <<"status">> => 200, <<"body">> => <<"8">> }},
+        best_response(<<"/height">>, Responses)
     ).
 
 best_response_non_map_error_round_trips_test_parallel() ->

--- a/src/preloaded/arweave/dev_arweave.erl
+++ b/src/preloaded/arweave/dev_arweave.erl
@@ -923,42 +923,39 @@ response_status(_Response) ->
 %% @doc Parse responses that contains block height to return the one with the
 %% highest value. This helps when one node lags behind.
 current_height_best_response(Responses) ->
-    FilteredResponsesHeight = lists:filtermap(
+    Best = lists:foldl(
         fun
-            ({ok, #{ <<"body">> := Body }} = Response) ->
-                try hb_json:decode(Body) of
-                    #{ <<"height">> := Height } ->
-                        {true, {hb_util:int(Height), Response}};
-                    Height when is_integer(Height) ->
-                        {true, {Height, Response}};
+            ({ok, #{ <<"body">> := Body }} = Response, CurrentBest) ->
+                Height = try hb_json:decode(Body) of
+                    #{ <<"height">> := DecodedHeight } ->
+                        hb_util:int(DecodedHeight);
+                    DecodedHeight when is_integer(DecodedHeight) ->
+                        DecodedHeight;
                     _ ->
-                        false
+                        undefined
                 catch _:_ ->
                     case hb_util:safe_int(Body) of
-                        {ok, Height} -> {true, {Height, Response}};
-                        {error, invalid} -> false
+                        {ok, ParsedHeight} -> ParsedHeight;
+                        {error, invalid} -> undefined
                     end
+                end,
+                case CurrentBest of
+                    undefined when is_integer(Height) -> {Height, Response};
+                    {BestHeight, _}
+                            when is_integer(Height), Height > BestHeight ->
+                        {Height, Response};
+                    _ -> CurrentBest
                 end;
-            (_) ->
-                false
+            (_, CurrentBest) ->
+                CurrentBest
         end,
+        undefined,
         Responses
     ),
-    case FilteredResponsesHeight of
-        [] ->
+    case Best of
+        undefined ->
             {error, no_viable_responses};
-        [{Height, Response} | Rest] ->
-            {_, BestResponse} =
-                lists:foldl(
-                    fun({NextHeight, NextResponse}, {BestHeight, Best}) ->
-                        case NextHeight > BestHeight of
-                            true -> {NextHeight, NextResponse};
-                            false -> {BestHeight, Best}
-                        end
-                    end,
-                    {Height, Response},
-                    Rest
-                ),
+        {_Height, BestResponse} ->
             BestResponse
     end.
 

--- a/src/preloaded/arweave/dev_arweave.erl
+++ b/src/preloaded/arweave/dev_arweave.erl
@@ -885,10 +885,20 @@ request(Method, Path, Extra, LogExtra, Opts) ->
                 <<"cache-control">> => [<<"no-cache">>, <<"no-store">>]
             }
         ),
-    to_message(Path, Method, best_response(Res), LogExtra, Opts).
+    to_message(Path, Method, best_response(Path, Res), LogExtra, Opts).
 
 %% @doc Select the best response from a list of responses by sorting them
 %% ascending by HTTP status code. Returns the first (best) response tuple.
+best_response(Path, {error, {no_viable_responses, Responses}}) ->
+    best_response(Path, Responses);
+best_response(<<"/block/current">>, Responses) when is_list(Responses) ->
+    case current_height_responses(Responses) of
+        [] -> best_response(Responses);
+        Heights -> current_height_best_response(Heights)
+    end;
+best_response(_Path, Response) ->
+    best_response(Response).
+
 best_response({error, {no_viable_responses, Responses}}) ->
     best_response(Responses);
 best_response([]) ->
@@ -910,6 +920,38 @@ response_status(Response) when is_map(Response) ->
     maps:get(<<"status">>, Response, 999);
 response_status(_Response) ->
     999.
+
+current_height_responses(Responses) ->
+    lists:filtermap(
+        fun
+            ({ok, #{ <<"body">> := Body }} = Response) ->
+                try hb_json:decode(Body) of
+                    #{ <<"height">> := Height } ->
+                        {true, {hb_util:int(Height), Response}};
+                    _ ->
+                        false
+                catch _:_ ->
+                    false
+                end;
+            (_) ->
+                false
+        end,
+        Responses
+    ).
+
+current_height_best_response([{Height, Response} | Rest]) ->
+    {_, BestResponse} =
+        lists:foldl(
+            fun({NextHeight, NextResponse}, {BestHeight, Best}) ->
+                case NextHeight > BestHeight of
+                    true -> {NextHeight, NextResponse};
+                    false -> {BestHeight, Best}
+                end
+            end,
+            {Height, Response},
+            Rest
+        ),
+    BestResponse.
 
 %% @doc Transform a response from the Arweave node into an AO-Core message.
 to_message(Path, Method, {error, #{ <<"status">> := 404 }}, LogExtra, _Opts) ->

--- a/src/preloaded/query/dev_copycat_arweave.erl
+++ b/src/preloaded/query/dev_copycat_arweave.erl
@@ -1361,6 +1361,48 @@ latest_height_failure_test_parallel() ->
         hb_mock_server:stop(MockHandle)
     end.
 
+latest_height_uses_highest_mockserver_height_test_parallel() ->
+    {ok, MockURL1, MockHandle1} = hb_mock_server:start([
+        {"/block/current", block_current, {200, <<"{\"height\": 5}">>}}
+    ]),
+    {ok, MockURL2, MockHandle2} = hb_mock_server:start([
+        {"/block/current", block_current, {200, <<"{\"height\": 8}">>}}
+    ]),
+    TestStore = hb_test_utils:test_store(),
+    Opts = #{
+        <<"store">> => [TestStore],
+        <<"arweave-index-blocks">> => false,
+        <<"routes">> => [
+            #{
+                <<"template">> => <<"^/arweave">>,
+                <<"nodes">> => [
+                    #{
+                        <<"match">> => <<"^/arweave">>,
+                        <<"with">> => MockURL1,
+                        <<"opts">> => #{ <<"http-client">> => httpc }
+                    },
+                    #{
+                        <<"match">> => <<"^/arweave">>,
+                        <<"with">> => MockURL2,
+                        <<"opts">> => #{ <<"http-client">> => httpc }
+                    }
+                ],
+                <<"parallel">> => false,
+                <<"responses">> => 2,
+                <<"stop-after">> => false,
+                <<"admissible-status">> => 200
+            }
+        ]
+    },
+    try
+        ?assertEqual({ok, 8}, latest_height(Opts)),
+        [_] = hb_mock_server:get_requests(block_current, 1, MockHandle1),
+        [_] = hb_mock_server:get_requests(block_current, 1, MockHandle2)
+    after
+        hb_mock_server:stop(MockHandle1),
+        hb_mock_server:stop(MockHandle2)
+    end.
+
 negative_resolved_height_test_parallel() ->
     {ok, MockURL, MockHandle} = hb_mock_server:start([
         {"/block/current", block_current,


### PR DESCRIPTION
Nodes can fall behind the current block height. Currently, the code only receives one response when asking for the current block, so if the node with the faster reply is the one that lags, the copycat Arweave index will not index the newest blocks. 

This PR allows receiving two responses (2) from nodes when requesting Arweave nodes for `/block/current`.

# Alternative solution

An alternative solution could be to implement a device that uses `<<"admissible">>` (or another property) to filter the entire response list. This is too complicated, and this is the only case that fits it.