### PR TITLE
fix: preserve signed TX fields during parsing

### DIFF
--- a/src/preloaded/codec/dev_tx.erl
+++ b/src/preloaded/codec/dev_tx.erl
@@ -1175,6 +1175,57 @@ real_2048_bit_rsa_tx_test() ->
         [<<"tj76flZk936u0S2owyEzUFBvBAYle9Al5LH8zJ7icNc">>]
     ).
 
+format_one_roundtrip_test() ->
+    Signed = ar_tx:sign(
+        #tx{
+            format = 1,
+            target = crypto:strong_rand_bytes(32),
+            quantity = 1,
+            reward = 1
+        },
+        hb:wallet()
+    ),
+    Structured = hb_message:convert(
+        Signed,
+        <<"structured@1.0">>,
+        <<"tx@1.0">>,
+        #{}
+    ),
+    Roundtripped = hb_message:convert(
+        Structured,
+        <<"tx@1.0">>,
+        <<"structured@1.0">>,
+        #{}
+    ),
+    ?assertEqual(Signed#tx.tags, Roundtripped#tx.tags),
+    ?assert(ar_tx:verify(Roundtripped)).
+
+duplicate_tags_roundtrip_test() ->
+    Signed = ar_tx:sign(
+        #tx{
+            format = 2,
+            tags = [
+                {<<"authority-actions">>, <<"Deposit">>},
+                {<<"authority-actions">>, <<"Withdraw">>}
+            ]
+        },
+        hb:wallet()
+    ),
+    Structured = hb_message:convert(
+        Signed,
+        <<"structured@1.0">>,
+        <<"tx@1.0">>,
+        #{}
+    ),
+    Roundtripped = hb_message:convert(
+        Structured,
+        <<"tx@1.0">>,
+        <<"structured@1.0">>,
+        #{}
+    ),
+    ?assertEqual(Signed#tx.tags, Roundtripped#tx.tags),
+    ?assert(ar_tx:verify(Roundtripped)).
+
 real_no_data_tx_test() ->
     do_real_tx_verify(
         <<"N1Cyu67lQtmZMQlIZVFpNfy3xz6k9wEZ8LLeDbOebbk">>,

--- a/src/preloaded/codec/dev_tx_to.erl
+++ b/src/preloaded/codec/dev_tx_to.erl
@@ -61,10 +61,20 @@ data_size_field(Prefix, Map, Opts) ->
 
 excluded_tags(TX, TABM, Opts) ->
     lib_arweave_common:excluded_tags(TX, TABM, Opts) ++
+    exclude_format_tag(TX, TABM, Opts) ++
     exclude_quantity_tag(TX, TABM, Opts) ++
     exclude_reward_tag(TX, TABM, Opts) ++
     exclude_data_root_tag(TX) ++
     exclude_data_size_tag(TX).
+
+%% @doc Exclude a format-one structural field from the transaction's tags.
+exclude_format_tag(#tx{ format = 1 }, TABM, _Opts) ->
+    case maps:get(<<"format">>, TABM, undefined) of
+        <<"1">> -> [<<"format">>];
+        _ -> []
+    end;
+exclude_format_tag(_TX, _TABM, _Opts) ->
+    [].
 
 decoded_field(Prefix, Key, Map, Default, Decode, Opts) ->
     case hb_maps:find(<<Prefix/binary, Key/binary>>, Map, Opts) of

--- a/src/preloaded/codec/lib_arweave_common.erl
+++ b/src/preloaded/codec/lib_arweave_common.erl
@@ -362,13 +362,20 @@ bundle_commitment_key(Tags, Opts) ->
 %% @doc Check whether a list of key-value pairs contains only normalized keys.
 normal_tags(BaseFields, Tags) ->
     ReservedFields = [<<"ao-types">>, <<"data">> | BaseFields],
-    lists:all(
-        fun({Key, _}) ->
-            hb_util:to_lower(hb_ao:normalize_key(Key)) =:= Key andalso
-            not lists:member(Key, ReservedFields)
-        end,
-        Tags
-    ).
+    NormalizedKeys =
+        [
+            hb_util:to_lower(hb_ao:normalize_key(Key))
+        ||
+            {Key, _} <- Tags
+        ],
+    length(NormalizedKeys) =:= length(lists:usort(NormalizedKeys)) andalso
+        lists:all(
+            fun({Key, _}) ->
+                hb_util:to_lower(hb_ao:normalize_key(Key)) =:= Key andalso
+                not lists:member(Key, ReservedFields)
+            end,
+            Tags
+        ).
 
 %% @doc Return the original tags of an item if it is applicable. Otherwise,
 %% return `undefined'.


### PR DESCRIPTION
Keep `format: 1` structural field out of reconstructed Arweave tags, and correctly preserve original tag lists when normalized keys collide. Adds testing for both cases, roundtripping exactly for signed transaction verification.