### PR TITLE
chore: add local store cacheing of derived Arweave data

### DIFF
--- a/src/core/resolver/hb_opts.erl
+++ b/src/core/resolver/hb_opts.erl
@@ -476,6 +476,7 @@ raw_default_message() ->
                     <<"store-module">> => hb_store_arweave,
                     <<"name">> => <<"cache-arweave">>,
                     <<"index-store">> => [?DEFAULT_PRIMARY_STORE],
+                    <<"local-store">> => [?DEFAULT_PRIMARY_STORE],
                     <<"remote-index">> => true,
                     <<"arweave-node">> => ?DEFAULT_GATEWAY
                 },


### PR DESCRIPTION
Adds the `local-store` option to the `hb_store_arweave` in the default config such that downloaded messages themselves are cached locally.