### PR TITLE
impr: Add topic debug_copycat_tx for print TXID that are being indexed

### DIFF
--- a/src/preloaded/query/dev_copycat_arweave.erl
+++ b/src/preloaded/query/dev_copycat_arweave.erl
@@ -436,7 +436,7 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, IndexMode, Opts) ->
         {indexed_tx,
             {type, tx},
             {pending, false},
-            {txid, {explicit, TXID}}
+            {txid, {string, TXID}}
         }),
     ?event(debug_copycat, {writing_index,
         {id, {explicit, TXID}},
@@ -638,7 +638,7 @@ process_pending_tx(TXID, IndexMode, Opts) ->
                         {indexed_tx,
                             {type, tx},
                             {pending, true},
-                            {txid, {explicit, TXID}}
+                            {txid, {string, TXID}}
                         }),
                     index_pending_children(TXID, TX, IndexMode, Store, Opts);
                 WriteError ->
@@ -741,7 +741,7 @@ index_full_bundle_items(
         {indexed_tx,
             {type, ans104},
             {pending, not is_integer(ItemStartOffset)},
-            {txid, {explicit, EncodedItemID}}
+            {txid, {string, EncodedItemID}}
         }),
     case hb_store_arweave:write_offset(
         Store,

--- a/src/preloaded/query/dev_copycat_arweave.erl
+++ b/src/preloaded/query/dev_copycat_arweave.erl
@@ -432,6 +432,12 @@ process_tx({{TX, _TXDataRoot}, EndOffset}, BlockStartOffset, IndexMode, Opts) ->
     TXID = hb_util:encode(TX#tx.id),
     TXEndOffset = BlockStartOffset + EndOffset,
     TXStartOffset = TXEndOffset - TX#tx.data_size,
+    ?event(debug_copycat_tx,
+        {indexed_tx,
+            {type, tx},
+            {pending, false},
+            {txid, {explicit, TXID}}
+        }),
     ?event(debug_copycat, {writing_index,
         {id, {explicit, TXID}},
         {offset, TXStartOffset},
@@ -628,6 +634,12 @@ process_pending_tx(TXID, IndexMode, Opts) ->
             case hb_store_arweave:write_offset(
                 Store, TXID, <<"tx@1.0">>, relative, TX#tx.data_size) of
                 ok ->
+                    ?event(debug_copycat_tx,
+                        {indexed_tx,
+                            {type, tx},
+                            {pending, true},
+                            {txid, {explicit, TXID}}
+                        }),
                     index_pending_children(TXID, TX, IndexMode, Store, Opts);
                 WriteError ->
                     ?event(
@@ -725,6 +737,12 @@ index_full_bundle_items(
                 catch _:_ -> error
                 end
         end,
+    ?event(debug_copycat_tx,
+        {indexed_tx,
+            {type, ans104},
+            {pending, not is_integer(ItemStartOffset)},
+            {txid, {explicit, EncodedItemID}}
+        }),
     case hb_store_arweave:write_offset(
         Store,
         EncodedItemID,


### PR DESCRIPTION
By setting `HB_PRINT=debug_copycat_tx`, we can request copycat to index a block. This will display all TXIDs being indexed. Useful to debug locally.

#903 hand `mode=inventory` defined in the `dev_copycat_arweave`. We should import that functionality to avoid running the node locally.