### PR TITLE
fix: `hb_store_arweave` `/` encoding in IDs

### DIFF
--- a/src/core/store/hb_store_arweave.erl
+++ b/src/core/store/hb_store_arweave.erl
@@ -61,7 +61,11 @@ group(_, _, _) -> {error, not_found}.
 %% multiple times.
 type(#{ <<"index-store">> := IndexStore }, #{ <<"type">> := ID }, NodeOpts)
         when ?IS_ID(ID) ->
-    case hb_store:read(IndexStore, hb_store_arweave_offset:path(ID), NodeOpts) of
+    case hb_store:read(
+        IndexStore,
+        #{ <<"read">> => hb_store_arweave_offset:path(ID) },
+        NodeOpts
+    ) of
         {ok, _Offset} ->
             {ok, simple};
         _ ->
@@ -75,7 +79,11 @@ read_offset(StoreOpts = #{ <<"index-store">> := IndexStore }, ID, _Opts) ->
     ReadRes =
         hb_prometheus:measure_and_report(
             fun() ->
-                hb_store:read(IndexStore, hb_store_arweave_offset:path(ID), StoreOpts)
+                hb_store:read(
+                    IndexStore,
+                    #{ <<"read">> => hb_store_arweave_offset:path(ID) },
+                    StoreOpts
+                )
             end,
             hb_store_arweave_index_check_duration_seconds
         ),
@@ -367,6 +375,20 @@ init_prometheus() ->
     hb_http_client:init_prometheus().
 
 %%% Tests
+
+slash_offset_key_read_test_parallel() ->
+    Store = [hb_test_utils:test_store(hb_store_lmdb)],
+    Opts = #{ <<"index-store">> => Store },
+    ID = <<"L2FiY2RlZmdoaWprbG0vL29wcXJzdHV2d3h5ejAxMi8">>,
+    ?assertEqual(
+        <<"/abcdefghijklm//opqrstuvwxyz012/">>,
+        hb_store_arweave_offset:path(ID)
+    ),
+    ok = write_offset(Opts, ID, <<"tx@1.0">>, 123, 456),
+    ?assertMatch(
+        {ok, #{ <<"start-offset">> := 123, <<"length">> := 456 }},
+        read_offset(Opts, ID, Opts)
+    ).
 
 write_read_tx_test() ->
     Store = [hb_test_utils:test_store()],

--- a/src/core/store/hb_store_arweave.erl
+++ b/src/core/store/hb_store_arweave.erl
@@ -377,17 +377,23 @@ init_prometheus() ->
 %%% Tests
 
 slash_offset_key_read_test_parallel() ->
-    Store = [hb_test_utils:test_store(hb_store_lmdb)],
-    Opts = #{ <<"index-store">> => Store },
+    IndexStore = [hb_test_utils:test_store(hb_store_lmdb)],
+    Opts = #{
+        <<"store">> => [#{
+            <<"store-module">> => hb_store_arweave,
+            <<"index-store">> => IndexStore
+        }]
+    },
+    Store = store_from_opts(Opts),
     ID = <<"L2FiY2RlZmdoaWprbG0vL29wcXJzdHV2d3h5ejAxMi8">>,
     ?assertEqual(
         <<"/abcdefghijklm//opqrstuvwxyz012/">>,
         hb_store_arweave_offset:path(ID)
     ),
-    ok = write_offset(Opts, ID, <<"tx@1.0">>, 123, 456),
+    ok = write_offset(Store, ID, <<"tx@1.0">>, 123, 456),
     ?assertMatch(
         {ok, #{ <<"start-offset">> := 123, <<"length">> := 456 }},
-        read_offset(Opts, ID, Opts)
+        read_offset(Store, ID, Opts)
     ).
 
 write_read_tx_test() ->

--- a/src/preloaded/query/dev_copycat_arweave.erl
+++ b/src/preloaded/query/dev_copycat_arweave.erl
@@ -145,7 +145,11 @@ is_tx_indexed(TXID, Opts) ->
     case hb_store_arweave:store_from_opts(Opts) of
         no_store -> false;
         #{ <<"index-store">> := Store } ->
-            case hb_store:read(Store, hb_store_arweave_offset:path(TXID), Opts) of
+            case hb_store:read(
+                Store,
+                #{ <<"read">> => hb_store_arweave_offset:path(TXID) },
+                Opts
+            ) of
                 {ok, _} -> true;
                 {error, not_found} -> false
             end


### PR DESCRIPTION
Fixes an issue with unfortunate Arweave IDs that happen to, in their raw 32 byte ID form, contain `/`. As with #959, but with a smaller blast radius.