### PR TITLE
impr: Allow `~hyperbuddy@1.0/format` calls to specify link resolution depth

### DIFF
--- a/src/core/resolver/hb_link.erl
+++ b/src/core/resolver/hb_link.erl
@@ -141,24 +141,29 @@ remove_link_specifier(Key) ->
     end.
 
 %% @doc Format a link as a short string suitable for printing. Checks the node
-%% options (optionally) given, to see if it should resolve the link to a value
-%% before printing.
+%% options (optionally) given, to see how many link levels it should resolve
+%% before printing. `true' resolves links without a depth limit.
 format(Link) -> format(Link, #{}).
 format(Link, Opts) ->
     format(Link, Opts, 0).
 format(Link, Opts, Indent) ->
     case hb_opts:get(debug_resolve_links, false, Opts) of
-        true ->
-            try
-                hb_format:message(
-                    hb_cache:ensure_all_loaded(Link, Opts),
-                    Opts,
-                    Indent
-                )
-            catch
-                _:_ -> << "!UNRESOLVABLE! ", (format_unresolved(Link, Opts))/binary >>
-            end;
-        false -> format_unresolved(Link, Opts, Indent)
+        true -> format_resolved(Link, Opts, Indent);
+        Depth when is_integer(Depth) andalso Depth > 0 ->
+            format_resolved(
+                Link,
+                Opts#{ <<"debug-resolve-links">> => Depth - 1 },
+                Indent
+            );
+        _ -> format_unresolved(Link, Opts, Indent)
+    end.
+
+%% @doc Resolve and format one link using the remaining resolution depth.
+format_resolved(Link, Opts, Indent) ->
+    try
+        hb_format:message(hb_cache:ensure_loaded(Link, Opts), Opts, Indent)
+    catch
+        _:_ -> << "!UNRESOLVABLE! ", (format_unresolved(Link, Opts))/binary >>
     end.
 
 %% @doc Format a link without resolving it.

--- a/src/preloaded/node/dev_hyperbuddy.erl
+++ b/src/preloaded/node/dev_hyperbuddy.erl
@@ -94,6 +94,8 @@ events(_, _Req, _Opts) ->
 %% ```
 %% GET /.../~hyperbuddy@1.0/format=request?truncate-keys=20
 %% ```
+%% `resolve-links' sets the link depth to resolve. It defaults to the node's
+%% `debug-resolve-links' option; `true' resolves all levels.
 format(Base, Req, Opts) ->
     % Find the scope of the environment that should be printed.
     Scope =
@@ -122,11 +124,22 @@ format(Base, Req, Opts) ->
         true ->
             CombinedMsg
         end,
-    MsgLoaded = hb_cache:ensure_all_loaded(MsgBeforeLoad, Opts),
+    ResolveLinksValue =
+        hb_maps:get(
+            <<"resolve-links">>,
+            Req,
+            hb_opts:get(debug_resolve_links, false, Opts),
+            Opts
+        ),
+    ResolveLinks =
+        case hb_util:safe_int(ResolveLinksValue) of
+            {ok, Depth} -> Depth;
+            {error, invalid} -> hb_util:bool(ResolveLinksValue)
+        end,
     TruncateKeys =
         case hb_maps:get(<<"truncate-keys">>, Req, infinity, Opts) of
             infinity -> infinity;
-            Value -> hb_util:int(Value)
+            MaxKeys -> hb_util:int(MaxKeys)
         end,
     ?event(debug_format, {using_truncation, TruncateKeys}),
     {ok,
@@ -134,10 +147,11 @@ format(Base, Req, Opts) ->
             <<"body">> =>
                 hb_util:bin(
                     hb_format:message(
-                        MsgLoaded,
+                        MsgBeforeLoad,
                         Opts#{
                             <<"linkify-mode">> => discard,
                             <<"cache-control">> => [<<"no-cache">>, <<"no-store">>],
+                            <<"debug-resolve-links">> => ResolveLinks,
                             <<"debug-print-truncate">> => TruncateKeys
                         }
                     )


### PR DESCRIPTION
Let debug formatting resolve links to a configured integer depth, decrementing the budget at each linked message.`~hyperbuddy@1.0` forwards its resolve-links request setting to the formatter and otherwise inherits the node default, avoiding an unconditional recursive cache load.