### PR TITLE
impr: `~process@1.0/now&push` forwarding support; node-scoped `~scheduler@1.0`s

### DIFF
--- a/src/core/test/hb_examples.erl
+++ b/src/core/test/hb_examples.erl
@@ -663,7 +663,7 @@ relay_schedule_ans104_test() ->
                 <<"priv-wallet">> => ComputeWallet,
                 <<"store">> =>
                     [
-                        ComputeStore = hb_test_utils:test_store(),
+                        hb_test_utils:test_store(),
                         #{
                             <<"store-module">> => hb_store_remote_node,
                             <<"name">> => <<"cache-TEST/remote-node">>,
@@ -672,32 +672,24 @@ relay_schedule_ans104_test() ->
                     ]
             }
         ),
-    % Get the scheduler location of the scheduling node and write it to the
-    % compute node's store.
-    {ok, SchedulerLocation} =
-        hb_http:get(
-            Scheduler,
-            <<"/~location@1.0/node">>,
+    % Register the scheduler's signed location record on the compute node.
+    SchedulerLocation =
+        hb_message:commit(
+            #{
+                <<"type">> => <<"location">>,
+                <<"url">> => Scheduler,
+                <<"nonce">> => erlang:system_time(millisecond) + 1,
+                <<"time-to-live">> => 60 * 60 * 1000
+            },
+            #{ <<"priv-wallet">> => SchedulerWallet }
+        ),
+    {ok, _} =
+        hb_http:post(
+            Compute,
+            <<"/~location@1.0/known">>,
+            SchedulerLocation,
             #{}
         ),
-    ?event({scheduler_location, SchedulerLocation}),
-    LocationOpts = #{ <<"store">> => [ComputeStore] },
-    {ok, LocationPath} = hb_cache:write(SchedulerLocation, LocationOpts),
-    lists:foreach(
-        fun(Signer) ->
-            ok = hb_store:link(
-                [ComputeStore],
-                #{
-                    hb_path:to_binary([
-                        <<"~location@1.0">>,
-                        hb_util:human_id(Signer)
-                    ]) => LocationPath
-                },
-                LocationOpts
-            )
-        end,
-        hb_message:signers(SchedulerLocation, LocationOpts)
-    ),
     % Create the relaying server.
     Relay =
         hb_http_server:start_node(#{

--- a/src/preloaded/process/dev_process.erl
+++ b/src/preloaded/process/dev_process.erl
@@ -637,7 +637,10 @@ now(RawBase, Req, Opts) ->
             ?event({now_called, {process, ProcessID}, {slot, CurrentSlot}}),
             hb_ao:resolve(
                 Base,
-                #{ <<"path">> => <<"compute">>, <<"slot">> => CurrentSlot },
+                (hb_maps:with([<<"push">>], Req, Opts))#{
+                    <<"path">> => <<"compute">>,
+                    <<"slot">> => CurrentSlot
+                },
                 Opts
             );
         CacheParam ->

--- a/src/preloaded/process/dev_push.erl
+++ b/src/preloaded/process/dev_push.erl
@@ -874,6 +874,9 @@ max_depth_test_cases() ->
         fun test_parse_max_depth/0
     ].
 
+cron_depth_zero_push_test_() ->
+    {timeout, 120, fun test_cron_depth_zero_push/0}.
+
 test_paranoid_push_result() ->
     % The `push_result' topic verifies the result before it is signed for
     % POSTing (at the `apply_security' entry): corrupting a committed
@@ -1330,6 +1333,174 @@ test_remote_routed_push() ->
     ?assertMatch(
         {ok, Slot} when Slot > 0,
         hb_ao:resolve(LoadedProc2, <<"now/at-slot">>, N2Opts)
+    ).
+
+%% @doc Play the same game one hop per node-local cron tick with `push = 0'.
+test_cron_depth_zero_push() ->
+    hb_process_test_vectors:init(),
+    SharedStore = hb_test_utils:test_store(hb_store_fs),
+    SharedOpts = #{ <<"store">> => [SharedStore] },
+    ReadOnlyShared = SharedStore#{ <<"access">> => [<<"read">>] },
+    Wallet1 = ar_wallet:new(),
+    Wallet2 = ar_wallet:new(),
+    Address1 = hb_util:human_id(Wallet1),
+    Address2 = hb_util:human_id(Wallet2),
+    UserWallet = ar_wallet:new(),
+    Opts = #{
+        <<"priv-wallet">> => UserWallet,
+        <<"store">> =>
+            [hb_test_utils:test_store(hb_store_lmdb), ReadOnlyShared]
+    },
+    Proc1 =
+        hb_process_test_vectors:aos_process(
+            SharedOpts#{
+                <<"priv-wallet">> => UserWallet,
+                <<"scheduler">> => Address1
+            }
+        ),
+    Proc2 =
+        hb_process_test_vectors:aos_process(
+            SharedOpts#{
+                <<"priv-wallet">> => UserWallet,
+                <<"scheduler">> => Address2
+            }
+        ),
+    {ok, _} = hb_cache:write(Proc1, SharedOpts),
+    {ok, _} = hb_cache:write(Proc2, SharedOpts),
+    Proc1ID = hb_message:id(Proc1, all, SharedOpts),
+    Proc2ID = hb_message:id(Proc2, all, SharedOpts),
+    Store1 = [hb_test_utils:test_store(hb_store_lmdb), ReadOnlyShared],
+    Store2 = [hb_test_utils:test_store(hb_store_lmdb), ReadOnlyShared],
+    Node1 = hb_http_server:start_node(#{
+        <<"priv-wallet">> => Wallet1,
+        <<"store">> => Store1
+    }),
+    Node2 = hb_http_server:start_node(#{
+        <<"priv-wallet">> => Wallet2,
+        <<"store">> => Store2
+    }),
+    share_location_record(Wallet1, Node1, Node2),
+    share_location_record(Wallet2, Node2, Node1),
+    {ok, _} = hb_http:post(Node1, <<"/schedule">>, Proc1, Opts),
+    {ok, _} = hb_http:post(Node2, <<"/schedule">>, Proc2, Opts),
+    Trust = <<
+        "ao.authorities = { \"", Address1/binary, "\",\"", Address2/binary,
+        "\" }; ao.addAssignable('all', function (msg) return true end); ",
+        "ao.isAssignable = function(m) return true end"
+    >>,
+    {ok, _} =
+        hb_http:post(
+            Node1,
+            <<Proc1ID/binary, "/schedule">>,
+            eval_message(Proc1ID, Trust, Opts),
+            Opts
+        ),
+    {ok, _} =
+        hb_http:post(
+            Node2,
+            <<Proc2ID/binary, "/schedule">>,
+            eval_message(
+                Proc2ID,
+                <<Trust/binary, "\n", (reply_script())/binary>>,
+                Opts
+            ),
+            Opts
+        ),
+    {ok, _} =
+        hb_http:post(
+            Node1,
+            <<Proc1ID/binary, "/schedule">>,
+            eval_message(
+                Proc1ID,
+                <<"Send({ Target = \"", Proc2ID/binary, "\", Action = \"Ping\" })">>,
+                Opts
+            ),
+            Opts
+        ),
+    Cron1 = start_now_push_cron(Node1, Proc1ID),
+    Cron2 = start_now_push_cron(Node2, Proc2ID),
+    GameSettled =
+        wait_until(
+            fun() -> remote_slot_current(Node1, Proc1ID) >= 3 end,
+            60000
+        ),
+    {ok, _} = hb_http:get(Node1, <<"/~cron@1.0/stop=", Cron1/binary>>, #{}),
+    {ok, _} = hb_http:get(Node2, <<"/~cron@1.0/stop=", Cron2/binary>>, #{}),
+    ?assert(GameSettled),
+    ?assertEqual(2, remote_slot_current(Node2, Proc2ID)),
+    ?assertEqual(
+        {error, not_found},
+        hb_cache:read(
+            <<"computed/", Proc2ID/binary, "/slot/2">>,
+            #{ <<"store">> => Store1 }
+        )
+    ),
+    ?assertEqual(
+        {error, not_found},
+        hb_cache:read(
+            <<"computed/", Proc1ID/binary, "/slot/3">>,
+            #{ <<"store">> => Store2 }
+        )
+    ),
+    ?assertEqual(
+        {ok, <<"Replying to...\n", Proc1ID/binary, "\nDone.">>},
+        hb_http:get(
+            Node2,
+            <<Proc2ID/binary, "/compute&slot=2/results/data">>,
+            #{}
+        )
+    ).
+
+%% @doc Post an operator-signed location record to the target node.
+share_location_record(Wallet, NodeURL, Target) ->
+    Record =
+        hb_message:commit(
+            #{
+                <<"type">> => <<"location">>,
+                <<"url">> => NodeURL,
+                <<"nonce">> => 1,
+                <<"time-to-live">> => 60 * 60 * 1000
+            },
+            #{ <<"priv-wallet">> => Wallet }
+        ),
+    {ok, _} =
+        hb_http:post(
+            Target,
+            <<"/~location@1.0/known">>,
+            Record,
+            #{}
+        ).
+
+%% @doc Read the current slot of a process from a node over HTTP.
+remote_slot_current(Node, ProcID) ->
+    {ok, Slot} = hb_http:get(Node, <<ProcID/binary, "/slot/current">>, #{}),
+    hb_util:int(Slot).
+
+%% @doc Establish a cron on the given node that drives `/<proc>/now' with
+%% `push = 0' on every tick, returning the cron task ID.
+start_now_push_cron(Node, ProcID) ->
+    {ok, #{ <<"body">> := TaskID }} =
+        hb_http:get(
+            Node,
+            <<
+                "/~cron@1.0/every?interval=250-milliseconds",
+                "&cron-path=/", ProcID/binary, "/now",
+                "&push=0"
+            >>,
+            #{}
+        ),
+    TaskID.
+
+%% @doc Commit an `Eval' message from the caller to the given process.
+eval_message(ProcID, Code, Opts) ->
+    hb_message:commit(
+        #{
+            <<"type">> => <<"Message">>,
+            <<"action">> => <<"Eval">>,
+            <<"target">> => ProcID,
+            <<"data">> => Code
+        },
+        Opts
     ).
 
 test_oracle_push() ->

--- a/src/preloaded/process/dev_scheduler_registry.erl
+++ b/src/preloaded/process/dev_scheduler_registry.erl
@@ -1,5 +1,5 @@
 -module(dev_scheduler_registry).
--export([start/0, find/1, find/2, find/3, get_wallet/0, get_processes/0]).
+-export([start/0, find/1, find/2, find/3, name/2, get_wallet/0, get_processes/0]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -27,15 +27,20 @@ find(ProcID, ProcMsgOrFalse) ->
 %% @doc Same as `find/2' but with additional options passed when spawning a 
 %% new process (if needed)
 find(ProcID, ProcMsgOrFalse, Opts) ->
-    case hb_name:lookup({<<"scheduler@1.0">>, ProcID}) of
+    case hb_name:lookup(name(ProcID, Opts)) of
         undefined -> maybe_new_proc(ProcID, ProcMsgOrFalse, Opts);
         Pid -> Pid
     end.
 
+%% @doc Calculate the node-scoped registry name of a scheduling server.
+name(ProcID, Opts) ->
+    Wallet = hb_opts:get(priv_wallet, hb:wallet(), Opts),
+    {<<"scheduler@1.0">>, hb_util:human_id(Wallet), ProcID}.
+
 %% @doc Return a list of all currently registered ProcID.
 get_processes() ->
     ?event({getting_processes, hb_name:all()}),
-    [ ProcID || {{<<"scheduler@1.0">>, ProcID}, _} <- hb_name:all() ].
+    [ ProcID || {{<<"scheduler@1.0">>, _Address, ProcID}, _} <- hb_name:all() ].
 
 maybe_new_proc(_ProcID, false, _Opts) -> not_found;
 maybe_new_proc(ProcID, ProcMsg, Opts) -> 
@@ -95,6 +100,16 @@ create_multiple_processes_test() ->
     ?assertNotEqual(Pid1, Pid2),
     ?assertEqual(Pid1, ?MODULE:find(ID1, Proc1)),
     ?assertEqual(Pid2, ?MODULE:find(ID2, Proc2)).
+
+identity_scoped_processes_test() ->
+    Opts1 = (test_opts())#{ <<"priv-wallet">> => ar_wallet:new() },
+    Opts2 = (test_opts())#{ <<"priv-wallet">> => ar_wallet:new() },
+    [Proc, _] = generate_test_procs(Opts1),
+    ID = hb_message:id(Proc, all, Opts1),
+    ?assertNotEqual(
+        ?MODULE:find(ID, Proc, Opts1),
+        ?MODULE:find(ID, Proc, Opts2)
+    ).
 
 get_all_processes_test() ->
     Opts = test_opts(),

--- a/src/preloaded/process/dev_scheduler_server.erl
+++ b/src/preloaded/process/dev_scheduler_server.erl
@@ -25,7 +25,7 @@ start(ProcID, Proc, Opts) ->
     spawn(
         fun() ->
             % Before we start, register the scheduler name.
-            case hb_name:register({<<"scheduler@1.0">>, ProcID}) of
+            case hb_name:register(dev_scheduler_registry:name(ProcID, Opts)) of
                 ok -> ok;
                 error ->
                     % Another scheduler is already registered on the process
@@ -372,7 +372,7 @@ new_proc_test() ->
 
 benchmark_test() ->
     BenchTime = 1,
-    Wallet = ar_wallet:new(),
+    Wallet = hb:wallet(),
     Opts = #{ <<"priv-wallet">> => Wallet },
     SignedItem = hb_message:commit(
         #{ <<"data">> => <<"test">>, <<"random-key">> => rand:uniform(10000) },


### PR DESCRIPTION
Forwards the `push` key through `~process@1.0/now` and scopes local scheduler registrations by node's wallet identity. The latter change is required in order to ensure that tests where schedulers are resident on different HTTP servers are actually correctly isolated. Without it, tests are not able to simulate two truly isolated scheduling environments.

Additionally, this PR adds  a two-node `~cron@1.0` `push`-er test that demonstrates two nodes monitoring local processes and pushing messages to remote schedules, which are then pushed by their respective local monitors.