### PR TITLE
fix: Arweave offset partial match

### DIFF
--- a/src/preloaded/arweave/dev_arweave_offset.erl
+++ b/src/preloaded/arweave/dev_arweave_offset.erl
@@ -57,12 +57,12 @@ parse(Key) ->
 %% @doc Parses and applies a unit modifier to a base value, supporting both
 %% the `kb` and `kib` unit formats.
 unit(Binary) ->
-    Unit =
+    UnitWithoutOptionalB =
         case Binary of
             <<Prefix:(byte_size(Binary) - 1)/binary, "b">> -> Prefix;
             _ -> Binary
         end,
-    unit(0, Unit).
+    unit(0, UnitWithoutOptionalB).
 unit(Complete, <<>>) -> Complete;
 unit(Base, <<Int:8/integer, Rest/binary>>) when Int >= $0 andalso Int =< $9 ->
     unit(Base * 10 + (Int - $0), Rest);
@@ -358,6 +358,40 @@ parse_offset_test() ->
         parse(<<"1337tib">>)
     ),
     ok.
+
+all_unit_forms_test() ->
+    ?assertEqual({ok, 1, undefined}, parse(<<"1">>)),
+    ?assertEqual({ok, 1, undefined}, parse(<<"1b">>)),
+    assert_unit_forms(
+        [
+            <<"k">>, <<"m">>, <<"g">>, <<"t">>,
+            <<"p">>, <<"e">>, <<"z">>, <<"y">>
+        ],
+        1000
+    ),
+    assert_unit_forms(
+        [
+            <<"ki">>, <<"mi">>, <<"gi">>, <<"ti">>,
+            <<"pi">>, <<"ei">>, <<"zi">>, <<"yi">>
+        ],
+        1024
+    ),
+    ok.
+
+assert_unit_forms(Units, Multiple) ->
+    lists:foldl(
+        fun(Unit, Value) ->
+            Expected = Value * Multiple,
+            ?assertEqual({ok, Expected, undefined}, parse(<<"1", Unit/binary>>)),
+            ?assertEqual(
+                {ok, Expected, undefined},
+                parse(<<"1", Unit/binary, "b">>)
+            ),
+            Expected
+        end,
+        1,
+        Units
+    ).
 
 partial_match_should_fail_test_parallel() ->
     InvalidReference = <<"42tf43cjcfkwqydcjdk7ty2wbonkabw5acywyzk6shbd7x272zxq">>,

--- a/src/preloaded/arweave/dev_arweave_offset.erl
+++ b/src/preloaded/arweave/dev_arweave_offset.erl
@@ -56,27 +56,32 @@ parse(Key) ->
 
 %% @doc Parses and applies a unit modifier to a base value, supporting both
 %% the `kb` and `kib` unit formats.
-unit(Binary) -> unit(0, Binary).
+unit(Binary) ->
+    Unit =
+        case Binary of
+            <<Prefix:(byte_size(Binary) - 1)/binary, "b">> -> Prefix;
+            _ -> Binary
+        end,
+    unit(0, Unit).
 unit(Complete, <<>>) -> Complete;
 unit(Base, <<Int:8/integer, Rest/binary>>) when Int >= $0 andalso Int =< $9 ->
     unit(Base * 10 + (Int - $0), Rest);
-unit(Base, <<"b">>) -> Base;
-unit(Base, <<"ki", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"b">>);
-unit(Base, <<"mi", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"ki">>);
-unit(Base, <<"gi", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"mi">>);
-unit(Base, <<"ti", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"gi">>);
-unit(Base, <<"pi", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"ti">>);
-unit(Base, <<"ei", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"pi">>);
-unit(Base, <<"zi", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"ei">>);
-unit(Base, <<"yi", _/binary>>) when Base > 0 -> unit(Base * 1024, <<"zi">>);
-unit(Base, <<"k", _/binary>>) when Base > 0 -> unit(Base * 1000, <<"b">>);
-unit(Base, <<"m", _/binary>>) when Base > 0 -> unit(Base * 1000, <<"k">>);
-unit(Base, <<"g", _/binary>>) when Base > 0 -> unit(Base * 1000, <<"m">>);
-unit(Base, <<"t", _/binary>>) when Base > 0 -> unit(Base * 1000, <<"g">>);
-unit(Base, <<"p", _/binary>>) when Base > 0 -> unit(Base * 1000, <<"t">>);
-unit(Base, <<"e", _/binary>>) when Base > 0 -> unit(Base * 1000, <<"p">>);
-unit(Base, <<"z", _/binary>>) when Base > 0 -> unit(Base * 1000, <<"e">>);
-unit(Base, <<"y", _/binary>>) when Base > 0 -> unit(Base * 1000, <<"z">>).
+unit(Base, <<"ki">>) when Base > 0 -> unit(Base * 1024, <<>>);
+unit(Base, <<"mi">>) when Base > 0 -> unit(Base * 1024, <<"ki">>);
+unit(Base, <<"gi">>) when Base > 0 -> unit(Base * 1024, <<"mi">>);
+unit(Base, <<"ti">>) when Base > 0 -> unit(Base * 1024, <<"gi">>);
+unit(Base, <<"pi">>) when Base > 0 -> unit(Base * 1024, <<"ti">>);
+unit(Base, <<"ei">>) when Base > 0 -> unit(Base * 1024, <<"pi">>);
+unit(Base, <<"zi">>) when Base > 0 -> unit(Base * 1024, <<"ei">>);
+unit(Base, <<"yi">>) when Base > 0 -> unit(Base * 1024, <<"zi">>);
+unit(Base, <<"k">>) when Base > 0 -> unit(Base * 1000, <<>>);
+unit(Base, <<"m">>) when Base > 0 -> unit(Base * 1000, <<"k">>);
+unit(Base, <<"g">>) when Base > 0 -> unit(Base * 1000, <<"m">>);
+unit(Base, <<"t">>) when Base > 0 -> unit(Base * 1000, <<"g">>);
+unit(Base, <<"p">>) when Base > 0 -> unit(Base * 1000, <<"t">>);
+unit(Base, <<"e">>) when Base > 0 -> unit(Base * 1000, <<"p">>);
+unit(Base, <<"z">>) when Base > 0 -> unit(Base * 1000, <<"e">>);
+unit(Base, <<"y">>) when Base > 0 -> unit(Base * 1000, <<"z">>).
 
 %% @doc Load an ANS-104 item whose header begins at the given global offset.
 %% When a length is supplied it is treated as the exact ANS-104 data length, so
@@ -353,6 +358,10 @@ parse_offset_test() ->
         parse(<<"1337tib">>)
     ),
     ok.
+
+partial_match_should_fail_test_parallel() ->
+    InvalidReference = <<"42tf43cjcfkwqydcjdk7ty2wbonkabw5acywyzk6shbd7x272zxq">>,
+    ?assertEqual(error, parse(InvalidReference)).
 
 offset_item_cases_test() ->
     Opts = #{},

--- a/src/preloaded/arweave/dev_arweave_offset.erl
+++ b/src/preloaded/arweave/dev_arweave_offset.erl
@@ -357,45 +357,8 @@ parse_offset_test() ->
         {ok, 1337 * 1024 * 1024 * 1024 * 1024, undefined},
         parse(<<"1337tib">>)
     ),
+    ?assertEqual(error, parse(<<"65t3aueqg2rkyk7c7csh7g3262xwkz5v5d7xtzit3rlpxjaa6ezq">>)),
     ok.
-
-all_unit_forms_test() ->
-    ?assertEqual({ok, 1, undefined}, parse(<<"1">>)),
-    ?assertEqual({ok, 1, undefined}, parse(<<"1b">>)),
-    assert_unit_forms(
-        [
-            <<"k">>, <<"m">>, <<"g">>, <<"t">>,
-            <<"p">>, <<"e">>, <<"z">>, <<"y">>
-        ],
-        1000
-    ),
-    assert_unit_forms(
-        [
-            <<"ki">>, <<"mi">>, <<"gi">>, <<"ti">>,
-            <<"pi">>, <<"ei">>, <<"zi">>, <<"yi">>
-        ],
-        1024
-    ),
-    ok.
-
-assert_unit_forms(Units, Multiple) ->
-    lists:foldl(
-        fun(Unit, Value) ->
-            Expected = Value * Multiple,
-            ?assertEqual({ok, Expected, undefined}, parse(<<"1", Unit/binary>>)),
-            ?assertEqual(
-                {ok, Expected, undefined},
-                parse(<<"1", Unit/binary, "b">>)
-            ),
-            Expected
-        end,
-        1,
-        Units
-    ).
-
-partial_match_should_fail_test_parallel() ->
-    InvalidReference = <<"42tf43cjcfkwqydcjdk7ty2wbonkabw5acywyzk6shbd7x272zxq">>,
-    ?assertEqual(error, parse(InvalidReference)).
 
 offset_item_cases_test() ->
     Opts = #{},


### PR DESCRIPTION
Fix cases where a TXID 52-character subdomain partialy match the Arweave offset subdomain logic. Eg: `57tggpyc4cue44oqdr5qdivtxciukiaidovacfvan7a7sia34caq`