### PR TITLE
chore: improve `CONTRIBUTING.md` with details of current canon.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,24 @@
 This repository contains HyperBEAM, an implementation of the AO-Core protocol.
 
-To familiarize yourself with AO-Core, read the `README.md` file.
+**IMPORTANT:** To get started building devices that run on HyperBEAM, or contributing
+to its core, it is **MANDATORY** to read the [CONTRIBUTING](./CONTRIBUTING.md) guide
+and highly advisable to read [hacking on HyperBEAM](./docs/misc/hacking-on-hyperbeam.md)
+before you get started. They will save you much more time than a typical contributing
+guide will. HyperBEAM is written in Erlang, but it implements AO-Core semantics.
+As a consequence, writing devices or kernel changes in it should be understood as
+writing in an _Erlang dialect_. The principles of this dialect are simple but
+failure to properly grasp them before building will lead to easily avoidable
+confusion and rejected PRs. Save yourself the time and read up now.
 
-To understand how to write code for HyperBEAM, read `CONTRIBUTING.md` for 
-repository-level guidelines, and `docs/misc/hacking-on-hyperbeam.md` learn about
-its debugging tools and infrastructure.
+**REMEMBER:** Refresh the `CONTRIBUTING.md` guide in your context _in full_ while
+building with HyperBEAM after _every_ compaction. It is short but important and
+will help you finish your tasks more efficiently.
+
+To familiarize yourself with AO-Core, read `hb_ao.erl`, `hb_cache.erl`,
+`hb_message.erl`, `hb_link`, `hb_maps`, and search for the basics of the `codec`
+and `commitment` models. It is also advisable to breifly refresh this in your
+context after compaction -- particularly if you are working on complex debugging
+or long-range building tasks.
 
 In addition to the rules outlined in `CONTRIBUTING.md`, you should abide by the
 following:
@@ -17,7 +31,9 @@ following:
    AO-Core's messages. Messages are built using maps under-the-hood, but may also
    be lazy-loaded (linkified), giving them different semantics.
 4. Before submitting any code as 'complete', you **must** validate that your
-   new changes do not break any existing tests across the full suite. You are 
+   new changes do not break any existing tests across the full suite using
+   `rebar3 eunit-all`. Note that `rebar3 eunit` does not invoke the preloaded
+   device tests, which can often highlight subtle errors. Remember, you are 
    never being asked to write a 'toy' implementation of features or changed. Your
    code must actually work in-production.
 5. Always attempt to leave the codebase in a better state than you found it. More

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,3 +177,92 @@ following:
     indent matching flow our code takes means that you can at least line up the
     returned details with the expression that caused it visually, but it is still
     far worse than the `maybe ... end` approach.
+
+## Anti-patterns
+  
+Some of most important patterns in the way HyperBEAM is maintained are in what
+you _don't see_. The complete set of rules for how _not_ to program is inherently
+not computable, but here are a few common patterns that we see leading to PRs
+being bounced:
+
+- **Do not:** Create 'out-of-band' `ets`, `persistent_term` or process dictionary
+  caches without extreme thought and care. In ~99% of cases, this is not what you
+  actually want to do.
+    - Why: AO-Core itself is a cached computation model. What you are trying to
+      achieve is almost certainly better written as a use of the existing cache/
+      store schemes.
+- **Do not:** Use logging frameworks (`logger` or `io:format`) raw outside of the
+  `?event` system.
+    - Why: Using `event`s instead means that you inherit the `hb_format:` pretty-
+      printer improves print safety dramatically, as well as making the results
+      much more readable to others. Failure to do so risks printing private keys
+      to logs, etc. Additionally, the `event` system is designed such that your
+      debugging/informational signals can be easily and systematically accessed
+      inside the AO-Core compute model as well as visible in prometheus/Grafana
+      integrations.
+- **Do not:** Use `dev_` direct device calls to exported functions in tests.
+    - Why: HyperBEAM implements AO-Core semantics. It is a runtime environment
+      for an execution mechanism which is _not_ just invoking Erlang module
+      functions. Tests that do not invoke the device properly through `hb_ao:`
+      calls will miss the intricacies and nuances of the execution environment
+      and return positive results for objectively broken code.
+- **Do not:** duplicate case clauses to fudge uncertain input types. We see this
+  particularly between `atom` and `binary` values in substandard PRs.
+- **Do not:** Introduce scripts in other languages as 'tests', 'smoke[s]', or
+  'acceptance gates'. In virtually every case none of these will be considered 
+  for merging.
+    - Why: Every developer and agent has a preference for their favorite language,
+      runtime, etc. They may even have good arguments. The burden to install each,
+      however, lands on the other engineers and contributors over time -- not the
+      originator. As a consequence, we keep things simple in virtually every case:
+      `EUnit` tests are the default and expectation, written directly in Erlang.
+      We expect to find them at the bottom of modules, or in separate `_test_vectors`
+      `.erl` files if they are significant in size/quantity.
+- **Do not:** Carelessly use or refer to `messages` as if they are normal Erlang `maps`.
+  Erlang has transparent compound data types, so their internals are visible by
+  all clients and they are not necessarily labelled to aid pattern matching, etc.
+  In HyperBEAM's case, our core data structure is `messages` but their primary
+  representation is often in the form of `map`s.
+    - Why: Failure to comprehend the difference will lead to severe and hard-to-debug
+      issues when the `map` you assumed you would receive is in-fact a
+      `{link, ..., ...}`, or a `map` containing such values. This can happen at
+      any moment, in any environment, because _the runtime decides when to load data_.
+      Additionally, carelessness around `message` and `map` differences can lead
+      to direct overwrites of `message` keys, dangerously rendering their attached
+      commitments invalid. Use `hb_message:uncommitted` to remove old commitments
+      that may be invalidated by the values being added to the message. `hb_ao:set`
+      may also provide the desired message functionality, depending upon the 
+      intended overwrite mechanics.
+- **Do not:** Embed message/transport encoding specifics inside devices.
+    - Why: HyperBEAM devices operate upon AO-Core data. The HTTP layer -- wrapping
+      the core `hb_ao` resolution paths handles the serialization/deserialization
+      layer separately. Letting the appropriate parts of the system handle
+      normalization allows your devices to be agnostic and to inherit support for
+      _all_ of the different codec devices that the node supports without any
+      additional effort. Devices are protocols are data transformation. Messages
+      let you operate on the widest possible array of inputs.
+- **Do not:** Use 'mock' HTTP servers in tests where you can use another HyperBEAM
+  `hb_http_server:` instance on a different port. The codebase is full of examples
+  of `EUnit` tests that follow the pattern of spawning micro 'networks' of nodes
+  and using them to demonstrate behavior. We even prefer hitting _real-world_
+  service endpoints as part of our `EUnit` tests in almost every case above creating
+  mock versions of services. The only current exceptions to this in the codebase
+  are where utilizing the real service would be prohibitively slow for the tests
+  (multiple minutes) or would require real-world payments to be made.
+    - Why: Using mocks lowers the utility of a test dramatically. A mock is 
+      generally quite unlikely to actually match the remote service's behavior.
+      A critical code quality issue with agents at time of writing is that they
+      produce abundant tests that _look_ like they are working, but do not actually
+      map to any real-world behaviors. These are categorically worse than simply not
+      having tests, because they create the perception of safety and trustworthiness
+      without substance. Even worse, to determine that the test is vacuous a
+      reader must parse it. In its extreme this is a DoS vector against progress.
+
+Much more important than these particular patterns, however: If you are findings
+that your code is frequently breaching these basic rules, you are likely not
+building carefully enough to contribute to this repository.
+
+_Code itself_ is almost free now. The bar is not _'it works'_. The bar is 'this
+is a robust substrate that others will be able to understand, depend upon for
+production deployments guarding many billions of USD-worth of value, and improve
+in the future'. If you would like your PRs to land, build with this mentality.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ become adopted as the standard in the codebase.
 
 Remember: Cypherpunks write code!
 
-# A Rough Guide to the HyperBEAM `canon`
+# The Current HyperBEAM `canon`: A Rough Guide.
 
 You should pick up and continue the style of the codebase as you learn how it 
 works. There is no real substitute for paying attention. There are, however, a 
@@ -70,25 +70,57 @@ following:
           `i_like(Base, Req, Opts) -> {ok, <<"Turtles!">>}.`) you may be tempted
           to call `~device@1.0/i_like`. Don't. Instead call `/i-like`.
           `hb_ao_device` will normalize the keys and match for you.
-        - `hb_opts` uses all atoms for its message keys. This is a mistake. It
-          is nice to be able to lookup keys via atoms (normalizing as above) and
-          we should maintain this, but under the surface the keys should be
-          normal-form binaries. To avoid issues when this is translated, perform
-          `Opts` lookups with only atoms, or use binaries of normal-form if you
-          must.
-- Try to keep lines to around 80 characters-ish. This is not a strict rule because
-  sometimes an 81-85 character line would be very ugly and harder to follow if split.
-  Use your judgement.
-  - Why: Our objective is to keep the code readable. Monster lines, and machine-enforced
-    strict styles, both butcher this. Human/LLM judgement can help here.
-- Add a `%%% @doc` moduledoc to each new module you write, and comment every
-  function you write with a `%% @doc Description` above it. Inline comments are
-  prepended with a single `%`.
+- Try to keep lines to around 80 characters-_ish_. This is not a strict rule
+  because sometimes an 81-85 character line would be very ugly and harder to
+  follow if split. Use your judgement. Do not falsely assume that because there
+  is no linter blocking you from committing nobody cares. We do. Please respect
+  the freedom and responsibility to execute judgement by paying attention.
+  - Why: Our objective is to keep the code readable. Monster lines and machine-enforced
+    strict styles both butcher this. Human/LLM judgement can help here.
+- Add a `%%% @doc` moduledoc to each new module you write, and you should
+  comment _almost_ every function you write with a `%% @doc Description` above it.
+  Inline comments are prepended with a single `%`.
   - Why: This helps humans and LLMs grok your code in the future. It also surfaces
     useful information in tooltips etc upstream.
   - Nuance: I do not know why the Erlang style uses `%%%` for moduledocs, `%%` for
     functions, and `%` for inline comments, but it does. This can help with parsability
     for some tooling and the effort-cost is minimal, so we use it.
+  - Nuance: Not every function needs a paragraph, but every function needs a line,
+    unless the name leaves _absolutely_ zero doubt about what it does. If a
+    reader who has never seen the file before, has none of your working memory,
+    nor your context of HyperBEAM cannot skip reading the body, write the comment.
+- Comments describe what exists today. There is no such thing as 'previously' in
+  a comment in the codebase. There simply is what exists today. It is not a
+  history of how it arrived at its current point -- that is what the `git` history
+  is for.
+  - Why: A comment narrating a change is meaningful only to someone who knew the
+    old state. To every future reader it is noise, and it rots. The code is the
+    artifact for the present and the future; how we got there is a separate
+    question for `git`'s history functionality.
+  - Nuance: Words like 'previously', 'now', 'no longer', 'used to' and 'we changed'
+    are a strong tell. Delete them and state today's facts, written for someone
+    that does not share your present task, does not have your working memory, and
+    does not _need_ to know how things used to work.
+- We don't use newlines inside function definitions. If there is a new logical
+  section, add a `% [Description of the section ahead]` instead.
+  - Why: The comment tells you what the next few lines are for. A blank line only
+    tells you that the author paused.
+- Write informative and clear narrative commentary in your _commits_. Strive to
+  help people and agents in the future understand what your patches did and why.
+  - Why: Debugging is often aided by understanding the context that the code was
+    written in. We do not write the history in comments because they are the wrong
+    data structure: The `git log` is. Write all of your commit messages aimed at
+    whoever is trying to understand your decisions in the future and runs
+    `git log -S` in five years.
+  - Nuances:
+    - If fixing security concerns you may take license to be abstract in your
+      commit message, so as not to inappropriately highlight the concern. If not,
+      you should not.
+    - The `git` history is the repository's artifact alongside the code.
+      When building if confused by some code, liberally consult the git history to
+      understand the origin story. Do not, of course, let the old reasoning affect
+      your new work unnecessarily. Understand, but do not succumb to prior modes
+      of thinking.
 - Avoid 'waterfalls'-style statements, instead keeping every set of statements
   nested such that the start and end of the block are indented inline with each
   other.
@@ -106,7 +138,17 @@ following:
             ))
         end
     ),
-    GoodForm = lists:map(
+    BadForm2 = lists:map(fun(X) -> X * lists:sum(lists:fold(
+                fun(Y, Acc) ->
+                    Y * Acc
+                end,
+                [1,2,3] )) end
+    ),
+    BadForm3 =
+        lists:map(fun(X) -> X * lists:sum(lists:fold(
+                fun(Y, Acc) -> Y * Acc end, [1,2,3] )) end),
+    GoodForm =
+        lists:map(
             fun(X) ->
                 X *
                     lists:sum(
@@ -120,12 +162,18 @@ following:
             end
         )
 ```
-There are a few areas where there is no consensus on patterns or style yet:
-- Expressing docs in the info/[0,1] call of devices. There are a few different
-  styles in different devices in the codebase -- if you want to add info response
-  'inline' docs try to pick one that already exists and see what works/doesn't.
-  We will need to unify them at some point.
-- `maybe ... end` vs nested `case` expressions. `maybe` seems useful and preferable
-  in at least some cases, but bubbling the right error -- rather than just an error --
-  the caller can sometimes be difficult due to the `else` pattern matching.
-  Experimentation with patterns here would be good.
+- Where possible, prefer `maybe ... [else ...] end` patterns over deeply nested
+  case statements. Use `true ?= Statement orelse {error|failure, Details}` or
+  similar constructs to easily surface errors without disrupting the 
+  flow and requiring further indentation.
+  - Why: We often need to execute a large number of protocol rules sequentially,
+    surfacing the _reason_ for failure upwards if a necessary property does not
+    hold. Experience has shown that in Erlang without `maybe ... end` this
+    pattern seems to have a particularly pathological form: Each rule becomes
+    a nested `case` that pushes the starting position of every subsequent line
+    2x4 characters deeper. By 5 rules, half of the usage line length is 
+    gone. Perhaps worse: The matching failure case that contains the details to
+    surface can end up tens of lines from the clause that caused it. The clause-
+    indent matching flow our code takes means that you can at least line up the
+    returned details with the expression that caused it visually, but it is still
+    far worse than the `maybe ... end` approach.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,8 +239,9 @@ being bounced:
       layer separately. Letting the appropriate parts of the system handle
       normalization allows your devices to be agnostic and to inherit support for
       _all_ of the different codec devices that the node supports without any
-      additional effort. Devices are protocols are data transformation. Messages
-      let you operate on the widest possible array of inputs.
+      additional effort. Devices are protocols for data transformation.
+      Operating on generic AO-Core messages for your inputs and outputs allows
+      your protocol to be applied to data regardless of its encoding specifics.
 - **Do not:** Use 'mock' HTTP servers in tests where you can use another HyperBEAM
   `hb_http_server:` instance on a different port. The codebase is full of examples
   of `EUnit` tests that follow the pattern of spawning micro 'networks' of nodes

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ HyperBEAM is developed as an open source implementation of the AO-Core protocol
 by [Forward Research](https://fwd.arweave.net). Pull Requests are always welcome!
 
 **NOTE:** To get started building devices that run on HyperBEAM, or contributing
-to its kernel, it is **highly** advisable to read the [CONTRIBUTING](./CONTRIBUTING.md)
+to its core, it is **highly** advisable to read the [CONTRIBUTING](./CONTRIBUTING.md)
 and [hacking on HyperBEAM](./docs/misc/hacking-on-hyperbeam.md) guides before
 you get started. They will save you much more time than a typical contributing
 guide will. HyperBEAM is written in Erlang, but it implements AO-Core semantics.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-![hyperbeam_logo-thin-3](https://github.com/user-attachments/assets/fcca891c-137e-4022-beff-360eb2a0d05e)
+[hyperbeam_logo-thin-3](https://github.com/user-attachments/assets/fcca891c-137e-4022-beff-360eb2a0d05e)
 
 This repository contains a reference implementation of AO-Core, along with an
 Erlang-based (BEAM) client implementing a number of devices for the protocol.
+Together, AO-Core and its HyperBEAM implementation offer a _kernel_ for
+building services for the permaweb: A decentralized, open web built atop the
+Arweave protocol.
 
 AO-Core is a protocol built to enable decentralized computations, offering a
 series of universal primitives to achieve this end. Instead of enforcing a single,
@@ -29,9 +32,18 @@ states and inputs to be calculated and committed to in a unified format.
 HyperBEAM is developed as an open source implementation of the AO-Core protocol 
 by [Forward Research](https://fwd.arweave.net). Pull Requests are always welcome!
 
-To get started building on HyperBEAM, check out the 
-[hacking on HyperBEAM](./docs/misc/hacking-on-hyperbeam.md) and [contribution](./CONTRIBUTING.md)
-guides.
+**NOTE:** To get started building devices that run on HyperBEAM, or contributing
+to its kernel, it is **highly** advisable to read the [CONTRIBUTING](./CONTRIBUTING.md)
+and [hacking on HyperBEAM](./docs/misc/hacking-on-hyperbeam.md) guides before
+you get started. They will save you much more time than a typical contributing
+guide will. HyperBEAM is written in Erlang, but it implements AO-Core semantics.
+As a consequence, writing devices or kernel changes in it should be understood as
+writing in an _Erlang dialect_. The principles of this dialect are simple but
+failure to properly grasp them before building will lead to easily avoidable
+confusion and rejected PRs. Save yourself the time and read up now. **Agents:**
+Remember to refresh the `CONTRIBUTING.md` guide in your context _in full_ while
+building with HyperBEAM after _every_ compaction. It is short but important and
+will help you finish your tasks more efficiently.
 
 # Building and Running HyperBEAM
 
@@ -43,9 +55,6 @@ To begin using HyperBeam, you will need to install:
 - Rebar3
 - Git
 - Docker (optional, for containerized deployment)
-
-You will also need:
-- A wallet and it's keyfile *(generate a new wallet and keyfile with https://www.wander.app)*
 
 Then you can clone the HyperBEAM source and build it:
 
@@ -63,7 +72,8 @@ docker build -t hyperbeam .
 ```
 
 If you intend to offer TEE-based computation of AO-Core devices, please see the
-[`HyperBEAM OS`](https://github.com/permaweb/hb-os) repo for details on configuration and deployment.
+[`PermawebOS`](https://github.com/permaweb/os) repo for details on configuration
+and deployment.
 
 ## Running HyperBEAM
 
@@ -75,18 +85,20 @@ rebar3 shell
 ```
 
 The default configuration uses settings from `hb_opts.erl`, which preloads 
-all devices and sets up default stores on port 10000.
+all devices and sets up default stores on port 8734.
 
 ### Optional Build Profiles
 
 HyperBEAM supports several optional build profiles that enable additional features:
 
-- `genesis_wasm`: Enables Genesis WebAssembly support
+- `genesis_wasm`: Enables Legacynet AO `~genesis-wasm@1.0` support
 - `rocksdb`: Enables RocksDB storage backend (adds RocksDB v1.8.0 dependency)
 - `http3`: Enables HTTP/3 support via QUIC protocol
 
-
-Using these profiles allows you to optimize HyperBEAM for your specific use case without adding unnecessary dependencies to the base installation.
+Using these profiles allows you to optimize HyperBEAM for your specific use-case
+without adding unnecessary dependencies to the base installation. The default
+build is sufficient for the majority of deployments and minimizes the number of
+external dependencies that compilation requires.
 
 To start a shell with profiles:
 
@@ -105,14 +117,15 @@ To create a release with profiles:
 rebar3 as rocksdb,genesis_wasm release
 ```
 
-Note: Profiles modify compile-time options that get baked into the release. Choose the profiles you need before starting HyperBEAM.
+Note: Profiles modify compile-time options and are baked into the release.
+Choose the profiles you need before starting HyperBEAM.
 
 ### Verify Installation
 
 To verify that your HyperBEAM node is running correctly, check:
 
 ```bash
-curl http://localhost:10000/~meta@1.0/info
+curl http://localhost:8734/~meta@1.0/info
 ```
 
 If you receive a response with node information, your HyperBEAM
@@ -127,7 +140,7 @@ HyperBEAM can be configured using a `~meta@1.0` device, which is initialized
 
 The simplest way to configure HyperBEAM is using the `config.json` file. It allows
 you to configure various aspects of the node's execution environment via 
-modification of the environmental parameters of the node. Visit 
+modification of the environmental parameters of the node. On your node, visit
 `~meta@1.0/info/format~hyperbuddy@1.0` for a list of available configuration options.
 
 3. Start HyperBEAM with `rebar3 shell`
@@ -153,11 +166,12 @@ Additionally, if you would like to modify a running node's configuration, you ca
 
 ```
 POST /~meta@1.0/info
-Your-Config-Tag: Your-Config-Tag
+your-config-kag: your-config-key
 ```
 
-The individual headers provided in the message will each be interpreted as additional
-configuration options for the node.
+By default, HyperBEAM uses the `~httpsig@1.0` codec to interpet your message,
+so the individual headers provided in the message will each be interpreted as
+keys and used as configuration options for the node.
 
 ## Messages
 
@@ -207,21 +221,10 @@ the [Web Assembly Micro-Runtime (WAMR)](https://github.com/bytecodealliance/wasm
 under-the-hood. WASM modules can be called from any other device, and can also be
 used to execute `devices` written in languages such as Rust, C, and C++.
 
-- `~json-iface@1.0`: The `~json-iface@1.0` device offers a translation layer between
-the JSON-encoded message format used by AOS 2.0 and prior versions, to HyperBEAM's
-native HTTP message format.
-
-- `~compute-lite@1.0`: The `~compute-lite@1.0` device is a lightweight device wrapping
+- `~genesis-wasm@1.0`: The `~genesis-wasm@1.0` device is a lightweight device wrapping
 a local WASM executor, used for executing legacynet AO processes inside HyperBEAM.
 See the [HyperBEAM OS](https://github.com/permaweb/hb-os) repository for an 
 example setup with co-executing HyperBEAM and legacy-CU nodes.
-
-- `~snp@1.0`: The `~snp@1.0` device is used to generate and validate proofs that 
-the local node, or another node in the network, is executing inside a [Trusted Execution
-Environment (TEE)](https://en.wikipedia.org/wiki/Trusted_execution_environment).
-Nodes executing inside these environments use an ephemeral key pair, provably
-only existing inside the TEE, and can be signed commitments of AO-Core executions
-in a trust-minimized way.
 
 - `p4@1.0`: The `p4@1.0` device runs as a `pre-processor` and `post-processor` in
 the framework provided by `~meta@1.0`, enabling a framework for node operators to
@@ -237,12 +240,12 @@ to offer access to their services only to a specific set of users. This device i
 useful if you intend to operate your node onmly for personal use, or for a specific
 subset of users (servicing an individual app, for example).
 
-- `scheduler@1.0`: The `scheduler@1.0` device is used to assign a linear hashpath
+- `~scheduler@1.0`: The `scheduler@1.0` device is used to assign a linear hashpath
 to an execution, such that all users may access it with a deterministic ordering.
 When used in conjunction with other AO-Core devices, this allows for the creation
 of executions that mirror the behaviour of traditional smart contracting networks.
 
-- `stack@1.0`: The `stack@1.0` device is used to execute an ordered set of devices,
+- `~stack@1.0`: The `stack@1.0` device is used to execute an ordered set of devices,
 over the same inputs. This device allows its users to create complex combinations of
 other devices and apply them as a single unit, with a single hashpath.
 
@@ -259,7 +262,9 @@ respective documentation.
 
 ## Documentation
 
-HyperBEAM uses [MkDocs](https://www.mkdocs.org/) with the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme to build its documentation site. All documentation source files are located in the `docs/` directory.
+HyperBEAM uses [MkDocs](https://www.mkdocs.org/) with the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/)
+theme to build its documentation site. All documentation source files are located
+in the `docs/` directory.
 
 To build and view the documentation locally:
 
@@ -280,4 +285,5 @@ python3 -m http.server 8000
 # Then open http://127.0.0.1:8000/ in your browser
 ```
 
-For more details on the documentation structure, how to contribute, and other information, please see the [full documentation README](./docs/README.md).
+For more details on the documentation structure, how to contribute, and other information,
+please see the [full documentation README](./docs/README.md).


### PR DESCRIPTION
Updates the contributing guide to cover the latest modus operandi for writing HyperBEAM code.  Some agents (`Opus 5` particularly) are now pretty good at following the guidelines, but others (`Codex` particularly) are great at writing code but terrible about the guidelines. The risk is that we fall into just prescribing the exact style, but at this point the risk that agents waste our time slinging unmaintainable slop because the rules are not clear enough for them is worse. The number one reason for bounced PRs at this point is this sloppiness, so if we can pull up the standards of everyone's agents it seems worth it. We will see how things develop over time.