### PR TITLE
fix: preserve bundled messages across codec and HTTP boundaries

### DIFF
--- a/src/core/http/hb_client_remote.erl
+++ b/src/core/http/hb_client_remote.erl
@@ -37,7 +37,7 @@ prefix_keys(Prefix, Message, Opts) ->
             hb_maps:put(<<Prefix/binary, Key/binary>>, Val, Acc, Opts)
         end,
         #{},
-        hb_message:convert(Message, tabm, Opts),
+		hb_ao:normalize_keys(Message, Opts),
 		Opts
     ).
 

--- a/src/core/http/hb_http.erl
+++ b/src/core/http/hb_http.erl
@@ -688,16 +688,9 @@ encode_reply(Status, TABMReq, Message, Opts) ->
                 maps:get(<<"body">>, ErrMsg, <<>>)
             };
         {_, <<"httpsig@1.0">>, _} ->
-            TABM =
-                hb_message:convert(
-                    Message,
-                    tabm,
-                    <<"structured@1.0">>,
-                    Opts#{ <<"topic">> => ao_internal }
-                ),
             EncMessage =
                 hb_message:convert(
-                    TABM,
+                    Message,
                     case AcceptBundle of
                         true ->
                             #{
@@ -713,8 +706,8 @@ encode_reply(Status, TABMReq, Message, Opts) ->
                                     hb_opts:get(generate_index, true, Opts)
                             }
                     end,
-                    tabm,
-                    Opts
+                    <<"structured@1.0">>,
+                    Opts#{ <<"topic">> => ao_internal }
                 ),
             {
                 Status,
@@ -1188,6 +1181,12 @@ record_request_metric(TotalDuration, ReplyDuration, StatusCode) ->
 test_opts() ->
     #{ <<"store">> => hb_test_utils:test_store(), <<"priv-wallet">> => hb:wallet() }.
 
+isolated_test_opts() ->
+    #{
+        <<"store">> => hb_test_utils:test_store(),
+        <<"priv-wallet">> => ar_wallet:new()
+    }.
+
 simple_ao_resolve_unsigned_test() ->
     URL = hb_http_server:start_node(),
     TestMsg = #{ <<"path">> => <<"/key1">>, <<"key1">> => <<"Value1">> },
@@ -1336,6 +1335,103 @@ ans104_wasm_test() ->
             Msg#{ <<"path">> => <<"/init/compute/results">> },
             ClientOpts
         )
+    ).
+
+nested_signed_bundle_over_http_test() ->
+    Parent = self(),
+    ServerOpts =
+        (isolated_test_opts())#{
+            <<"port">> => 0,
+            <<"on">> => #{
+                <<"request">> => #{
+                    <<"device">> => #{
+                        <<"request">> =>
+                            fun(_, HookReq, HookOpts) ->
+                                Parent ! {nested_httpsig_request, HookReq},
+                                {error, #{
+                                    <<"status">> => 200,
+                                    <<"response">> =>
+                                        nested_signed_response(HookOpts)
+                                }}
+                            end
+                    }
+                }
+            }
+        },
+    ClientOpts =
+        (isolated_test_opts())#{ <<"http-only-result">> => false },
+    Inner = nested_signed_response(ClientOpts),
+    Request =
+        hb_message:commit(
+            #{
+                <<"accept-bundle">> => true,
+                <<"codec-device">> => <<"httpsig@1.0">>,
+                <<"require-codec">> => <<"httpsig@1.0">>,
+                <<"response">> => Inner
+            },
+            ClientOpts,
+            #{
+                <<"commitment-device">> => <<"httpsig@1.0">>,
+                <<"bundle">> => true
+            }
+        ),
+    {ok, Reply} =
+        post(
+            hb_http_server:start_node(ServerOpts),
+            <<"/~meta@1.0/info">>,
+            Request,
+            ClientOpts
+        ),
+    Received =
+        receive
+            {nested_httpsig_request, #{ <<"request">> := Req }} -> Req
+        after 5_000 ->
+            error(nested_httpsig_request_timeout)
+        end,
+    ?assert(hb_message:verify(Received, all, ServerOpts)),
+    ReceivedInner = maps:get(<<"response">>, Received),
+    ?assertEqual(Inner, ReceivedInner),
+    ?assert(hb_message:verify(ReceivedInner, all, ServerOpts)),
+    ?assertEqual(
+        ReceivedInner,
+        maps:get(
+            <<"response">>,
+            hb_cache:ensure_all_loaded(Received, ServerOpts)
+        )
+    ),
+    ReplyInner = maps:get(<<"response">>, Reply),
+    ?assert(hb_message:verify(Reply, all, ClientOpts)),
+    ?assert(hb_message:verify(ReplyInner, all, ClientOpts)),
+    ?assertEqual(
+        ReplyInner,
+        hb_cache:ensure_all_loaded(ReplyInner, ClientOpts)
+    ).
+
+nested_signed_response(Opts) ->
+    Response = #{
+        <<"body">> => #{ <<"nested">> => #{ <<"value">> => <<"x">> } },
+        <<"status">> => 200
+    },
+    {ok, _} = hb_cache:write(Response, Opts),
+    Unsigned =
+        hb_cache:ensure_all_loaded(
+            hb_message:commit(
+                Response,
+                Opts,
+                #{
+                    <<"commitment-device">> => <<"httpsig@1.0">>,
+                    <<"type">> => <<"unsigned">>
+                }
+            ),
+            Opts
+        ),
+    hb_message:commit(
+        Unsigned,
+        Opts,
+        #{
+            <<"commitment-device">> => <<"httpsig@1.0">>,
+            <<"bundle">> => true
+        }
     ).
 
 send_large_signed_request_test() ->

--- a/src/core/http/hb_http.erl
+++ b/src/core/http/hb_http.erl
@@ -525,7 +525,14 @@ reply(InitReq, TABMReq, RawStatus, RawMessage, Opts) ->
             true -> fin;
             false -> nofin
         end,
-    cowboy_req:stream_body(EncodedBody, Fin, PostStreamReq),
+    % Stream the body back to the caller if there is content. If we already
+    % signal a non-content reply, skip.
+    case Status of
+        NonContentStatus
+            when (NonContentStatus == 204)
+            orelse (NonContentStatus == 304) -> skip;
+        _ -> cowboy_req:stream_body(EncodedBody, Fin, PostStreamReq)
+    end,
     EndTime = os:system_time(millisecond),
     ReqDuration = EndTime - hb_maps:get(start_time, Req, undefined, Opts),
     ReplyDuration = EndTime - ReplyStartTime,

--- a/src/preloaded/codec/dev_httpsig.erl
+++ b/src/preloaded/codec/dev_httpsig.erl
@@ -5,8 +5,9 @@
 %%% are found in this module, while the codec functions are relayed to the 
 %%% `dev_httpsig_conv' module.
 -module(dev_httpsig).
+-device_libraries([lib_arweave_common]).
 %%% Codec API functions
--export([to/3, from/3]).
+-export([to/3, to_hint/3, from/3]).
 %%% Uni-directional codec support (_to_ binary/header+body components), but not 
 %%% back.
 -export([serialize/2, serialize/3]).
@@ -285,6 +286,13 @@ maybe_bundle_tag_commitment(Commitment, Req, _Opts) ->
     case hb_util:atom(maps:get(<<"bundle">>, Req, false)) of
         true -> Commitment#{ <<"bundle">> => <<"true">> };
         false -> Commitment
+    end.
+
+%% @doc Apply the bundle state of an HTTPSig commitment to a conversion.
+to_hint(Msg, Req, Opts) ->
+    case lib_arweave_common:bundle_hint(<<"httpsig@1.0">>, Msg, Req, Opts) of
+        not_found -> {ok, Req};
+        Hint -> Hint
     end.
 
 %% @doc Derive the set of keys to commit to from a `commit` request and a 

--- a/src/preloaded/codec/dev_httpsig_conv.erl
+++ b/src/preloaded/codec/dev_httpsig_conv.erl
@@ -366,29 +366,8 @@ to(TABM, Req = #{ <<"index">> := true }, _FormatOpts, Opts) ->
             % Return the encoded HTTPSig message without modification.
             {ok, EncOriginal}
     end;
-to(TABM, Req, FormatOpts, Opts) when is_map(TABM) ->
-    % Ensure that the material for the message is loaded, if the request is
-    % asking for a bundle.
-    Msg =
-        case hb_util:atom(hb_maps:get(<<"bundle">>, Req, false, Opts)) of
-            false -> encode_ids(TABM);
-            true ->
-                % Convert back to the fully loaded structured@1.0 message, then
-                % convert to TABM with bundling enabled.
-                Structured = hb_message:convert(TABM, <<"structured@1.0">>, Opts),
-                Loaded = hb_cache:ensure_all_loaded(Structured, Opts),
-                encode_ids(
-                    hb_message:convert(
-                        Loaded,
-                        tabm,
-                        #{
-                            <<"device">> => <<"structured@1.0">>,
-                            <<"bundle">> => true
-                        },
-                        Opts
-                    )
-                )
-        end,
+to(TABM, _Req, FormatOpts, Opts) when is_map(TABM) ->
+    Msg = encode_ids(TABM),
     % Group the IDs into a dictionary, so that they can be distributed as
     % HTTP headers. If we did not do this, ID keys would be lower-cased and
     % their comparability against the original keys would be lost.

--- a/src/preloaded/codec/dev_json.erl
+++ b/src/preloaded/codec/dev_json.erl
@@ -2,7 +2,8 @@
 %%% message as TABM and returns an encoded JSON string representation.
 %%% This codec utilizes the httpsig@1.0 codec for signing and verifying.
 -module(dev_json).
--export([to/3, from/3, commit/3, verify/3, committed/3, content_type/1]).
+-device_libraries([lib_arweave_common]).
+-export([to/3, to_hint/3, from/3, commit/3, verify/3, committed/3, content_type/1]).
 -export([deserialize/3, serialize/3]).
 -include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
@@ -10,11 +11,20 @@
 %% @doc Return the content type for the codec.
 content_type(_) -> {ok, <<"application/json">>}.
 
+%% @doc Apply the bundle state of the delegated HTTPSig commitment.
+to_hint(Msg, Req, Opts) ->
+    case lib_arweave_common:bundle_hint(<<"httpsig@1.0">>, Msg, Req, Opts) of
+        not_found -> {ok, Req};
+        Hint -> Hint
+    end.
+
 %% @doc Encode a message to a JSON string, using JSON-native typing.
 to(Msg, _Req, _Opts) when is_binary(Msg) ->
     {ok, hb_util:bin(json:encode(Msg))};
 to(Msg, Req, Opts) ->
     ConvOpts = Opts#{ <<"hashpath">> => ignore },
+    HintedReq = hb_util:ok(to_hint(Msg, Req, Opts)),
+    Bundle = hb_maps:get(<<"bundle">>, HintedReq, false, Opts),
     % The input to this function will be a TABM message, so we:
     % 1. Convert it to a structured message.
     % 2. Load any linked items if we are in `bundle' mode.
@@ -28,7 +38,7 @@ to(Msg, Req, Opts) ->
             ConvOpts
         ),
     Loaded =
-        case hb_maps:get(<<"bundle">>, Req, false, Opts) of
+        case Bundle of
             true -> hb_cache:ensure_all_loaded(Restructured, Opts);
             false -> Restructured
         end,
@@ -38,7 +48,8 @@ to(Msg, Req, Opts) ->
             tabm,
             #{
                 <<"device">> => <<"structured@1.0">>,
-                <<"encode-types">> => [<<"atom">>]
+                <<"encode-types">> => [<<"atom">>],
+                <<"bundle">> => Bundle
             },
             ConvOpts
         ),
@@ -60,8 +71,9 @@ from(JSON, Req, Opts) ->
             tabm,
             ConvOpts
         ),
+    HintedReq = hb_util:ok(to_hint(Structured, Req, Opts)),
     ?event(debug_json, {structured, Structured}, Opts),
-    case hb_maps:get(<<"accept-codec">>, Req, undefined, Opts) of
+    case hb_maps:get(<<"accept-codec">>, HintedReq, undefined, Opts) of
         <<"structured@1.0">> -> {ok, Structured};
         _ ->
             % Re-encode the structured message back to TABM for the caller.
@@ -69,7 +81,7 @@ from(JSON, Req, Opts) ->
                 hb_message:convert(
                     Structured,
                     tabm,
-                    Req#{ <<"device">> => <<"structured@1.0">> },
+                    HintedReq#{ <<"device">> => <<"structured@1.0">> },
                     ConvOpts
                 ),
             ?event(debug_json, {tabm, TABM}, Opts),

--- a/src/preloaded/message/dev_message.erl
+++ b/src/preloaded/message/dev_message.erl
@@ -90,7 +90,13 @@ id(Base, _, NodeOpts) when is_binary(Base) ->
     {ok, hb_util:human_id(hb_path:hashpath(Base, NodeOpts))};
 id(List, Req, NodeOpts) when is_list(List) ->
     % Return the list of IDs for a list of messages.
-    id(hb_message:convert(List, tabm, NodeOpts), Req, NodeOpts);
+    SourceSpec =
+        hb_message:add_bundle_hint(
+            #{ <<"device">> => <<"structured@1.0">> },
+            Req#{ <<"device">> => ?DEFAULT_ID_DEVICE },
+            NodeOpts
+        ),
+    id(hb_message:convert(List, tabm, SourceSpec, NodeOpts), Req, NodeOpts);
 id(RawBase, Req, NodeOpts) ->
     % Ensure that the base message is normalized before proceeding.
     IDOpts = NodeOpts#{ <<"linkify-mode">> => discard },
@@ -334,6 +340,10 @@ verify(Self, Req, Opts) ->
                                     <<"commitment-device">>,
                                     Commitment,
                                     undefined
+                                ),
+                            <<"bundle">> =>
+                                hb_util:atom(
+                                    maps:get(<<"bundle">>, Commitment, false)
                                 )
                         },
                         Opts
@@ -872,6 +882,29 @@ case_insensitive_get(Key, Msg, Opts) ->
 %%% Internal module functionality tests:
 get_keys_mod_test() ->
     ?assertEqual([a], hb_maps:keys(#{a => 1}, #{})).
+
+list_id_preserves_bundle_hint_test() ->
+    Opts = #{
+        <<"store">> => hb_test_utils:test_store(),
+        <<"priv-wallet">> => hb:wallet()
+    },
+    List = [
+        hb_message:commit(
+            #{ <<"payload">> => #{ <<"deep">> => <<"value">> } },
+            Opts,
+            #{ <<"commitment-device">> => <<"httpsig@1.0">>, <<"bundle">> => true }
+        )
+    ],
+    Source = #{
+        <<"device">> => <<"structured@1.0">>,
+        <<"hint-device">> => ?DEFAULT_ID_DEVICE
+    },
+    Expected = hb_message:id(
+        hb_message:convert(List, tabm, Source, Opts),
+        none,
+        Opts
+    ),
+    ?assertEqual(Expected, hb_message:id(List, none, Opts)).
 
 is_private_mod_test() ->
     ?assertEqual(true, hb_private:is_private(<<"private">>)),

--- a/src/preloaded/node/dev_meta.erl
+++ b/src/preloaded/node/dev_meta.erl
@@ -716,12 +716,9 @@ request_response_hooks_test() ->
                                     end
                             }
                         }
-                },
-            <<"http-extra-opts">> => #{
-                <<"cache-control">> => [<<"no-store">>, <<"no-cache">>]
-            }
+                }
         }),
-    hb_http:get(Node, <<"/~meta@1.0/info">>, #{}),
+    {ok, _} = hb_http:get(Node, <<"/~meta@1.0/info">>, #{}),
     % Receive both of the responses from the hooks, if possible.
     Res =
         receive

--- a/src/preloaded/test/hb_codec_test_vectors.erl
+++ b/src/preloaded/test/hb_codec_test_vectors.erl
@@ -603,6 +603,12 @@ verify_nested_complex_signed_test(Codec, Opts) ->
         #{ <<"device">> := <<"tx@1.0">> } -> Codec#{ <<"device">> => <<"ans104@1.0">> };
         _ -> Codec
     end,
+    ConversionCodec =
+        case Codec of
+            #{ <<"device">> := Device, <<"bundle">> := true } -> Device;
+            _ ->
+                Codec
+        end,
     Msg =
         hb_message:commit(#{
             <<"path">> => <<"schedule">>,
@@ -639,9 +645,15 @@ verify_nested_complex_signed_test(Codec, Opts) ->
     ?assert(hb_message:verify(Inner, all, Opts)),
     ?assert(hb_message:verify(LoadedInitialInner, all, Opts)),
     % % Test encoding and decoding.
-    Encoded = hb_message:convert(Msg, Codec, <<"structured@1.0">>, Opts),
+    Encoded = hb_message:convert(Msg, ConversionCodec, <<"structured@1.0">>, Opts),
     ?event({encoded, Encoded}),
-    Decoded = hb_message:convert(Encoded, <<"structured@1.0">>, Codec, Opts),
+    Decoded =
+        hb_message:convert(
+            Encoded,
+            <<"structured@1.0">>,
+            ConversionCodec,
+            Opts
+        ),
     ?event({decoded, Decoded}),
     LoadedMsg = hb_cache:ensure_all_loaded(Decoded, Opts),
     ?event({loaded, LoadedMsg}),
@@ -998,14 +1010,21 @@ deep_multisignature_test() ->
         hb_message:commit(
             Msg,
             Opts#{ <<"priv-wallet">> => Wallet1 },
-            Codec
+            #{
+                <<"commitment-device">> => Codec,
+                <<"bundle">> => true,
+                <<"committed">> => [<<"body">>]
+            }
         ),
     ?event({signed_msg, SignedMsg}),
     MsgSignedTwice =
         hb_message:commit(
             SignedMsg,
             Opts#{ <<"priv-wallet">> => Wallet2 },
-            Codec
+            #{
+                <<"commitment-device">> => Codec,
+                <<"committed">> => [<<"data">>, <<"test-key">>]
+            }
         ),
     ?event({signed_msg_twice, MsgSignedTwice}),
     ?assert(hb_message:verify(MsgSignedTwice, all, Opts)),


### PR DESCRIPTION
Preserves nested bundled messages across codec conversion and HTTPSig HTTP transport. Also removes an unnecessary TABM->HTTPSig->TABM conversion round trip while serializing bundles.

All changes:
- Propagates commitment bundle hints through `structured@1.0`, `httpsig@1.0`, and `json@1.0`, a la `ans104@1.0` and `tx@1.0`.
- Preserves bundle mode during verification and list ID generation.
- Encodes HTTPSig HTTP replies directly from structured messages rather than via an intermediate `tabm` representation. This ensures that the bundle hint is applied properly at the encoding boundary.
- Avoids converting remote results to TABM merely to prefix their keys in remote note AO-Core calls.
- Removes the redundant structured-to-TABM round trip inside HTTPSig encoding.
- Avoids streaming bodies for no-content `status: 204|304` responses.
- Simplifies a meta request-hook test to use normal HTTP options.