### PR TITLE
fix(hyperbuddy): serve metrics with a parseable content-type

### DIFF
--- a/src/preloaded/node/dev_hyperbuddy.erl
+++ b/src/preloaded/node/dev_hyperbuddy.erl
@@ -57,7 +57,15 @@ metrics(_, Req, Opts) ->
                     RawHeaderMap,
 					Opts
                 ),
-            {ok, Headers#{ <<"body">> => Body }};
+            % Prometheus names its exposition format in a `version' parameter.
+            % `0.0.4' is not a valid structured-field value, so the parameter is
+            % dropped and the bare media type served.
+            {ok,
+                Headers#{
+                    <<"content-type">> => <<"text/plain">>,
+                    <<"body">> => Body
+                }
+            };
         false ->
             {ok, #{ <<"body">> => <<"Prometheus metrics disabled.">> }}
     end.


### PR DESCRIPTION
Fix Hyperbuddy metrics responses to use a structured-field-safe text/plain content type, preventing HTTPSig response handling from rejecting Prometheus’s version parameter