### PR TITLE
fix: prevent lua module loading recursion by reading module body, then data, through the plain message device.

### DIFF
--- a/src/core/http/hb_http.erl
+++ b/src/core/http/hb_http.erl
@@ -182,50 +182,92 @@ request_response(Method, Peer, Path, Response, Duration, Opts) ->
     ReturnAOResult =
         hb_opts:get(http_only_result, true, Opts) andalso
         hb_maps:get(<<"ao-result">>, NormHeaderMap, false, Opts),
-    case ReturnAOResult of
-        Key when is_binary(Key) ->
-            Msg = http_response_to_httpsig(Status, NormHeaderMap, Body, Opts),
-            ?event(
-                debug_http_outbound,
-                {result_is_single_key, {key, Key}, {msg, Msg}},
-                Opts
-            ),
-            case {Key, hb_maps:get(Key, Msg, undefined, Opts)} of
-                {<<"body">>, undefined} ->
-                    {hb_http_client:response_status_to_atom(Status), <<>>};
-                {_, undefined} ->
-                    {failure,
-                        <<
-                            "Result key '",
-                            Key/binary,
-                            "' not found in response from '",
-                            Peer/binary,
-                            "' for path '",
-                            Path/binary,
-                            "': ",
-                            Body/binary
-                        >>
-                    };
-                {_, Value} ->
-                    {hb_http_client:response_status_to_atom(Status), Value}
-            end;
-        false ->
-            % Find the codec device from the headers, if set.
-            CodecDev =
-                hb_maps:get(
-                    <<"codec-device">>,
-                    NormHeaderMap,
-                    <<"httpsig@1.0">>,
+    RawResult =
+        case ReturnAOResult of
+            Key when is_binary(Key) ->
+                Msg = http_response_to_httpsig(Status, NormHeaderMap, Body, Opts),
+                ?event(
+                    debug_http_outbound,
+                    {result_is_single_key, {key, Key}, {msg, Msg}},
                     Opts
                 ),
-            outbound_result_to_message(
-                CodecDev,
-                Status,
-                NormHeaderMap,
-                Body,
-                Opts
-            )
-    end.
+                case {Key, hb_maps:get(Key, Msg, undefined, Opts)} of
+                    {<<"body">>, undefined} ->
+                        {hb_http_client:response_status_to_atom(Status), <<>>};
+                    {_, undefined} ->
+                        {failure,
+                            <<
+                                "Result key '",
+                                Key/binary,
+                                "' not found in response from '",
+                                Peer/binary,
+                                "' for path '",
+                                Path/binary,
+                                "': ",
+                                Body/binary
+                            >>
+                        };
+                    {_, Value} ->
+                        {hb_http_client:response_status_to_atom(Status), Value}
+                end;
+            false ->
+                % Find the codec device from the headers, if set.
+                CodecDev =
+                    hb_maps:get(
+                        <<"codec-device">>,
+                        NormHeaderMap,
+                        <<"httpsig@1.0">>,
+                        Opts
+                    ),
+                outbound_result_to_message(
+                    CodecDev,
+                    Status,
+                    NormHeaderMap,
+                    Body,
+                    Opts
+                )
+        end,
+    add_remote_link_store_to_result(RawResult, Peer, Opts).
+
+%% @doc Attach response-peer provenance after both full-message decoding and
+%% the `ao-result' single-key fast path. Downstream push uses the latter by
+%% default, so applying this only during full decoding leaves its links local.
+add_remote_link_store_to_result({Status, Result}, Peer, Opts) ->
+    {Status, add_remote_link_store(Result, Peer, Opts)};
+add_remote_link_store_to_result(Result, _Peer, _Opts) ->
+    Result.
+
+%% @doc Links in a decoded HTTP response are only meaningful relative to the
+%% peer that emitted them. Preserve that provenance so a later bundled response
+%% can dereference a child from the same peer instead of assuming it exists in
+%% this node's local cache. Existing link-local store options remain authoritative.
+add_remote_link_store({link, ID, LinkOpts}, Peer, Opts) ->
+    case maps:is_key(<<"store">>, LinkOpts) of
+        true ->
+            {link, ID, LinkOpts};
+        false ->
+            LocalStores =
+                hb_store:scope(hb_opts:get(store, [], Opts), local),
+            RemoteStore = #{
+                <<"store-module">> => hb_store_remote_node,
+                <<"node">> => Peer,
+                <<"access">> => [<<"read">>],
+                <<"local-store">> => LocalStores
+            },
+            {link, ID, LinkOpts#{
+                <<"store">> => LocalStores ++ [RemoteStore],
+                <<"scope">> => [local, remote]
+            }}
+    end;
+add_remote_link_store(Map, Peer, Opts) when is_map(Map) ->
+    maps:map(
+        fun(_Key, Value) -> add_remote_link_store(Value, Peer, Opts) end,
+        Map
+    );
+add_remote_link_store(List, Peer, Opts) when is_list(List) ->
+    lists:map(fun(Value) -> add_remote_link_store(Value, Peer, Opts) end, List);
+add_remote_link_store(Value, _Peer, _Opts) ->
+    Value.
 
 %% @doc Convert an HTTP response to a message.
 outbound_result_to_message(<<"ans104@1.0">>, Status, Headers, Body, Opts) ->
@@ -481,14 +523,10 @@ prepare_request(Format, Method, Peer, Path, RawMessage, Opts) ->
 
 %% @doc Reply to the client's HTTP request with a message.
 reply(Req, TABMReq, Message, Opts) ->
-    Status =
-        case hb_maps:get(<<"status">>, Message, not_found, Opts) of
-            not_found -> 200;
-            S-> S
-        end,
+    Status = http_status(hb_maps:get(<<"status">>, Message, not_found, Opts)),
     reply(Req, TABMReq, Status, Message, Opts).
 reply(Req, TABMReq, BinStatus, RawMessage, Opts) when is_binary(BinStatus) ->
-    reply(Req, TABMReq, binary_to_integer(BinStatus), RawMessage, Opts);
+    reply(Req, TABMReq, http_status(BinStatus), RawMessage, Opts);
 reply(InitReq, TABMReq, RawStatus, RawMessage, Opts) ->
     ReplyStartTime = os:system_time(millisecond),
     KeyNormMessage = hb_ao:normalize_keys(RawMessage, Opts),
@@ -560,6 +598,17 @@ reply(InitReq, TABMReq, RawStatus, RawMessage, Opts) ->
         }
     ),
     {ok, PostStreamReq, no_state}.
+
+%% @doc Interpret a message's `status' as an HTTP status only when it is a
+%% valid status code. Devices may also use this field for application-level
+%% statuses such as `ok', which should be returned with HTTP 200.
+http_status(not_found) -> 200;
+http_status(Status) when is_integer(Status), Status >= 100, Status =< 599 -> Status;
+http_status(Status) when is_binary(Status) ->
+    try http_status(binary_to_integer(Status))
+    catch error:badarg -> 200
+    end;
+http_status(_Status) -> 200.
 
 %% @doc Determine if the stream should be finalized.
 should_finalize_stream(429, _EncodedBody) -> true;
@@ -1235,6 +1284,12 @@ simple_ao_resolve_signed_test() ->
         ),
     ?assertEqual(<<"Value1">>, Res).
 
+http_status_test() ->
+    ?assertEqual(200, http_status(<<"ok">>)),
+    ?assertEqual(200, http_status(not_found)),
+    ?assertEqual(200, http_status(<<"200">>)),
+    ?assertEqual(404, http_status(404)).
+
 paranoid_http_result_test() ->
     % The `http_result' topic verifies each response at the reply boundary (in
     % `encode_reply', before wire conversion): a validly committed result
@@ -1464,6 +1519,47 @@ nested_signed_response(Opts) ->
             <<"commitment-device">> => <<"httpsig@1.0">>,
             <<"bundle">> => true
         }
+    ).
+
+remote_response_links_retain_peer_test() ->
+    ServerStore = [hb_test_utils:test_store(hb_store_volatile, <<"http-link-server">>)],
+    ClientStore = [hb_test_utils:test_store(hb_store_volatile, <<"http-link-client">>)],
+    FastClientStore =
+        [hb_test_utils:test_store(hb_store_volatile, <<"http-link-fast-client">>)],
+    ServerOpts = #{ <<"store">> => ServerStore, <<"port">> => 0 },
+    ClientOpts = #{ <<"store">> => ClientStore, <<"http-only-result">> => false },
+    FastClientOpts = #{ <<"store">> => FastClientStore },
+    URL = hb_http_server:start_node(ServerOpts),
+    Parent = #{ <<"child">> => #{ <<"value">> => <<"from-peer">> } },
+    {ok, ParentID} = hb_cache:write(Parent, ServerOpts),
+    {ok, Reply} =
+        get(
+            URL,
+            #{
+                <<"path">> => <<"/~cache@1.0/read">>,
+                <<"read">> => ParentID,
+                <<"accept-bundle">> => false
+            },
+            ClientOpts
+        ),
+    {link, ChildID, LinkOpts} = maps:get(<<"child">>, Reply),
+    ?assertEqual([local, remote], maps:get(<<"scope">>, LinkOpts)),
+    StorelessLink =
+        {link,
+            ChildID,
+            maps:without([<<"store">>, <<"scope">>], LinkOpts)},
+    {ok, FastPathLink} =
+        add_remote_link_store_to_result(
+            {ok, StorelessLink},
+            URL,
+            FastClientOpts
+        ),
+    FastPathChild = hb_cache:ensure_all_loaded(FastPathLink, FastClientOpts),
+    ?assertEqual(<<"from-peer">>, hb_ao:get(<<"value">>, FastPathChild, FastClientOpts)),
+    LoadedReply = hb_cache:ensure_all_loaded(Reply, ClientOpts),
+    ?assertEqual(
+        <<"from-peer">>,
+        hb_ao:get(<<"child/value">>, LoadedReply, ClientOpts)
     ).
 
 send_large_signed_request_test() ->

--- a/src/core/http/hb_http.erl
+++ b/src/core/http/hb_http.erl
@@ -247,7 +247,10 @@ add_remote_link_store({link, ID, LinkOpts}, Peer, Opts) ->
             {link, ID, LinkOpts};
         false ->
             LocalStores =
-                hb_store:scope(hb_opts:get(store, [], Opts), local),
+                hb_store:filter(
+                    hb_opts:get(store, [], Opts),
+                    fun(Scope, _) -> Scope == local end
+                ),
             RemoteStore = #{
                 <<"store-module">> => hb_store_remote_node,
                 <<"node">> => Peer,
@@ -1525,7 +1528,7 @@ remote_response_links_retain_peer_test() ->
     ServerStore = [hb_test_utils:test_store(hb_store_volatile, <<"http-link-server">>)],
     ClientStore = [hb_test_utils:test_store(hb_store_volatile, <<"http-link-client">>)],
     FastClientStore =
-        [hb_test_utils:test_store(hb_store_volatile, <<"http-link-fast-client">>)],
+        hb_test_utils:test_store(hb_store_volatile, <<"http-link-fast-client">>),
     ServerOpts = #{ <<"store">> => ServerStore, <<"port">> => 0 },
     ClientOpts = #{ <<"store">> => ClientStore, <<"http-only-result">> => false },
     FastClientOpts = #{ <<"store">> => FastClientStore },

--- a/src/core/resolver/hb_cache.erl
+++ b/src/core/resolver/hb_cache.erl
@@ -710,9 +710,10 @@ read_all_commitments(Msg, Opts) ->
                                     true,
                                     {
                                         CommitmentID,
-                                        ensure_all_loaded(
+                                        load_commitment(
                                             Commitment,
-                                            Opts#{ <<"commitment">> => true }
+                                            UncommittedID,
+                                            Opts
                                         )
                                     }
                                 };
@@ -866,9 +867,10 @@ prepare_typed_values(Target, RootPath, Subpaths, Values, Store, Opts) ->
                     case do_read_commitment(CommPath, Opts) of
                         {ok, Commitment} ->
                             LoadedCommitment =
-                                ensure_all_loaded(
+                                load_commitment(
                                     Commitment,
-                                    Opts#{ <<"commitment">> => true }
+                                    RootPath,
+                                    Opts
                                 ),
                             ?event(read_commitment,
                                 {found_target_commitment,
@@ -960,6 +962,34 @@ prepare_typed_values(Target, RootPath, Subpaths, Values, Store, Opts) ->
                 true -> Merged;
                 false -> ensure_all_loaded(Merged, Opts)
             end
+    end.
+
+%% @doc Fully load a commitment while recovering the legacy representation of
+%% an empty `committed' key list. Lua historically decoded that empty list as
+%% `#{}`. Its cache ID is also the uncommitted ID of an empty message, so loading
+%% the link from a commitment stored at that same root recursively re-entered
+%% the root forever. A first-hop link back to the commitment's base therefore
+%% represents the empty committed-key list.
+load_commitment(Commitment, BasePath, Opts) ->
+    CommitmentOpts = Opts#{ <<"commitment">> => true },
+    case maps:get(<<"committed">>, Commitment, not_found) of
+        {link, LinkID, LinkOpts = #{
+            <<"type">> := <<"link">>,
+            <<"lazy">> := true
+        }} ->
+            LinkReadOpts =
+                hb_util:deep_merge(CommitmentOpts, LinkOpts, CommitmentOpts),
+            case do_read_commitment(LinkID, LinkReadOpts) of
+                {ok, BasePath} ->
+                    ensure_all_loaded(
+                        Commitment#{ <<"committed">> => [] },
+                        CommitmentOpts
+                    );
+                _ ->
+                    ensure_all_loaded(Commitment, CommitmentOpts)
+            end;
+        _ ->
+            ensure_all_loaded(Commitment, CommitmentOpts)
     end.
 
 apply_type_to_immediate(Value, #{ <<"type">> := Type }) ->
@@ -1155,6 +1185,33 @@ test_store_unsigned_empty_message(Store) ->
     MatchRes = hb_message:match(Item, RetrievedItem, strict, Opts),
     ?event_debug({match_result, MatchRes}),
     ?assert(MatchRes).
+
+test_store_lua_decoded_empty_commitment(Store) ->
+    ?event_debug(debug_store_test, {store, Store}),
+    hb_store:reset(Store),
+    Opts = #{ <<"store">> => Store },
+    SignedEmpty =
+        hb_message:commit(
+            #{},
+            Opts,
+            #{ <<"type">> => <<"unsigned">> }
+        ),
+    % Lua historically decoded the empty committed-key list as an empty map.
+    % Recreate that persisted representation to ensure it remains readable.
+    LuaDecoded =
+        SignedEmpty#{
+            <<"commitments">> =>
+                maps:map(
+                    fun(_ID, Commitment) ->
+                        Commitment#{ <<"committed">> => #{} }
+                    end,
+                    maps:get(<<"commitments">>, SignedEmpty)
+                )
+        },
+    {ok, Path} = write(LuaDecoded, Opts),
+    {ok, Retrieved} = read(Path, Opts),
+    [Commitment] = maps:values(maps:get(<<"commitments">>, Retrieved)),
+    ?assertEqual([], maps:get(<<"committed">>, Commitment)).
 
 test_store_unsigned_nested_empty_message(Store) ->
     ?event_debug(debug_store_test, {store, Store}),
@@ -1444,6 +1501,8 @@ cache_suite_test_() ->
     hb_store:generate_test_suite([
         {"store unsigned empty message",
             fun test_store_unsigned_empty_message/1},
+        {"store Lua-decoded empty commitment",
+            fun test_store_lua_decoded_empty_commitment/1},
         {"store binary", fun test_store_binary/1},
         {"store unsigned nested empty message",
             fun test_store_unsigned_nested_empty_message/1},

--- a/src/preloaded/process/dev_push.erl
+++ b/src/preloaded/process/dev_push.erl
@@ -244,6 +244,13 @@ do_push(PrimaryProcess, Assignment, Opts) ->
                     ),
                     Opts
                 ),
+            % The HTTP response signer represents each downstream result as a
+            % link. These entries are produced by `push@1.0' rather than the
+            % execution device, so they are not covered by the compute result's
+            % existing commitment and would otherwise be omitted from the
+            % normal result cache write. Store the downstream tree explicitly
+            % before it can be linkified.
+            {ok, _} = hb_cache:write(Downstream, Opts),
             {ok, maps:merge(Downstream, AdditionalRes#{
                 <<"slot">> => Slot,
                 <<"process">> => ID
@@ -1434,7 +1441,23 @@ test_max_depth_one_walks_one_hop() ->
                 #{ <<"resulted-in">> := <<"skipped">> },
                 Next
             )
-    end.
+    end,
+    %% HTTP response signing uses an unsigned commitment, which linkifies the
+    %% downstream entries without writing them. Verify the push device already
+    %% persisted those entries so the signed response remains resolvable.
+    SignedPushResult =
+        hb_message:commit(
+            PushResult,
+            Opts,
+            #{
+                <<"device">> => <<"httpsig@1.0">>,
+                <<"type">> => <<"unsigned">>
+            }
+        ),
+    ?assertMatch(
+        #{ <<"1">> := #{ <<"resulted-in">> := _ } },
+        hb_cache:ensure_all_loaded(SignedPushResult, Opts)
+    ).
 
 %% @doc `~process@1.0/compute' called with `push = true' fires an async
 %% `~push@1.0/push' for the freshly-computed slot. Calling

--- a/src/preloaded/vm/dev_lua.erl
+++ b/src/preloaded/vm/dev_lua.erl
@@ -145,13 +145,14 @@ load_modules([ModuleID | Rest], Opts, Acc) when ?IS_ID(ModuleID) ->
 load_modules([Module|Rest], Opts, Acc) when is_map(Module) ->
     % We have found a message with a Lua module inside. Search for the binary
     % of the program in the body and the data.
+    PlainModule = {as, <<"message@1.0">>, Module},
     ModuleBin =
         hb_ao:get_first(
             [
-                {Module, <<"body">>},
-                {Module, <<"data">>}
+                {PlainModule, <<"body">>},
+                {PlainModule, <<"data">>}
             ],
-            Module,
+            not_found,
             Opts
         ),
     case ModuleBin of
@@ -161,8 +162,8 @@ load_modules([Module|Rest], Opts, Acc) when is_map(Module) ->
                 <<"body">> =>
                     <<
                         """
-                        Lua module not loadable. Lua modules must have a
-                        `body' element set to a binary of the code to load.
+                        Lua module not loadable. Lua modules must have a `body'
+                        or `data' element set to a binary of the code to load.
                         """
                     >>,
                 <<"module">> => Module
@@ -315,20 +316,18 @@ compute(Key, RawBase, RawReq, Opts) ->
             Opts#{ <<"hashpath">> => ignore }
         ),
     ?event(debug_lua, parameters_found),
-    % Resolve all hyperstate links
-    ResolvedParams = hb_cache:ensure_all_loaded(Params, Opts),
     % Call the VM function with the given arguments.
     ?event(lua,
         {calling_lua_func,
             {function, Function},
-            {args, ResolvedParams},
+            {args, Params},
             {req, Req}
         }
     ),
     process_response(
         try luerl:call_function_dec(
             [Function],
-            encode(ResolvedParams, Opts),
+            encode(Params, Opts),
             State
         )
         catch
@@ -425,7 +424,11 @@ normalize(Base, _Req, RawOpts) ->
 
 %% @doc Decode a Lua result into a HyperBEAM `structured@1.0' message.
 decode(EncMsg, Opts) ->
-    hb_message:normalize_commitments(do_decode(EncMsg, Opts), Opts, verify).
+    hb_message:normalize_commitments(
+        normalize_decoded_commitments(do_decode(EncMsg, Opts)),
+        Opts,
+        verify
+    ).
 do_decode(EncMsg, _Opts) when is_list(EncMsg) andalso length(EncMsg) == 0 ->
     % The value is an empty table, so we assume it is a message rather than
     % a list.
@@ -452,22 +455,52 @@ do_decode(Msg, Opts) when is_map(Msg) ->
 do_decode(Other, _Opts) ->
     Other.
 
+%% @doc Restore the list type of commitment key sets after crossing the Lua
+%% boundary. Lua has only one table type, so an empty list is decoded as an
+%% empty message by `do_decode/2'. HTTPSig commitments define `committed' as a
+%% list; leaving an empty value as `#{}` makes it share the empty-message cache
+%% ID and can create a self-referential cache entry.
+normalize_decoded_commitments(Msg) when is_map(Msg) ->
+    maps:map(
+        fun(<<"commitments">>, Commitments) when is_map(Commitments) ->
+                maps:map(
+                    fun(_ID, Commitment) ->
+                        normalize_decoded_commitment(Commitment)
+                    end,
+                    Commitments
+                );
+           (_Key, Value) ->
+                normalize_decoded_commitments(Value)
+        end,
+        Msg
+    );
+normalize_decoded_commitments(List) when is_list(List) ->
+    lists:map(fun normalize_decoded_commitments/1, List);
+normalize_decoded_commitments(Value) ->
+    Value.
+
+normalize_decoded_commitment(Commitment) when is_map(Commitment) ->
+    case maps:get(<<"committed">>, Commitment, not_found) of
+        Committed when is_map(Committed), ?IS_EMPTY_MESSAGE(Committed) ->
+            Commitment#{ <<"committed">> => [] };
+        _ ->
+            Commitment
+    end;
+normalize_decoded_commitment(Commitment) ->
+    Commitment.
+
 %% @doc Encode a HyperBEAM `structured@1.0' message into a Lua term.
 encode(Map, Opts) ->
-    hb_message:normalize_commitments(do_encode(Map, Opts), Opts).
+    do_encode(Map, Opts).
 do_encode(Map, Opts) when is_map(Map) ->
-    hb_cache:ensure_all_loaded(
-        case hb_util:is_ordered_list(Map, Opts) of
-            true -> do_encode(hb_util:message_to_ordered_list(Map), Opts);
-            false -> maps:to_list(maps:map(fun(_, V) -> do_encode(V, Opts) end, Map))
-        end,
-        Opts
-    );
+    case hb_util:is_ordered_list(Map, Opts) of
+        true -> do_encode(hb_util:message_to_ordered_list(Map), Opts);
+        false -> maps:to_list(maps:map(fun(_, V) -> do_encode(V, Opts) end, Map))
+    end;
 do_encode(List, Opts) when is_list(List) ->
-    hb_cache:ensure_all_loaded(
-        lists:map(fun(V) -> do_encode(V, Opts) end, List),
-        Opts
-    );
+    lists:map(fun(V) -> do_encode(V, Opts) end, List);
+do_encode(Link, Opts) when ?IS_LINK(Link) ->
+    do_encode(hb_cache:ensure_all_loaded(Link, Opts), Opts);
 do_encode(Atom, _Opts) when is_atom(Atom) and (Atom /= false) and (Atom /= true)->
     hb_util:bin(Atom);
 do_encode(Other, _Opts) ->
@@ -523,7 +556,33 @@ simple_invocation_test() ->
         },
         <<"parameters">> => []
     },
-    ?assertEqual(2, hb_ao:get(<<"assoctable/b">>, Base, #{})).
+    ?assertEqual(2, hb_ao:get(<<"assoctable/b">>, Base, #{})),
+    % Inline Lua processes store the module source in `data'. Read that field
+    % through the plain message device so a missing `body' cannot recursively
+    % invoke Lua's default function.
+    InlineBase = #{
+        <<"device">> => <<"lua@5.3a">>,
+        <<"content-type">> => <<"application/lua">>,
+        <<"data">> => Script,
+        <<"parameters">> => []
+    },
+    ?assertEqual(2, hb_ao:get(<<"assoctable/b">>, InlineBase, #{})).
+
+empty_commitment_key_list_decode_test() ->
+    CommitmentID = <<"test-commitment">>,
+    Decoded = normalize_decoded_commitments(#{
+        <<"commitments">> => #{
+            CommitmentID => #{ <<"committed">> => #{} }
+        }
+    }),
+    ?assertEqual(
+        [],
+        hb_ao:get(
+            <<"commitments/test-commitment/committed">>,
+            Decoded,
+            #{}
+        )
+    ).
 
 post_invocation_message_validation_test() ->
     {ok, Script} = file:read_file("test/test.lua"),


### PR DESCRIPTION
- Prevent Lua module loading recursion by reading module body, then data, through the plain message device.

- Preserve lazy links across the Lua boundary instead of recursively resolving entire parameter trees.

- Normalize Lua-decoded empty commitment key maps back to lists and recover legacy cached representations.

- Cache downstream push results before HTTP signing converts them into links.
Preserve remote peer provenance on response links so linked results can be resolved from their originating node.

- Treat application statuses such as ok as HTTP 200 instead of attempting binary_to_integer/1.
Add coverage for inline Lua modules, empty commitments, signed push responses, remote links, and application-level statuses.