### PR TITLE
fix: serialize sync with node-local singleton

### DIFF
--- a/src/preloaded/process/dev_arweave_scheduler.erl
+++ b/src/preloaded/process/dev_arweave_scheduler.erl
@@ -205,19 +205,24 @@ load_message(Base, Req, Opts) ->
             <<"base">> -> Base;
             <<"self">> -> Req;
             not_found -> hb_maps:get(<<"body">>, Req, Req, Opts);
-            Key -> hb_maps:get(Key, Req, Opts)
+            Key -> hb_maps:get(Key, Req, not_found, Opts)
         end,
-    try {ok, hb_cache:ensure_all_loaded(Raw, Opts)}
-    catch
-        error:{necessary_message_not_found, _, _} ->
-            {error,
-                #{
-                    <<"status">> => 404,
-                    <<"reason">> =>
-                        <<"Cannot fully load message to schedule.">>
-                }
-            }
+    case Raw of
+        not_found -> missing_message();
+        _ ->
+            try {ok, hb_cache:ensure_all_loaded(Raw, Opts)}
+            catch
+                error:{necessary_message_not_found, _, _} -> missing_message()
+            end
     end.
+
+missing_message() ->
+    {error,
+        #{
+            <<"status">> => 404,
+            <<"reason">> => <<"Cannot fully load message to schedule.">>
+        }
+    }.
 
 committed(Message, Opts) ->
     case hb_message:with_only_committed(Message, Opts) of

--- a/src/preloaded/process/dev_arweave_scheduler_cache.erl
+++ b/src/preloaded/process/dev_arweave_scheduler_cache.erl
@@ -100,15 +100,16 @@ write_targets_map(Targets, RawOpts) ->
     Store = hb_opts:get(store, no_viable_store, Opts),
     hb_store:link(Store, Targets, Opts).
 
-%% @doc Read an indexed target's header and recover its signed TXID. Reading
-%% the target path follows both cache links; resolving the store path directly
-%% would instead return the header's uncommitted cache ID.
+%% @doc Resolve an indexed target's signed TXID and read its cached header.
 read_target(Address, Ordinate, RawOpts) ->
     Opts = opts(RawOpts),
-    case hb_cache:read(target_path(Address, Ordinate), Opts) of
-        {ok, RawHeader} ->
-            Header = hb_message:normalize_commitments(RawHeader, Opts),
-            {ok, hb_util:human_id(hb_message:id(Header, signed, Opts)), Header};
+    Store = hb_opts:get(store, no_viable_store, Opts),
+    case hb_store:resolve(Store, target_path(Address, Ordinate), Opts) of
+        {ok, TXID} ->
+            case hb_cache:read(TXID, Opts) of
+                {ok, Header} -> {ok, TXID, Header};
+                {error, not_found} -> not_found
+            end;
         {error, not_found} -> not_found
     end.
 
@@ -278,8 +279,9 @@ linked_state_and_target_test() ->
     ok = write_target(ProcessID, <<"101-3">>, TXID, Opts),
     ?assertEqual([<<"101-3">>], list_targets(ProcessID, Opts)),
     {ok, ReadTXID, ReadHeader} = read_target(ProcessID, <<"101-3">>, Opts),
+    ?assertEqual(TXID, ReadTXID),
     ?assertEqual(
-        ReadTXID,
+        TXID,
         hb_util:human_id(hb_message:id(ReadHeader, signed, Opts))
     ),
     ok = hb_store:stop(Store).

--- a/src/preloaded/process/dev_arweave_scheduler_cache.erl
+++ b/src/preloaded/process/dev_arweave_scheduler_cache.erl
@@ -104,13 +104,23 @@ write_targets_map(Targets, RawOpts) ->
 read_target(Address, Ordinate, RawOpts) ->
     Opts = opts(RawOpts),
     Store = hb_opts:get(store, no_viable_store, Opts),
-    case hb_store:resolve(Store, target_path(Address, Ordinate), Opts) of
+    case resolve_target(Store, target_path(Address, Ordinate), Opts) of
         {ok, TXID} ->
             case hb_cache:read(TXID, Opts) of
                 {ok, Header} -> {ok, TXID, Header};
                 {error, not_found} -> not_found
             end;
         {error, not_found} -> not_found
+    end.
+
+resolve_target(Store, Path, Opts) when not is_list(Store) ->
+    resolve_target([Store], Path, Opts);
+resolve_target([], _Path, _Opts) -> {error, not_found};
+resolve_target([Store | Rest], Path, Opts) ->
+    case hb_store:resolve(Store, Path, Opts) of
+        {ok, Path} -> resolve_target(Rest, Path, Opts);
+        {ok, TXID} -> {ok, TXID};
+        _ -> resolve_target(Rest, Path, Opts)
     end.
 
 %% @doc List the ordinates that target an address. Callers parse and sort the
@@ -278,10 +288,14 @@ linked_state_and_target_test() ->
     {ok, _} = write_header(Header, Opts),
     ok = write_target(ProcessID, <<"101-3">>, TXID, Opts),
     ?assertEqual([<<"101-3">>], list_targets(ProcessID, Opts)),
-    {ok, ReadTXID, ReadHeader} = read_target(ProcessID, <<"101-3">>, Opts),
+    EmptyStore = hb_test_utils:test_store(hb_store_volatile, <<"empty">>),
+    ok = hb_store:start(EmptyStore),
+    ReadOpts = Opts#{ <<"scheduler-store">> => [EmptyStore, Store] },
+    {ok, ReadTXID, ReadHeader} = read_target(ProcessID, <<"101-3">>, ReadOpts),
     ?assertEqual(TXID, ReadTXID),
     ?assertEqual(
         TXID,
         hb_util:human_id(hb_message:id(ReadHeader, signed, Opts))
     ),
+    ok = hb_store:stop(EmptyStore),
     ok = hb_store:stop(Store).

--- a/src/preloaded/process/dev_arweave_scheduler_cache.erl
+++ b/src/preloaded/process/dev_arweave_scheduler_cache.erl
@@ -126,8 +126,8 @@ list_targets(Address, RawOpts) ->
 write_assignment(Assignment, RawOpts) ->
     Opts = opts(RawOpts),
     Store = hb_opts:get(store, no_viable_store, Opts),
-    ProcessID = hb_maps:get(<<"process">>, Assignment, Opts),
-    Slot = hb_maps:get(<<"slot">>, Assignment, Opts),
+    ProcessID = hb_maps:get(<<"process">>, Assignment, not_found, Opts),
+    Slot = hb_maps:get(<<"slot">>, Assignment, not_found, Opts),
     case hb_cache:write(Assignment, Opts) of
         {ok, _} ->
             hb_store:link(
@@ -177,7 +177,12 @@ assignments_to_bundle(ProcessID, Assignments, More, RawOpts) ->
                 hb_message:normalize_commitments(
                     hb_maps:from_list(
                         [
-                            {hb_maps:get(<<"slot">>, Assignment, Opts), Assignment}
+                            {
+                                hb_maps:get(
+                                    <<"slot">>, Assignment, not_found, Opts
+                                ),
+                                Assignment
+                            }
                         ||
                             Assignment <- Assignments
                         ]

--- a/src/preloaded/process/dev_arweave_scheduler_cache.erl
+++ b/src/preloaded/process/dev_arweave_scheduler_cache.erl
@@ -47,13 +47,19 @@ list_processes(RawOpts) ->
         _ -> []
     end.
 
-%% @doc Cache a data-free signed transaction header under its TXID.
+%% @doc Cache a signed transaction header under its TXID.
 write_header(Header, RawOpts) ->
     hb_cache:write(Header, opts(RawOpts)).
 
 %% @doc Read a cached signed transaction header by TXID.
 read_header(TXID, RawOpts) ->
-    hb_cache:read(TXID, opts(RawOpts)).
+    Opts = hb_store:scope(opts(RawOpts), local),
+    try hb_cache:read(TXID, Opts) of
+        {ok, Header} -> {ok, hb_cache:ensure_all_loaded(Header, Opts)};
+        Error -> Error
+    catch
+        _:_ -> {error, not_found}
+    end.
 
 %% @doc Cache and read canonical block messages under scheduler-owned height
 %% paths. This avoids coupling the scheduler package to the Arweave device's
@@ -283,3 +289,26 @@ linked_state_and_target_test() ->
         hb_util:human_id(hb_message:id(ReadHeader, signed, Opts))
     ),
     ok = hb_store:stop(Store).
+
+header_read_is_local_test() ->
+    Local = hb_test_utils:test_store(hb_store_volatile, <<"ar-sched-local">>),
+    Backing = hb_test_utils:test_store(hb_store_volatile, <<"ar-sched-remote">>),
+    Remote =
+        #{
+            <<"store-module">> => hb_store_multi,
+            <<"scope">> => remote,
+            <<"stores">> => [Backing],
+            <<"workers-per-store">> => 1
+        },
+    ok = hb_store:start(Local),
+    ok = hb_store:start(Remote),
+    CommitOpts = #{ <<"priv-wallet">> => ar_wallet:new() },
+    Header = hb_message:commit(#{ <<"message">> => <<"header">> }, CommitOpts),
+    TXID = hb_message:id(Header, signed, CommitOpts),
+    {ok, _} = hb_cache:write(Header, #{ <<"store">> => [Remote] }),
+    Opts = #{ <<"store">> => [Local, Remote] },
+    ?assertEqual({error, not_found}, read_header(TXID, Opts)),
+    {ok, _} = hb_cache:write(Header, #{ <<"store">> => [Local] }),
+    ?assertMatch({ok, _}, read_header(TXID, Opts)),
+    ok = hb_store:stop(Remote),
+    ok = hb_store:stop(Local).

--- a/src/preloaded/process/dev_arweave_scheduler_cache.erl
+++ b/src/preloaded/process/dev_arweave_scheduler_cache.erl
@@ -53,13 +53,7 @@ write_header(Header, RawOpts) ->
 
 %% @doc Read a cached signed transaction header by TXID.
 read_header(TXID, RawOpts) ->
-    Opts = hb_store:scope(opts(RawOpts), local),
-    try hb_cache:read(TXID, Opts) of
-        {ok, Header} -> {ok, hb_cache:ensure_all_loaded(Header, Opts)};
-        Error -> Error
-    catch
-        _:_ -> {error, not_found}
-    end.
+    hb_cache:read(TXID, opts(RawOpts)).
 
 %% @doc Cache and read canonical block messages under scheduler-owned height
 %% paths. This avoids coupling the scheduler package to the Arweave device's
@@ -289,26 +283,3 @@ linked_state_and_target_test() ->
         hb_util:human_id(hb_message:id(ReadHeader, signed, Opts))
     ),
     ok = hb_store:stop(Store).
-
-header_read_is_local_test() ->
-    Local = hb_test_utils:test_store(hb_store_volatile, <<"ar-sched-local">>),
-    Backing = hb_test_utils:test_store(hb_store_volatile, <<"ar-sched-remote">>),
-    Remote =
-        #{
-            <<"store-module">> => hb_store_multi,
-            <<"scope">> => remote,
-            <<"stores">> => [Backing],
-            <<"workers-per-store">> => 1
-        },
-    ok = hb_store:start(Local),
-    ok = hb_store:start(Remote),
-    CommitOpts = #{ <<"priv-wallet">> => ar_wallet:new() },
-    Header = hb_message:commit(#{ <<"message">> => <<"header">> }, CommitOpts),
-    TXID = hb_message:id(Header, signed, CommitOpts),
-    {ok, _} = hb_cache:write(Header, #{ <<"store">> => [Remote] }),
-    Opts = #{ <<"store">> => [Local, Remote] },
-    ?assertEqual({error, not_found}, read_header(TXID, Opts)),
-    {ok, _} = hb_cache:write(Header, #{ <<"store">> => [Local] }),
-    ?assertMatch({ok, _}, read_header(TXID, Opts)),
-    ok = hb_store:stop(Remote),
-    ok = hb_store:stop(Local).

--- a/src/preloaded/process/dev_arweave_scheduler_sync.erl
+++ b/src/preloaded/process/dev_arweave_scheduler_sync.erl
@@ -457,7 +457,7 @@ fetch_header(TXID, Opts, Fallback) ->
     case dev_arweave_scheduler_cache:read_header(TXID, Opts) of
         {ok, Header} ->
             case validate_header(TXID, Header, Opts) of
-                {ok, _, _} = Valid -> Valid;
+                {ok, _, #tx{ data = <<>> }} = Valid -> Valid;
                 _ -> Fallback(TXID, Opts)
             end;
         _ -> Fallback(TXID, Opts)
@@ -948,21 +948,36 @@ data_bearing_spawn_is_cached_before_slot_zero_test() ->
     Store = hb_test_utils:test_store(hb_store_volatile, <<"ar-sched-spawn">>),
     ok = hb_store:start(Store),
     Opts = #{ <<"store">> => [Store], <<"priv-wallet">> => ar_wallet:new() },
-    Header =
+    FullHeader =
         hb_message:commit(
             #{ <<"type">> => <<"Process">>, <<"data">> => <<"spawn body">> },
             Opts,
             #{ <<"commitment-device">> => <<"tx@1.0">> }
         ),
-    ProcessID = hb_util:human_id(hb_message:id(Header, signed, Opts)),
-    {ok, Header, #tx{ data_size = DataSize }} =
-        validate_header(ProcessID, Header, Opts),
+    ProcessID = hb_util:human_id(hb_message:id(FullHeader, signed, Opts)),
+    {ok, FullHeader, FullTX = #tx{ data_size = DataSize }} =
+        validate_header(ProcessID, FullHeader, Opts),
     ?assert(DataSize > 0),
+    ?assertNotEqual(<<>>, FullTX#tx.data),
+    Header =
+        hb_message:convert(
+            FullTX#tx{ data = <<>> },
+            <<"structured@1.0">>,
+            <<"tx@1.0">>,
+            Opts#{ <<"exclude-data">> => true }
+        ),
+    {ok, _} = dev_arweave_scheduler_cache:write_header(FullHeader, Opts),
+    Fallback =
+        fun(ProcessID, FallbackOpts) ->
+            validate_header(ProcessID, Header, FallbackOpts)
+        end,
+    {ok, Header, #tx{ data = <<>> }} =
+        fetch_header(ProcessID, Opts, Fallback),
     ok = write_spawn_assignment(ProcessID, 100, 2, Header, Opts),
-    ?assertMatch(
-        {ok, _},
-        dev_arweave_scheduler_cache:read_header(ProcessID, Opts)
-    ),
+    {ok, CachedHeader} =
+        dev_arweave_scheduler_cache:read_header(ProcessID, Opts),
+    #tx{ data = <<>>, data_size = DataSize } =
+        hb_message:convert(CachedHeader, <<"tx@1.0">>, Opts),
     {ok, Assignment} =
         dev_arweave_scheduler_cache:read_assignment(ProcessID, 0, Opts),
     ?assertEqual(0, hb_maps:get(<<"slot">>, Assignment, not_found, Opts)),
@@ -973,6 +988,10 @@ data_bearing_spawn_is_cached_before_slot_zero_test() ->
     ?assertEqual(
         2,
         hb_maps:get(<<"block-index">>, Assignment, not_found, Opts)
+    ),
+    ?assertEqual(
+        not_found,
+        hb_maps:get([<<"body">>, <<"data">>], Assignment, not_found, Opts)
     ),
     ok = hb_store:stop(Store).
 

--- a/src/preloaded/process/dev_arweave_scheduler_sync.erl
+++ b/src/preloaded/process/dev_arweave_scheduler_sync.erl
@@ -14,7 +14,6 @@
 -define(DEFAULT_FROM_HEIGHT, 1978888).
 -define(DEFAULT_HEADER_WORKERS, 16).
 -define(DEFAULT_SYNC_INTERVAL_MS, 1000).
--define(DEFAULT_PROCESS_IDLE_MS, 1000).
 
 %% @doc Bring the global target index to the confirmed chain frontier. The
 %% pass is serialized per scheduler store, and repeated callers within
@@ -43,8 +42,7 @@ process(ProcessID, Opts) ->
                             materialize_process(HumanProcessID, Global, Opts),
                             undefined
                         }
-                    end,
-                    process_idle_timeout(Opts)
+                    end
                 )
             end;
         error ->
@@ -180,7 +178,17 @@ initialize_process(
         {ok, Height, Index, SpawnOrdinate} ?= spawn_ordinate(ProcessID, Opts),
         ok ?= require_covered_spawn(ProcessID, Height, From, To),
         {ok, Header, #tx{}} ?= fetch_header(ProcessID, Opts),
-        ok ?= write_spawn_assignment(ProcessID, Height, Index, Header, Opts),
+        {ok, _} ?=
+            dev_arweave_scheduler_cache:write_header(Header, Opts),
+        ok ?=
+            write_assignment(
+                ProcessID,
+                0,
+                Height,
+                Index,
+                ProcessID,
+                Opts
+            ),
         State =
             #{
                 <<"process">> => ProcessID,
@@ -192,16 +200,6 @@ initialize_process(
             dev_arweave_scheduler_cache:write_process(ProcessID, State, Opts),
         {ok, State}
     else
-        Error -> Error
-    end.
-
-%% @doc Persist the verified process header before linking slot zero to it.
-%% Process spawns may carry data, but only data-free transactions enter the
-%% global target index in `transaction_targets/1'.
-write_spawn_assignment(ProcessID, Height, Index, Header, Opts) ->
-    case dev_arweave_scheduler_cache:write_header(Header, Opts) of
-        {ok, _} ->
-            write_assignment(ProcessID, 0, Height, Index, ProcessID, Opts);
         Error -> Error
     end.
 
@@ -451,16 +449,13 @@ fetch_block_remote(Height, Opts) ->
 %% fetch it without data. The signed commitment must reproduce the requested
 %% TXID before it is admitted to the scheduler store.
 fetch_header(TXID, Opts) ->
-    fetch_header(TXID, Opts, fun fetch_header_remote/2).
-
-fetch_header(TXID, Opts, Fallback) ->
     case dev_arweave_scheduler_cache:read_header(TXID, Opts) of
         {ok, Header} ->
             case validate_header(TXID, Header, Opts) of
                 {ok, _, #tx{ data = <<>> }} = Valid -> Valid;
-                _ -> Fallback(TXID, Opts)
+                _ -> fetch_header_remote(TXID, Opts)
             end;
-        _ -> Fallback(TXID, Opts)
+        _ -> fetch_header_remote(TXID, Opts)
     end.
 
 fetch_header_remote(TXID, Opts) ->
@@ -734,56 +729,28 @@ no_result_cache(Opts) ->
 
 %% @doc Run one scheduler-store task at a time through a node-local worker.
 %% Global synchronization and each process have separate names, so one slow
-%% process initialization does not block unrelated schedules. Process workers
-%% retire when idle, while the global worker retains its recent synchronization
-%% state. Every caller monitors its worker so retirement races can retry safely.
+%% process initialization does not block unrelated schedules. Unexpected task
+%% failures terminate the worker; every queued caller monitors it and the next
+%% request starts with a clean mailbox.
 exclusive(Name, Fun) ->
-    exclusive(Name, Fun, infinity).
-
-exclusive(Name, Fun, IdleTimeout) ->
-    Runner =
-        hb_name:singleton(
-            Name,
-            fun() ->
-                try runner(undefined, IdleTimeout)
-                after hb_name:unregister(Name)
-                end
-            end
-        ),
+    Runner = hb_name:singleton(Name, fun() -> runner(undefined) end),
     Monitor = erlang:monitor(process, Runner),
     Runner ! {run, self(), Monitor, Fun},
     receive
         {ran, Monitor, Result} ->
             erlang:demonitor(Monitor, [flush]),
             Result;
-        {'DOWN', Monitor, process, Runner, Reason}
-                when Reason =:= normal; Reason =:= noproc ->
-            exclusive(Name, Fun, IdleTimeout);
         {'DOWN', Monitor, process, Runner, Reason} ->
             exit({arweave_scheduler_sync_runner_down, Reason})
     end.
 
-runner(State, IdleTimeout) ->
+runner(State) ->
     receive
         {run, Caller, Ref, Fun} ->
             {Result, NewState} = Fun(State),
             Caller ! {ran, Ref, Result},
-            runner(NewState, IdleTimeout)
-    after IdleTimeout ->
-        ok
+            runner(NewState)
     end.
-
-process_idle_timeout(Opts) ->
-    max(
-        1,
-        hb_util:int(
-            hb_opts:get(
-                arweave_scheduler_process_idle,
-                ?DEFAULT_PROCESS_IDLE_MS,
-                Opts
-            )
-        )
-    ).
 
 scheduler_store(Opts) ->
     hb_opts:get(
@@ -847,153 +814,14 @@ singleton_serialization_test() ->
                     fun(State) ->
                         Count = case State of undefined -> 0; _ -> State end,
                         {{ok, Count}, Count + 1}
-                    end,
-                    20
+                    end
                 ),
             Parent ! {complete, Result}
         end,
     _ = [spawn(Run) || _ <- lists:seq(1, 12)],
     Results = [receive {complete, {ok, N}} -> N end || _ <- lists:seq(1, 12)],
     ?assertEqual(lists:seq(0, 11), lists:sort(Results)),
-    ?assert(
-        hb_util:wait_until(
-            fun() -> ets:lookup(hb_name_registry, Name) =:= [] end,
-            500
-        )
-    ).
-
-distinct_workers_concurrent_test() ->
-    Parent = self(),
-    Names = [{?MODULE, test, make_ref()}, {?MODULE, test, make_ref()}],
-    _ =
-        [
-            spawn(
-                fun() ->
-                    Result =
-                        exclusive(
-                            Name,
-                            fun(_State) ->
-                                Parent ! {entered, Name, self()},
-                                receive release -> {{ok, Name}, undefined} end
-                            end,
-                            20
-                        ),
-                    Parent ! {complete, Result}
-                end
-            )
-        ||
-            Name <- Names
-        ],
-    [NameA, NameB] = Names,
-    PidA = receive {entered, NameA, A} -> A end,
-    PidB = receive {entered, NameB, B} -> B end,
-    ?assertNotEqual(PidA, PidB),
-    PidA ! release,
-    PidB ! release,
-    Results = [receive {complete, {ok, Name}} -> Name end || _ <- Names],
-    ?assertEqual(lists:sort(Names), lists:sort(Results)),
-    ?assert(
-        hb_util:wait_until(
-            fun() ->
-                lists:all(
-                    fun(Name) ->
-                        ets:lookup(hb_name_registry, Name) =:= []
-                    end,
-                    Names
-                )
-            end,
-            500
-        )
-    ).
-
-retirement_race_retries_test() ->
-    Name = {?MODULE, test, make_ref()},
-    Parent = self(),
-    Retiring =
-        spawn(
-            fun() ->
-                ok = hb_name:register(Name),
-                Parent ! registered,
-                receive
-                    retire -> receive {run, _, _, _} -> ok end
-                end
-            end
-        ),
-    receive registered -> ok end,
-    Retiring ! retire,
-    ?assertEqual(
-        {ok, retried},
-        exclusive(Name, fun(_State) -> {{ok, retried}, undefined} end, 20)
-    ),
-    ?assert(
-        hb_util:wait_until(
-            fun() -> ets:lookup(hb_name_registry, Name) =:= [] end,
-            500
-        )
-    ).
-
-unusable_cached_header_falls_back_test() ->
-    Store = hb_test_utils:test_store(hb_store_volatile, <<"ar-sched-header">>),
-    ok = hb_store:start(Store),
-    Opts = #{ <<"store">> => [Store], <<"priv-wallet">> => ar_wallet:new() },
-    TXID = hb_util:human_id(crypto:strong_rand_bytes(32)),
-    BadHeader = hb_message:commit(#{ <<"message">> => <<"bad">> }, Opts),
-    {ok, BadID} = hb_cache:write(BadHeader, Opts),
-    ok = hb_store:link(Store, #{ TXID => BadID }, Opts),
-    Fallback = fun(TXID, _FallbackOpts) -> {ok, fetched} end,
-    ?assertEqual({ok, fetched}, fetch_header(TXID, Opts, Fallback)),
-    ok = hb_store:stop(Store).
-
-data_bearing_spawn_is_cached_before_slot_zero_test() ->
-    Store = hb_test_utils:test_store(hb_store_volatile, <<"ar-sched-spawn">>),
-    ok = hb_store:start(Store),
-    Opts = #{ <<"store">> => [Store], <<"priv-wallet">> => ar_wallet:new() },
-    FullHeader =
-        hb_message:commit(
-            #{ <<"type">> => <<"Process">>, <<"data">> => <<"spawn body">> },
-            Opts,
-            #{ <<"commitment-device">> => <<"tx@1.0">> }
-        ),
-    ProcessID = hb_util:human_id(hb_message:id(FullHeader, signed, Opts)),
-    {ok, FullHeader, FullTX = #tx{ data_size = DataSize }} =
-        validate_header(ProcessID, FullHeader, Opts),
-    ?assert(DataSize > 0),
-    ?assertNotEqual(<<>>, FullTX#tx.data),
-    Header =
-        hb_message:convert(
-            FullTX#tx{ data = <<>> },
-            <<"structured@1.0">>,
-            <<"tx@1.0">>,
-            Opts#{ <<"exclude-data">> => true }
-        ),
-    {ok, _} = dev_arweave_scheduler_cache:write_header(FullHeader, Opts),
-    Fallback =
-        fun(ProcessID, FallbackOpts) ->
-            validate_header(ProcessID, Header, FallbackOpts)
-        end,
-    {ok, Header, #tx{ data = <<>> }} =
-        fetch_header(ProcessID, Opts, Fallback),
-    ok = write_spawn_assignment(ProcessID, 100, 2, Header, Opts),
-    {ok, CachedHeader} =
-        dev_arweave_scheduler_cache:read_header(ProcessID, Opts),
-    #tx{ data = <<>>, data_size = DataSize } =
-        hb_message:convert(CachedHeader, <<"tx@1.0">>, Opts),
-    {ok, Assignment} =
-        dev_arweave_scheduler_cache:read_assignment(ProcessID, 0, Opts),
-    ?assertEqual(0, hb_maps:get(<<"slot">>, Assignment, not_found, Opts)),
-    ?assertEqual(
-        100,
-        hb_maps:get(<<"block-height">>, Assignment, not_found, Opts)
-    ),
-    ?assertEqual(
-        2,
-        hb_maps:get(<<"block-index">>, Assignment, not_found, Opts)
-    ),
-    ?assertEqual(
-        not_found,
-        hb_maps:get([<<"body">>, <<"data">>], Assignment, not_found, Opts)
-    ),
-    ok = hb_store:stop(Store).
+    stop_test_runner(Name).
 
 public_process_path_test() ->
     Store =

--- a/src/preloaded/process/dev_arweave_scheduler_sync.erl
+++ b/src/preloaded/process/dev_arweave_scheduler_sync.erl
@@ -14,24 +14,17 @@
 -define(DEFAULT_FROM_HEIGHT, 1978888).
 -define(DEFAULT_HEADER_WORKERS, 16).
 -define(DEFAULT_SYNC_INTERVAL_MS, 1000).
--define(SYNC_TABLE, dev_arweave_scheduler_sync_checks).
 
 %% @doc Bring the global target index to the confirmed chain frontier. The
-%% transaction is serialized per scheduler store, and repeated callers within
+%% pass is serialized per scheduler store, and repeated callers within
 %% the short check interval reuse the completed global record without another
 %% network-tip request.
 sync(Opts) ->
-    CacheOpts = dev_arweave_scheduler_cache:opts(Opts),
-    Store = hb_opts:get(store, no_viable_store, CacheOpts),
-    ensure_sync_table(),
-    case recent_state(Store, Opts) of
-        {ok, _} = Recent -> Recent;
-        stale ->
-            global:trans(
-                {?MODULE, Store},
-                fun() -> maybe_sync(Store, Opts) end
-            )
-    end.
+    Store = scheduler_store(Opts),
+    exclusive(
+        {?MODULE, sync, Store},
+        fun(Cached) -> sync_request(Cached, Opts) end
+    ).
 
 %% @doc Synchronize the global index and materialize one process's relevant
 %% entries into contiguous AO slots. Each process is serialized independently;
@@ -39,14 +32,16 @@ sync(Opts) ->
 process(ProcessID, Opts) ->
     case canonical_process_id(ProcessID) of
         {ok, HumanProcessID} ->
-            CacheOpts = dev_arweave_scheduler_cache:opts(Opts),
-            Store = hb_opts:get(store, no_viable_store, CacheOpts),
+            Store = scheduler_store(Opts),
             maybe
                 {ok, Global} ?= sync(Opts),
-                global:trans(
-                    {?MODULE, Store, HumanProcessID},
-                    fun() ->
-                        materialize_process(HumanProcessID, Global, Opts)
+                exclusive(
+                    {?MODULE, process, Store, HumanProcessID},
+                    fun(_State) ->
+                        {
+                            materialize_process(HumanProcessID, Global, Opts),
+                            undefined
+                        }
                     end
                 )
             end;
@@ -60,24 +55,26 @@ process(ProcessID, Opts) ->
             }
     end.
 
-maybe_sync(Store, Opts) ->
-    case recent_state(Store, Opts) of
-        {ok, _} = Recent -> Recent;
+sync_request(Cached, Opts) ->
+    case recent_state(Cached, Opts) of
+        {ok, _} = Recent -> {Recent, Cached};
         stale ->
-            StateResult = dev_arweave_scheduler_cache:read_global(Opts),
-            Result = do_sync(StateResult, Opts),
+            Result =
+                do_sync(
+                    dev_arweave_scheduler_cache:read_global(Opts),
+                    Opts
+                ),
             case Result of
                 {ok, State} ->
-                    ets:insert(
-                        ?SYNC_TABLE,
-                        {Store, erlang:monotonic_time(millisecond), State}
-                    );
-                _ -> ok
-            end,
-            Result
+                    {
+                        Result,
+                        {erlang:monotonic_time(millisecond), State}
+                    };
+                _ -> {Result, undefined}
+            end
     end.
 
-recent_state(Store, Opts) ->
+recent_state(Cached, Opts) ->
     Interval =
         hb_util:int(
             hb_opts:get(
@@ -88,8 +85,8 @@ recent_state(Store, Opts) ->
         ),
     Now = erlang:monotonic_time(millisecond),
     ConfiguredFrom = from_height(Opts),
-    case ets:lookup(?SYNC_TABLE, Store) of
-        [{Store, CheckedAt, State}]
+    case Cached of
+        {CheckedAt, State}
                 when Interval > 0, Now - CheckedAt < Interval ->
             case hb_util:int(hb_maps:get(<<"from">>, State, -1, #{})) of
                 ConfiguredFrom -> {ok, State};
@@ -286,7 +283,8 @@ write_process_assignments(
         {ok, NewNextSlot} ->
             NewState =
                 State#{
-                    <<"synced-to">> => hb_maps:get(<<"to">>, Global, Opts),
+                    <<"synced-to">> =>
+                        hb_maps:get(<<"to">>, Global, not_found, Opts),
                     <<"next-slot">> => NewNextSlot
                 },
             case dev_arweave_scheduler_cache:write_process(
@@ -575,14 +573,16 @@ canonical_process_id(ProcessID) ->
     end.
 
 trim_ascii(<<C, Rest/binary>>)
-        when C =:= $\s; C =:= $\t; C =:= $\r; C =:= $\n ->
+        when C =:= $\s; C =:= $\t; C =:= $\n; C =:= 11;
+             C =:= 12; C =:= $\r ->
     trim_ascii(Rest);
 trim_ascii(Bin) -> trim_ascii_right(Bin, byte_size(Bin)).
 
 trim_ascii_right(_, 0) -> <<>>;
 trim_ascii_right(Bin, Len) ->
     case binary:at(Bin, Len - 1) of
-        C when C =:= $\s; C =:= $\t; C =:= $\r; C =:= $\n ->
+        C when C =:= $\s; C =:= $\t; C =:= $\n; C =:= 11;
+               C =:= 12; C =:= $\r ->
             trim_ascii_right(Bin, Len - 1);
         _ -> binary:part(Bin, 0, Len)
     end.
@@ -730,34 +730,37 @@ no_result_cache(Opts) ->
         <<"cache-control">> => [<<"no-cache">>, <<"no-store">>]
     }.
 
-ensure_sync_table() ->
-    Owner =
-        hb_name:singleton(
-            {?MODULE, ?SYNC_TABLE},
-            fun() ->
-                ets:new(
-                    ?SYNC_TABLE,
-                    [
-                        named_table,
-                        public,
-                        set,
-                        {read_concurrency, true},
-                        {write_concurrency, true}
-                    ]
-                ),
-                sync_table_owner()
-            end
-        ),
-    Ref = make_ref(),
-    Owner ! {ready, self(), Ref},
-    receive {Ref, ok} -> ?SYNC_TABLE end.
-
-sync_table_owner() ->
+%% @doc Run one scheduler-store task at a time through a node-local worker.
+%% Global synchronization and each process have separate names, so one slow
+%% process initialization does not block unrelated schedules. Unexpected task
+%% failures terminate the worker; every queued caller monitors it and the next
+%% request starts with a clean mailbox.
+exclusive(Name, Fun) ->
+    Runner = hb_name:singleton(Name, fun() -> runner(undefined) end),
+    Monitor = erlang:monitor(process, Runner),
+    Runner ! {run, self(), Monitor, Fun},
     receive
-        {ready, Caller, Ref} ->
-            Caller ! {Ref, ok},
-            sync_table_owner()
+        {ran, Monitor, Result} ->
+            erlang:demonitor(Monitor, [flush]),
+            Result;
+        {'DOWN', Monitor, process, Runner, Reason} ->
+            exit({arweave_scheduler_sync_runner_down, Reason})
     end.
+
+runner(State) ->
+    receive
+        {run, Caller, Ref, Fun} ->
+            {Result, NewState} = Fun(State),
+            Caller ! {ran, Ref, Result},
+            runner(NewState)
+    end.
+
+scheduler_store(Opts) ->
+    hb_opts:get(
+        store,
+        no_viable_store,
+        dev_arweave_scheduler_cache:opts(Opts)
+    ).
 
 %%% Tests
 
@@ -772,8 +775,9 @@ targets_test() ->
             tags =
                 [
                     {<<"Assign-To">>,
-                        <<" ", A/binary, ",", B/binary, ",,", A/binary,
-                            ",", NativeAddress/binary, ",invalid ">>}
+                        <<11, 12, " ", A/binary, ",", B/binary, ",,",
+                            A/binary, ",", NativeAddress/binary,
+                            ",invalid \t\r\n", 11, 12>>}
                 ]
         },
     ?assertEqual(
@@ -801,6 +805,79 @@ ordinate_test() ->
     ?assertEqual({ok, {1966084, 23}}, parse_ordinate(<<"1966084-23">>)),
     ?assertEqual(error, parse_ordinate(<<"1966084">>)),
     ?assertEqual(error, parse_ordinate(<<"-1-2">>)).
+
+singleton_serialization_test() ->
+    Name = {?MODULE, test, make_ref()},
+    Parent = self(),
+    Run =
+        fun() ->
+            Result =
+                exclusive(
+                    Name,
+                    fun(State) ->
+                        Count = case State of undefined -> 0; _ -> State end,
+                        {{ok, Count}, Count + 1}
+                    end
+                ),
+            Parent ! {complete, Result}
+        end,
+    _ = [spawn(Run) || _ <- lists:seq(1, 12)],
+    Results = [receive {complete, {ok, N}} -> N end || _ <- lists:seq(1, 12)],
+    ?assertEqual(lists:seq(0, 11), lists:sort(Results)),
+    stop_test_runner(Name).
+
+public_process_path_test() ->
+    Store =
+        hb_test_utils:test_store(hb_store_volatile, <<"ar-sched-public">>),
+    ok = hb_store:start(Store),
+    Opts =
+        #{
+            <<"store">> => [Store],
+            <<"arweave-scheduler-from">> => 100,
+            <<"arweave-scheduler-sync-interval">> => 10000,
+            <<"priv-wallet">> => ar_wallet:new()
+        },
+    ProcessID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    Global = #{ <<"from">> => 100, <<"to">> => 101 },
+    ProcessState =
+        #{
+            <<"process">> => ProcessID,
+            <<"spawn-ordinate">> => <<"100-0">>,
+            <<"synced-to">> => 101,
+            <<"next-slot">> => 1
+        },
+    {ok, _} = dev_arweave_scheduler_cache:write_global(Global, Opts),
+    {ok, _} =
+        dev_arweave_scheduler_cache:write_process(
+            ProcessID, ProcessState, Opts
+        ),
+    SyncName = {?MODULE, sync, scheduler_store(Opts)},
+    ?assertEqual(
+        {ok, seeded},
+        exclusive(
+            SyncName,
+            fun(_Cached) ->
+                {
+                    {ok, seeded},
+                    {erlang:monotonic_time(millisecond), Global}
+                }
+            end
+        )
+    ),
+    ?assertEqual({ok, ProcessState}, process(ProcessID, Opts)),
+    stop_test_runner(SyncName),
+    stop_test_runner(
+        {?MODULE, process, scheduler_store(Opts), ProcessID}
+    ),
+    ok = hb_store:stop(Store).
+
+stop_test_runner(Name) ->
+    case hb_name:lookup(Name) of
+        undefined -> ok;
+        Runner ->
+            exit(Runner, kill),
+            hb_name:unregister(Name)
+    end.
 
 block_validation_test() ->
     State = #{ <<"block-hash">> => <<"previous">> },

--- a/src/preloaded/process/dev_arweave_scheduler_sync.erl
+++ b/src/preloaded/process/dev_arweave_scheduler_sync.erl
@@ -14,6 +14,7 @@
 -define(DEFAULT_FROM_HEIGHT, 1978888).
 -define(DEFAULT_HEADER_WORKERS, 16).
 -define(DEFAULT_SYNC_INTERVAL_MS, 1000).
+-define(DEFAULT_PROCESS_IDLE_MS, 1000).
 
 %% @doc Bring the global target index to the confirmed chain frontier. The
 %% pass is serialized per scheduler store, and repeated callers within
@@ -42,7 +43,8 @@ process(ProcessID, Opts) ->
                             materialize_process(HumanProcessID, Global, Opts),
                             undefined
                         }
-                    end
+                    end,
+                    process_idle_timeout(Opts)
                 )
             end;
         error ->
@@ -177,16 +179,8 @@ initialize_process(
     maybe
         {ok, Height, Index, SpawnOrdinate} ?= spawn_ordinate(ProcessID, Opts),
         ok ?= require_covered_spawn(ProcessID, Height, From, To),
-        {ok, _, #tx{ data_size = 0 }} ?= fetch_header(ProcessID, Opts),
-        ok ?=
-            write_assignment(
-                ProcessID,
-                0,
-                Height,
-                Index,
-                ProcessID,
-                Opts
-            ),
+        {ok, Header, #tx{}} ?= fetch_header(ProcessID, Opts),
+        ok ?= write_spawn_assignment(ProcessID, Height, Index, Header, Opts),
         State =
             #{
                 <<"process">> => ProcessID,
@@ -198,15 +192,16 @@ initialize_process(
             dev_arweave_scheduler_cache:write_process(ProcessID, State, Opts),
         {ok, State}
     else
-        {ok, _, #tx{}} ->
-            {error,
-                #{
-                    <<"status">> => 422,
-                    <<"reason">> =>
-                        <<"An Arweave-scheduled process must be data-free.">>,
-                    <<"process">> => ProcessID
-                }
-            };
+        Error -> Error
+    end.
+
+%% @doc Persist the verified process header before linking slot zero to it.
+%% Process spawns may carry data, but only data-free transactions enter the
+%% global target index in `transaction_targets/1'.
+write_spawn_assignment(ProcessID, Height, Index, Header, Opts) ->
+    case dev_arweave_scheduler_cache:write_header(Header, Opts) of
+        {ok, _} ->
+            write_assignment(ProcessID, 0, Height, Index, ProcessID, Opts);
         Error -> Error
     end.
 
@@ -456,9 +451,16 @@ fetch_block_remote(Height, Opts) ->
 %% fetch it without data. The signed commitment must reproduce the requested
 %% TXID before it is admitted to the scheduler store.
 fetch_header(TXID, Opts) ->
+    fetch_header(TXID, Opts, fun fetch_header_remote/2).
+
+fetch_header(TXID, Opts, Fallback) ->
     case dev_arweave_scheduler_cache:read_header(TXID, Opts) of
-        {ok, Header} -> validate_header(TXID, Header, Opts);
-        _ -> fetch_header_remote(TXID, Opts)
+        {ok, Header} ->
+            case validate_header(TXID, Header, Opts) of
+                {ok, _, _} = Valid -> Valid;
+                _ -> Fallback(TXID, Opts)
+            end;
+        _ -> Fallback(TXID, Opts)
     end.
 
 fetch_header_remote(TXID, Opts) ->
@@ -732,28 +734,56 @@ no_result_cache(Opts) ->
 
 %% @doc Run one scheduler-store task at a time through a node-local worker.
 %% Global synchronization and each process have separate names, so one slow
-%% process initialization does not block unrelated schedules. Unexpected task
-%% failures terminate the worker; every queued caller monitors it and the next
-%% request starts with a clean mailbox.
+%% process initialization does not block unrelated schedules. Process workers
+%% retire when idle, while the global worker retains its recent synchronization
+%% state. Every caller monitors its worker so retirement races can retry safely.
 exclusive(Name, Fun) ->
-    Runner = hb_name:singleton(Name, fun() -> runner(undefined) end),
+    exclusive(Name, Fun, infinity).
+
+exclusive(Name, Fun, IdleTimeout) ->
+    Runner =
+        hb_name:singleton(
+            Name,
+            fun() ->
+                try runner(undefined, IdleTimeout)
+                after hb_name:unregister(Name)
+                end
+            end
+        ),
     Monitor = erlang:monitor(process, Runner),
     Runner ! {run, self(), Monitor, Fun},
     receive
         {ran, Monitor, Result} ->
             erlang:demonitor(Monitor, [flush]),
             Result;
+        {'DOWN', Monitor, process, Runner, Reason}
+                when Reason =:= normal; Reason =:= noproc ->
+            exclusive(Name, Fun, IdleTimeout);
         {'DOWN', Monitor, process, Runner, Reason} ->
             exit({arweave_scheduler_sync_runner_down, Reason})
     end.
 
-runner(State) ->
+runner(State, IdleTimeout) ->
     receive
         {run, Caller, Ref, Fun} ->
             {Result, NewState} = Fun(State),
             Caller ! {ran, Ref, Result},
-            runner(NewState)
+            runner(NewState, IdleTimeout)
+    after IdleTimeout ->
+        ok
     end.
+
+process_idle_timeout(Opts) ->
+    max(
+        1,
+        hb_util:int(
+            hb_opts:get(
+                arweave_scheduler_process_idle,
+                ?DEFAULT_PROCESS_IDLE_MS,
+                Opts
+            )
+        )
+    ).
 
 scheduler_store(Opts) ->
     hb_opts:get(
@@ -817,14 +847,134 @@ singleton_serialization_test() ->
                     fun(State) ->
                         Count = case State of undefined -> 0; _ -> State end,
                         {{ok, Count}, Count + 1}
-                    end
+                    end,
+                    20
                 ),
             Parent ! {complete, Result}
         end,
     _ = [spawn(Run) || _ <- lists:seq(1, 12)],
     Results = [receive {complete, {ok, N}} -> N end || _ <- lists:seq(1, 12)],
     ?assertEqual(lists:seq(0, 11), lists:sort(Results)),
-    stop_test_runner(Name).
+    ?assert(
+        hb_util:wait_until(
+            fun() -> ets:lookup(hb_name_registry, Name) =:= [] end,
+            500
+        )
+    ).
+
+distinct_workers_concurrent_test() ->
+    Parent = self(),
+    Names = [{?MODULE, test, make_ref()}, {?MODULE, test, make_ref()}],
+    _ =
+        [
+            spawn(
+                fun() ->
+                    Result =
+                        exclusive(
+                            Name,
+                            fun(_State) ->
+                                Parent ! {entered, Name, self()},
+                                receive release -> {{ok, Name}, undefined} end
+                            end,
+                            20
+                        ),
+                    Parent ! {complete, Result}
+                end
+            )
+        ||
+            Name <- Names
+        ],
+    [NameA, NameB] = Names,
+    PidA = receive {entered, NameA, A} -> A end,
+    PidB = receive {entered, NameB, B} -> B end,
+    ?assertNotEqual(PidA, PidB),
+    PidA ! release,
+    PidB ! release,
+    Results = [receive {complete, {ok, Name}} -> Name end || _ <- Names],
+    ?assertEqual(lists:sort(Names), lists:sort(Results)),
+    ?assert(
+        hb_util:wait_until(
+            fun() ->
+                lists:all(
+                    fun(Name) ->
+                        ets:lookup(hb_name_registry, Name) =:= []
+                    end,
+                    Names
+                )
+            end,
+            500
+        )
+    ).
+
+retirement_race_retries_test() ->
+    Name = {?MODULE, test, make_ref()},
+    Parent = self(),
+    Retiring =
+        spawn(
+            fun() ->
+                ok = hb_name:register(Name),
+                Parent ! registered,
+                receive
+                    retire -> receive {run, _, _, _} -> ok end
+                end
+            end
+        ),
+    receive registered -> ok end,
+    Retiring ! retire,
+    ?assertEqual(
+        {ok, retried},
+        exclusive(Name, fun(_State) -> {{ok, retried}, undefined} end, 20)
+    ),
+    ?assert(
+        hb_util:wait_until(
+            fun() -> ets:lookup(hb_name_registry, Name) =:= [] end,
+            500
+        )
+    ).
+
+unusable_cached_header_falls_back_test() ->
+    Store = hb_test_utils:test_store(hb_store_volatile, <<"ar-sched-header">>),
+    ok = hb_store:start(Store),
+    Opts = #{ <<"store">> => [Store], <<"priv-wallet">> => ar_wallet:new() },
+    TXID = hb_util:human_id(crypto:strong_rand_bytes(32)),
+    BadHeader = hb_message:commit(#{ <<"message">> => <<"bad">> }, Opts),
+    {ok, BadID} = hb_cache:write(BadHeader, Opts),
+    ok = hb_store:link(Store, #{ TXID => BadID }, Opts),
+    Fallback = fun(TXID, _FallbackOpts) -> {ok, fetched} end,
+    ?assertEqual({ok, fetched}, fetch_header(TXID, Opts, Fallback)),
+    ok = hb_store:stop(Store).
+
+data_bearing_spawn_is_cached_before_slot_zero_test() ->
+    Store = hb_test_utils:test_store(hb_store_volatile, <<"ar-sched-spawn">>),
+    ok = hb_store:start(Store),
+    Opts = #{ <<"store">> => [Store], <<"priv-wallet">> => ar_wallet:new() },
+    Header =
+        hb_message:commit(
+            #{ <<"type">> => <<"Process">>, <<"data">> => <<"spawn body">> },
+            Opts,
+            #{ <<"commitment-device">> => <<"tx@1.0">> }
+        ),
+    ProcessID = hb_util:human_id(hb_message:id(Header, signed, Opts)),
+    {ok, Header, #tx{ data_size = DataSize }} =
+        validate_header(ProcessID, Header, Opts),
+    ?assert(DataSize > 0),
+    ok = write_spawn_assignment(ProcessID, 100, 2, Header, Opts),
+    ?assertMatch(
+        {ok, _},
+        dev_arweave_scheduler_cache:read_header(ProcessID, Opts)
+    ),
+    {ok, Assignment} =
+        dev_arweave_scheduler_cache:read_assignment(ProcessID, 0, Opts),
+    ?assertEqual(0, hb_maps:get(<<"slot">>, Assignment, not_found, Opts)),
+    ?assertEqual(
+        100,
+        hb_maps:get(<<"block-height">>, Assignment, not_found, Opts)
+    ),
+    ?assertEqual(
+        2,
+        hb_maps:get(<<"block-index">>, Assignment, not_found, Opts)
+    ),
+    ok = hb_store:stop(Store).
 
 public_process_path_test() ->
     Store =


### PR DESCRIPTION
* replaces the scheduler-owned ETS cache and broken `global:trans` locks with node-local `hb_name:singleton` workers scoped per store and process
* fixes `hb_maps:get` calls that incorrectly used `Opts` as the missing-value default
* completes the protocol’s ASCII whitespace trimming for comma-separated `Assign-To` members
* regression tests + code formatting 