### PR TITLE
fix: Allow to use this project under _checkouts folder for debugging

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -143,7 +143,7 @@
     {"(linux|darwin|solaris)", compile,
         "sh -c '"
             "case \"$PWD\" in "
-            "*/_build/*) ;; "
+            "*/_build/*|*/_checkouts/*) ;; "
             "*) make -C . preloaded-store ;; "
             "esac"
         "'"}


### PR DESCRIPTION
Do not run the `preloaded-store` command when building under the `_checkouts` folder. This is used to debug devices.