### PR TITLE
impr: miscellaneous codec improvements for `httpsig@1.0`, `tx@1.0` and `ans104@1.0`

### DIFF
--- a/src/core/http/hb_client_gateway.erl
+++ b/src/core/http/hb_client_gateway.erl
@@ -78,12 +78,12 @@ read(ID, Opts) ->
             end
     end.
 
-%% @doc Gives the fields of a transaction that are needed to construct an
-%% ANS-104 message.
+%% @doc Gives the fields needed to construct an Arweave message.
 item_spec() ->
     <<"""
         node {
             id
+            bundledIn { id }
             anchor
             signature
             recipient
@@ -355,6 +355,13 @@ result_to_message(Item, Opts) ->
         _ ->
             result_to_message(undefined, Item, Opts)
     end.
+%% @doc Load an L1 transaction in its native form.
+result_to_message(ExpectedID, #{ <<"bundledIn">> := null }, Opts) ->
+    hb_ao:resolve(
+        #{ <<"device">> => <<"arweave@2.9">> },
+        #{ <<"path">> => <<"tx">>, <<"tx">> => ExpectedID },
+        Opts
+    );
 result_to_message(ExpectedID, Item, Opts) ->
     GQLOpts =
         Opts#{
@@ -561,9 +568,17 @@ scheduler_location_test() ->
 
 %% @doc Test l1 message from graphql
 l1_transaction_test() ->
-    _Node = hb_http_server:start_node(#{}),
-    {ok, Res} = read(<<"uJBApOt4ma3pTfY6Z4xmknz5vAasup4KcGX7FJ0Of8w">>, #{}),
+    ID = <<"uJBApOt4ma3pTfY6Z4xmknz5vAasup4KcGX7FJ0Of8w">>,
+    Node = hb_http_server:start_node(
+        #{ <<"store">> => [#{ <<"store-module">> => hb_store_gateway }] }
+    ),
+    ClientOpts = #{ <<"store">> => [hb_test_utils:test_store(hb_store_volatile)] },
+    {ok, Res} = hb_http:get(Node, ID, ClientOpts),
     ?event(gateway, {l1_transaction, Res}),
+    Devices = hb_message:commitment_devices(Res, ClientOpts),
+    ?assert(lists:member(<<"tx@1.0">>, Devices)),
+    ?assertNot(lists:member(<<"ans104@1.0">>, Devices)),
+    ?assert(hb_message:verify(Res, all, ClientOpts)),
     Data = maps:get(<<"data">>, Res),
     ?assertEqual(<<"Hello World">>, Data).
 

--- a/src/core/http/hb_client_remote.erl
+++ b/src/core/http/hb_client_remote.erl
@@ -112,8 +112,8 @@ upload(Msg, Opts, _CommitmentDevice) ->
     hb_ao:raw(
         <<"arweave@2.9">>,
         <<"tx">>,
-        #{},
-        Msg#{ <<"method">> => <<"POST">> },
+        Msg,
+        #{ <<"method">> => <<"POST">>, <<"target">> => <<"base">> },
         Opts
     ).
 
@@ -143,7 +143,8 @@ upload_single_layer_message_test() ->
     Msg = #{
         <<"data">> => <<"TEST">>,
         <<"basic">> => <<"value">>,
-        <<"integer">> => 1
+        <<"integer">> => 1,
+        <<"target">> => hb_util:human_id(<<0:256>>)
     },
     Committed =
         hb_message:commit(

--- a/src/preloaded/codec/dev_httpsig_conv.erl
+++ b/src/preloaded/codec/dev_httpsig_conv.erl
@@ -608,10 +608,10 @@ group_maps(Map, Parent, Top, Opts) when is_map(Map) ->
                     end;
                 _ ->
                     ?event_debug({group_maps, {norm_key, NormKey}, {value, Value}}),
-                    case byte_size(Value) > ?MAX_HEADER_LENGTH of
-                        % the value is too large to be encoded as a header
-                        % within a part, so instead lift it to be a top level
-                        % part
+                    case NormKey =:= <<"content-disposition">>
+                            orelse byte_size(Value) > ?MAX_HEADER_LENGTH of
+                        % Content-Disposition frames multipart parts, while
+                        % large values cannot be headers. Lift either one.
                         true ->
                             NewTop = hb_maps:put(FlatK, Value, CurTop, Opts),
                             {CurMap, NewTop};
@@ -904,3 +904,15 @@ encode_message_with_links_test() ->
     % Ensure that the result is the same as the original message
     ?event({decoded, Dec}),
     ?assert(hb_message:match(Msg, Dec, strict, #{})).
+
+nested_content_disposition_roundtrip_test() ->
+    Msg = #{
+        <<"child">> => #{
+            <<"content-disposition">> => <<"attachment">>,
+            <<"value">> => <<"x">>
+        }
+    },
+    Codec = #{ <<"device">> => <<"httpsig@1.0">>, <<"bundle">> => true },
+    Encoded = hb_message:convert(Msg, Codec, <<"structured@1.0">>, #{}),
+    Decoded = hb_message:convert(Encoded, <<"structured@1.0">>, Codec, #{}),
+    ?assertEqual(Msg, Decoded).


### PR DESCRIPTION
Fixes three separate codec issues individually:

1. 4142f732ac7e6b648d0f4f0d8329aad5efb26863: Redirects reads of Arweave base layer transactions away from GraphQL and instead points them at the node's `~arweave@2.9` device.
2. c94af88dc1270d7d3d77fd04e60a0929afe932ff: Fixes as issues with uploads of `~ans104@1.0` messages that have a `target` key that is not encodable as a commitment `field-target` value. h/t to @NickJ202 's #1023 that raised an instance where this issue occurs in `~scheduler@1.0`. This commit patches the underlying issue but #1023's error handling should likely still land in some form.
3. 562d62f03038776f163f310f286c8e6a9cc0bbe1: Improves the encoding of `content-digest` headers for nested messages containing it. We separate `content-digest` into its own, distinct multipart form component such that it does not collide with the other `content-digest` value needed for the message to be encoded.