### PR TITLE
fix: escape `~httpsig@1.0` header values during encoding for the wire

### DIFF
--- a/src/core/util/hb_escape.erl
+++ b/src/core/util/hb_escape.erl
@@ -9,6 +9,7 @@
 %%% strings because transmission.
 -module(hb_escape).
 -export([encode/1, decode/1, encode_keys/2, decode_keys/2]).
+-export([encode_header/1, decode_header/1]).
 -export([encode_quotes/1, decode_quotes/1]).
 -export([encode_ampersand/1]).
 -include_lib("eunit/include/eunit.hrl").
@@ -30,6 +31,18 @@ decode(<<$%, _/binary>>, Original) ->
     iolist_to_binary(lists:reverse(percent_unescape(Original, [])));
 decode(<<_C, Rest/binary>>, Original) ->
     decode(Rest, Original).
+
+encode_header(<<>>) -> <<>>;
+encode_header(<<$\\, Rest/binary>>) -> <<"\\\\", (encode_header(Rest))/binary>>;
+encode_header(<<$\r, Rest/binary>>) -> <<"\\r", (encode_header(Rest))/binary>>;
+encode_header(<<$\n, Rest/binary>>) -> <<"\\n", (encode_header(Rest))/binary>>;
+encode_header(<<C, Rest/binary>>) -> <<C, (encode_header(Rest))/binary>>.
+
+decode_header(<<>>) -> <<>>;
+decode_header(<<$\\, $\\, Rest/binary>>) -> <<$\\, (decode_header(Rest))/binary>>;
+decode_header(<<$\\, $r, Rest/binary>>) -> <<$\r, (decode_header(Rest))/binary>>;
+decode_header(<<$\\, $n, Rest/binary>>) -> <<$\n, (decode_header(Rest))/binary>>;
+decode_header(<<C, Rest/binary>>) -> <<C, (decode_header(Rest))/binary>>.
 
 %% @doc Encode a string with escaped quotes.
 encode_quotes(String) when is_binary(String) ->

--- a/src/preloaded/codec/dev_httpsig_conv.erl
+++ b/src/preloaded/codec/dev_httpsig_conv.erl
@@ -44,7 +44,15 @@ from(Link, _Req, _Opts) when ?IS_LINK(Link) -> {ok, Link};
 from(HTTP, _Req, Opts) ->
     % First, parse all headers excluding the signature-related headers, as they
     % are handled separately.
-    Headers = hb_maps:without([<<"body">>], HTTP, Opts),
+    Headers =
+        maps:map(
+            fun(<<"signature">>, Value) -> Value;
+               (<<"signature-input">>, Value) -> Value;
+               (_Key, Value) when is_binary(Value) -> hb_escape:decode_header(Value);
+               (_Key, Value) -> Value
+            end,
+            hb_maps:without([<<"body">>], HTTP, Opts)
+        ),
     % Next, we need to potentially parse the body, get the ordering of the body
     % parts, and add them to the TABM.
     {OrderedBodyKeys, BodyTABM} = body_to_tabm(HTTP, Opts),
@@ -786,7 +794,7 @@ field_to_http(Httpsig, {Name, Value}, Opts) when is_binary(Value) ->
         end,
     case maps:get(where, Opts, DefaultWhere) of
         headers ->
-            Httpsig#{ NormalizedName => Value };
+            Httpsig#{ NormalizedName => hb_escape:encode_header(Value) };
         body ->
             OldBody = hb_maps:get(<<"body">>, Httpsig, #{}, Opts),
             Httpsig#{ <<"body">> => OldBody#{ NormalizedName => Value } }

--- a/src/preloaded/test/hb_codec_test_vectors.erl
+++ b/src/preloaded/test/hb_codec_test_vectors.erl
@@ -100,6 +100,8 @@ test_suite() ->
             fun structured_field_atom_parsing_test/2},
         {<<"Structured field decimal parsing">>,
             fun structured_field_decimal_parsing_test/2},
+        {<<"Header escaping">>,
+            fun header_escaping_test/2},
         {<<"Unsigned id">>,
             fun unsigned_id_test/2},
         % Nested structures
@@ -575,6 +577,13 @@ structured_field_decimal_parsing_test(Codec, Opts) ->
     Msg = #{ integer_field => 1234567890 },
     Encoded = hb_message:convert(Msg, Codec, <<"structured@1.0">>, Opts),
     Decoded = hb_message:convert(Encoded, <<"structured@1.0">>, Codec, Opts),
+    ?assert(hb_message:match(Msg, Decoded, strict, Opts)).
+
+header_escaping_test(Codec, Opts) ->
+    Msg = hb_message:commit(#{ <<"description">> => <<"line 1\nline 2">> }, Opts, Codec),
+    Encoded = hb_message:convert(Msg, Codec, <<"structured@1.0">>, Opts),
+    Decoded = hb_message:convert(Encoded, <<"structured@1.0">>, Codec, Opts),
+    ?assert(hb_message:verify(Decoded, all, Opts)),
     ?assert(hb_message:match(Msg, Decoded, strict, Opts)).
 
 %% @doc Test that the data field is correctly managed when we have multiple


### PR DESCRIPTION
Allows the encoding of non-header compliant values into headers via `\` encoding. Supports `\\` such that escaping is fully idempotent.