### PR TITLE
docs: Add ulimit to eunit-all tests command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,10 @@ following:
    be lazy-loaded (linkified), giving them different semantics.
 4. Before submitting any code as 'complete', you **must** validate that your
    new changes do not break any existing tests across the full suite using
-   `rebar3 eunit-all`. Note that `rebar3 eunit` does not invoke the preloaded
-   device tests, which can often highlight subtle errors. Remember, you are 
-   never being asked to write a 'toy' implementation of features or changed. Your
-   code must actually work in-production.
+   `ulimit -n 65536 && rebar3 eunit-all`. Raising the file descriptor limit
+   avoids `emfile` errors during the full suite. Note that `rebar3 eunit` does
+   not invoke the preloaded device tests, which can often highlight subtle
+   errors. Remember, you are never being asked to write a 'toy' implementation 
+   of features or changed. Your code must actually work in-production.
 5. Always attempt to leave the codebase in a better state than you found it. More
    precise, clear, and minimal -- while maintaining the existing featureset.

--- a/docs/build/extending-hyperbeam.md
+++ b/docs/build/extending-hyperbeam.md
@@ -74,7 +74,7 @@ Then iterate with:
 rebar3 device package    # build _hb_device_*.beam-archive.zip
 rebar3 device verify     # check archive invariants
 rebar3 device test       # run dev_<root> EUnit against a fresh store
-rebar3 eunit-all         # run core EUnit plus packaged-device EUnit
+ulimit -n 65536 && rebar3 eunit-all # run core plus packaged-device EUnit
 rebar3 device publish    # sign and upload to Arweave
 ```
 

--- a/src/forge/plugin/priv/_README.md
+++ b/src/forge/plugin/priv/_README.md
@@ -19,7 +19,7 @@ rebar3 device verify
 
 ```sh
 rebar3 device test
-rebar3 eunit-all
+ulimit -n 65536 && rebar3 eunit-all
 ```
 
 ## Local Node


### PR DESCRIPTION
Add ulimit to the `rebar3 eunit-all` command to prevent agents from encountering the `EMFILE` error.