### PR TITLE
fix: `ao-types` in `~tx@1.0` messages without `original-tags`

### DIFF
--- a/src/preloaded/codec/lib_arweave_common.erl
+++ b/src/preloaded/codec/lib_arweave_common.erl
@@ -361,7 +361,7 @@ bundle_commitment_key(Tags, Opts) ->
 
 %% @doc Check whether a list of key-value pairs contains only normalized keys.
 normal_tags(BaseFields, Tags) ->
-    ReservedFields = [<<"data">> | BaseFields],
+    ReservedFields = [<<"ao-types">>, <<"data">> | BaseFields],
     lists:all(
         fun({Key, _}) ->
             hb_util:to_lower(hb_ao:normalize_key(Key)) =:= Key andalso


### PR DESCRIPTION
Adds `ao-types` to the list of reserved Arweave tags. This ensures `ao-types` metadata tags are correctly identified and preserved, preventing unintended normalization or rejection by the system.