### PR TITLE
fix: Do not load empty device

### DIFF
--- a/src/core/device/hb_device_load.erl
+++ b/src/core/device/hb_device_load.erl
@@ -31,6 +31,8 @@
 %% then memoised in the process cache unless it is a forge seed.
 reference(Loaded, _Opts) when is_map(Loaded) ->
     {ok, Loaded};
+reference(<<>>, _Opts) ->
+    {error, not_found};
 reference(Ref, Opts) when is_binary(Ref) ->
     NormRef = hb_ao:normalize_key(Ref),
     case from_forge_bootstrap(NormRef, Opts) of
@@ -38,6 +40,9 @@ reference(Ref, Opts) when is_binary(Ref) ->
         {error, not_found} -> resolve_cached(NormRef, Opts);
         {error, Err} -> {error, Err}
     end.
+
+do_not_try_to_load_empty_device_test() ->
+    ?assertEqual({error, not_found}, reference(<<>>, #{})).
 
 resolve_cached(Ref, Opts) ->
     case resolve(Ref, Opts) of


### PR DESCRIPTION
Do not try to load an empty device. This will cause some errors, such as trying to list all devices when we don't want that.

````
hb_device_load:resolve_cached/2 [src/core/device/hb_device_load.erl:43]

{case_clause,{composite,[<<"ans104@1.0">>,<<"arweave@2.9">>, ...
```
