### PR TITLE
fix: ignore malformed `~cookie@1.0` request parameters

### DIFF
--- a/src/preloaded/auth/dev_cookie.erl
+++ b/src/preloaded/auth/dev_cookie.erl
@@ -294,7 +294,9 @@ from_cookie(Cookies, Req, Opts) when is_list(Cookies) ->
         ),
     {ok, MergedParsed};
 from_cookie(Cookie, _Req, _Opts) when is_binary(Cookie) ->
-    BinaryCookiePairs = split(semicolon, Cookie),
+    BinaryCookiePairs = [
+        Pair || Pair <- split(semicolon, Cookie), binary:match(Pair, <<"=">>) =/= nomatch
+    ],
     KeyValList =
         lists:map(
             fun(BinaryCookiePair) ->

--- a/src/preloaded/auth/dev_cookie_test_vectors.erl
+++ b/src/preloaded/auth/dev_cookie_test_vectors.erl
@@ -800,3 +800,12 @@ to_with_private_cookies_does_not_load_body_test() ->
         {ok, #{ <<"set-cookie">> := [<<"sid=\"v1\"">>] }},
         dev_cookie:to(Msg, #{ <<"format">> => <<"set-cookie">> }, #{})
     ).
+
+malformed_cookie_pair_test() ->
+    {ok, Msg} = dev_cookie:from(
+        #{ <<"cookie">> => <<68, 3, 67, 56, "; sid=valid">> }, #{}, #{}
+    ),
+    ?assertEqual(
+        {ok, #{ <<"sid">> => <<"valid">> }},
+        dev_cookie:extract(Msg, #{}, #{})
+    ).


### PR DESCRIPTION
Filters invalid request cookie elements from inbound messages.