### PR TITLE
fix: garbage-collect the Lua VM before snapshotting

### DIFF
--- a/src/preloaded/vm/dev_lua.erl
+++ b/src/preloaded/vm/dev_lua.erl
@@ -387,7 +387,12 @@ snapshot(Base, _Req, Opts) ->
         not_found ->
             {error, <<"Cannot snapshot Lua state: state not initialized.">>};
         State ->
-            {ok, #{ <<"body">> => term_to_binary(luerl:externalize(State)) }}
+            % NB: luerl never garbage collects on its own. `luerl_heap:gc/1'
+            % runs only when called, so an uncollected VM serialises every
+            % table ever allocated.
+            {ok, #{
+                <<"body">> => term_to_binary(luerl:externalize(luerl:gc(State)))
+            }}
     end.
 
 %% @doc Restore the Lua state from a snapshot, if it exists.


### PR DESCRIPTION
### Summary
`dev_lua:snapshot/3` serializes the whole luerl VM with `term_to_binary(luerl:externalize(State))` and never garbage-collects it. Luerl reclaims table-store slots only inside `luerl_heap:gc/1`, and nothing in HyperBEAM calls it, so the snapshot retains every table the process has ever allocated and grows without bound, even when the Lua-visible state is a fixed size. It is written on every snapshot slot, so per-message cost grows with accumulated slots.

### Measurements

Reproduced on `edge` `7135fdba` using `test/test.lua` as the fixture, with the process driven through its default `compute`, which writes the same result on every message. Sampling the serialized snapshot as slots accumulate:

| after N messages | `edge` | with `luerl:gc` |
|---|---|---|
| 2 | 61,578 B | 21,061 B |
| 25 | 500,338 B | 23,853 B |
| 50 | 978,383 B | 24,163 B |
| 100 | **1,935,003 B** | **28,038 B** |

Stock grows ~19 KB per slot and is **69× larger by slot 100**, for a workload whose Lua-visible state does not grow. That growth is dead tables the VM has never been asked to collect. Exact byte counts move by ~0.1% between runs, since each run spawns a process with a fresh identity and those bytes sit inside the serialized state; the ratios are stable.

Collected, the snapshot tracks live state rather than slot count. It is not byte-identical across those samples, and should not be: the state handed to the script carries per-slot process fields, so successive snapshots differ legitimately. Byte-identity is only meaningful where the Lua state between two snapshots is genuinely unchanged and that case is measured below.

### Restore

`snapshot/3` does not write the collected state back into `priv`, collects a copy purely for serialization, and the running VM continues on the uncollected state. The only behavioral surface is restore which is measured directly: drive a process 40 messages, snapshot, restore through `normalize/3` into a base with no `priv` state, then re-snapshot and continue.

| after 40 messages | `edge` | with `luerl:gc` |
|---|---|---|
| snapshot | 771,017 B | **25,893 B** |
| restores via `normalize/3` | ok | ok |
| re-snapshot byte-identical | true | true |
| continues, `count` 40 → 41 | 41 | 41 |
| matches the never-restored process | true | true |

The restored VM re-serializes to byte-identical bytes and continues to the same result as the process that never restarted. This is also the unchanged-state case referred to above: between those two snapshots the Lua state really is identical, and the bytes match exactly.

### Why this cannot be fixed at the application layer

Per CONTRIBUTING rule 2, the application-layer fix was tried first: calling `collectgarbage()` from inside the Lua contract. It does not suffice: it is unsound, and it fails inside HyperBEAM.

In luerl 1.3.0, the version pinned in `rebar.lock` here, `collectgarbage("collect")` is not a stub: `luerl_lib_basic:collectgarbage/3` calls `luerl_heap:gc/1` on the in-flight state. `luerl_heap:gc/1` derives its root set from the state handed to it, so it is only correct at a settled point, which is what `snapshot/3` is. With a frame on the dynamic stack it cannot see the in-flight continuation, and objects still reachable from that frame are freed.

Run through `lua@5.3a`, a contract calling `collectgarbage()` inside a `pcall`:

```
Erlang error while running Lua: {badkey,29}
  erlang:map_get/[29, ...]
  status 500, phase compute
```

The Lua `pcall` does not catch it: the error is raised below Lua, in the Erlang heap code, and the whole computation fails. Identical on unmodified `edge`, so this is a property of luerl rather than anything this PR changes.

No Lua program can safely collect its own VM, so the collection point has to be one the application layer cannot reach.

### Note on luerl's `externalize/1`

Misleadingly named: `luerl_lib_math:externalize/1` converts only the RNG state so it survives `term_to_binary`. It does not touch the table store, so it is not a substitute for collecting.

### Testing

`rebar3 device test --with-core` (the full suite: every device plus the core modules) against `edge` at `7135fdba`, and against this branch: **3,497 passed, 5 failed, identical both ways**. The same 5 fail on unmodified `edge`: four `scheduler@1.0` `http_get_legacy_*` tests and `push@1.0: test_push_prompts_encoding_change`, so this PR introduces no new failures or flakes (rule 1). `rebar3 device test --devices dev_lua` on its own: 38/38, including `pure_lua_restore_test`.

For completeness: the teardown printed `Segmentation fault` after `All 38 tests passed` on this branch and on unmodified `edge`. It is unrelated to this change and I have not investigated it further.
