### PR TITLE
feat: add node-address-bound TLS termination

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -20377,6 +20377,36 @@ These options control identity and security settings.
 | `scheduler_location_ttl` | Integer | 604800000 | TTL for scheduler registration (7 days in ms) |
 <!-- Complex options like trusted_device_signers, trusted are omitted -->
 
+#### TLS termination
+
+TLS is opt-in and uses ACME HTTP-01 to obtain and renew a certificate whose
+leaf key is the node's RSA `priv-wallet`:
+
+```text
+port: 443
+protocol: http2
+
+tls/domains/ao-types: .=list
+tls/domains/1: node.example.com
+
+tls/acme/directory-url: https://acme.example/directory
+tls/acme/terms-of-service-agreed: true
+tls/acme/http-port: 80
+```
+
+`tls/acme/http-port` defaults to `80` and must be reachable for HTTP-01
+validation. This cleartext listener serves only the exact ACME challenge path.
+The ACME directory uses the operating-system trust store unless
+`tls/acme/ca-certificate` supplies a PEM CA certificate. TLS supports `http1`
+and `http2`, not `http3`.
+
+The certificate leaf contains the exact `priv-wallet` public key. Certificate
+viewers expose a fingerprint of that TLS key; the node address instead hashes
+the wallet's raw RSA modulus.
+
+The `tls` node-message field cannot be changed while the listener is running;
+restart the node to adopt a different TLS policy.
+
 ### Caching & Storage
 
 These options control caching behavior. **Note:** Detailed storage configuration (`store` option) involves complex data structures and cannot be set via `config.flat`.

--- a/docs/run/configuring-your-machine.md
+++ b/docs/run/configuring-your-machine.md
@@ -79,6 +79,36 @@ These options control identity and security settings.
 | `scheduler_location_ttl` | Integer | 604800000 | TTL for scheduler registration (7 days in ms) |
 <!-- Complex options like trusted_device_signers, trusted are omitted -->
 
+#### TLS termination
+
+TLS is opt-in and uses ACME HTTP-01 to obtain and renew a certificate whose
+leaf key is the node's RSA `priv-wallet`:
+
+```text
+port: 443
+protocol: http2
+
+tls/domains/ao-types: .=list
+tls/domains/1: node.example.com
+
+tls/acme/directory-url: https://acme.example/directory
+tls/acme/terms-of-service-agreed: true
+tls/acme/http-port: 80
+```
+
+`tls/acme/http-port` defaults to `80` and must be reachable for HTTP-01
+validation. This cleartext listener serves only the exact ACME challenge path.
+The ACME directory uses the operating-system trust store unless
+`tls/acme/ca-certificate` supplies a PEM CA certificate. TLS supports `http1`
+and `http2`, not `http3`.
+
+The certificate leaf contains the exact `priv-wallet` public key. Certificate
+viewers expose a fingerprint of that TLS key; the node address instead hashes
+the wallet's raw RSA modulus.
+
+The `tls` node-message field cannot be changed while the listener is running;
+restart the node to adopt a different TLS policy.
+
 ### Caching & Storage
 
 These options control caching behavior. **Note:** Detailed storage configuration (`store` option) involves complex data structures and cannot be set via `config.flat`.

--- a/docs/run/configuring-your-machine.md
+++ b/docs/run/configuring-your-machine.md
@@ -106,6 +106,12 @@ The certificate leaf contains the exact `priv-wallet` public key. Certificate
 viewers expose a fingerprint of that TLS key; the node address instead hashes
 the wallet's raw RSA modulus.
 
+If the ACME directory is unreachable at boot (CA outage, rate limits), the
+node still starts: it serves a short-lived self-signed certificate carrying
+the same wallet key and retries issuance hourly, installing the CA
+certificate live once issuance succeeds. Browsers warn during that window,
+but the wallet binding above still holds.
+
 The `tls` node-message field cannot be changed while the listener is running;
 restart the node to adopt a different TLS policy.
 

--- a/scripts/test-tls-acme-pebble.sh
+++ b/scripts/test-tls-acme-pebble.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -eu
+
+PEBBLE_IMAGE='ghcr.io/letsencrypt/pebble@sha256:ddf230642b1a584f519f32e347de1b05a6e4c1f6c35c1863b33effeab5f78199'
+PEBBLE_NAME="hb-tls-pebble-$$"
+TEST_DIR=$(mktemp -d "${TMPDIR:-/tmp}/hb-tls-pebble.XXXXXX")
+
+cleanup() {
+	docker rm -f "$PEBBLE_NAME" >/dev/null 2>&1 || true
+	rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT INT TERM
+
+docker run --detach --name "$PEBBLE_NAME" \
+	--add-host host.docker.internal:host-gateway \
+	--publish 127.0.0.1:14000:14000 \
+	--publish 127.0.0.1:15000:15000 \
+	--env PEBBLE_VA_NOSLEEP=1 \
+	--env PEBBLE_WFE_NONCEREJECT=0 \
+	"$PEBBLE_IMAGE" >/dev/null
+
+docker cp "$PEBBLE_NAME:/test/certs/pebble.minica.pem" \
+	"$TEST_DIR/pebble.minica.pem"
+
+attempt=0
+until curl --silent --show-error --fail \
+	--cacert "$TEST_DIR/pebble.minica.pem" \
+	https://localhost:14000/dir >/dev/null; do
+	attempt=$((attempt + 1))
+	[ "$attempt" -lt 60 ] || {
+		echo "Pebble did not become ready." >&2; exit 1;
+	}
+	sleep 0.25
+done
+
+curl --silent --show-error --fail --cacert "$TEST_DIR/pebble.minica.pem" \
+	https://localhost:15000/roots/0 \
+	--output "$TEST_DIR/pebble.root.pem"
+
+HB_PEBBLE_DIRECTORY_URL=https://localhost:14000/dir \
+HB_PEBBLE_CA="$TEST_DIR/pebble.minica.pem" \
+HB_PEBBLE_ISSUER_CA="$TEST_DIR/pebble.root.pem" \
+	HB_PORT=0 rebar3 device test \
+		--devices dev_tls \
+		--with-core \
+		--module hb_tls_examples \
+		--timeout 300

--- a/src/core/http/hb_http_client.erl
+++ b/src/core/http/hb_http_client.erl
@@ -100,13 +100,11 @@ httpc_req(Args, Opts) ->
     ?event({httpc_req, {priv_args, Args}}),
     case parse_peer(Peer, Opts) of
         {error, _} = Err -> Err;
-        {ok, {Host, Port}} ->
-            Scheme = case Port of
-                443 -> "https";
-                _ -> "http"
-            end,
+        {ok, {Scheme, Host, Port}} ->
             ?event(debug_http_client, {httpc_req, {explicit, Args}}),
-            URL = binary_to_list(iolist_to_binary([Scheme, "://", Host, ":", integer_to_binary(Port), Path])),
+            URL = binary_to_list(iolist_to_binary(
+                [Scheme, "://", Host, ":", integer_to_binary(Port), Path]
+            )),
             FilteredHeaders = hb_maps:without([<<"content-type">>, <<"cookie">>], Headers, Opts),
             HeaderKV =
                 [
@@ -175,11 +173,7 @@ hackney_req(Args, Opts) ->
     ?event({hackney_req, {priv_args, Args}}),
     case parse_peer(Peer, Opts) of
         {error, _} = Err -> Err;
-        {ok, {Host, Port}} ->
-            Scheme = case Port of
-                443 -> <<"https">>;
-                _ -> <<"http">>
-            end,
+        {ok, {Scheme, Host, Port}} ->
             URL = <<Scheme/binary, "://",
                 (hb_util:bin(Host))/binary, ":",
                 (integer_to_binary(Port))/binary,
@@ -367,10 +361,11 @@ terminate(_Reason, _State) ->
 open_connection(#{ peer := Peer }, Opts) ->
     case parse_peer(Peer, Opts) of
         {error, _} = Err -> Err;
-        {ok, {Host, Port}} -> open_connection_gun(Host, Port, Peer, Opts)
+        {ok, {Scheme, Host, Port}} ->
+            open_connection_gun(Scheme, Host, Port, Peer, Opts)
     end.
 
-open_connection_gun(Host, Port, Peer, Opts) ->
+open_connection_gun(Scheme, Host, Port, Peer, Opts) ->
     ?event(http_outbound, {parsed_peer, {peer, Peer}, {host, Host}, {port, Port}}),
     BaseGunOpts =
         #{
@@ -389,12 +384,13 @@ open_connection_gun(Host, Port, Peer, Opts) ->
                     http_client_connect_timeout,
                     ?DEFAULT_CONNECT_TIMEOUT,
                     Opts
-                )
+                ),
+            tls_opts => client_tls_options(Scheme, Opts)
         },
     Transport =
-        case Port of
-            443 -> tls;
-            _ -> tcp
+        case Scheme of
+            <<"https">> -> tls;
+            <<"http">> -> tcp
         end,
     DefaultProto =
         case hb_features:http3() of
@@ -405,8 +401,8 @@ open_connection_gun(Host, Port, Peer, Opts) ->
     GunOpts =
         case Proto = hb_opts:get(protocol, DefaultProto, Opts) of
             http3 -> BaseGunOpts#{protocols => [http3], transport => quic};
-            http2 -> BaseGunOpts#{protocols => [http2]};
-            http1 -> BaseGunOpts#{protocols => [http]}
+            http2 -> BaseGunOpts#{protocols => [http2], transport => Transport};
+            http1 -> BaseGunOpts#{protocols => [http], transport => Transport}
         end,
     ?event(http_outbound,
         {gun_open,
@@ -419,20 +415,35 @@ open_connection_gun(Host, Port, Peer, Opts) ->
 	gun:open(Host, Port, GunOpts).
 
 parse_peer(Peer, Opts) ->
-    Parsed = uri_string:parse(Peer),
-    case Parsed of
-        #{ host := Host, port := Port } ->
-            {ok, {hb_util:list(Host), Port}};
-        URI = #{ host := Host } ->
-            {ok, {
-                hb_util:list(Host),
-                case hb_maps:get(scheme, URI, undefined, Opts) of
-                    <<"https">> -> 443;
-                    _ -> hb_opts:get(port, 8734, Opts)
-                end
-            }};
-        _ ->
-            {error, {bad_peer, Peer}}
+    try
+        URI = #{host := Host} = uri_string:parse(Peer),
+        DefaultScheme = case maps:get(port, URI, undefined) of
+            443 -> <<"https">>;
+            _ -> <<"http">>
+        end,
+        Scheme = hb_util:to_lower(
+            hb_util:bin(maps:get(scheme, URI, DefaultScheme))
+        ),
+        true = Scheme =:= <<"http">> orelse Scheme =:= <<"https">>,
+        DefaultPort = case Scheme of
+            <<"https">> -> 443;
+            <<"http">> -> hb_opts:get(port, 8734, Opts)
+        end,
+        {ok, {Scheme, hb_util:list(Host), maps:get(port, URI, DefaultPort)}}
+    catch
+        _:_ -> {error, {bad_peer, Peer}}
+    end.
+
+client_tls_options(<<"http">>, _Opts) ->
+    [];
+client_tls_options(<<"https">>, Opts) ->
+    case hb_opts:get(http_client_tls_ca, not_found, Opts) of
+        not_found -> [];
+        CertificateAuthorities ->
+            [
+                {verify, verify_peer},
+                {cacerts, CertificateAuthorities}
+            ]
     end.
 
 do_gun_request(PID, Args, Opts) ->
@@ -517,6 +528,9 @@ await_response(Args, Opts) ->
 							{error, too_much_data}
 					end
 			end;
+		{data, fin, Data}
+                when Limit =/= infinity, Counter + byte_size(Data) > Limit ->
+            {error, too_much_data};
 		{data, fin, Data} ->
 			FinData = iolist_to_binary([Acc | Data]),
 			download_metric(FinData, Opts),

--- a/src/core/http/hb_http_client_tests.erl
+++ b/src/core/http/hb_http_client_tests.erl
@@ -56,6 +56,22 @@ hackney_post_test_() ->
         ?assertMatch({ok, _, _, _}, Result)
     end}.
 
+gun_final_frame_limit_test() ->
+    {ok, Peer, Server} = hb_mock_server:start([
+        {"/body", body, {200, <<"four">>}}
+    ]),
+    try
+        ?assertEqual(
+            {error, too_much_data},
+            hb_http_client:request(#{
+                peer => Peer, path => <<"/body">>, method => <<"GET">>,
+                headers => #{}, body => <<>>, limit => 3
+            }, #{ <<"http-client">> => gun, <<"protocol">> => http1 })
+        )
+    after
+        hb_mock_server:stop(Server)
+    end.
+
 summarize({caught, C, R}) when is_tuple(R) ->
     {caught, C, element(1, R)};
 summarize({caught, C, R}) ->

--- a/src/core/http/hb_http_server.erl
+++ b/src/core/http/hb_http_server.erl
@@ -329,7 +329,7 @@ prepare_tls(TLS, Wallet, ServerID, NodeMsg) ->
             #{ <<"path">> => <<"obtain">> }, Private, NodeMsg
         ),
         ResolveOpts = hb_private:set(NodeMsg, Private, NodeMsg),
-        {ok, BootstrapResult} = hb_ao:resolve(
+        Chain = case hb_ao:resolve(
             #{ <<"device">> => <<"tls@1.0">> },
             Request,
             ResolveOpts#{
@@ -337,10 +337,20 @@ prepare_tls(TLS, Wallet, ServerID, NodeMsg) ->
                 <<"hashpath">> => ignore,
                 <<"cache-control">> => [<<"no-cache">>, <<"no-store">>]
             }
-        ),
-        Chain = hb_maps:get(
-            <<"certificate-chain">>, BootstrapResult, not_found, NodeMsg
-        ),
+        ) of
+            {ok, BootstrapResult} ->
+                hb_maps:get(
+                    <<"certificate-chain">>, BootstrapResult, not_found, NodeMsg
+                );
+            BootstrapError ->
+                %% Boot on a wallet-key self-signed fallback rather than not
+                %% at all; the runtime loop retries issuance hourly and
+                %% installs the real certificate live once the CA cooperates.
+                ?event(tls, {acme_bootstrap_failed, {error, BootstrapError}}),
+                hb_tls:self_signed_chain(
+                    Wallet, hb_maps:get(<<"domains">>, TLS, [], NodeMsg)
+                )
+        end,
         {ok, TLSOpts} = hb_tls:socket_options(Wallet, Chain),
         TLSOpts
     catch
@@ -377,7 +387,7 @@ stop_tls(ServerID) ->
     case hb_name:lookup({<<"tls@1.0">>, ServerID}) of
         PID when is_pid(PID) ->
             PID ! {stop, self()},
-            receive {stopped, PID} -> ok end;
+            receive {stopped, PID} -> ok after 5000 -> ok end;
         undefined -> ok
     end,
     cowboy:stop_listener({tls_http_01, ServerID}),

--- a/src/core/http/hb_http_server.erl
+++ b/src/core/http/hb_http_server.erl
@@ -174,8 +174,9 @@ print_greeter(Config, PrivWallet) ->
             string:pad(
                 lists:flatten(
                     io_lib:format(
-                        "http://~s:~p",
+                        "~s://~s:~p",
                         [
+                            scheme(Config),
                             hb_opts:get(node_host, <<"localhost">>, Config),
                             hb_opts:get(port, 8734, Config)
                         ]
@@ -219,26 +220,26 @@ new_server(RawNodeMsg) ->
         end,
     % Put server ID into node message so it's possible to update current server
     hb_http:start(),
-    ServerID =
-        hb_util:human_id(
-            ar_wallet:to_address(
-                hb_opts:get(
-                    priv_wallet,
-                    no_wallet,
-                    NodeMsg
-                )
-            )
-        ),
+    Wallet = hb_opts:get(priv_wallet, no_wallet, NodeMsg),
+    ServerID = hb_util:human_id(ar_wallet:to_address(Wallet)),
+    TLS = hb_tls:config(NodeMsg),
+    DefaultProtocol =
+        case hb_features:http3() of
+            true -> http3;
+            false -> http2
+        end,
+    Protocol = hb_opts:get(protocol, DefaultProtocol, NodeMsg),
+    case {Protocol, TLS} of
+        {http3, TLSConfig} when is_map(TLSConfig) ->
+            error('tls-not-supported-for-http3');
+        {Supported, _} when Supported =:= http1; Supported =:= http2;
+                Supported =:= http3 -> ok;
+        _ -> error({'unknown-protocol', Protocol})
+    end,
     % Put server ID into node message so it's possible to update current server
     % params.
     NodeMsgWithID = hb_maps:put(<<"http-server">>, ServerID, NodeMsg),
-    Dispatcher = cowboy_router:compile([{'_', [{'_', ?MODULE, ServerID}]}]),
-    ProtoOpts = #{
-        env => #{ dispatch => Dispatcher, node_msg => NodeMsgWithID },
-        stream_handlers => [cowboy_stream_h],
-        max_connections => infinity,
-        idle_timeout => hb_opts:get(idle_timeout, 300000, NodeMsg)
-    },
+    ProtoOpts = listener_protocol_options(ServerID, NodeMsgWithID),
     PrometheusOpts =
         case hb_opts:get(prometheus, not hb_features:test(), NodeMsg) of
             true ->
@@ -270,20 +271,23 @@ new_server(RawNodeMsg) ->
                 ),
                 ProtoOpts
         end,
-    DefaultProto =
-        case hb_features:http3() of
-            true -> http3;
-            false -> http2
-        end,
-    {ok, Port, Listener} =
-        case Protocol = hb_opts:get(protocol, DefaultProto, NodeMsg) of
-            http3 ->
-                start_http3(ServerID, PrometheusOpts, NodeMsg);
-            Pro when Pro =:= http2; Pro =:= http1 ->
-                % The HTTP/2 server has fallback mode to 1.1 as necessary.
-                start_http2(ServerID, PrometheusOpts, NodeMsg);
-            _ -> {error, {unknown_protocol, Protocol}}
-        end,
+    TLSOpts = prepare_tls(TLS, Wallet, ServerID, NodeMsg),
+    {Port, Listener} = try
+        case case {Protocol, TLSOpts} of
+                {http3, []} -> start_http3(ServerID, PrometheusOpts, NodeMsg);
+                {Pro, _} when Pro =:= http2; Pro =:= http1 ->
+                    start_http2(ServerID, PrometheusOpts, NodeMsg, TLSOpts)
+            end of
+            {ok, StartedPort, StartedListener} ->
+                {StartedPort, StartedListener};
+            {error, ListenerReason} ->
+                error({'http-server-start-failed', ListenerReason})
+        end
+    catch
+        Class:StartReason:Stack ->
+            case TLS of false -> ok; _ -> stop_tls(ServerID) end,
+            erlang:raise(Class, StartReason, Stack)
+    end,
     % Update the node message with the actual port that was used, in the event
     % that the OS assigned a different port. This happens, for example, when we
     % use port 0.
@@ -297,7 +301,87 @@ new_server(RawNodeMsg) ->
             {store, hb_opts:get(store, no_store, NodeMsg)}
         }
     ),
+    set_proc_server_id(ServerID),
     {ok, Listener, Port}.
+
+prepare_tls(false, _Wallet, ServerID, _NodeMsg) ->
+    stop_tls(ServerID),
+    [];
+prepare_tls(TLS, Wallet, ServerID, NodeMsg) ->
+    ACME = hb_maps:get(<<"acme">>, TLS, not_found, NodeMsg),
+    true = is_map(ACME),
+    ChallengeRef = {tls_http_01, ServerID},
+    stop_tls(ServerID),
+    try
+        ChallengeNode = challenge_node(ACME, ServerID, NodeMsg),
+        {ok, _, _} = start_http2(
+            ChallengeRef,
+            listener_protocol_options(ChallengeRef, ChallengeNode),
+            ChallengeNode,
+            []
+        ),
+        PrivateTLS = #{
+            <<"server-id">> => ServerID,
+            <<"lifecycle-capability">> => make_ref()
+        },
+        Private = #{ <<"tls">> => PrivateTLS },
+        Request = hb_private:set(
+            #{ <<"path">> => <<"obtain">> }, Private, NodeMsg
+        ),
+        ResolveOpts = hb_private:set(NodeMsg, Private, NodeMsg),
+        {ok, BootstrapResult} = hb_ao:resolve(
+            #{ <<"device">> => <<"tls@1.0">> },
+            Request,
+            ResolveOpts#{
+                <<"only">> => local,
+                <<"hashpath">> => ignore,
+                <<"cache-control">> => [<<"no-cache">>, <<"no-store">>]
+            }
+        ),
+        Chain = hb_maps:get(
+            <<"certificate-chain">>, BootstrapResult, not_found, NodeMsg
+        ),
+        {ok, TLSOpts} = hb_tls:socket_options(Wallet, Chain),
+        TLSOpts
+    catch
+        Class:Reason:Stack ->
+            stop_tls(ServerID),
+            erlang:raise(Class, Reason, Stack)
+    end.
+
+challenge_node(ACME, ServerID, NodeMsg) ->
+    ChallengeRef = {tls_http_01, ServerID},
+    hb_private:set(
+        (hb_private:reset(NodeMsg))#{
+            <<"port">> => hb_maps:get(<<"http-port">>, ACME, 80, NodeMsg),
+            <<"force-signed">> => false,
+            <<"http-server">> => ChallengeRef,
+            <<"on">> => #{
+                <<"request">> => #{ <<"device">> => <<"tls@1.0">> }
+            }
+        },
+        #{ <<"tls">> => #{ <<"server-id">> => ServerID } },
+        NodeMsg
+    ).
+
+listener_protocol_options(ServerID, NodeMsg) ->
+    Dispatcher = cowboy_router:compile([{'_', [{'_', ?MODULE, ServerID}]}]),
+    #{
+        env => #{ dispatch => Dispatcher, node_msg => NodeMsg },
+        stream_handlers => [cowboy_stream_h],
+        max_connections => infinity,
+        idle_timeout => hb_opts:get(idle_timeout, 300000, NodeMsg)
+    }.
+
+stop_tls(ServerID) ->
+    case hb_name:lookup({<<"tls@1.0">>, ServerID}) of
+        PID when is_pid(PID) ->
+            PID ! {stop, self()},
+            receive {stopped, PID} -> ok end;
+        undefined -> ok
+    end,
+    cowboy:stop_listener({tls_http_01, ServerID}),
+    ok.
 
 start_http3(ServerID, ProtoOpts, NodeMsg) ->
     ?event(http, {start_http3, ServerID}),
@@ -305,7 +389,7 @@ start_http3(ServerID, ProtoOpts, NodeMsg) ->
     ServerPID =
         spawn(fun() ->
             application:ensure_all_started(quicer),
-            {ok, Listener} =
+            {ok, _Listener} =
                 cowboy:start_quic(
                     ServerID, 
                     TransOpts = #{
@@ -349,7 +433,7 @@ http3_conn_sup_loop() ->
             http3_conn_sup_loop()
     end.
 
-start_http2(ServerID, ProtoOpts, NodeMsg) ->
+start_http2(ServerID, ProtoOpts, NodeMsg, TLSOpts) ->
     ?event(http, {start_http2, ServerID}),
     MaxConnections = maps:get(<<"max-connections">>, NodeMsg, 10000),
     NumAcceptors =
@@ -358,17 +442,14 @@ start_http2(ServerID, ProtoOpts, NodeMsg) ->
             NodeMsg,
             erlang:system_info(schedulers) * 4
         ),
+    RequestedPort = hb_opts:get(port, 0, NodeMsg),
     TransportOpts = #{
-        socket_opts => [{port, RequestedPort = hb_opts:get(port, 0, NodeMsg)}],
+        socket_opts => [{port, RequestedPort} | TLSOpts],
         max_connections => MaxConnections,
         num_acceptors => NumAcceptors
     },
-    StartRes =
-        cowboy:start_clear(
-            ServerID,
-            TransportOpts,
-            ProtoOpts
-        ),
+    StartFun = case TLSOpts of [] -> start_clear; _ -> start_tls end,
+    StartRes = cowboy:StartFun(ServerID, TransportOpts, ProtoOpts),
     case StartRes of
         {ok, Listener} ->
             ActualPort = ranch:get_port(ServerID),
@@ -392,14 +473,19 @@ start_http2(ServerID, ProtoOpts, NodeMsg) ->
             ),
             cowboy:set_env(ServerID, node_msg, #{}),
             cowboy:stop_listener(ServerID),
-            start_http2(ServerID, ProtoOpts, NodeMsg)
+            start_http2(ServerID, ProtoOpts, NodeMsg, TLSOpts);
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 %% @doc Entrypoint for all HTTP requests. Receives the Cowboy request option and
 %% the server ID, which can be used to lookup the node message.
 init(Req, ServerID) ->
-    case cowboy_req:method(Req) of
-        <<"OPTIONS">> -> cors_reply(Req, ServerID);
+    case {cowboy_req:method(Req), ServerID} of
+        {<<"OPTIONS">>, {tls_http_01, _}} ->
+            {ok, Body} = read_body(Req),
+            handle_request(Req, Body, ServerID);
+        {<<"OPTIONS">>, _} -> cors_reply(Req, ServerID);
         _ ->
             {ok, Body} = read_body(Req),
             handle_request(Req, Body, ServerID)
@@ -546,27 +632,24 @@ set_opts(Opts) ->
             ok = cowboy:set_env(ServerRef, node_msg, Opts)
     end.
 set_opts(Request, Opts) ->
-    PreparedOpts = Opts,
     PreparedRequest = hb_message:uncommitted(Request),
-    MergedOpts =
-        maps:merge(
-            PreparedOpts,
-            PreparedRequest
-        ),
-    ?event(set_opts, {merged_opts, {explicit, MergedOpts}}),
-    History =
-        hb_opts:get(node_history, [], Opts)
-            ++
-                [
-                    hb_private:reset(
-                        maps:without([<<"node-history">>], PreparedRequest)
-                    )
-                ],
-    FinalOpts = MergedOpts#{
-        <<"http-server">> => hb_opts:get(http_server, no_server, Opts),
-        <<"node-history">> => History
-    },
-    {set_opts(FinalOpts), FinalOpts}.
+    case hb_maps:is_key(<<"tls">>, PreparedRequest, Opts) of
+        true ->
+            {error, <<"TLS configuration cannot be changed at runtime.">>};
+        false ->
+            MergedOpts = maps:merge(Opts, PreparedRequest),
+            ?event(set_opts, {merged_opts, {explicit, MergedOpts}}),
+            History = hb_opts:get(node_history, [], Opts) ++ [
+                hb_private:reset(
+                    maps:without([<<"node-history">>], PreparedRequest)
+                )
+            ],
+            FinalOpts = MergedOpts#{
+                <<"http-server">> => hb_opts:get(http_server, no_server, Opts),
+                <<"node-history">> => History
+            },
+            {set_opts(FinalOpts), FinalOpts}
+    end.
 
 %% @doc Get the node message for the current process.
 get_opts() ->
@@ -632,7 +715,14 @@ start_node(Opts) ->
     ok = hb_process_sampler:ensure_started(ServerOpts),
     ok = hb_system_monitor:ensure_started(ServerOpts),
     {ok, _Listener, Port} = new_server(ServerOpts),
-    <<"http://localhost:", (hb_util:bin(Port))/binary, "/">>.
+    Scheme = scheme(get_opts()),
+    <<Scheme/binary, "://localhost:", (hb_util:bin(Port))/binary, "/">>.
+
+scheme(NodeMsg) ->
+    case hb_tls:config(NodeMsg) of
+        TLS when is_map(TLS) -> <<"https">>;
+        false -> <<"http">>
+    end.
 
 %%% Tests
 %%% The following only covering the HTTP server initialization process. For tests
@@ -705,6 +795,22 @@ set_opts_test() ->
     ?event(debug_node_history, {node_history_length, length(NodeHistory3)}),
     ?assert(length(NodeHistory3) == 3),
     ?assert(Key3 == <<"world3">>).
+
+set_tls_opts_rejected_test() ->
+    ?assertEqual(
+        {error, <<"TLS configuration cannot be changed at runtime.">>},
+        set_opts(#{ <<"tls">> => false }, #{})
+    ).
+
+tls_http3_rejected_before_start_test() ->
+    ?assertError(
+        'tls-not-supported-for-http3',
+        start_node(#{
+            <<"priv-wallet">> => ar_wallet:load_keyfile("test/key-1.json"),
+            <<"protocol">> => http3,
+            <<"tls">> => #{}
+        })
+    ).
 
 restart_server_test() ->
     % We force HTTP2, overriding the HTTP3 feature, because HTTP3 restarts don't work yet.

--- a/src/core/http/hb_tls.erl
+++ b/src/core/http/hb_tls.erl
@@ -1,0 +1,94 @@
+%%% @doc TLS policy and node-wallet key adapter.
+-module(hb_tls).
+-export([config/1, certificate_expiry/1, install/3, socket_options/2]).
+-include_lib("public_key/include/public_key.hrl").
+
+-define(UNIX_EPOCH, 62167219200).
+
+config(NodeMsg) ->
+    case hb_opts:get(tls, false, NodeMsg) of
+        false -> false;
+        TLS ->
+            case hb_cache:ensure_all_loaded(TLS, NodeMsg) of
+                Config when is_map(Config) -> Config;
+                Invalid -> error({'invalid-tls-config', Invalid})
+            end
+    end.
+
+%% @doc Replace a listener's leaf without dropping established connections.
+install(ServerID, Wallet, Chain) ->
+    case socket_options(Wallet, Chain) of
+        {error, _} = Error -> Error;
+        {ok, TLSOpts} ->
+            try
+                TransportOpts = ranch:get_transport_options(ServerID),
+                SocketOpts = maps:get(socket_opts, TransportOpts, []),
+                Keep = lists:foldl(
+                    fun(Key, Opts) -> lists:keydelete(Key, 1, Opts) end,
+                    SocketOpts,
+                    [port, certs_keys]
+                ),
+                NewOpts = TransportOpts#{socket_opts =>
+                    [{port, ranch:get_port(ServerID)} | TLSOpts ++ Keep]},
+                ok = ranch:suspend_listener(ServerID),
+                try
+                    ok = ranch:set_transport_options(ServerID, NewOpts),
+                    ok = ranch:resume_listener(ServerID)
+                catch
+                    Class:Reason:Stack ->
+                        ranch:resume_listener(ServerID),
+                        erlang:raise(Class, Reason, Stack)
+                end
+            catch
+                _:UpdateReason ->
+                    {error, {'tls-listener-update-failed', UpdateReason}}
+            end
+    end.
+
+%% @doc Millisecond Unix expiry of the leaf certificate.
+certificate_expiry([Leaf | _]) ->
+    Certificate = public_key:pkix_decode_cert(Leaf, otp),
+    TBS = Certificate#'OTPCertificate'.tbsCertificate,
+    certificate_time(TBS#'OTPTBSCertificate'.validity#'Validity'.notAfter).
+
+certificate_time({generalTime, Time}) ->
+    certificate_time(Time);
+certificate_time({utcTime, [Y1, Y2 | Rest]}) ->
+    Century = case [Y1, Y2] >= "50" of true -> "19"; false -> "20" end,
+    certificate_time(Century ++ [Y1, Y2 | Rest]);
+certificate_time(Time) ->
+    {ok, [Y, M, D, H, I, S], _} =
+        io_lib:fread("~4d~2d~2d~2d~2d~2d", Time),
+    1000 * (calendar:datetime_to_gregorian_seconds(
+        {{Y, M, D}, {H, I, S}}
+    ) - ?UNIX_EPOCH).
+
+%% @doc Build SSL options only when the leaf carries the exact wallet key.
+socket_options({{{rsa, E}, D, N}, {{rsa, E}, N}}, [Leaf | _] = Chain) ->
+    try
+        Certificate = public_key:pkix_decode_cert(Leaf, otp),
+        TBS = Certificate#'OTPCertificate'.tbsCertificate,
+        SPKI = TBS#'OTPTBSCertificate'.subjectPublicKeyInfo,
+        true = SPKI#'OTPSubjectPublicKeyInfo'.subjectPublicKey =:=
+            rsa_public_key(E, N),
+        Sign = fun(Data, Digest, Options) ->
+            crypto:sign(rsa, Digest, Data,
+                [E, binary:decode_unsigned(N), binary:decode_unsigned(D)],
+                Options)
+        end,
+        {ok, [{certs_keys, [#{
+            cert => Chain,
+            key => #{algorithm => rsa, sign_fun => Sign}
+        }]}]}
+    catch
+        error:{badmatch, false} -> {error, 'certificate-key-mismatch'};
+        _:_ -> {error, 'invalid-certificate-chain'}
+    end;
+socket_options(_, _) ->
+    {error, 'unsupported-tls-wallet'}.
+
+rsa_public_key(E, N) ->
+    #'RSAPublicKey'{
+        publicExponent = E,
+        modulus = binary:decode_unsigned(N)
+    }.

--- a/src/core/http/hb_tls.erl
+++ b/src/core/http/hb_tls.erl
@@ -1,6 +1,7 @@
 %%% @doc TLS policy and node-wallet key adapter.
 -module(hb_tls).
 -export([config/1, certificate_expiry/1, install/3, socket_options/2]).
+-export([self_signed_chain/2]).
 -include_lib("public_key/include/public_key.hrl").
 
 -define(UNIX_EPOCH, 62167219200).
@@ -92,3 +93,53 @@ rsa_public_key(E, N) ->
         publicExponent = E,
         modulus = binary:decode_unsigned(N)
     }.
+
+%% @doc A short-lived in-memory self-signed chain carrying the wallet key, so
+%% a node can serve TLS before (or without) a CA-issued certificate. The SPKI
+%% is the wallet key, so socket_options/2 and the address binding both hold.
+%% OTP 28 ASN.1: algorithm parameters must be an explicit NULL open type, and
+%% the SAN extnValue must be the decoded list (pkix_sign re-encodes it).
+self_signed_chain({{{rsa, E}, D, N}, {{rsa, E}, N}}, [Domain | _] = Domains) ->
+    Key = #'RSAPrivateKey'{
+        modulus = binary:decode_unsigned(N),
+        publicExponent = E,
+        privateExponent = binary:decode_unsigned(D)
+    },
+    Now = os:system_time(second),
+    Subject = {rdnSequence, [[#'AttributeTypeAndValue'{
+        type = ?'id-at-commonName',
+        value = {utf8String, Domain}
+    }]]},
+    [public_key:pkix_sign(#'OTPTBSCertificate'{
+        version = v3,
+        serialNumber = erlang:unique_integer([positive]),
+        signature = #'SignatureAlgorithm'{
+            algorithm = ?'sha256WithRSAEncryption',
+            parameters = {asn1_OPENTYPE, <<5, 0>>}
+        },
+        issuer = Subject,
+        validity = #'Validity'{
+            notBefore = utc_time(Now - 300),
+            notAfter = utc_time(Now + 7 * 24 * 60 * 60)
+        },
+        subject = Subject,
+        subjectPublicKeyInfo = #'OTPSubjectPublicKeyInfo'{
+            algorithm = #'PublicKeyAlgorithm'{
+                algorithm = ?'rsaEncryption',
+                parameters = {asn1_OPENTYPE, <<5, 0>>}
+            },
+            subjectPublicKey = rsa_public_key(E, N)
+        },
+        extensions = [#'Extension'{
+            extnID = ?'id-ce-subjectAltName',
+            critical = false,
+            extnValue = [{dNSName, binary_to_list(Name)} || Name <- Domains]
+        }]
+    }, Key)].
+
+utc_time(Unix) ->
+    {{Y, Mo, Day}, {H, Mi, S}} =
+        calendar:gregorian_seconds_to_datetime(Unix + ?UNIX_EPOCH),
+    {utcTime, lists:flatten(io_lib:format(
+        "~2..0w~2..0w~2..0w~2..0w~2..0w~2..0wZ",
+        [Y rem 100, Mo, Day, H, Mi, S]))}.

--- a/src/core/test/hb_tls_examples.erl
+++ b/src/core/test/hb_tls_examples.erl
@@ -1,6 +1,7 @@
 %%% @doc End-to-end examples for node-wallet TLS against a real ACME server.
 -module(hb_tls_examples).
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("public_key/include/public_key.hrl").
 
 %% @doc Run the Pebble example when its environment has been configured.
 pebble_test_() ->
@@ -109,6 +110,69 @@ recv_ssl_response(Socket, Acc) ->
     case ssl:recv(Socket, 0, 5000) of
         {ok, Data} -> recv_ssl_response(Socket, <<Acc/binary, Data/binary>>);
         {error, closed} -> Acc
+    end.
+
+%% @doc The wallet-key self-signed fallback: accepted by socket_options (its
+%% SPKI is the wallet key), refused for any other wallet, and carrying the
+%% structural binding (sha256 of the served modulus is the wallet address).
+self_signed_chain_test() ->
+    Wallet = ar_wallet:load_keyfile("test/key-1.json"),
+    Chain = [Leaf] = hb_tls:self_signed_chain(Wallet, [<<"fallback.example">>]),
+    ?assertMatch({ok, _}, hb_tls:socket_options(Wallet, Chain)),
+    ?assertEqual({error, 'certificate-key-mismatch'}, hb_tls:socket_options(
+        ar_wallet:load_keyfile("test/key-2.json"), Chain)),
+    ?assert(hb_tls:certificate_expiry(Chain) > erlang:system_time(millisecond)),
+    Certificate = public_key:pkix_decode_cert(Leaf, otp),
+    SPKI = (Certificate#'OTPCertificate'.tbsCertificate)
+        #'OTPTBSCertificate'.subjectPublicKeyInfo,
+    #'RSAPublicKey'{modulus = Modulus} =
+        SPKI#'OTPSubjectPublicKeyInfo'.subjectPublicKey,
+    ?assertEqual(ar_wallet:to_address(Wallet),
+        crypto:hash(sha256, binary:encode_unsigned(Modulus))).
+
+%% @doc A node with an unreachable ACME directory still boots, serving the
+%% wallet-key fallback over TLS to an http/1.1 client that sends capitalized
+%% header names.
+fallback_boot_test_() ->
+    {timeout, 60, fun fallback_boot/0}.
+
+fallback_boot() ->
+    Wallet = ar_wallet:load_keyfile("test/key-1.json"),
+    URL = hb_http_server:start_node(#{
+        <<"priv-wallet">> => Wallet,
+        <<"port">> => 0,
+        <<"protocol">> => http2,
+        <<"tls">> => #{
+            <<"domains">> => [<<"localhost">>],
+            <<"acme">> => #{
+                <<"directory-url">> => <<"https://localhost:1/dir">>,
+                <<"http-port">> => 0,
+                <<"terms-of-service-agreed">> => true
+            }
+        }
+    }),
+    #{port := Port} = uri_string:parse(URL),
+    ServerID = hb_util:human_id(ar_wallet:to_address(Wallet)),
+    try
+        Leaf = peer_certificate(<<"localhost">>, Port),
+        ?assertMatch({ok, _}, hb_tls:socket_options(Wallet, [Leaf])),
+        {ok, Socket} = ssl:connect("localhost", Port,
+            [{verify, verify_none}, {active, false}, {mode, binary},
+             {alpn_advertised_protocols, [<<"http/1.1">>]}], 5000),
+        ok = ssl:send(Socket, <<
+            "GET /~meta@1.0/info/address HTTP/1.1\r\n",
+            "HOST: localhost\r\n",
+            "X-Legacy-Client: TRUE\r\n",
+            "Connection: close\r\n\r\n"
+        >>),
+        Response = recv_ssl_response(Socket, <<>>),
+        ?assertNotEqual(nomatch, binary:match(Response, <<" 200 ">>)),
+        ?assertNotEqual(nomatch, binary:match(
+            Response, hb_util:human_id(ar_wallet:to_address(Wallet))))
+    after
+        stop_runtime({<<"tls@1.0">>, ServerID}),
+        catch cowboy:stop_listener(ServerID),
+        catch cowboy:stop_listener({tls_http_01, ServerID})
     end.
 
 %% @doc Return the leaf certificate currently served by the node.

--- a/src/core/test/hb_tls_examples.erl
+++ b/src/core/test/hb_tls_examples.erl
@@ -1,0 +1,124 @@
+%%% @doc End-to-end examples for node-wallet TLS against a real ACME server.
+-module(hb_tls_examples).
+-include_lib("eunit/include/eunit.hrl").
+
+%% @doc Run the Pebble example when its environment has been configured.
+pebble_test_() ->
+    case os:getenv("HB_PEBBLE_DIRECTORY_URL") of
+        false -> [];
+        _ -> {timeout, 300, fun pebble/0}
+    end.
+
+%% @doc Issue, serve, renew, and verify a node-wallet certificate with Pebble.
+pebble() ->
+    DirectoryURL = os:getenv("HB_PEBBLE_DIRECTORY_URL"),
+    {ok, ACMECACertificate} =
+        file:read_file(os:getenv("HB_PEBBLE_CA")),
+    {ok, IssuerCACertificate} =
+        file:read_file(os:getenv("HB_PEBBLE_ISSUER_CA")),
+    IssuerCAs = [DER || {'Certificate', DER, not_encrypted} <-
+        public_key:pem_decode(IssuerCACertificate)],
+    Wallet = ar_wallet:load_keyfile("test/key-1.json"),
+    Domain = <<"host.docker.internal">>,
+    URL = hb_http_server:start_node(#{
+        <<"priv-wallet">> => Wallet,
+        <<"port">> => 0,
+        <<"protocol">> => http2,
+        <<"tls">> => #{
+            <<"domains">> => [Domain],
+            <<"acme">> => #{
+                <<"directory-url">> => hb_util:bin(DirectoryURL),
+                <<"http-port">> => 5002,
+                <<"ca-certificate">> => ACMECACertificate,
+                <<"terms-of-service-agreed">> => true
+            }
+        }
+    }),
+    #{port := Port} = uri_string:parse(URL),
+    ServerID = hb_util:human_id(ar_wallet:to_address(Wallet)),
+    RuntimeName = {<<"tls@1.0">>, ServerID},
+    PublicURL = <<"https://", Domain/binary, ":",
+        (integer_to_binary(Port))/binary, "/">>,
+    ResolverOrder = inet_db:res_option(lookup),
+    ok = inet_db:set_lookup([file | lists:delete(file, ResolverOrder)]),
+    ok = inet_db:add_host({127, 0, 0, 1}, [hb_util:list(Domain)]),
+    ClientOpts = #{
+        <<"http-client">> => gun,
+        <<"http-client-tls-ca">> => IssuerCAs,
+        <<"protocol">> => http2
+    },
+    try
+        FirstCertificate = peer_certificate(Domain, Port),
+        ?assertMatch({ok, _},
+            hb_tls:socket_options(Wallet, [FirstCertificate])),
+        ?assertEqual({error, 'certificate-key-mismatch'},
+            hb_tls:socket_options(ar_wallet:load_keyfile("test/key-2.json"),
+                [FirstCertificate])),
+        {ok, _} = hb_http:get(PublicURL, <<"/~meta@1.0/info">>, ClientOpts),
+        ?assertMatch({error, #{ <<"status">> := 404 }}, hb_http:get(
+            <<"http://localhost:5002/">>, <<"/~meta@1.0/info">>,
+            #{ <<"protocol">> => http1 }
+        )),
+        {ok, EstablishedSocket} = ssl:connect(
+            hb_util:list(Domain),
+            Port,
+            [
+                {verify, verify_none},
+                {active, false},
+                {mode, binary},
+                {alpn_advertised_protocols, [<<"http/1.1">>]}
+            ],
+            5000
+        ),
+        RuntimePID = hb_name:lookup(RuntimeName),
+        RuntimePID ! renew,
+        ?assert(hb_util:wait_until(fun() ->
+            try peer_certificate(Domain, Port) =/= FirstCertificate
+            catch _:_ -> false
+            end
+        end, 180000)),
+        ?assertMatch({ok, _}, hb_tls:socket_options(Wallet,
+            [peer_certificate(Domain, Port)])),
+        ok = ssl:send(EstablishedSocket, <<
+            "GET /~meta@1.0/info/address HTTP/1.1\r\n",
+            "Host: host.docker.internal\r\n",
+            "Connection: close\r\n\r\n"
+        >>),
+        ?assertNotEqual(nomatch, binary:match(
+            recv_ssl_response(EstablishedSocket, <<>>), <<" 200 ">>
+        ))
+    after
+        stop_runtime(RuntimeName),
+        inet_db:del_host({127, 0, 0, 1}),
+        inet_db:set_lookup(ResolverOrder),
+        catch cowboy:stop_listener(ServerID),
+        catch cowboy:stop_listener({tls_http_01, ServerID})
+    end.
+
+%% @doc Stop the singleton runtime if the example started it.
+stop_runtime(Name) ->
+    case hb_name:lookup(Name) of
+        PID when is_pid(PID) ->
+            PID ! {stop, self()},
+            receive {stopped, PID} -> ok end;
+        undefined -> ok
+    end.
+
+%% @doc Read an HTTP response until the server closes its TLS connection.
+recv_ssl_response(Socket, Acc) ->
+    case ssl:recv(Socket, 0, 5000) of
+        {ok, Data} -> recv_ssl_response(Socket, <<Acc/binary, Data/binary>>);
+        {error, closed} -> Acc
+    end.
+
+%% @doc Return the leaf certificate currently served by the node.
+peer_certificate(Domain, Port) ->
+    {ok, Socket} = ssl:connect(
+        hb_util:list(Domain),
+        Port,
+        [{verify, verify_none}, {active, false}],
+        5000
+    ),
+    {ok, Certificate} = ssl:peercert(Socket),
+    ok = ssl:close(Socket),
+    Certificate.

--- a/src/preloaded/node/dev_tls.erl
+++ b/src/preloaded/node/dev_tls.erl
@@ -75,7 +75,8 @@ obtain(_Base, Request, Opts) ->
             andalso RequestCapability =:= OptsCapability of
         false -> not_found();
         true ->
-            case call(ensure_started(Opts), obtain, infinity) of
+            %% Bounded above the ACME client's own 180s issuance deadline.
+            case call(ensure_started(Opts), obtain, 200000) of
                 {ok, Chain} -> {ok, #{
                     <<"status">> => 200,
                     <<"certificate-chain">> => Chain
@@ -91,14 +92,17 @@ ensure_started(Opts) ->
     TLS = hb_tls:config(Opts),
     true = is_map(TLS),
     ServerID = server_id(Opts),
-    hb_name:singleton(runtime_name(ServerID), fun() -> loop(#{
-        server_id => ServerID,
-        tls => TLS,
-        wallet => hb_opts:get(priv_wallet, no_viable_wallet, Opts),
-        account_wallet => ar_wallet:new(),
-        challenges => #{},
-        operation => idle
-    }) end).
+    hb_name:singleton(runtime_name(ServerID), fun() ->
+        process_flag(trap_exit, true),
+        loop(#{
+            server_id => ServerID,
+            tls => TLS,
+            wallet => hb_opts:get(priv_wallet, no_viable_wallet, Opts),
+            account_wallet => ar_wallet:new(),
+            challenges => #{},
+            operation => idle
+        })
+    end).
 
 loop(State) ->
     receive
@@ -122,14 +126,31 @@ loop(State) ->
         {acme_result, Result} when map_get(operation, State) =/= idle ->
             loop(complete(Result, State));
         renew when map_get(operation, State) =:= idle ->
-            loop(issue(renew, State));
+            loop(renew(State));
         renew -> loop(State);
         {renew_after, Delay} -> loop(schedule(Delay, State));
+        {'EXIT', _, normal} -> loop(State);
+        {'EXIT', _, Reason} when map_get(operation, State) =/= idle ->
+            loop(complete({error, {'tls-worker-died', Reason}}, State));
         {stop, From} ->
             hb_name:unregister(runtime_name(maps:get(server_id, State))),
             From ! {stopped, self()},
             exit(shutdown);
         _ -> loop(State)
+    end.
+
+%% @doc A pending chain means the last install failed after a successful
+%% issuance: retry the install without spending another issuance against the
+%% CA's rate limits. Re-issue only if there is no pending chain, or it will
+%% not outlive the next retry cycle.
+renew(State) ->
+    Chain = maps:get(pending_chain, State, undefined),
+    Usable = Chain =/= undefined andalso
+        hb_tls:certificate_expiry(Chain)
+            - erlang:system_time(millisecond) > ?RENEW_RETRY_MS,
+    case Usable of
+        true -> complete({ok, Chain}, State#{operation => renew});
+        false -> issue(renew, State)
     end.
 
 issue(Operation, State) ->
@@ -150,15 +171,15 @@ complete(Result, State = #{operation := {obtain, From, Ref}}) ->
     From ! {Ref, Result},
     case Result of
         {ok, Chain} -> schedule_certificate(Chain, State#{operation => idle});
-        {error, _} -> State#{operation => idle}
+        {error, Reason} -> retry(Reason, State#{operation => idle})
     end;
 complete({ok, Chain}, State = #{operation := renew}) ->
     Idle = State#{operation => idle},
     case hb_tls:install(
         maps:get(server_id, State), maps:get(wallet, State), Chain
     ) of
-        ok -> schedule_certificate(Chain, Idle);
-        {error, Reason} -> retry(Reason, Idle)
+        ok -> schedule_certificate(Chain, maps:remove(pending_chain, Idle));
+        {error, Reason} -> retry(Reason, Idle#{pending_chain => Chain})
     end;
 complete({error, Reason}, State = #{operation := renew}) ->
     retry(Reason, State#{operation => idle}).

--- a/src/preloaded/node/dev_tls.erl
+++ b/src/preloaded/node/dev_tls.erl
@@ -1,0 +1,216 @@
+%%% @doc Node-wallet TLS and ACME renewal device.
+-module(dev_tls).
+-export([info/1, request/3, well_known/3, obtain/3]).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(CALL_TIMEOUT, 5000).
+-define(MAX_TIMER_MS, 16#ffffffff).
+-define(RENEW_BEFORE_MS, 30 * 24 * 60 * 60 * 1000).
+-define(RENEW_RETRY_MS, 60 * 60 * 1000).
+
+info(_) ->
+    #{ exports => [<<"request">>, <<"well-known">>, <<"obtain">>] }.
+
+%% @doc Route the exact HTTP-01 path through the normal AO-Core hook.
+request(_Base, HookRequest, Opts) ->
+    Request = hb_maps:get(<<"request">>, HookRequest, #{}, Opts),
+    Path = hb_maps:get(<<"path">>, Request, <<>>, Opts),
+    case binary:split(Path, <<"/">>, [global]) of
+        [<<>>, <<".well-known">>, <<"acme-challenge">>, Token]
+                when Token =/= <<>> ->
+            {ok, HookRequest#{ <<"body">> => [
+                #{ <<"device">> => <<"tls@1.0">> },
+                #{
+                    <<"path">> => <<"well-known">>,
+                    <<"method">> => hb_maps:get(
+                        <<"method">>, Request, <<"GET">>, Opts
+                    ),
+                    <<"token">> => Token
+                }
+            ] }};
+        _ -> not_found()
+    end.
+
+%% @doc Serve an active key authorization from the singleton.
+well_known(_Base, Request, Opts) ->
+    case hb_maps:get(<<"method">>, Request, <<"GET">>, Opts) of
+        <<"GET">> ->
+            Token = hb_maps:get(<<"token">>, Request, undefined, Opts),
+            case call(hb_name:lookup(runtime_name(server_id(Opts))),
+                    {get, Token}, ?CALL_TIMEOUT) of
+                {ok, Authorization} -> {ok, #{
+                    <<"status">> => 200,
+                    <<"content-type">> => <<"text/plain">>,
+                    <<"cache-control">> => [<<"no-store">>],
+                    <<"body">> => Authorization
+                }};
+                _ -> not_found()
+            end;
+        _ ->
+            {error, #{
+                <<"status">> => 405,
+                <<"allow">> => <<"GET">>,
+                <<"cache-control">> => [<<"no-store">>],
+                <<"body">> => <<"Method not allowed.">>
+            }}
+    end.
+
+not_found() ->
+    {error, #{
+        <<"status">> => 404,
+        <<"cache-control">> => [<<"no-store">>],
+        <<"body">> => <<"Not found.">>
+    }}.
+
+%% @doc Obtain the boot certificate behind an unforgeable private capability.
+obtain(_Base, Request, Opts) ->
+    RequestCapability = hb_private:get(
+        <<"tls/lifecycle-capability">>, Request, undefined, Opts
+    ),
+    OptsCapability = hb_private:get(
+        <<"tls/lifecycle-capability">>, Opts, not_found, Opts
+    ),
+    case is_reference(RequestCapability)
+            andalso RequestCapability =:= OptsCapability of
+        false -> not_found();
+        true ->
+            case call(ensure_started(Opts), obtain, infinity) of
+                {ok, Chain} -> {ok, #{
+                    <<"status">> => 200,
+                    <<"certificate-chain">> => Chain
+                }};
+                {error, Reason} -> {error, #{
+                    <<"status">> => 500,
+                    <<"body">> => hb_util:bin(io_lib:format("~p", [Reason]))
+                }}
+            end
+    end.
+
+ensure_started(Opts) ->
+    TLS = hb_tls:config(Opts),
+    true = is_map(TLS),
+    ServerID = server_id(Opts),
+    hb_name:singleton(runtime_name(ServerID), fun() -> loop(#{
+        server_id => ServerID,
+        tls => TLS,
+        wallet => hb_opts:get(priv_wallet, no_viable_wallet, Opts),
+        account_wallet => ar_wallet:new(),
+        challenges => #{},
+        operation => idle
+    }) end).
+
+loop(State) ->
+    receive
+        {obtain, From, Ref} when map_get(operation, State) =:= idle ->
+            loop(issue({obtain, From, Ref}, State));
+        {obtain, From, Ref} ->
+            From ! {Ref, {error, 'tls-issuance-in-progress'}},
+            loop(State);
+        {{put, Token, Authorization}, From, Ref} ->
+            From ! {Ref, ok},
+            Challenges = maps:get(challenges, State),
+            loop(State#{challenges => Challenges#{Token => Authorization}});
+        {{delete, Token}, From, Ref} ->
+            From ! {Ref, ok},
+            loop(State#{challenges => maps:remove(
+                Token, maps:get(challenges, State)
+            )});
+        {{get, Token}, From, Ref} ->
+            From ! {Ref, maps:find(Token, maps:get(challenges, State))},
+            loop(State);
+        {acme_result, Result} when map_get(operation, State) =/= idle ->
+            loop(complete(Result, State));
+        renew when map_get(operation, State) =:= idle ->
+            loop(issue(renew, State));
+        renew -> loop(State);
+        {renew_after, Delay} -> loop(schedule(Delay, State));
+        {stop, From} ->
+            hb_name:unregister(runtime_name(maps:get(server_id, State))),
+            From ! {stopped, self()},
+            exit(shutdown);
+        _ -> loop(State)
+    end.
+
+issue(Operation, State) ->
+    Parent = self(),
+    spawn_link(fun() ->
+        Challenge = fun(Action) -> call(Parent, Action, ?CALL_TIMEOUT) end,
+        Parent ! {acme_result, dev_tls_acme:obtain(
+            maps:get(tls, State),
+            maps:get(wallet, State),
+            maps:get(account_wallet, State),
+            Challenge,
+            maps:get(tls, State)
+        )}
+    end),
+    State#{operation => Operation}.
+
+complete(Result, State = #{operation := {obtain, From, Ref}}) ->
+    From ! {Ref, Result},
+    case Result of
+        {ok, Chain} -> schedule_certificate(Chain, State#{operation => idle});
+        {error, _} -> State#{operation => idle}
+    end;
+complete({ok, Chain}, State = #{operation := renew}) ->
+    Idle = State#{operation => idle},
+    case hb_tls:install(
+        maps:get(server_id, State), maps:get(wallet, State), Chain
+    ) of
+        ok -> schedule_certificate(Chain, Idle);
+        {error, Reason} -> retry(Reason, Idle)
+    end;
+complete({error, Reason}, State = #{operation := renew}) ->
+    retry(Reason, State#{operation => idle}).
+
+schedule_certificate(Chain, State) ->
+    Remaining = hb_tls:certificate_expiry(Chain)
+        - erlang:system_time(millisecond),
+    Delay = case Remaining > 2 * ?RENEW_BEFORE_MS of
+        true -> Remaining - ?RENEW_BEFORE_MS;
+        false when Remaining > 0 -> max(1000, Remaining div 2);
+        false -> ?RENEW_RETRY_MS
+    end,
+    schedule(Delay, State).
+
+schedule(Delay, State) when Delay > ?MAX_TIMER_MS ->
+    erlang:send_after(?MAX_TIMER_MS, self(),
+        {renew_after, Delay - ?MAX_TIMER_MS}),
+    State;
+schedule(Delay, State) ->
+    erlang:send_after(Delay, self(), renew),
+    State.
+
+retry(Reason, State) ->
+    ?event(tls, {acme_renewal_failed, {reason, Reason}}),
+    schedule(?RENEW_RETRY_MS, State).
+
+call(undefined, _Request, _Timeout) ->
+    {error, 'tls-runtime-not-found'};
+call(PID, Request, Timeout) ->
+    Ref = make_ref(),
+    PID ! {Request, self(), Ref},
+    receive {Ref, Response} -> Response
+    after Timeout -> {error, 'tls-runtime-timeout'}
+    end.
+
+runtime_name(ServerID) -> {<<"tls@1.0">>, ServerID}.
+
+server_id(Opts) ->
+    hb_private:get(<<"tls/server-id">>, Opts, undefined, Opts).
+
+%%% Tests
+
+request_hook_test() ->
+    Hook = #{ <<"request">> => #{
+        <<"path">> => <<"/.well-known/acme-challenge/AbC_123-xy">>,
+        <<"method">> => <<"GET">>
+    }},
+    ?assertMatch({ok, #{ <<"body">> := [_, #{
+        <<"path">> := <<"well-known">>, <<"token">> := <<"AbC_123-xy">>
+    }] }}, request(#{}, Hook, #{})),
+    ?assertMatch({error, #{ <<"status">> := 404 }},
+        request(#{}, #{ <<"request">> => #{ <<"path">> => <<"/other">> } }, #{})).
+
+lifecycle_requires_private_capability_test() ->
+    ?assertMatch({error, #{ <<"status">> := 404 }}, obtain(#{}, #{}, #{})).

--- a/src/preloaded/node/dev_tls_acme.erl
+++ b/src/preloaded/node/dev_tls_acme.erl
@@ -350,31 +350,44 @@ validate_token(_) -> throw({acme, 'invalid-acme-token'}).
 %% @doc Create a SAN PKCS#10 request using the node wallet's exact key.
 csr(Wallet, Domains) ->
     Names = [binary_to_list(Domain) || Domain <- Domains],
+    Extensions = [{asn1_OPENTYPE, public_key:der_encode(
+        'Extensions', [#'Extension'{
+            extnID = ?'id-ce-subjectAltName',
+            critical = false,
+            extnValue = public_key:der_encode('GeneralNames',
+                [{dNSName, Name} || Name <- Names])
+        }]
+    )}],
+    {Info, EncodedInfo} = csr_info(Wallet, Names, Extensions,
+        'CertificationRequestInfo_attributes_SETOF'),
+    {ok, Encoded} = 'PKCS-10':encode(
+        'CertificationRequest',
+        #'CertificationRequest'{
+            certificationRequestInfo = Info,
+            signatureAlgorithm = #'CertificationRequest_signatureAlgorithm'{
+                algorithm = ?'sha256WithRSAEncryption',
+                parameters = {asn1_OPENTYPE, <<5, 0>>}
+            },
+            signature = rsa_sign(Wallet, EncodedInfo)
+        }
+    ),
+    Encoded.
+
+csr_info(Wallet, Names, Extensions, AttributeRecord) ->
     Info = #'CertificationRequestInfo'{
         version = 0,
         subject = distinguished_name(hd(Names)),
         subjectPKInfo = csr_public_key_info(Wallet),
-        attributes = [#'CertificationRequestInfo_attributes_SETOF'{
-            type = ?'pkcs-9-at-extensionRequest',
-            values = [{asn1_OPENTYPE, public_key:der_encode(
-                'Extensions', [#'Extension'{
-                    extnID = ?'id-ce-subjectAltName',
-                    critical = false,
-                    extnValue = public_key:der_encode('SubjectAltName',
-                        [{dNSName, Name} || Name <- Names])
-                }]
-            )}]
-        }]
+        attributes = [{AttributeRecord,
+            {1, 2, 840, 113549, 1, 9, 14}, Extensions}]
     },
-    EncodedInfo = public_key:der_encode('CertificationRequestInfo', Info),
-    public_key:der_encode('CertificationRequest', #'CertificationRequest'{
-        certificationRequestInfo = Info,
-        signatureAlgorithm = #'CertificationRequest_signatureAlgorithm'{
-            algorithm = ?'sha256WithRSAEncryption',
-            parameters = {asn1_OPENTYPE, <<5, 0>>}
-        },
-        signature = rsa_sign(Wallet, EncodedInfo)
-    }).
+    try
+        {ok, Encoded} = 'PKCS-10':encode('CertificationRequestInfo', Info),
+        {Info, Encoded}
+    catch error:_ when AttributeRecord =/=
+            'AttributePKCS-10' ->
+        csr_info(Wallet, Names, Extensions, 'AttributePKCS-10')
+    end.
 
 csr_public_key_info(Wallet) ->
     #'CertificationRequestInfo_subjectPKInfo'{
@@ -406,8 +419,9 @@ csr_key_test() ->
     Encoded = csr(Wallet, [<<"localhost">>, <<"node.example">>]),
     CSR = public_key:der_decode('CertificationRequest', Encoded),
     Info = CSR#'CertificationRequest'.certificationRequestInfo,
+    {ok, EncodedInfo} = 'PKCS-10':encode('CertificationRequestInfo', Info),
     ?assert(public_key:verify(
-        public_key:der_encode('CertificationRequestInfo', Info),
+        EncodedInfo,
         sha256,
         CSR#'CertificationRequest'.signature,
         wallet_public_key(Wallet)

--- a/src/preloaded/node/dev_tls_acme.erl
+++ b/src/preloaded/node/dev_tls_acme.erl
@@ -1,0 +1,426 @@
+%%% @doc Bounded RFC 8555 client for a node-wallet certificate.
+-module(dev_tls_acme).
+-export([obtain/5]).
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("public_key/include/public_key.hrl").
+
+-define(ISSUANCE_TIMEOUT, 180000).
+-define(POLL_INTERVAL, 1000).
+-define(REQUEST_TIMEOUT, 30000).
+-define(RESPONSE_LIMIT, 2 * 1024 * 1024).
+
+obtain(TLS, Wallet, AccountWallet, Challenge, Opts) ->
+    try
+        {ACME, DirectoryURL, Domains} = config(TLS, Opts),
+        State0 = #{
+            wallet => Wallet,
+            account_wallet => AccountWallet,
+            nonce => undefined,
+            kid => undefined,
+            thumbprint => account_thumbprint(AccountWallet),
+            http_opts => http_options(ACME, Opts),
+            deadline => erlang:monotonic_time(millisecond) + ?ISSUANCE_TIMEOUT
+        },
+        State1 = State0#{directory => get_json(DirectoryURL, State0)},
+        State2 = create_account(State1),
+        {Order, OrderURL, State3} = create_order(Domains, State2),
+        State4 = authorize(maps:get(<<"authorizations">>, Order),
+            Challenge, State3),
+        {_Ready, State5} = poll(OrderURL, <<"ready">>, State4),
+        State6 = finalize(maps:get(<<"finalize">>, Order), Domains, State5),
+        {Valid, State7} = poll(OrderURL, <<"valid">>, State6),
+        {_Headers, PEM, _State8} = expect(jws_post(
+            maps:get(<<"certificate">>, Valid), post_as_get, State7
+        ), [200]),
+        {ok, certificate_chain(PEM)}
+    catch
+        throw:{acme, Reason} -> {error, Reason};
+        _:Reason -> {error, Reason}
+    end.
+
+config(TLS, Opts) ->
+    ACME = case hb_maps:get(<<"acme">>, TLS, undefined, Opts) of
+        Value when is_map(Value) -> Value;
+        _ -> throw({acme, 'invalid-acme-config'})
+    end,
+    require(
+        hb_maps:get(<<"terms-of-service-agreed">>, ACME, false, Opts) =:= true,
+        'acme-terms-not-agreed'
+    ),
+    DirectoryURL = hb_maps:get(<<"directory-url">>, ACME, undefined, Opts),
+    require(is_binary(DirectoryURL) andalso byte_size(DirectoryURL) > 0,
+        'invalid-acme-directory-url'),
+    request_parts(DirectoryURL),
+    Domains = domains(hb_maps:get(<<"domains">>, TLS, undefined, Opts)),
+    {ACME, DirectoryURL, Domains}.
+
+require(true, _Reason) -> ok;
+require(false, Reason) -> throw({acme, Reason}).
+
+domains(Domains) when is_list(Domains), Domains =/= [] ->
+    require(lists:all(fun(Domain) ->
+        is_binary(Domain) andalso byte_size(Domain) > 0
+            andalso binary:match(Domain, <<"*">>) =:= nomatch
+    end, Domains), 'invalid-tls-domains'),
+    [hb_util:to_lower(Domain) || Domain <- Domains];
+domains(_) ->
+    throw({acme, 'invalid-tls-domains'}).
+
+account_thumbprint(Wallet) ->
+    #{<<"e">> := E, <<"n">> := N} = jwk(Wallet),
+    Canonical = <<
+        "{\"e\":\"", E/binary,
+        "\",\"kty\":\"RSA\",\"n\":\"", N/binary, "\"}"
+    >>,
+    hb_util:encode(crypto:hash(sha256, Canonical)).
+
+create_account(State) ->
+    {Headers, _Body, State1} = expect(jws_post(
+        directory_url(<<"newAccount">>, State),
+        #{
+            <<"termsOfServiceAgreed">> => true
+        },
+        jwk,
+        State
+    ), [200, 201]),
+    case header(<<"location">>, Headers) of
+        not_found -> throw({acme, 'acme-account-location-missing'});
+        KID -> State1#{kid => KID}
+    end.
+
+create_order(Domains, State) ->
+    Payload = #{<<"identifiers">> => [
+        #{<<"type">> => <<"dns">>, <<"value">> => Domain}
+    || Domain <- Domains]},
+    {Headers, Body, State1} = expect(jws_post(
+        directory_url(<<"newOrder">>, State), Payload, State
+    ), [201]),
+    case header(<<"location">>, Headers) of
+        not_found -> throw({acme, 'acme-order-location-missing'});
+        URL -> {json(Body), URL, State1}
+    end.
+
+authorize([], _Challenge, State) -> State;
+authorize([URL | Rest], Challenge, State) ->
+    {_Headers, Body, State1} = expect(jws_post(URL, post_as_get, State), [200]),
+    Authorization = json(Body),
+    case maps:get(<<"status">>, Authorization) of
+        <<"valid">> -> authorize(Rest, Challenge, State1);
+        _ ->
+            HTTPChallenge = http_challenge(Authorization),
+            Token = maps:get(<<"token">>, HTTPChallenge),
+            validate_token(Token),
+            KeyAuthorization = <<Token/binary, ".",
+                (maps:get(thumbprint, State1))/binary>>,
+            ok = Challenge({put, Token, KeyAuthorization}),
+            try
+                {_H, _B, State2} = expect(jws_post(
+                    maps:get(<<"url">>, HTTPChallenge), #{}, State1
+                ), [200, 202]),
+                {_Valid, State3} = poll(URL, <<"valid">>, State2),
+                authorize(Rest, Challenge, State3)
+            after
+                Challenge({delete, Token})
+            end
+    end.
+
+http_challenge(Authorization) ->
+    case [Challenge || Challenge <- maps:get(<<"challenges">>, Authorization, []),
+            maps:get(<<"type">>, Challenge, undefined) =:= <<"http-01">>] of
+        [Challenge | _] -> Challenge;
+        [] -> throw({acme, 'acme-http-01-not-offered'})
+    end.
+
+finalize(URL, Domains, State) ->
+    {_Headers, _Body, State1} = expect(jws_post(
+        URL,
+        #{<<"csr">> => hb_util:encode(csr(maps:get(wallet, State), Domains))},
+        State
+    ), [200, 202]),
+    State1.
+
+poll(URL, Expected, State) ->
+    deadline(State),
+    {Headers, Body, State1} = expect(jws_post(URL, post_as_get, State), [200]),
+    Object = json(Body),
+    case maps:get(<<"status">>, Object, undefined) of
+        Expected -> {Object, State1};
+        <<"invalid">> -> throw({acme, {'acme-object-invalid', Object}});
+        _ ->
+            wait(retry_after(Headers, ?POLL_INTERVAL), State1),
+            poll(URL, Expected, State1)
+    end.
+
+jws_post(URL, Payload, State) -> jws_post(URL, Payload, kid, State).
+jws_post(URL, Payload, Auth, State) ->
+    jws_post(URL, Payload, Auth, State, 2).
+
+jws_post(_URL, _Payload, _Auth, _State, 0) ->
+    {error, 'acme-bad-nonce'};
+jws_post(URL, Payload, Auth, State0, Retries) ->
+    deadline(State0),
+    State = ensure_nonce(State0),
+    Protected0 = #{
+        <<"alg">> => <<"RS256">>,
+        <<"nonce">> => maps:get(nonce, State),
+        <<"url">> => URL
+    },
+    Protected = case Auth of
+        jwk -> Protected0#{<<"jwk">> => jwk(maps:get(account_wallet, State))};
+        kid -> Protected0#{<<"kid">> => maps:get(kid, State)}
+    end,
+    Protected64 = hb_util:encode(hb_json:encode(Protected)),
+    Payload64 = case Payload of
+        post_as_get -> <<>>;
+        _ -> hb_util:encode(hb_json:encode(Payload))
+    end,
+    SigningInput = <<Protected64/binary, ".", Payload64/binary>>,
+    Body = hb_json:encode(#{
+        <<"protected">> => Protected64,
+        <<"payload">> => Payload64,
+        <<"signature">> => hb_util:encode(rsa_sign(
+            maps:get(account_wallet, State), SigningInput
+        ))
+    }),
+    Headers = #{
+        <<"content-type">> => <<"application/jose+json">>,
+        <<"user-agent">> => <<"HyperBEAM ACME">>
+    },
+    case request(URL, <<"POST">>, Headers, Body, State) of
+        {ok, Status, ResponseHeaders, ResponseBody} ->
+            State1 = State#{nonce => case header(
+                <<"replay-nonce">>, ResponseHeaders
+            ) of not_found -> undefined; Nonce -> Nonce end},
+            case is_bad_nonce(Status, ResponseBody) of
+                true -> jws_post(URL, Payload, Auth, State1, Retries - 1);
+                false -> {ok, Status, ResponseHeaders, ResponseBody, State1}
+            end;
+        {error, _} = Error -> Error
+    end.
+
+ensure_nonce(#{nonce := Nonce} = State)
+        when is_binary(Nonce), byte_size(Nonce) > 0 -> State;
+ensure_nonce(State) ->
+    {Headers, _Body} = expect(request(
+        directory_url(<<"newNonce">>, State),
+        <<"GET">>,
+        #{<<"user-agent">> => <<"HyperBEAM ACME">>},
+        <<>>,
+        State
+    ), [200, 204]),
+    case header(<<"replay-nonce">>, Headers) of
+        not_found -> throw({acme, 'acme-nonce-missing'});
+        Nonce -> State#{nonce => Nonce}
+    end.
+
+request(URL, Method, Headers, Body, State) ->
+    deadline(State),
+    {Peer, Path} = request_parts(URL),
+    hb_http_client:request(#{
+        peer => Peer,
+        path => Path,
+        method => Method,
+        headers => Headers,
+        body => Body,
+        limit => ?RESPONSE_LIMIT
+    }, maps:get(http_opts, State)).
+
+get_json(URL, State) ->
+    {_Headers, Body} = expect(request(
+        URL,
+        <<"GET">>,
+        #{<<"user-agent">> => <<"HyperBEAM ACME">>},
+        <<>>,
+        State
+    ), [200]),
+    json(Body).
+
+expect({ok, Status, Headers, Body}, Statuses) ->
+    case lists:member(Status, Statuses) of
+        true -> {Headers, Body};
+        false -> throw({acme, {'unexpected-acme-status', Status, problem(Body)}})
+    end;
+expect({ok, Status, Headers, Body, State}, Statuses) ->
+    case expect({ok, Status, Headers, Body}, Statuses) of
+        {Headers, Body} -> {Headers, Body, State}
+    end;
+expect({error, Reason}, _Statuses) ->
+    throw({acme, Reason}).
+
+request_parts(URL) ->
+    URI = uri_string:parse(URL),
+    Scheme = hb_util:to_lower(hb_util:bin(maps:get(scheme, URI, <<>>))),
+    require(Scheme =:= <<"https">> andalso maps:is_key(host, URI)
+        andalso not maps:is_key(userinfo, URI), {'invalid-acme-url', URL}),
+    Peer = uri_string:recompose(
+        (maps:without([query, fragment], URI))#{path => <<>>}
+    ),
+    Path = hb_util:bin(maps:get(path, URI, <<"/">>)),
+    case maps:find(query, URI) of
+        {ok, Query} -> {Peer, <<Path/binary, "?", (hb_util:bin(Query))/binary>>};
+        error -> {Peer, Path}
+    end.
+
+json(Body) ->
+    case decode_json(Body) of
+        {ok, Value} -> Value;
+        error -> throw({acme, 'invalid-acme-json'})
+    end.
+
+decode_json(Body) ->
+    try {ok, hb_json:decode(Body)} catch _:_ -> error end.
+
+certificate_chain(PEM) ->
+    case [DER || {'Certificate', DER, not_encrypted} <-
+            public_key:pem_decode(PEM)] of
+        [] -> throw({acme, 'invalid-acme-certificate-chain'});
+        Chain -> Chain
+    end.
+
+directory_url(Key, State) ->
+    case maps:get(Key, maps:get(directory, State), undefined) of
+        URL when is_binary(URL) -> URL;
+        _ -> throw({acme, {'acme-directory-key-missing', Key}})
+    end.
+
+jwk({{{rsa, E}, _D, N}, {{rsa, E}, N}}) ->
+    #{
+        <<"e">> => hb_util:encode(binary:encode_unsigned(E)),
+        <<"kty">> => <<"RSA">>,
+        <<"n">> => hb_util:encode(N)
+    }.
+
+rsa_sign({{{rsa, E}, D, N}, {{rsa, E}, N}}, Data) ->
+    crypto:sign(rsa, sha256, Data,
+        [E, binary:decode_unsigned(N), binary:decode_unsigned(D)],
+        [{rsa_padding, rsa_pkcs1_padding}]).
+
+header(Name, Headers) ->
+    proplists:get_value(Name, Headers, not_found).
+
+is_bad_nonce(400, Body) ->
+    case decode_json(Body) of
+        {ok, #{<<"type">> := Type}} ->
+            binary:match(Type, <<"badNonce">>) =/= nomatch;
+        _ -> false
+    end;
+is_bad_nonce(_, _) -> false.
+
+problem(Body) ->
+    case decode_json(Body) of {ok, Problem} -> Problem; error -> Body end.
+
+retry_after(Headers, Default) ->
+    try binary_to_integer(header(<<"retry-after">>, Headers)) * 1000
+    catch _:_ -> Default
+    end.
+
+wait(Delay, State) ->
+    case deadline(State) > Delay of
+        true -> timer:sleep(Delay);
+        false -> throw({acme, 'acme-timeout'})
+    end.
+
+deadline(State) ->
+    Remaining = maps:get(deadline, State)
+        - erlang:monotonic_time(millisecond),
+    case Remaining > 0 of
+        true -> Remaining;
+        false -> throw({acme, 'acme-timeout'})
+    end.
+
+http_options(ACME, Opts) ->
+    CA = case hb_maps:get(<<"ca-certificate">>, ACME, not_found, Opts) of
+        not_found -> public_key:cacerts_get();
+        PEM -> certificate_chain(PEM)
+    end,
+    #{
+        <<"http-client">> => gun,
+        <<"protocol">> => http1,
+        <<"http-retry">> => 0,
+        <<"http-client-connect-timeout">> => ?REQUEST_TIMEOUT,
+        <<"http-client-send-timeout">> => ?REQUEST_TIMEOUT,
+        <<"http-client-tls-ca">> => CA
+    }.
+
+validate_token(Token) when is_binary(Token), byte_size(Token) > 0 ->
+    require(re:run(Token, <<"^[A-Za-z0-9_-]+$">>, [{capture, none}]) =:= match,
+        'invalid-acme-token');
+validate_token(_) -> throw({acme, 'invalid-acme-token'}).
+
+%% @doc Create a SAN PKCS#10 request using the node wallet's exact key.
+csr(Wallet, Domains) ->
+    Names = [binary_to_list(Domain) || Domain <- Domains],
+    Info = #'CertificationRequestInfo'{
+        version = 0,
+        subject = distinguished_name(hd(Names)),
+        subjectPKInfo = csr_public_key_info(Wallet),
+        attributes = [#'CertificationRequestInfo_attributes_SETOF'{
+            type = ?'pkcs-9-at-extensionRequest',
+            values = [{asn1_OPENTYPE, public_key:der_encode(
+                'Extensions', [#'Extension'{
+                    extnID = ?'id-ce-subjectAltName',
+                    critical = false,
+                    extnValue = public_key:der_encode('SubjectAltName',
+                        [{dNSName, Name} || Name <- Names])
+                }]
+            )}]
+        }]
+    },
+    EncodedInfo = public_key:der_encode('CertificationRequestInfo', Info),
+    public_key:der_encode('CertificationRequest', #'CertificationRequest'{
+        certificationRequestInfo = Info,
+        signatureAlgorithm = #'CertificationRequest_signatureAlgorithm'{
+            algorithm = ?'sha256WithRSAEncryption',
+            parameters = {asn1_OPENTYPE, <<5, 0>>}
+        },
+        signature = rsa_sign(Wallet, EncodedInfo)
+    }).
+
+csr_public_key_info(Wallet) ->
+    #'CertificationRequestInfo_subjectPKInfo'{
+        algorithm = #'CertificationRequestInfo_subjectPKInfo_algorithm'{
+            algorithm = ?'rsaEncryption',
+            parameters = {asn1_OPENTYPE, <<5, 0>>}
+        },
+        subjectPublicKey = public_key:der_encode(
+            'RSAPublicKey', wallet_public_key(Wallet)
+        )
+    }.
+
+wallet_public_key({{{rsa, E}, _D, N}, {{rsa, E}, N}}) ->
+    #'RSAPublicKey'{
+        publicExponent = E,
+        modulus = binary:decode_unsigned(N)
+    }.
+
+distinguished_name(Name) ->
+    {rdnSequence, [[#'AttributeTypeAndValue'{
+        type = ?'id-at-commonName',
+        value = {utf8String, Name}
+    }]]}.
+
+%%% Tests
+
+csr_key_test() ->
+    Wallet = ar_wallet:load_keyfile("test/key-1.json"),
+    Encoded = csr(Wallet, [<<"localhost">>, <<"node.example">>]),
+    CSR = public_key:der_decode('CertificationRequest', Encoded),
+    Info = CSR#'CertificationRequest'.certificationRequestInfo,
+    ?assert(public_key:verify(
+        public_key:der_encode('CertificationRequestInfo', Info),
+        sha256,
+        CSR#'CertificationRequest'.signature,
+        wallet_public_key(Wallet)
+    )),
+    CSRKey = Info#'CertificationRequestInfo'.subjectPKInfo,
+    ?assertEqual(wallet_public_key(Wallet), public_key:der_decode(
+        'RSAPublicKey',
+        CSRKey#'CertificationRequestInfo_subjectPKInfo'.subjectPublicKey
+    )).
+
+protocol_validation_test() ->
+    ?assertThrow({acme, {'invalid-acme-url', _}},
+        request_parts(<<"http://acme.example/directory">>)),
+    ?assert(is_bad_nonce(400, hb_json:encode(#{
+        <<"type">> => <<"urn:ietf:params:acme:error:badNonce">>
+    }))).


### PR DESCRIPTION
Adds native TLS termination to HyperBEAM’s normal Cowboy/Ranch listener.

Certificates are obtained and renewed through a new `~tls@1.0` device. The certificate leaf uses the node’s exact RSA `priv-wallet` as the source key, allowing users to check by eye that at the HTTPS connection they have with a HyperBEAM node matches exactly the node's wallet identity.

`HTTP-01` challenges are routed through the normal `on/request` hook of the node. Runtime state is held by one `hb_name` process, with no separate TLS server or OTP supervision tree. Certificate rotation preserves existing connections.

Supports HTTP/1.1 and HTTP/2. HTTP/3 is rejected when TLS termination is enabled for now.