### PR TITLE
feat(`hb_store_arlmdb`): Streaming remote LMDB stores on Arweave

### DIFF
--- a/src/core/resolver/hb_opts.erl
+++ b/src/core/resolver/hb_opts.erl
@@ -65,6 +65,15 @@
     <<"name">> => <<"cache-mainnet/lmdb">>,
     <<"store-module">> => hb_store_lmdb
 }).
+%% The published Arweave offset index: a mined transaction holding
+%% 8,560,638,056 packed rows mapping ANS-104 data item IDs to their weave
+%% byte ranges, read in place by `hb_store_arlmdb'. Offset resolution
+%% through it is served by Arweave peers alone.
+-define(DEFAULT_OFFSET_INDEX, #{
+    <<"store-module">> => hb_store_arlmdb,
+    <<"name">> => <<"published-offset-index">>,
+    <<"root">> => <<"7vg2832WFsisEcBr1oBQ8ldc4EGOkjQdwW46hDvJsOs">>
+}).
 -define(DEFAULT_GATEWAY, <<"https://arweave.net">>).
 -define(
     DEFAULT_HTTP_OPTS,
@@ -475,10 +484,10 @@ raw_default_message() ->
                 #{
                     <<"store-module">> => hb_store_arweave,
                     <<"name">> => <<"cache-arweave">>,
-                    <<"index-store">> => [?DEFAULT_PRIMARY_STORE],
+                    <<"index-store">> =>
+                        [?DEFAULT_PRIMARY_STORE, ?DEFAULT_OFFSET_INDEX],
                     <<"local-store">> => [?DEFAULT_PRIMARY_STORE],
-                    <<"remote-index">> => true,
-                    <<"arweave-node">> => ?DEFAULT_GATEWAY
+                    <<"remote-index">> => false
                 },
                 #{
                     <<"store-module">> => hb_store_gateway,

--- a/src/core/store/hb_store_arlmdb.erl
+++ b/src/core/store/hb_store_arlmdb.erl
@@ -28,6 +28,14 @@
 %%% `pad' bytes at page offset `24 + I * pad', with `lower bsr 1' rows in the
 %%% page, ascending strictly.
 %%%
+%%% Fetched chunks are retained in the stores named by the `chunk-store' key
+%%% of the store message, defaulting to a volatile store that expires every
+%%% five minutes; `[]' retains nothing. Published containers are
+%%% defragmented -- the first chunk carries the meta pages, main root and
+%%% sub-root, branch pages cluster four to a chunk, and leaves follow in key
+%%% order -- so the chunks a read retains answer most of the reads that
+%%% follow it.
+%%%
 %%% Every container shape outside this contract is refused with a distinct
 %%% error, never treated as a miss, and a failed byte-range fetch surfaces as
 %%% `{error, {unavailable, ...}}': a proven miss requires a successfully read
@@ -40,6 +48,12 @@
 
 %%% The byte-level constants of the LMDB 1.0 container.
 -define(PAGE_SIZE, 65536).
+%% An Arweave chunk holds four pages, and a published container's data begins
+%% on a chunk boundary, so every page fetch lies within one chunk of the
+%% container.
+-define(CHUNK_SIZE, (4 * ?PAGE_SIZE)).
+%% The default chunk store expires its whole table on this cadence.
+-define(CHUNK_TTL_MS, 300000).
 -define(PAGE_HDR, 24).
 -define(MDB_MAGIC, 16#BEEFC0DE).
 -define(MDB_VERSION, 3).
@@ -51,7 +65,8 @@
 
 %% @doc Resolve the root transaction's weave location and tags, validate the
 %% container's meta page, and return the store instance. The instance holds
-%% only the location and tags: pages are never cached.
+%% only the location and tags; fetched chunks are retained by the chunk
+%% store alone.
 start(StoreOpts = #{ <<"root">> := Root }, _Req, _Opts) ->
     maybe
         {ok, Start, Size} ?= read_location(Root, StoreOpts),
@@ -186,7 +201,7 @@ read_meta(Start, Size, Opts) ->
             Size >= 2 * ?PAGE_SIZE
                 orelse {error, {'invalid-container-size', Size}},
         {ok, <<Page0:?PAGE_SIZE/binary, Page1:?PAGE_SIZE/binary>>} ?=
-            fetch(Start, 0, 2 * ?PAGE_SIZE, Opts),
+            fetch(Start, Size, 0, 2 * ?PAGE_SIZE, Opts),
         {ok, Meta0} ?= parse_meta(Page0),
         {ok, Meta1} ?= parse_meta(Page1),
         validate_meta(
@@ -415,17 +430,72 @@ read_page(PgNo, #{ last_page := LastPage, start := Start, size := Size }, Opts) 
         true ?=
             PgNo =< LastPage andalso (PgNo + 1) * ?PAGE_SIZE =< Size
                 orelse {error, {'invalid-page-number', PgNo}},
-        fetch(Start, PgNo * ?PAGE_SIZE, ?PAGE_SIZE, Opts)
+        fetch(Start, Size, PgNo * ?PAGE_SIZE, ?PAGE_SIZE, Opts)
     end.
 
-%% @doc Fetch a byte range of the container from the weave. Failed fetches are
-%% unavailability, never misses.
-fetch(Start, Offset, Length, Opts) ->
-    case hb_store_arweave:read_chunks(Start + Offset, Length, Opts) of
-        {ok, Data} when byte_size(Data) =:= Length -> {ok, Data};
-        {ok, Data} -> {error, {unavailable, {short_read, byte_size(Data)}}};
+%% @doc Fetch a byte range of the container, sliced from the chunk that holds
+%% it. Pages align within the container's chunks, so a range never spans two.
+%% Failed fetches are unavailability, never misses.
+fetch(Start, Size, Offset, Length, Opts) ->
+    Chunk = Offset div ?CHUNK_SIZE,
+    Within = Offset - (Chunk * ?CHUNK_SIZE),
+    maybe
+        true ?=
+            Within + Length =< ?CHUNK_SIZE
+                orelse {error, {'invalid-fetch-span', Offset, Length}},
+        {ok, Bytes} ?= read_chunk(Start, Size, Chunk, Opts),
+        true ?=
+            Within + Length =< byte_size(Bytes)
+                orelse {error, {unavailable, {short_read, byte_size(Bytes)}}},
+        {ok, binary:part(Bytes, Within, Length)}
+    end.
+
+%% @doc One whole chunk of the container, from the chunk store when it is
+%% held, and from the weave -- retained for the next read -- when it is not.
+%% The defragmented layout clusters the tree: the first chunk carries the
+%% meta pages, main root and sub-root, and a chunk holding one branch page
+%% holds its neighbours, so held chunks answer most of every descent.
+read_chunk(Start, Size, Chunk, Opts) ->
+    Stores = chunk_store(Opts),
+    Key =
+        <<
+            (hb_util:bin(Start))/binary, "/chunk=", (hb_util:bin(Chunk))/binary
+        >>,
+    case hb_store:read(Stores, Key, Opts) of
+        {ok, Bytes} -> {ok, Bytes};
+        _ -> fill_chunk(Stores, Key, Start, Size, Chunk, Opts)
+    end.
+
+%% @doc Fetch a chunk from the weave and retain it. Retention is best-effort:
+%% a store that refuses the write costs the next read a fetch, nothing more.
+fill_chunk(Stores, Key, Start, Size, Chunk, Opts) ->
+    ChunkStart = Chunk * ?CHUNK_SIZE,
+    Length = min(?CHUNK_SIZE, Size - ChunkStart),
+    case hb_store_arweave:read_chunks(Start + ChunkStart, Length, Opts) of
+        {ok, Bytes} when byte_size(Bytes) =:= Length ->
+            case hb_store:write(Stores, #{ Key => Bytes }, Opts) of
+                ok -> ok;
+                Refused -> ?event(store_arlmdb, {chunk_not_retained, Refused})
+            end,
+            {ok, Bytes};
+        {ok, Bytes} -> {error, {unavailable, {short_read, byte_size(Bytes)}}};
         Error -> {error, {unavailable, Error}}
     end.
+
+%% @doc The stores retaining fetched chunks, from the `chunk-store' key of
+%% the store message. The default is a volatile store named for the
+%% container, expiring wholesale every five minutes; `[]' retains nothing.
+chunk_store(#{ <<"chunk-store">> := Stores }) when is_list(Stores) -> Stores;
+chunk_store(#{ <<"chunk-store">> := Store }) -> [Store];
+chunk_store(StoreOpts = #{ <<"root">> := Root }) ->
+    Name = maps:get(<<"name">>, StoreOpts, Root),
+    [
+        #{
+            <<"store-module">> => hb_store_volatile,
+            <<"name">> => <<Name/binary, "-chunks">>,
+            <<"max-ttl-ms">> => ?CHUNK_TTL_MS
+        }
+    ].
 
 %%% Tests
 
@@ -535,4 +605,28 @@ invalid_container_test() ->
     ?assertMatch(
         {error, {'invalid-main-flags', 0}},
         hb_store:start([Store])
+    ).
+
+%% @doc Retained chunks serve repeated reads without the weave: a key looked
+%% up once answers again through a store whose routes are gone, while an
+%% indexed key whose leaf chunk was never fetched cannot. The second key's
+%% unavailability reaches the store manager, which reports an exhausted
+%% store list as its terminal miss.
+chunk_retention_test_() ->
+    {timeout, 120, fun chunk_retention/0}.
+chunk_retention() ->
+    Store = (test_store())#{ <<"name">> => <<?LIVE_INDEX/binary, "-cached">> },
+    Key =
+        <<"~arweave@2.9/offset="
+            "AAAAhyV8_NwududSxuraAj7DLWiZHDTqVKWrZglpNok">>,
+    {ok, First} = hb_store:read([Store], Key, #{}),
+    Unrouted = Store#{ <<"routes">> => [] },
+    ?assertEqual({ok, First}, hb_store:read([Unrouted], Key, #{})),
+    Fresh =
+        <<"~arweave@2.9/offset="
+            "KgADUJYkEY0dbUKTI3aDZy2c_nb4WLh7VDh2ZHrb1yY">>,
+    ?assertMatch({error, _}, hb_store:read([Unrouted], Fresh, #{})),
+    ?assertMatch(
+        {ok, #{ <<"start">> := 381838173656091 }},
+        hb_store:read([Store], Fresh, #{})
     ).

--- a/src/core/store/hb_store_arlmdb.erl
+++ b/src/core/store/hb_store_arlmdb.erl
@@ -457,9 +457,13 @@ fetch(Start, Size, Offset, Length, Opts) ->
 %% holds its neighbours, so held chunks answer most of every descent.
 read_chunk(Start, Size, Chunk, Opts) ->
     Stores = chunk_store(Opts),
+    % The key is the `~arweave@2.9' device's own address for the chunk: the
+    % 1-based absolute weave offset of its first byte, so every store and
+    % device retaining weave chunks shares one namespace.
     Key =
         <<
-            (hb_util:bin(Start))/binary, "/chunk=", (hb_util:bin(Chunk))/binary
+            "~arweave@2.9/chunk=",
+            (hb_util:bin(Start + (Chunk * ?CHUNK_SIZE) + 1))/binary
         >>,
     case hb_store:read(Stores, Key, Opts) of
         {ok, Bytes} -> {ok, Bytes};

--- a/src/core/store/hb_store_arlmdb.erl
+++ b/src/core/store/hb_store_arlmdb.erl
@@ -1,0 +1,538 @@
+%%% @doc A read-only store that serves keys from a published Arweave index:
+%%% a transaction whose data is an LMDB 1.0 container of fixed-width rows, and
+%%% whose tags make the index self-describing. The store fetches the container
+%%% in place with byte-range requests -- it never downloads the file.
+%%%
+%%% The root transaction's tags parameterize every lookup:
+%%% ```
+%%%     device:            `lmdb@1.0', the container format.
+%%%     prefix:            Keys that the index serves. All other keys are
+%%%                        immediate misses, such that the store manager falls
+%%%                        through to the next store in the list.
+%%%     normalize-key:     A relative AO-Core path, resolved with the key's
+%%%                        remainder (after the prefix) as the request body.
+%%%                        The result is the row bits to seek to.
+%%%     normalize-result:  A relative AO-Core path, resolved with the matching
+%%%                        row as the request body. The result is the message
+%%%                        that the read returns.
+%%% '''
+%%% The container is an LMDB 1.0 file (`MDB_DATA_VERSION' 3, 64 KiB pages,
+%%% little-endian). Each page opens with a 24 byte header: the page number and
+%%% the transaction ID as 64 bit integers, then `pad', `flags', `lower', and
+%%% `upper' as 16 bit integers. The meta pages are pages 0 and 1; the one with
+%%% the higher transaction ID wins. The main database must be `MDB_DUPSORT bor
+%%% MDB_DUPFIXED' with a single-leaf root holding one `F_SUBDATA' node keyed
+%%% `<<0>>', whose data is the sub-database record: its `pad' is the row width
+%%% in bytes. The sub-database's branch pages hold full rows as node keys, and
+%%% its leaves are `P_LEAF2': no nodes and no slot array -- row `I' is the
+%%% `pad' bytes at page offset `24 + I * pad', with `lower bsr 1' rows in the
+%%% page, ascending strictly.
+%%%
+%%% Every container shape outside this contract is refused with a distinct
+%%% error, never treated as a miss, and a failed byte-range fetch surfaces as
+%%% `{error, {unavailable, ...}}': a proven miss requires a successfully read
+%%% leaf.
+-module(hb_store_arlmdb).
+-export([start/3, stop/3, scope/0, scope/1]).
+-export([read/3, resolve/3, type/3]).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%%% The byte-level constants of the LMDB 1.0 container.
+-define(PAGE_SIZE, 65536).
+-define(PAGE_HDR, 24).
+-define(MDB_MAGIC, 16#BEEFC0DE).
+-define(MDB_VERSION, 3).
+-define(MAIN_DB_FLAGS, 16#14). % MDB_DUPSORT bor MDB_DUPFIXED
+-define(P_BRANCH, 16#01).
+-define(P_LEAF, 16#02).
+-define(P_LEAF2, 16#20).
+-define(F_SUBDATA, 16#02).
+
+%% @doc Resolve the root transaction's weave location and tags, validate the
+%% container's meta page, and return the store instance. The instance holds
+%% only the location and tags: pages are never cached.
+start(StoreOpts = #{ <<"root">> := Root }, _Req, _Opts) ->
+    maybe
+        {ok, Start, Size} ?= read_location(Root, StoreOpts),
+        {ok, _Meta} ?= read_meta(Start, Size, StoreOpts),
+        {ok, Tags} ?= read_tags(Root, StoreOpts),
+        ?event(store_arlmdb,
+            {started, {root, Root}, {start, Start}, {size, Size}}
+        ),
+        {ok, #{ <<"start">> => Start, <<"size">> => Size, <<"tags">> => Tags }}
+    end.
+
+%% @doc The instance holds no processes: nothing to stop.
+stop(_StoreOpts, _Req, _NodeOpts) -> ok.
+
+%% @doc Reads are served by remote byte-range fetches.
+scope() -> remote.
+scope(#{ <<"scope">> := Scope }) -> Scope;
+scope(_) -> scope().
+
+%% @doc Index keys carry no links: resolution is the identity.
+resolve(_StoreOpts, #{ <<"resolve">> := Key }, _NodeOpts) -> {ok, Key}.
+
+%% @doc A key is `simple' when the index holds a row for it.
+type(StoreOpts, #{ <<"type">> := Key }, NodeOpts) ->
+    case read(StoreOpts, #{ <<"read">> => Key }, NodeOpts) of
+        {ok, _} -> {ok, simple};
+        Error -> Error
+    end.
+
+%% @doc Serve a read for a key under the index's prefix. All other keys are
+%% immediate misses, so that the store manager falls through cleanly.
+read(StoreOpts, #{ <<"read">> := Key }, _NodeOpts) ->
+    #{ <<"start">> := Start, <<"size">> := Size, <<"tags">> := Tags } =
+        hb_store:find(StoreOpts),
+    Prefix = maps:get(<<"prefix">>, Tags),
+    PrefixSize = byte_size(Prefix),
+    case Key of
+        <<Prefix:PrefixSize/binary, Suffix/binary>> ->
+            lookup(Suffix, Start, Size, Tags, StoreOpts);
+        _ ->
+            {error, not_found}
+    end.
+
+%% @doc Look up one key: normalize its remainder to the seek bits, descend to
+%% the first row at-or-after them, and normalize the row to the result.
+lookup(Suffix, Start, Size, Tags, Opts) ->
+    maybe
+        {ok, Seek} ?=
+            normalize(maps:get(<<"normalize-key">>, Tags), Suffix, Opts),
+        true ?= is_bitstring(Seek) orelse {error, {'invalid-seek', Seek}},
+        {ok, Meta} ?= read_meta(Start, Size, Opts),
+        {ok, SubDB} ?= read_main_db(Meta, Opts),
+        {ok, Row} ?= seek(Seek, SubDB, Meta, Opts),
+        ?event(store_arlmdb, {row_found, {suffix, Suffix}, {row, Row}}),
+        normalize(maps:get(<<"normalize-result">>, Tags), Row, Opts)
+    end.
+
+%% @doc Execute one of the index's tag paths as a relative AO-Core path, with
+%% the given binary as the body of the base message alone.
+normalize(Path, Body, Opts) ->
+    hb_ao:resolve(#{ <<"path">> => Path, <<"0.body">> => Body }, Opts).
+
+%% @doc Find the absolute weave offset and size of the root's data. The
+%% gateway reports the offset of the final byte, 1-indexed.
+read_location(Root, Opts) ->
+    Res =
+        hb_http:request(
+            #{
+                <<"method">> => <<"GET">>,
+                <<"path">> => <<"/arweave/tx/", Root/binary, "/offset">>
+            },
+            Opts
+        ),
+    case Res of
+        {ok, #{ <<"body">> := Body }} ->
+            Info = hb_json:decode(Body),
+            End = hb_util:int(maps:get(<<"offset">>, Info)),
+            Size = hb_util:int(maps:get(<<"size">>, Info)),
+            {ok, End - Size, Size};
+        Error ->
+            {error, {unavailable, {offset, Root, Error}}}
+    end.
+
+%% @doc Read and decode the root transaction's tags. Names and values arrive
+%% base64url-encoded in the gateway's JSON form.
+read_tags(Root, Opts) ->
+    Res =
+        hb_http:request(
+            #{
+                <<"method">> => <<"GET">>,
+                <<"path">> => <<"/arweave/tx/", Root/binary>>
+            },
+            Opts
+        ),
+    case Res of
+        {ok, #{ <<"body">> := Body }} ->
+            required_tags(
+                maps:from_list(
+                    [
+                        {hb_util:decode(Name), hb_util:decode(Value)}
+                    ||
+                        #{ <<"name">> := Name, <<"value">> := Value } <-
+                            maps:get(<<"tags">>, hb_json:decode(Body), [])
+                    ]
+                )
+            );
+        Error ->
+            {error, {unavailable, {tags, Root, Error}}}
+    end.
+
+%% @doc Require the tags that parameterize the index's lookups.
+required_tags(
+    Tags = #{
+        <<"device">> := <<"lmdb@1.0">>,
+        <<"prefix">> := _,
+        <<"normalize-key">> := _,
+        <<"normalize-result">> := _
+    }
+) ->
+    {ok, Tags};
+required_tags(#{ <<"device">> := Device }) when Device =/= <<"lmdb@1.0">> ->
+    {error, {'unsupported-container-device', Device}};
+required_tags(Tags) ->
+    {error, {'missing-tags', maps:keys(Tags)}}.
+
+%% @doc Read both meta pages and validate the container, returning the meta
+%% written by the most recent transaction. The returned meta also carries the
+%% container's weave location, parameterizing every page fetch beneath it.
+read_meta(Start, Size, Opts) ->
+    maybe
+        true ?=
+            Size >= 2 * ?PAGE_SIZE
+                orelse {error, {'invalid-container-size', Size}},
+        {ok, <<Page0:?PAGE_SIZE/binary, Page1:?PAGE_SIZE/binary>>} ?=
+            fetch(Start, 0, 2 * ?PAGE_SIZE, Opts),
+        {ok, Meta0} ?= parse_meta(Page0),
+        {ok, Meta1} ?= parse_meta(Page1),
+        validate_meta(
+            (newest_meta(Meta0, Meta1))#{ start => Start, size => Size }
+        )
+    end.
+
+%% @doc Parse a meta page: the `MDB_meta' record follows the page header.
+parse_meta(
+    <<
+        _:?PAGE_HDR/binary,
+        ?MDB_MAGIC:32/little, ?MDB_VERSION:32/little,
+        _Address:64/little, _MapSize:64/little,
+        DB0:48/binary, DB1:48/binary,
+        LastPage:64/little, TxnID:64/little,
+        _/binary
+    >>
+) ->
+    {ok, #{
+        db0 => parse_db(DB0),
+        db1 => parse_db(DB1),
+        last_page => LastPage,
+        txn => TxnID
+    }};
+parse_meta(
+    <<_:?PAGE_HDR/binary, Magic:32/little, Version:32/little, _/binary>>
+) ->
+    {error, {'invalid-meta', {magic, Magic}, {version, Version}}}.
+
+%% @doc Parse a 48 byte `MDB_db' record.
+parse_db(
+    <<
+        Pad:32/little, Flags:16/little, Depth:16/little,
+        _Branch:64/little, _Leaf:64/little, _Overflow:64/little,
+        Entries:64/little, Root:64/little
+    >>
+) ->
+    #{ pad => Pad, flags => Flags, depth => Depth,
+       entries => Entries, root => Root }.
+
+%% @doc Choose the meta page written by the most recent transaction.
+newest_meta(Meta0 = #{ txn := Txn0 }, #{ txn := Txn1 }) when Txn0 >= Txn1 ->
+    Meta0;
+newest_meta(_Meta0, Meta1) ->
+    Meta1.
+
+%% @doc Enforce the container invariants that this store implements.
+validate_meta(Meta = #{ db0 := DB0, db1 := DB1 }) ->
+    #{ pad := PageSize } = DB0,
+    #{ flags := MainFlags } = DB1,
+    #{ last_page := LastPage, size := Size } = Meta,
+    maybe
+        true ?=
+            PageSize =:= ?PAGE_SIZE
+                orelse {error, {'invalid-page-size', PageSize}},
+        true ?=
+            MainFlags =:= ?MAIN_DB_FLAGS
+                orelse {error, {'invalid-main-flags', MainFlags}},
+        true ?=
+            (LastPage + 1) * ?PAGE_SIZE =< Size
+                orelse {error, {'invalid-last-page', LastPage}},
+        {ok, Meta}
+    end.
+
+%% @doc Read the main database's root: a single-node leaf whose `F_SUBDATA'
+%% data is the record of the sub-database holding the index rows.
+read_main_db(Meta = #{ db1 := #{ root := Root, depth := Depth } }, Opts) ->
+    maybe
+        true ?= Depth =:= 1 orelse {error, {'invalid-main-depth', Depth}},
+        {ok, Page} ?= read_page(Root, Meta, Opts),
+        {ok, 1} ?= main_leaf_nodes(Page),
+        sub_db(Page, node(Page, 0))
+    end.
+
+%% @doc Require the main root to be an ordinary leaf with a single node.
+main_leaf_nodes(Page) ->
+    case parse_page(Page) of
+        {?P_LEAF, 1} -> {ok, 1};
+        {?P_LEAF, Count} -> {error, {'invalid-main-entries', Count}};
+        {Flags, _} -> {error, {'invalid-main-page-flags', Flags}}
+    end.
+
+%% @doc Require the main node to be the `<<0>>'-keyed sub-database reference
+%% and return the parsed sub-database record.
+sub_db(Page, Node = #{ key := Key, flags := Flags }) ->
+    maybe
+        true ?= Key =:= <<0>> orelse {error, {'invalid-main-key', Key}},
+        true ?=
+            Flags band ?F_SUBDATA =/= 0
+                orelse {error, {'invalid-main-node-flags', Flags}},
+        {ok, DB} ?= sub_db_record(node_data(Page, Node)),
+        {ok, parse_db(DB)}
+    end.
+
+%% @doc Require a full 48 byte sub-database record.
+sub_db_record(<<DB:48/binary, _/binary>>) -> {ok, DB};
+sub_db_record(Short) -> {error, {'invalid-sub-db', byte_size(Short)}}.
+
+%% @doc Descend the sub-database to the first row at-or-after the seek bits
+%% and require it to begin with them.
+seek(Seek, #{ pad := Pad, root := Root, depth := Depth }, Meta, Opts) ->
+    SeekSize = bit_size(Seek),
+    RowBits = Pad * 8,
+    maybe
+        true ?=
+            Pad > 0 andalso ?PAGE_HDR + Pad =< ?PAGE_SIZE
+                orelse {error, {'invalid-row-width', Pad}},
+        true ?=
+            SeekSize =< RowBits
+                orelse {error, {'invalid-seek-size', SeekSize}},
+        Target = <<Seek/bitstring, 0:(RowBits - SeekSize)>>,
+        {ok, Row} ?= descend(Root, Depth, Target, Pad, none, Meta, Opts),
+        true ?= byte_size(Row) =:= Pad orelse {error, {'invalid-row', Row}},
+        confirm(Row, Seek)
+    end.
+
+%% @doc Require the found row to begin with the seek bits: a row at-or-after
+%% the target that diverges within them is a proven miss.
+confirm(Row, Seek) ->
+    SeekSize = bit_size(Seek),
+    case Row of
+        <<Lead:SeekSize/bitstring, _/bitstring>> when Lead =:= Seek ->
+            {ok, Row};
+        _ ->
+            {error, not_found}
+    end.
+
+%% @doc Take one step of the descent. Branch pages recurse into the last child
+%% whose key is at-or-under the target, with the first node standing for
+%% negative infinity. The nearest next-node key seen on the way down is the
+%% successor row for targets that fall after every row in the leaf reached.
+descend(PgNo, Depth, Target, Pad, Next, Meta, Opts) ->
+    maybe
+        true ?= Depth > 0 orelse {error, {'invalid-depth', PgNo}},
+        {ok, Page} ?= read_page(PgNo, Meta, Opts),
+        step(parse_page(Page), Page, Depth, Target, Pad, Next, Meta, Opts)
+    end.
+
+%% @doc Recurse through a branch, search a fixed-width leaf, and refuse every
+%% other page kind.
+step({?P_BRANCH, Count}, Page, Depth, Target, Pad, Next, Meta, Opts) ->
+    Slot = branch_slot(Page, 1, Count, Target, 0),
+    NewNext =
+        if Slot + 1 < Count -> maps:get(key, node(Page, Slot + 1));
+        true -> Next
+        end,
+    descend(child(node(Page, Slot)), Depth - 1, Target, Pad, NewNext, Meta, Opts);
+step({Flags, Count}, Page, _Depth, Target, Pad, Next, _Meta, _Opts)
+        when Flags =:= (?P_LEAF bor ?P_LEAF2) ->
+    maybe
+        true ?=
+            ?PAGE_HDR + (Count * Pad) =< ?PAGE_SIZE
+                orelse {error, {'invalid-leaf-count', Count}},
+        case leaf_slot(Page, 0, Count, Pad, Target) of
+            Slot when Slot < Count -> {ok, row(Page, Slot, Pad)};
+            _ when Next =:= none -> {error, not_found};
+            _ -> {ok, Next}
+        end
+    end;
+step({Flags, _Count}, _Page, _Depth, _Target, _Pad, _Next, _Meta, _Opts) ->
+    {error, {'invalid-page-flags', Flags}}.
+
+%% @doc Find the last branch slot whose key is at-or-under the target. Keys
+%% ascend, so the scan stops at the first key over it.
+branch_slot(_Page, Slot, Count, _Target, Best) when Slot >= Count -> Best;
+branch_slot(Page, Slot, Count, Target, Best) ->
+    case maps:get(key, node(Page, Slot)) =< Target of
+        true -> branch_slot(Page, Slot + 1, Count, Target, Slot);
+        false -> Best
+    end.
+
+%% @doc Binary-search a fixed-width leaf for the first row at-or-after the
+%% target, returning its index (or the row count if every row is under it).
+leaf_slot(_Page, Low, High, _Pad, _Target) when Low >= High -> Low;
+leaf_slot(Page, Low, High, Pad, Target) ->
+    Mid = (Low + High) div 2,
+    case row(Page, Mid, Pad) < Target of
+        true -> leaf_slot(Page, Mid + 1, High, Pad, Target);
+        false -> leaf_slot(Page, Low, Mid, Pad, Target)
+    end.
+
+%% @doc The row at the given index of a fixed-width leaf.
+row(Page, Slot, Pad) ->
+    Offset = ?PAGE_HDR + (Slot * Pad),
+    <<_:Offset/binary, Row:Pad/binary, _/binary>> = Page,
+    Row.
+
+%% @doc Split a node page's header into its flags and slot count.
+parse_page(
+    <<
+        _PgNo:64/little, _Txn:64/little, _Pad:16/little,
+        Flags:16/little, Lower:16/little, _Upper:16/little,
+        _/binary
+    >>
+) ->
+    {Flags, Lower bsr 1}.
+
+%% @doc Read the node at the given slot. Slot offsets are relative to the end
+%% of the page header.
+node(Page, Slot) ->
+    SlotOffset = ?PAGE_HDR + (Slot * 2),
+    <<_:SlotOffset/binary, NodeOffset:16/little, _/binary>> = Page,
+    Offset = ?PAGE_HDR + NodeOffset,
+    <<
+        _:Offset/binary,
+        Lo:16/little, Hi:16/little, Flags:16/little, KSize:16/little,
+        Key:KSize/binary,
+        _/binary
+    >> = Page,
+    #{ lo => Lo, hi => Hi, flags => Flags, ksize => KSize,
+       key => Key, offset => Offset }.
+
+%% @doc A leaf node's data: after the key, rounded up to even length.
+node_data(Page, #{ offset := Offset, ksize := KSize }) ->
+    DataOffset = Offset + 8 + KSize + (KSize band 1),
+    <<_:DataOffset/binary, Data/binary>> = Page,
+    Data.
+
+%% @doc A branch node's child page number.
+child(#{ lo := Lo, hi := Hi, flags := Flags }) ->
+    Lo bor (Hi bsl 16) bor (Flags bsl 32).
+
+%% @doc Fetch a page by number, refusing page numbers outside the container.
+read_page(PgNo, #{ last_page := LastPage, start := Start, size := Size }, Opts) ->
+    maybe
+        true ?=
+            PgNo =< LastPage andalso (PgNo + 1) * ?PAGE_SIZE =< Size
+                orelse {error, {'invalid-page-number', PgNo}},
+        fetch(Start, PgNo * ?PAGE_SIZE, ?PAGE_SIZE, Opts)
+    end.
+
+%% @doc Fetch a byte range of the container from the weave. Failed fetches are
+%% unavailability, never misses.
+fetch(Start, Offset, Length, Opts) ->
+    case hb_store_arweave:read_chunks(Start + Offset, Length, Opts) of
+        {ok, Data} when byte_size(Data) =:= Length -> {ok, Data};
+        {ok, Data} -> {error, {unavailable, {short_read, byte_size(Data)}}};
+        Error -> {error, {unavailable, Error}}
+    end.
+
+%%% Tests
+
+%% The live offset index: maps `~arweave@2.9/offset=<id>' keys to the weave
+%% locations of ANS-104 data items.
+-define(LIVE_INDEX, <<"7vg2832WFsisEcBr1oBQ8ldc4EGOkjQdwW46hDvJsOs">>).
+%% A mined LMDB container that predates the published-index container format.
+-define(OLD_CONTAINER, <<"b159UDeD87YEFujWBMM8bISZ8DL8Wm1jLa-Bs_LQGAw">>).
+
+%% @doc A store message for the live index. The instance registry is keyed by
+%% name, so the root doubles as the name and instances persist across tests.
+test_store() ->
+    #{
+        <<"store-module">> => hb_store_arlmdb,
+        <<"name">> => ?LIVE_INDEX,
+        <<"root">> => ?LIVE_INDEX
+    }.
+
+%% @doc The live index resolves indexed data item IDs to their weave
+%% locations through the full store API.
+read_indexed_offset_test() ->
+    Store = test_store(),
+    ok = hb_store:start([Store]),
+    ?assertMatch(
+        {ok, #{ <<"start">> := 381852134215637, <<"length">> := 3947 }},
+        hb_store:read(
+            [Store],
+            <<"~arweave@2.9/offset=AAAAhyV8_NwududSxuraAj7DLWiZHDTqVKWrZglpNok">>,
+            #{}
+        )
+    ),
+    ?assertMatch(
+        {ok, #{ <<"start">> := 381680833668862, <<"length">> := 1356 }},
+        hb_store:read(
+            [Store],
+            <<"~arweave@2.9/offset=1QAAJqd60JFNvY3lBfIS5CFPjXteQSHMTp8cuvBJuHA">>,
+            #{}
+        )
+    ).
+
+%% @doc The index holds data items alone: an L1 transaction ID is a proven
+%% miss, found by reading the leaf where its row would sit.
+unindexed_key_test() ->
+    Store = test_store(),
+    ok = hb_store:start([Store]),
+    ?assertEqual(
+        {error, not_found},
+        hb_store:read(
+            [Store],
+            <<"~arweave@2.9/offset=", (?OLD_CONTAINER)/binary>>,
+            #{}
+        )
+    ).
+
+%% @doc Keys outside the index's prefix are served by the other stores in the
+%% list, and index keys fall through the stores ahead of it.
+fallthrough_test() ->
+    Local = hb_test_utils:test_store(hb_store_fs),
+    Stores = [Local, test_store()],
+    ok = hb_store:start(Stores),
+    ok = hb_store:write(Stores, #{ <<"local-key">> => <<"local-value">> }, #{}),
+    ?assertEqual(
+        {ok, <<"local-value">>},
+        hb_store:read(Stores, <<"local-key">>, #{})
+    ),
+    ?assertMatch(
+        {ok, #{ <<"start">> := 381852134215637, <<"length">> := 3947 }},
+        hb_store:read(
+            Stores,
+            <<"~arweave@2.9/offset=AAAAhyV8_NwududSxuraAj7DLWiZHDTqVKWrZglpNok">>,
+            #{}
+        )
+    ).
+
+%% @doc `hb_store_arweave' finds the offsets of items that its key-value index
+%% lacks from a published index in the same `index-store' list.
+read_offset_fallback_test() ->
+    ArweaveStore =
+        #{
+            <<"store-module">> => hb_store_arweave,
+            <<"index-store">> => [test_store()]
+        },
+    ok = hb_store:start([ArweaveStore]),
+    ?assertMatch(
+        {ok, #{
+            <<"codec-device">> := <<"ans104@1.0">>,
+            <<"version">> := 2,
+            <<"start-offset">> := 381852134215637,
+            <<"length">> := 3947
+        }},
+        hb_store_arweave:read_offset(
+            ArweaveStore,
+            <<"AAAAhyV8_NwududSxuraAj7DLWiZHDTqVKWrZglpNok">>,
+            #{}
+        )
+    ).
+
+%% @doc A mined LMDB file that is not in the container format this store
+%% implements is refused loudly at start, never silently skipped.
+invalid_container_test() ->
+    Store =
+        #{
+            <<"store-module">> => hb_store_arlmdb,
+            <<"name">> => ?OLD_CONTAINER,
+            <<"root">> => ?OLD_CONTAINER
+        },
+    ?assertMatch(
+        {error, {'invalid-main-flags', 0}},
+        hb_store:start([Store])
+    ).

--- a/src/core/store/hb_store_arlmdb.erl
+++ b/src/core/store/hb_store_arlmdb.erl
@@ -18,8 +18,8 @@
 %%% '''
 %%% The container is an LMDB 1.0 file (`MDB_DATA_VERSION' 3, 64 KiB pages,
 %%% little-endian). Each page opens with a 24 byte header: the page number and
-%%% the transaction ID as 64 bit integers, then `pad', `flags', `lower', and
-%%% `upper' as 16 bit integers. The meta pages are pages 0 and 1; the one with
+%%% the LMDB internal transaction as 64 bit ints, then `pad', `flags',
+%%% `lower', and `upper' as 16 bit integers. The meta pages are pages 0 and 1; the one with
 %%% the higher transaction ID wins. The main database must be `MDB_DUPSORT bor
 %%% MDB_DUPFIXED' with a single-leaf root holding one `F_SUBDATA' node keyed
 %%% `<<0>>', whose data is the sub-database record: its `pad' is the row width
@@ -583,7 +583,7 @@ read_offset_fallback_test() ->
         {ok, #{
             <<"codec-device">> := <<"ans104@1.0">>,
             <<"version">> := 2,
-            <<"start-offset">> := 381852134215637,
+            <<"start">> := 381852134215637,
             <<"length">> := 3947
         }},
         hb_store_arweave:read_offset(

--- a/src/core/store/hb_store_arlmdb.erl
+++ b/src/core/store/hb_store_arlmdb.erl
@@ -16,11 +16,16 @@
 %%%                        row as the request body. The result is the message
 %%%                        that the read returns.
 %%% '''
+%%% Reads answer with one row's message. Lists answer with the ascending run
+%%% of rows sharing the normalized key's bits, each normalized as a read's
+%%% row is, resumed inclusively from the raw row bits of the request's
+%%% `from' and bounded by its `limit' (1,000 rows when unnamed).
+%%%
 %%% The container is an LMDB 1.0 file (`MDB_DATA_VERSION' 3, 64 KiB pages,
-%%% little-endian). Each page opens with a 24 byte header: the page number and
-%%% the LMDB internal transaction as 64 bit ints, then `pad', `flags',
-%%% `lower', and `upper' as 16 bit integers. The meta pages are pages 0 and 1; the one with
-%%% the higher transaction ID wins. The main database must be `MDB_DUPSORT bor
+%%% little-endian). Each page opens with a 24 byte header: the page number
+%%% and the LMDB internal transaction as 64 bit ints, then `pad', `flags',
+%%% `lower', and `upper' as 16 bit integers. The meta pages are pages 0 and
+%%% 1; the one with the higher transaction ID wins. The main database must be `MDB_DUPSORT bor
 %%% MDB_DUPFIXED' with a single-leaf root holding one `F_SUBDATA' node keyed
 %%% `<<0>>', whose data is the sub-database record: its `pad' is the row width
 %%% in bytes. The sub-database's branch pages hold full rows as node keys, and
@@ -42,7 +47,7 @@
 %%% leaf.
 -module(hb_store_arlmdb).
 -export([start/3, stop/3, scope/0, scope/1]).
--export([read/3, resolve/3, type/3]).
+-export([read/3, list/3, resolve/3, type/3]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -108,6 +113,53 @@ read(StoreOpts, #{ <<"read">> := Key }, _NodeOpts) ->
             lookup(Suffix, Start, Size, Tags, StoreOpts);
         _ ->
             {error, not_found}
+    end.
+
+%% @doc Serve a bounded ascending run of rows for a key under the index's
+%% prefix. `from' -- raw row bits, sought inclusively -- resumes a run, and
+%% `limit' bounds it; each row normalizes exactly as a read's does. An
+%% in-range empty page is `{ok, []}': `not_found' names only keys the index
+%% does not serve.
+list(StoreOpts, Req = #{ <<"list">> := Key }, _NodeOpts) ->
+    #{ <<"start">> := Start, <<"size">> := Size, <<"tags">> := Tags } =
+        hb_store:find(StoreOpts),
+    Prefix = maps:get(<<"prefix">>, Tags),
+    PrefixSize = byte_size(Prefix),
+    case Key of
+        <<Prefix:PrefixSize/binary, Suffix/binary>> ->
+            run(Suffix, Req, Start, Size, Tags, StoreOpts);
+        _ ->
+            {error, not_found}
+    end.
+
+%% @doc Collect and normalize one page of the run a key names.
+run(Suffix, Req, Start, Size, Tags, Opts) ->
+    maybe
+        {ok, Prefix} ?=
+            normalize(maps:get(<<"normalize-key">>, Tags), Suffix, Opts),
+        true ?= is_bitstring(Prefix) orelse {error, {'invalid-seek', Prefix}},
+        From = maps:get(<<"from">>, Req, Prefix),
+        true ?= is_bitstring(From) orelse {error, {'invalid-from', From}},
+        Limit = hb_util:int(maps:get(<<"limit">>, Req, 1000)),
+        {ok, Meta} ?= read_meta(Start, Size, Opts),
+        {ok, SubDB = #{ pad := Pad }} ?= read_main_db(Meta, Opts),
+        true ?=
+            Pad > 0 andalso ?PAGE_HDR + Pad =< ?PAGE_SIZE
+                orelse {error, {'invalid-row-width', Pad}},
+        true ?=
+            bit_size(From) =< Pad * 8
+                orelse {error, {'invalid-seek-size', bit_size(From)}},
+        Target = <<From/bitstring, 0:(Pad * 8 - bit_size(From))>>,
+        {ok, Rows} ?= scan(Target, Prefix, Limit, SubDB, Meta, Opts, []),
+        normalize_rows(maps:get(<<"normalize-result">>, Tags), Rows, Opts, [])
+    end.
+
+%% @doc Normalize each row of a run in order, as reads normalize one.
+normalize_rows(_Path, [], _Opts, Msgs) -> {ok, lists:reverse(Msgs)};
+normalize_rows(Path, [Row | Rows], Opts, Msgs) ->
+    maybe
+        {ok, Msg} ?= normalize(Path, Row, Opts),
+        normalize_rows(Path, Rows, Opts, [Msg | Msgs])
     end.
 
 %% @doc Look up one key: normalize its remainder to the seek bits, descend to
@@ -313,20 +365,65 @@ seek(Seek, #{ pad := Pad, root := Root, depth := Depth }, Meta, Opts) ->
             SeekSize =< RowBits
                 orelse {error, {'invalid-seek-size', SeekSize}},
         Target = <<Seek/bitstring, 0:(RowBits - SeekSize)>>,
-        {ok, Row} ?= descend(Root, Depth, Target, Pad, none, Meta, Opts),
-        true ?= byte_size(Row) =:= Pad orelse {error, {'invalid-row', Row}},
-        confirm(Row, Seek)
+        {ok, Landing} ?= descend(Root, Depth, Target, Pad, none, Meta, Opts),
+        case first_row(Landing, Pad) of
+            none -> {error, not_found};
+            Row when byte_size(Row) =:= Pad -> confirm(Row, Seek);
+            Row -> {error, {'invalid-row', Row}}
+        end
+    end.
+
+%% @doc The first row at-or-after a descent's target: the landed slot when
+%% the leaf holds one, and the successor row carried down otherwise.
+first_row({Page, Slot, Count, _Next}, Pad) when Slot < Count ->
+    row(Page, Slot, Pad);
+first_row({_Page, _Slot, _Count, Next}, _Pad) -> Next.
+
+%% @doc Collect up to the limit of rows carrying the prefix, from the first
+%% row at-or-after the target. Crossing a leaf re-seeks at the successor row
+%% the descent carries down: the pages above the leaves are retained, so a
+%% crossing costs one leaf fetch.
+scan(Target, Prefix, Limit, SubDB, Meta, Opts, Rows) ->
+    #{ pad := Pad, root := Root, depth := Depth } = SubDB,
+    maybe
+        {ok, {Page, Slot, Count, Next}} ?=
+            descend(Root, Depth, Target, Pad, none, Meta, Opts),
+        {Taken, Left} = collect(Page, Slot, Count, Pad, Prefix, Limit, Rows),
+        case Left > 0 andalso Next =/= none andalso carries(Next, Prefix) of
+            true -> scan(Next, Prefix, Left, SubDB, Meta, Opts, Taken);
+            false -> {ok, lists:reverse(Taken)}
+        end
+    end.
+
+%% @doc The rows of one leaf from a slot onward that carry the prefix, onto
+%% the reversed accumulator, with the limit that remains. A row that diverges
+%% from the prefix ends the run: rows ascend, so no later row carries it.
+collect(_Page, Slot, Count, _Pad, _Prefix, Limit, Rows)
+        when Slot >= Count; Limit =:= 0 ->
+    {Rows, Limit};
+collect(Page, Slot, Count, Pad, Prefix, Limit, Rows) ->
+    Row = row(Page, Slot, Pad),
+    case carries(Row, Prefix) of
+        true ->
+            collect(Page, Slot + 1, Count, Pad, Prefix, Limit - 1, [Row | Rows]);
+        false ->
+            {Rows, 0}
+    end.
+
+%% @doc Whether a row begins with the given prefix bits.
+carries(Row, Prefix) ->
+    PrefixSize = bit_size(Prefix),
+    case Row of
+        <<Lead:PrefixSize/bitstring, _/bitstring>> -> Lead =:= Prefix;
+        _ -> false
     end.
 
 %% @doc Require the found row to begin with the seek bits: a row at-or-after
 %% the target that diverges within them is a proven miss.
 confirm(Row, Seek) ->
-    SeekSize = bit_size(Seek),
-    case Row of
-        <<Lead:SeekSize/bitstring, _/bitstring>> when Lead =:= Seek ->
-            {ok, Row};
-        _ ->
-            {error, not_found}
+    case carries(Row, Seek) of
+        true -> {ok, Row};
+        false -> {error, not_found}
     end.
 
 %% @doc Take one step of the descent. Branch pages recurse into the last child
@@ -355,11 +452,7 @@ step({Flags, Count}, Page, _Depth, Target, Pad, Next, _Meta, _Opts)
         true ?=
             ?PAGE_HDR + (Count * Pad) =< ?PAGE_SIZE
                 orelse {error, {'invalid-leaf-count', Count}},
-        case leaf_slot(Page, 0, Count, Pad, Target) of
-            Slot when Slot < Count -> {ok, row(Page, Slot, Pad)};
-            _ when Next =:= none -> {error, not_found};
-            _ -> {ok, Next}
-        end
+        {ok, {Page, leaf_slot(Page, 0, Count, Pad, Target), Count, Next}}
     end;
 step({Flags, _Count}, _Page, _Depth, _Target, _Pad, _Next, _Meta, _Opts) ->
     {error, {'invalid-page-flags', Flags}}.
@@ -633,4 +726,44 @@ chunk_retention() ->
     ?assertMatch(
         {ok, #{ <<"start">> := 381838173656091 }},
         hb_store:read([Store], Fresh, #{})
+    ).
+
+%% @doc List serves prefix-bounded ascending runs: a full-id run matches its
+%% read, resumes inclusively from raw row bits, answers past its end with
+%% the empty page rather than a miss, and keys outside the index's prefix
+%% fall through.
+list_runs_test_() ->
+    {timeout, 120, fun list_runs/0}.
+list_runs() ->
+    Store = test_store(),
+    ID = <<"AAAAhyV8_NwududSxuraAj7DLWiZHDTqVKWrZglpNok">>,
+    Key = <<"~arweave@2.9/offset=", ID/binary>>,
+    {ok, Read} = hb_store:read([Store], Key, #{}),
+    ?assertEqual(
+        {ok, [Read]},
+        hb_store:list([Store], #{ <<"list">> => Key }, #{})
+    ),
+    ?assertEqual(
+        {ok, [Read]},
+        hb_store:list([Store], #{ <<"list">> => Key, <<"limit">> => 5 }, #{})
+    ),
+    % The raw row resumes its own run inclusively; its successor is past it.
+    <<Prefix:77/bitstring, _/bitstring>> = hb_util:native_id(ID),
+    Row = <<Prefix/bitstring, 381852134215637:49, 3947:34>>,
+    ?assertEqual(
+        {ok, [Read]},
+        hb_store:list([Store], #{ <<"list">> => Key, <<"from">> => Row }, #{})
+    ),
+    <<RowInt:160/integer>> = Row,
+    ?assertEqual(
+        {ok, []},
+        hb_store:list(
+            [Store],
+            #{ <<"list">> => Key, <<"from">> => <<(RowInt + 1):160/integer>> },
+            #{}
+        )
+    ),
+    ?assertEqual(
+        {error, not_found},
+        hb_store:list([Store], #{ <<"list">> => <<"other/key">> }, #{})
     ).

--- a/src/core/store/hb_store_arweave.erl
+++ b/src/core/store/hb_store_arweave.erl
@@ -104,9 +104,31 @@ read_index_offset(StoreOpts = #{ <<"index-store">> := IndexStore }, ID) ->
                 <<"length">> => Length
             }};
         _ ->
-            not_found
+            read_published_offset(StoreOpts, ID)
     end;
 read_index_offset(_, _) -> not_found.
+
+%% @doc Read the offset of a data item from a published offset index in the
+%% `index-store' list, keyed by the item's ID under the `~arweave@2.9/offset='
+%% prefix. Published indexes hold confirmed ANS-104 items alone.
+read_published_offset(StoreOpts = #{ <<"index-store">> := IndexStore }, ID) ->
+    ReadRes =
+        hb_store:read(
+            IndexStore,
+            #{ <<"read">> => <<"~arweave@2.9/offset=", ID/binary>> },
+            StoreOpts
+        ),
+    case ReadRes of
+        {ok, #{ <<"start">> := StartOffset, <<"length">> := Length }} ->
+            {ok, #{
+                <<"version">> => 2,
+                <<"codec-device">> => <<"ans104@1.0">>,
+                <<"start-offset">> => StartOffset,
+                <<"length">> => Length
+            }};
+        _ ->
+            not_found
+    end.
 
 %% @doc Find the offset of a message from the nodes serving the `~arweave@2.9'
 %% routes, adding it to the local index so that they are asked once per message.

--- a/src/core/store/hb_store_arweave.erl
+++ b/src/core/store/hb_store_arweave.erl
@@ -79,51 +79,47 @@ read_offset(StoreOpts, ID, Opts) ->
     end.
 
 %% @doc Read the offset of the data at the given key from the local index alone.
-%% Nodes answer each other's offset requests from their own indexes, such that a
-%% cycle of routes cannot recurse.
-read_index_offset(StoreOpts = #{ <<"index-store">> := IndexStore }, ID) ->
+read_index_offset(StoreOpts = #{ <<"index-store">> := _ }, ID) ->
+    maybe
+        % First check the full offset path from the `~arweave@2.9` device.
+        not_found ?= read_offset_path(StoreOpts, <<"~arweave@2.9/offset=", ID/binary>>),
+        % ...otherwise, check the raw binary path for the ID.
+        read_offset_path(StoreOpts, hb_store_arweave_offset:path(ID))
+    end;
+read_index_offset(_, _) -> not_found.
+
+%% @doc Read and parse offset results. Processes both a message response or a
+%% version 1 binary encoded response.
+read_offset_path(StoreOpts = #{ <<"index-store">> := IndexStore }, Path) ->
     ReadRes =
         hb_prometheus:measure_and_report(
             fun() ->
                 hb_store:read(
                     IndexStore,
-                    #{ <<"read">> => hb_store_arweave_offset:path(ID) },
+                    #{ <<"read">> => Path },
                     StoreOpts
                 )
             end,
             hb_store_arweave_index_check_duration_seconds
         ),
     case ReadRes of
-        {ok, OffsetBinary} ->
+        {ok, Res} when is_map(Res) ->
+            {ok, Res#{
+                <<"version">> => maps:get(<<"version">>, Res, 2),
+                <<"codec-device">> =>
+                    maps:get(
+                        <<"codec-device">>,
+                        Res,
+                        <<"ans104@1.0">>
+                    )
+            }};
+        {ok, OffsetBinary} when is_binary(OffsetBinary) ->
             {Version, CodecName, StartOffset, Length} =
                 hb_store_arweave_offset:decode(OffsetBinary),
             {ok, #{
                 <<"version">> => Version,
                 <<"codec-device">> => CodecName,
-                <<"start-offset">> => StartOffset,
-                <<"length">> => Length
-            }};
-        _ ->
-            read_published_offset(StoreOpts, ID)
-    end;
-read_index_offset(_, _) -> not_found.
-
-%% @doc Read the offset of a data item from a published offset index in the
-%% `index-store' list, keyed by the item's ID under the `~arweave@2.9/offset='
-%% prefix. Published indexes hold confirmed ANS-104 items alone.
-read_published_offset(StoreOpts = #{ <<"index-store">> := IndexStore }, ID) ->
-    ReadRes =
-        hb_store:read(
-            IndexStore,
-            #{ <<"read">> => <<"~arweave@2.9/offset=", ID/binary>> },
-            StoreOpts
-        ),
-    case ReadRes of
-        {ok, #{ <<"start">> := StartOffset, <<"length">> := Length }} ->
-            {ok, #{
-                <<"version">> => 2,
-                <<"codec-device">> => <<"ans104@1.0">>,
-                <<"start-offset">> => StartOffset,
+                <<"start">> => StartOffset,
                 <<"length">> => Length
             }};
         _ ->
@@ -204,7 +200,7 @@ do_read(StoreOpts, ID, Opts) ->
             #{
                 <<"version">> := Version,
                 <<"codec-device">> := CodecName,
-                <<"start-offset">> := StartOffset,
+                <<"start">> := StartOffset,
                 <<"length">> := Length
             }} ->
             Loaded =
@@ -466,7 +462,7 @@ slash_offset_key_read_test_parallel() ->
     ),
     ok = write_offset(Store, ID, <<"tx@1.0">>, 123, 456),
     ?assertMatch(
-        {ok, #{ <<"start-offset">> := 123, <<"length">> := 456 }},
+        {ok, #{ <<"start">> := 123, <<"length">> := 456 }},
         read_offset(Store, ID, Opts)
     ).
 

--- a/src/preloaded/arweave/dev_arweave.erl
+++ b/src/preloaded/arweave/dev_arweave.erl
@@ -175,7 +175,7 @@ head_raw(Base, Request, Opts) ->
                 {ok,
                     #{
                         <<"codec-device">> := CodecDevice,
-                        <<"start-offset">> := StartOffset,
+                        <<"start">> := StartOffset,
                         <<"length">> := Length
                     }} ->
                         CodecFun =

--- a/src/preloaded/codec/dev_base64url.erl
+++ b/src/preloaded/codec/dev_base64url.erl
@@ -15,10 +15,10 @@ encode(Base, _Req, Opts) ->
     with_body(Base, Opts, fun hb_util:encode/1).
 
 %% @doc Apply a codec function to the base message's body, in place.
-with_body(Base, Opts, Codec) ->
+with_body(Base, Opts, Func) ->
     case hb_maps:find(<<"body">>, Base, Opts) of
         {ok, Body} when is_binary(Body) ->
-            {ok, hb_ao:set(Base, #{ <<"body">> => Codec(Body) }, Opts)};
+            {ok, hb_ao:set(Base, #{ <<"body">> => Func(Body) }, Opts)};
         _ ->
             {error, {'invalid-body', <<"No binary `body' key found.">>}}
     end.

--- a/src/preloaded/codec/dev_base64url.erl
+++ b/src/preloaded/codec/dev_base64url.erl
@@ -1,0 +1,48 @@
+%%% @doc Encode and decode the `body' of a message as unpadded base64url
+%%% (RFC 4648, section 5): the encoding of IDs and binaries across the
+%%% Arweave data protocols.
+-module(dev_base64url).
+-export([decode/3, encode/3]).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%% @doc Replace the base message's base64url `body' with its decoded bytes.
+decode(Base, _Req, Opts) ->
+    with_body(Base, Opts, fun hb_util:decode/1).
+
+%% @doc Replace the base message's binary `body' with its base64url encoding.
+encode(Base, _Req, Opts) ->
+    with_body(Base, Opts, fun hb_util:encode/1).
+
+%% @doc Apply a codec function to the base message's body, in place.
+with_body(Base, Opts, Codec) ->
+    case hb_maps:find(<<"body">>, Base, Opts) of
+        {ok, Body} when is_binary(Body) ->
+            {ok, hb_ao:set(Base, #{ <<"body">> => Codec(Body) }, Opts)};
+        _ ->
+            {error, {'invalid-body', <<"No binary `body' key found.">>}}
+    end.
+
+%%% Tests
+
+%% @doc Round-trip a random binary through encode and decode.
+round_trip_test() ->
+    Data = crypto:strong_rand_bytes(32),
+    {ok, Encoded} =
+        hb_ao:resolve(
+            #{
+                <<"path">> => <<"~base64url@1.0/encode/body">>,
+                <<"body">> => Data
+            },
+            #{}
+        ),
+    ?assertEqual(hb_util:encode(Data), Encoded),
+    {ok, Decoded} =
+        hb_ao:resolve(
+            #{
+                <<"path">> => <<"~base64url@1.0/decode/body">>,
+                <<"body">> => Encoded
+            },
+            #{}
+        ),
+    ?assertEqual(Data, Decoded).

--- a/src/preloaded/codec/dev_bits.erl
+++ b/src/preloaded/codec/dev_bits.erl
@@ -6,9 +6,9 @@
 %%%     format = fields | "repeat(" fields ")"
 %%%     fields = field ("," field)*
 %%%     field  = name ":" size ("+" type)?
+%%%     type   = "integer" | "float" | "atom" | enum(atom ("," atom)*)
 %%%     name   = any bytes except `:' and `,'; `_' alone is padding
 %%%     size   = a positive decimal bit count
-%%%     type   = "integer"
 %%% '''
 %%% For example, `_:77,start:49+integer,length:34+integer' names the two
 %%% trailing fields of a 160-bit row and discards its leading 77 bits, and
@@ -23,11 +23,15 @@
 %%% consumed and omitted from the result (any other name, including ones
 %%% merely beginning with `_', is an ordinary field, and a repeated name
 %%% keeps the last field's value). `integer' fields decode as unsigned
-%%% big-endian integers of their bit size; untyped fields decode as
-%%% bitstrings, byte-aligned only when their size is a multiple of eight.
-%%% The empty format, an empty field name, a non-positive or non-decimal
-%%% size, an unknown type, and a body whose bit size does not match the
-%%% format are refused.
+%%% big-endian integers of their bit size; `float' fields as IEEE floats of
+%%% 16, 32 or 64 bits; `atom' fields as the atom whose UTF-8 name fills the
+%%% field, at byte-multiple sizes; `enum' fields as the member named by the
+%%% field's unsigned integer value, zero-indexed, returned as a binary;
+%%% untyped fields decode as bitstrings, byte-aligned only when their size
+%%% is a multiple of eight. The empty format, an empty field name, a
+%%% non-positive or non-decimal size, an unknown type, a float or atom size
+%%% outside those above, an enum value past its last member, and a body
+%%% whose bit size does not match the format are refused.
 %%%
 %%% Keys:
 %%% ```
@@ -60,7 +64,7 @@ decode({repeat, Fields}, Body) ->
         true ?=
             bit_size(Body) rem Record =:= 0
                 orelse {error, {'invalid-body-size', bit_size(Body), Record}},
-        {ok, decode_records(Fields, Record, Body, [])}
+        decode_records(Fields, Record, Body, [])
     end;
 decode(Fields, Body) ->
     Total = record_size(Fields),
@@ -68,7 +72,7 @@ decode(Fields, Body) ->
         true ?=
             Total =:= bit_size(Body)
                 orelse {error, {'invalid-body-size', bit_size(Body), Total}},
-        {ok, decode_fields(Fields, Body, #{})}
+        decode_fields(Fields, Body, #{})
     end.
 
 %% @doc The bit size of one record of the given fields.
@@ -76,15 +80,14 @@ record_size(Fields) ->
     lists:sum([ Size || {_Name, Size, _Type} <- Fields ]).
 
 %% @doc Decode each record of a repeated body in order.
-decode_records(_Fields, _Record, <<>>, Records) -> lists:reverse(Records);
+decode_records(_Fields, _Record, <<>>, Records) ->
+    {ok, lists:reverse(Records)};
 decode_records(Fields, Record, Body, Records) ->
     <<Head:Record/bitstring, Rest/bitstring>> = Body,
-    decode_records(
-        Fields,
-        Record,
-        Rest,
-        [decode_fields(Fields, Head, #{}) | Records]
-    ).
+    maybe
+        {ok, Decoded} ?= decode_fields(Fields, Head, #{}),
+        decode_records(Fields, Record, Rest, [Decoded | Records])
+    end.
 
 %% @doc Return the leading N bits of the base message's body.
 take(Base, Req, Opts) ->
@@ -117,7 +120,9 @@ parse_format(<<"repeat(", Inner/binary>>) ->
         {ok, {repeat, Fields}}
     end;
 parse_format(Format) ->
-    parse_fields(binary:split(Format, <<",">>, [global]), []).
+    % The depth-aware split keeps an enum's comma-separated members inside
+    % their field.
+    parse_fields(hb_util:split_depth_string_aware($,, Format), []).
 parse_fields([], Fields) -> {ok, lists:reverse(Fields)};
 parse_fields([Spec | Rest], Fields) ->
     maybe
@@ -132,6 +137,10 @@ parse_field(Spec) ->
             case binary:split(SizeType, <<"+">>) of
                 [Size] -> sized_field(Name, Size, bitstring);
                 [Size, <<"integer">>] -> sized_field(Name, Size, integer);
+                [Size, <<"float">>] -> float_field(Name, Size);
+                [Size, <<"atom">>] -> atom_field(Name, Size);
+                [Size, <<"enum(", Members/binary>>] ->
+                    enum_field(Name, Size, Members);
                 [_Size, Type] -> {error, {'invalid-format-type', Type}}
             end;
         _ ->
@@ -145,6 +154,42 @@ sized_field(Name, Size, Type) ->
         {ok, {Name, Bits, Type}}
     end.
 
+%% @doc A float field, at the IEEE sizes alone.
+float_field(Name, Size) ->
+    maybe
+        {ok, Field = {_, Bits, _}} ?= sized_field(Name, Size, float),
+        true ?=
+            lists:member(Bits, [16, 32, 64])
+                orelse {error, {'invalid-float-size', Bits}},
+        {ok, Field}
+    end.
+
+%% @doc An atom field: its UTF-8 name fills the field, so the size must be a
+%% whole number of bytes.
+atom_field(Name, Size) ->
+    maybe
+        {ok, Field = {_, Bits, _}} ?= sized_field(Name, Size, atom),
+        true ?=
+            Bits rem 8 =:= 0
+                orelse {error, {'invalid-atom-size', Bits}},
+        {ok, Field}
+    end.
+
+%% @doc An enum field: the members arrive as the comma-separated remainder of
+%% the type, up to its closing parenthesis.
+enum_field(Name, Size, Members) ->
+    MembersSize = byte_size(Members) - 1,
+    case Members of
+        <<Names:MembersSize/binary, ")">> when Names =/= <<>> ->
+            sized_field(
+                Name,
+                Size,
+                {enum, binary:split(Names, <<",">>, [global])}
+            );
+        _ ->
+            {error, {'invalid-format-type', <<"enum(", Members/binary>>}}
+    end.
+
 %% @doc Parse a positive bit count, refusing malformed values.
 parse_size(Value) ->
     try hb_util:int(Value) of
@@ -154,21 +199,38 @@ parse_size(Value) ->
     end.
 
 %% @doc Decode the fields from the body in order, skipping `_' padding.
-decode_fields([], <<>>, Msg) -> Msg;
+decode_fields([], <<>>, Msg) -> {ok, Msg};
 decode_fields([{Name, Size, Type} | Rest], Body, Msg) ->
     <<Value:Size/bitstring, Remaining/bitstring>> = Body,
     case Name of
         <<"_">> -> decode_fields(Rest, Remaining, Msg);
-        _ -> decode_fields(Rest, Remaining, Msg#{ Name => typed(Type, Value) })
+        _ ->
+            maybe
+                {ok, Typed} ?= typed(Type, Value),
+                decode_fields(Rest, Remaining, Msg#{ Name => Typed })
+            end
     end.
 
 %% @doc Convert a decoded bitstring by field type. Integers are unsigned and
-%% big-endian.
-typed(bitstring, Bits) -> Bits;
+%% big-endian; an enum value past its last member is refused.
+typed(bitstring, Bits) -> {ok, Bits};
 typed(integer, Bits) ->
     Size = bit_size(Bits),
     <<Int:Size/integer>> = Bits,
-    Int.
+    {ok, Int};
+typed(float, Bits) ->
+    Size = bit_size(Bits),
+    <<Float:Size/float>> = Bits,
+    {ok, Float};
+typed(atom, Bits) -> {ok, hb_util:atom(Bits)};
+typed({enum, Members}, Bits) ->
+    {ok, Index} = typed(integer, Bits),
+    maybe
+        true ?=
+            Index < length(Members)
+                orelse {error, {'invalid-enum-value', Index, Members}},
+        {ok, lists:nth(Index + 1, Members)}
+    end.
 
 %%% Tests
 
@@ -325,4 +387,52 @@ from_published_intervals() ->
         end,
         0,
         lists:sublist(Records, 100)
+    ).
+
+%% @doc Decode float, atom and enum fields, refusing malformed sizes and an
+%% enum value past its last member.
+from_typed_fields_test() ->
+    {ok, Decoded} =
+        hb_ao:resolve(
+            #{
+                <<"path">> =>
+                    <<"~bits@1.0/from=ratio:32+float,unit:40+atom,"
+                        "codec:4+enum(tx@1.0,ans104@1.0),_:4">>,
+                <<"body">> =>
+                    <<1.5:32/float, "chunk", 1:4, 0:4>>
+            },
+            #{}
+        ),
+    ?assertEqual(1.5, hb_maps:get(<<"ratio">>, Decoded)),
+    ?assertEqual(chunk, hb_maps:get(<<"unit">>, Decoded)),
+    ?assertEqual(<<"ans104@1.0">>, hb_maps:get(<<"codec">>, Decoded)),
+    ?assertMatch(
+        {error, _},
+        hb_ao:resolve(
+            #{
+                <<"path">> => <<"~bits@1.0/from=bad:24+float">>,
+                <<"body">> => <<0:24>>
+            },
+            #{}
+        )
+    ),
+    ?assertMatch(
+        {error, _},
+        hb_ao:resolve(
+            #{
+                <<"path">> => <<"~bits@1.0/from=bad:12+atom">>,
+                <<"body">> => <<0:12>>
+            },
+            #{}
+        )
+    ),
+    ?assertMatch(
+        {error, _},
+        hb_ao:resolve(
+            #{
+                <<"path">> => <<"~bits@1.0/from=c:4+enum(a,b),_:4">>,
+                <<"body">> => <<3:4, 0:4>>
+            },
+            #{}
+        )
     ).

--- a/src/preloaded/codec/dev_bits.erl
+++ b/src/preloaded/codec/dev_bits.erl
@@ -1,0 +1,328 @@
+%%% @doc A codec over declaratively packed bits.
+%%%
+%%% A format describes a packed binary as a sequence of bit fields, or as a
+%%% homogeneous sequence of records of such fields:
+%%% ```
+%%%     format = fields | "repeat(" fields ")"
+%%%     fields = field ("," field)*
+%%%     field  = name ":" size ("+" type)?
+%%%     name   = any bytes except `:' and `,'; `_' alone is padding
+%%%     size   = a positive decimal bit count
+%%%     type   = "integer"
+%%% '''
+%%% For example, `_:77,start:49+integer,length:34+integer' names the two
+%%% trailing fields of a 160-bit row and discards its leading 77 bits, and
+%%% `repeat(start:64+integer,end:64+integer)' reads a body as consecutive
+%%% 128-bit records, decoding to the list of their messages in order. A
+%%% repeated body's bit size must be a whole multiple of the record size --
+%%% the empty body is the empty list -- and `repeat' does not nest.
+%%%
+%%% Fields pack contiguously in the order written, with no alignment or
+%%% padding between them, and their sizes must sum to exactly the decoded
+%%% body's bit size. A field named `_' is anonymous padding: its bits are
+%%% consumed and omitted from the result (any other name, including ones
+%%% merely beginning with `_', is an ordinary field, and a repeated name
+%%% keeps the last field's value). `integer' fields decode as unsigned
+%%% big-endian integers of their bit size; untyped fields decode as
+%%% bitstrings, byte-aligned only when their size is a multiple of eight.
+%%% The empty format, an empty field name, a non-positive or non-decimal
+%%% size, an unknown type, and a body whose bit size does not match the
+%%% format are refused.
+%%%
+%%% Keys:
+%%% ```
+%%%     from=Format:  Decode the base message's `body' per `Format' into a
+%%%                   message of the named fields.
+%%%     take=N:       Return the leading `N' bits of the base message's
+%%%                   `body' as a bitstring.
+%%% '''
+-module(dev_bits).
+-export([from/3, take/3]).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%% @doc Decode the base message's body into a message of the fields named by
+%% the format given as the key's argument, or into a list of such messages
+%% for a `repeat(...)' format.
+from(Base, Req, Opts) ->
+    maybe
+        {ok, Body} ?= find_body(Base, Opts),
+        {ok, Parsed} ?= parse_format(hb_maps:get(<<"from">>, Req, <<>>, Opts)),
+        decode(Parsed, Body)
+    end.
+
+%% @doc Decode a body as the single record, or the record sequence, that its
+%% parsed format describes. The body's bit size must equal the record size,
+%% or a whole multiple of it under `repeat'.
+decode({repeat, Fields}, Body) ->
+    Record = record_size(Fields),
+    maybe
+        true ?=
+            bit_size(Body) rem Record =:= 0
+                orelse {error, {'invalid-body-size', bit_size(Body), Record}},
+        {ok, decode_records(Fields, Record, Body, [])}
+    end;
+decode(Fields, Body) ->
+    Total = record_size(Fields),
+    maybe
+        true ?=
+            Total =:= bit_size(Body)
+                orelse {error, {'invalid-body-size', bit_size(Body), Total}},
+        {ok, decode_fields(Fields, Body, #{})}
+    end.
+
+%% @doc The bit size of one record of the given fields.
+record_size(Fields) ->
+    lists:sum([ Size || {_Name, Size, _Type} <- Fields ]).
+
+%% @doc Decode each record of a repeated body in order.
+decode_records(_Fields, _Record, <<>>, Records) -> lists:reverse(Records);
+decode_records(Fields, Record, Body, Records) ->
+    <<Head:Record/bitstring, Rest/bitstring>> = Body,
+    decode_records(
+        Fields,
+        Record,
+        Rest,
+        [decode_fields(Fields, Head, #{}) | Records]
+    ).
+
+%% @doc Return the leading N bits of the base message's body.
+take(Base, Req, Opts) ->
+    maybe
+        {ok, Body} ?= find_body(Base, Opts),
+        {ok, Bits} ?= parse_size(hb_maps:get(<<"take">>, Req, <<>>, Opts)),
+        true ?=
+            Bits =< bit_size(Body)
+                orelse {error, {'invalid-body-size', bit_size(Body), Bits}},
+        <<Taken:Bits/bitstring, _/bitstring>> = Body,
+        {ok, Taken}
+    end.
+
+%% @doc Find the body of the base message, refusing messages without one.
+find_body(Base, Opts) ->
+    case hb_maps:find(<<"body">>, Base, Opts) of
+        {ok, Body} when is_bitstring(Body) -> {ok, Body};
+        _ -> {error, {'invalid-body', <<"No binary `body' key found.">>}}
+    end.
+
+%% @doc Parse a comma-separated `name:size[+type]' format.
+parse_format(<<>>) -> {error, {'invalid-format', <<>>}};
+parse_format(<<"repeat(", Inner/binary>>) ->
+    maybe
+        {ok, Fields} ?=
+            case binary:split(Inner, <<")">>) of
+                [Format, <<>>] -> parse_format(Format);
+                _ -> {error, {'invalid-format', <<"repeat(", Inner/binary>>}}
+            end,
+        {ok, {repeat, Fields}}
+    end;
+parse_format(Format) ->
+    parse_fields(binary:split(Format, <<",">>, [global]), []).
+parse_fields([], Fields) -> {ok, lists:reverse(Fields)};
+parse_fields([Spec | Rest], Fields) ->
+    maybe
+        {ok, Field} ?= parse_field(Spec),
+        parse_fields(Rest, [Field | Fields])
+    end.
+
+%% @doc Parse a single field: a name, a bit size, and an optional value type.
+parse_field(Spec) ->
+    case binary:split(Spec, <<":">>) of
+        [Name, SizeType] when Name =/= <<>> ->
+            case binary:split(SizeType, <<"+">>) of
+                [Size] -> sized_field(Name, Size, bitstring);
+                [Size, <<"integer">>] -> sized_field(Name, Size, integer);
+                [_Size, Type] -> {error, {'invalid-format-type', Type}}
+            end;
+        _ ->
+            {error, {'invalid-format-field', Spec}}
+    end.
+
+%% @doc Attach a parsed bit size to a field.
+sized_field(Name, Size, Type) ->
+    maybe
+        {ok, Bits} ?= parse_size(Size),
+        {ok, {Name, Bits, Type}}
+    end.
+
+%% @doc Parse a positive bit count, refusing malformed values.
+parse_size(Value) ->
+    try hb_util:int(Value) of
+        Bits when Bits > 0 -> {ok, Bits};
+        Bits -> {error, {'invalid-size', Bits}}
+    catch _:_ -> {error, {'invalid-size', Value}}
+    end.
+
+%% @doc Decode the fields from the body in order, skipping `_' padding.
+decode_fields([], <<>>, Msg) -> Msg;
+decode_fields([{Name, Size, Type} | Rest], Body, Msg) ->
+    <<Value:Size/bitstring, Remaining/bitstring>> = Body,
+    case Name of
+        <<"_">> -> decode_fields(Rest, Remaining, Msg);
+        _ -> decode_fields(Rest, Remaining, Msg#{ Name => typed(Type, Value) })
+    end.
+
+%% @doc Convert a decoded bitstring by field type. Integers are unsigned and
+%% big-endian.
+typed(bitstring, Bits) -> Bits;
+typed(integer, Bits) ->
+    Size = bit_size(Bits),
+    <<Int:Size/integer>> = Bits,
+    Int.
+
+%%% Tests
+
+%% @doc Decode a packed body, skipping padding and typing integers.
+from_test() ->
+    {ok, Decoded} =
+        hb_ao:resolve(
+            #{
+                <<"path">> => <<"~bits@1.0/from=_:3,count:13+integer,tail:16">>,
+                <<"body">> => <<2#101:3, 999:13, "ok">>
+            },
+            #{}
+        ),
+    ?assertEqual(999, hb_maps:get(<<"count">>, Decoded)),
+    ?assertEqual(<<"ok">>, hb_maps:get(<<"tail">>, Decoded)),
+    ?assertEqual(error, hb_maps:find(<<"_">>, Decoded)).
+
+%% @doc Untyped fields decode as bitstrings on non-byte boundaries.
+from_bitstring_field_test() ->
+    {ok, Decoded} =
+        hb_ao:resolve(
+            #{
+                <<"path">> => <<"~bits@1.0/from=lead:5,rest:11+integer">>,
+                <<"body">> => <<2#10110:5, 1234:11>>
+            },
+            #{}
+        ),
+    ?assertEqual(<<2#10110:5>>, hb_maps:get(<<"lead">>, Decoded)),
+    ?assertEqual(1234, hb_maps:get(<<"rest">>, Decoded)).
+
+%% @doc Bodies that do not match their format's size are refused.
+from_size_mismatch_test() ->
+    ?assertMatch(
+        {error, _},
+        hb_ao:resolve(
+            #{
+                <<"path">> => <<"~bits@1.0/from=value:16+integer">>,
+                <<"body">> => <<1>>
+            },
+            #{}
+        )
+    ).
+
+%% @doc Malformed formats are refused.
+from_malformed_format_test() ->
+    ?assertMatch(
+        {error, _},
+        hb_ao:resolve(
+            #{
+                <<"path">> => <<"~bits@1.0/from=value:banana">>,
+                <<"body">> => <<1>>
+            },
+            #{}
+        )
+    ),
+    ?assertMatch(
+        {error, _},
+        hb_ao:resolve(
+            #{
+                <<"path">> => <<"~bits@1.0/from=value:8+float">>,
+                <<"body">> => <<1>>
+            },
+            #{}
+        )
+    ).
+
+%% @doc Take leading bits across byte boundaries, refusing over-long takes.
+take_test() ->
+    {ok, Taken} =
+        hb_ao:resolve(
+            #{
+                <<"path">> => <<"~bits@1.0/take=7">>,
+                <<"body">> => <<255, 1>>
+            },
+            #{}
+        ),
+    ?assertEqual(<<127:7>>, Taken),
+    ?assertMatch(
+        {error, _},
+        hb_ao:resolve(
+            #{
+                <<"path">> => <<"~bits@1.0/take=17">>,
+                <<"body">> => <<255, 1>>
+            },
+            #{}
+        )
+    ).
+
+%% @doc Decode a repeated body to its records in order, refusing a body that
+%% is not a whole multiple of the record size and a nested repeat.
+from_repeat_test() ->
+    Format = <<"~bits@1.0/from=repeat(start:64+integer,end:64+integer)">>,
+    {ok, Records} =
+        hb_ao:resolve(
+            #{
+                <<"path">> => Format,
+                <<"body">> => <<1:64, 2:64, 3:64, 5:64, 8:64, 13:64>>
+            },
+            #{}
+        ),
+    ?assertEqual(
+        [
+            #{ <<"start">> => 1, <<"end">> => 2 },
+            #{ <<"start">> => 3, <<"end">> => 5 },
+            #{ <<"start">> => 8, <<"end">> => 13 }
+        ],
+        Records
+    ),
+    ?assertMatch(
+        {error, _},
+        hb_ao:resolve(
+            #{ <<"path">> => Format, <<"body">> => <<1:64, 2:64, 3:32>> },
+            #{}
+        )
+    ),
+    ?assertMatch(
+        {error, _},
+        hb_ao:resolve(
+            #{
+                <<"path">> => <<"~bits@1.0/from=repeat(repeat(a:8))">>,
+                <<"body">> => <<1>>
+            },
+            #{}
+        )
+    ).
+
+%% @doc Decode the first chunk of the published RedStone exclusion-interval
+%% artifact, `CAEPGRdVcywDxFrSDz2NMhsHD1-WDQIKDLJOCjpjOPE': 16,384 whole
+%% records per 256 KiB chunk, whose first interval is known and whose
+%% records ascend without overlap.
+from_published_intervals_test_() ->
+    {timeout, 120, fun from_published_intervals/0}.
+from_published_intervals() ->
+    {ok, Body} = hb_store_arweave:read_chunks(390190281040118, 262144, #{}),
+    {ok, Records} =
+        hb_ao:resolve(
+            #{
+                <<"path">> =>
+                    <<"~bits@1.0/from=repeat(start:64+integer,end:64+integer)">>,
+                <<"body">> => Body
+            },
+            #{}
+        ),
+    ?assertEqual(16384, length(Records)),
+    [First | _] = Records,
+    ?assertEqual(
+        #{ <<"start">> => 165257438863606, <<"end">> => 165257438865427 },
+        First
+    ),
+    lists:foldl(
+        fun(Record, Previous) ->
+            ?assert(hb_maps:get(<<"start">>, Record) >= Previous),
+            hb_maps:get(<<"end">>, Record)
+        end,
+        0,
+        lists:sublist(Records, 100)
+    ).

--- a/src/preloaded/query/dev_copycat_arweave.erl
+++ b/src/preloaded/query/dev_copycat_arweave.erl
@@ -1649,11 +1649,11 @@ pending_range_indexes_bundle_children_test() ->
                 <<"~copycat@1.0/arweave&mode=full&from=pending&to=pending">>,
                 Opts),
         ?assertMatch(
-            {ok, #{ <<"start-offset">> := relative }},
+            {ok, #{ <<"start">> := relative }},
             hb_store_arweave:read_offset(ReadStore, TXID, Opts)
         ),
         ?assertMatch(
-            {ok, #{ <<"start-offset">> := #{ <<"relative">> := TXID } }},
+            {ok, #{ <<"start">> := #{ <<"relative">> := TXID } }},
             hb_store_arweave:read_offset(ReadStore, ChildID, Opts)
         ),
         {ok, ChildMsg} =

--- a/src/preloaded/query/dev_query_arweave.erl
+++ b/src/preloaded/query/dev_query_arweave.erl
@@ -555,7 +555,7 @@ annotate_offsets([], _StoreOpts, _LastOffset, _Ordinate, _Opts) -> [];
 annotate_offsets([ID|IDs], StoreOpts, LastOffset, Ordinate, Opts) ->
     {Offset, Annotated} =
         case hb_store_arweave:read_offset(StoreOpts, ID, Opts) of
-            {ok, #{ <<"start-offset">> := StartOffset, <<"length">> := Length }} ->
+            {ok, #{ <<"start">> := StartOffset, <<"length">> := Length }} ->
                 {
                     StartOffset,
                     #{

--- a/src/preloaded/query/dev_query_test_vectors.erl
+++ b/src/preloaded/query/dev_query_test_vectors.erl
@@ -849,7 +849,7 @@ transactions_query_ids_preserve_arweave_tx_id_test_parallel() ->
     {ok, _Node, Opts} = test_env_with_blocks(1892487, 1892487),
     ID = <<"mT7pIQx9ORnemXoIzWmKwymiZJxtOSvzxm3P44M9C1A">>,
     ?assertMatch(
-        {ok, #{ <<"start-offset">> := _ }},
+        {ok, #{ <<"start">> := _ }},
         hb_store_arweave:read_offset(hb_store_arweave:store_from_opts(Opts), ID, Opts)
     ),
     ?assertMatch(
@@ -881,9 +881,9 @@ transactions_query_cursor_by_offset_test_parallel() ->
     EarlierID = <<"xBpOR2KOjYEgv5HmddMlAgYa-yMvfEVl-0XzRIfm2uY">>,
     LaterID = <<"HVr7EpRhlPkbwdnoXKHf25p7BPa0qJOs6C7XueLthA0">>,
     StoreOpts = hb_store_arweave:store_from_opts(Opts),
-    {ok, #{ <<"start-offset">> := EarlierOffset }} =
+    {ok, #{ <<"start">> := EarlierOffset }} =
         hb_store_arweave:read_offset(StoreOpts, EarlierID, Opts),
-    {ok, #{ <<"start-offset">> := LaterOffset }} =
+    {ok, #{ <<"start">> := LaterOffset }} =
         hb_store_arweave:read_offset(StoreOpts, LaterID, Opts),
     Query = transactions_cursor_query(),
     VerifyFun =


### PR DESCRIPTION
This PR adds support for use LMDB 1.0 stores directly from Arweave _in-place_, without having to download them first.

LMDB is a fast, simple memory-mapped database. It is also the default store type that HyperBEAM uses to offer its services.

What makes LMDB special is its approach to memory layout and usage. Instead of explicitly handling the reading of bytes from disk into memory, LMDB organizes its data carefully into `page`s that it delegates to the operating system to manage on its behalf (via `mmap`) -- loading and unloading pages as necessary. The beauty of this mechanism is that it offloads an otherwise [extremely complex](https://martinfowler.com/bliki/TwoHardThings.html) task to machinery that is already highly tuned to handle it. h/t to @hyc for an awesome design.

The present patch extends the core memory-mapping concept of LMDB through an additional storage layer: Instead of lazy loading pages from disk, we can load them from an Arweave transaction directly. By setting the page size to a divisor of Arweave's 256kb chunks, we make it such that a single chunk read begets us a set of pages that we can treat like read-ahead results that we can cache and re-use later. While this PR introduces support for a subset of all LMDB 1.0 DBs, using a simple [lmdb-defrag](https://molecule.arweave.net/#/lmdb-defrag) tool that sits as an optional adjunct to this PR we can reorganize the file such that the most useful pages (those containing many branches, for example) are more likely to be cached from unrelated chunk reads.

To see the utility of this, let's consider a real-world use case. This PR changes the default Arweave ID lookup mechanism to cut-out gateway requests entirely -- even for those that have performed _zero_ Arweave indexing work on their nodes. Instead, HyperBEAM nodes by default now read from [a single transaction](https://viewblock.io/arweave/tx/7vg2832WFsisEcBr1oBQ8ldc4EGOkjQdwW46hDvJsOs) that contains an index of 8.6 billion `~arweave@2.9/offset=ID: GlobalArweaveByteOffset` hashpaths.

This database is ~160 GB in total. Yet, in order to read from its B-tree we only need to access its two meta pages, its primary key page, and the root of the real tree. At this size with 64kb pages, we need to download one additional branch page, and then finally the 'leaf' page that contains our offset. Because the LMDB is `defrag`'ed into an Arweave-friendly format, though, the first three pages all come together in a _single_ chunk `GET` operation from an Arweave node. Subsequently, we need only 3 chunk reads in a completely cold setup to find our offset.

Helpful diagram from Claude that elucidates the structure:

<img width="2480" height="1520" alt="image" src="https://github.com/user-attachments/assets/161db4f5-6855-4799-9fb2-2b2e27574263" />


Databases that are `lmdb-defrag`ed place all of their branch pages logically together, however. Subsequently, in the case of Arweave offsets above after downloading just ~75MB (progressively as needed, without requiring preloading) while loading other IDs from the network, all of the branch pages are 'hot' and an ID lookup requires just a single chunk read.

Additionally, this PR introduces two small helper devices:
- `~bits@1.0`: A device for serializing and deserializing bit-packed values in AO-Core.
- `~base64url@1.0`: As it says on the tin -- offering `decode` and `encode`.

Both are described in their specification moduledocs.