### PR TITLE
feat(ao): raw execution mode for full resolutions

### DIFF
--- a/src/core/resolver/hb_ao.erl
+++ b/src/core/resolver/hb_ao.erl
@@ -86,15 +86,15 @@
 %%% The HyperBEAM resolver also takes a number of runtime options that change
 %%% the way that the environment operates:
 %%% 
-%%% `update_hashpath':  Whether to add the `Req' to `HashPath' for the `Res'.
-%%% 					Default: true.
-%%% `add_key':          Whether to add the key to the start of the arguments.
-%%% 					Default: `<not set>'.
+%%% `hashpath':         Whether to add the `Req' to `HashPath' for the `Res'.
+%%% `add-key':          Whether to add the key to the start of the arguments.
+%%% `resolve-mode':     Set to `raw' to apply device functions directly,
+%%% 					skipping the resolver's management stages.
 %%% </pre>
 -module(hb_ao).
 %%% Main AO-Core API:
 -export([resolve/2, resolve/3, resolve_many/2]).
--export([raw/3, raw/4, raw/5]).
+-export([raw/2, raw/3, raw/4, raw/5]).
 -export([normalize_key/1, normalize_key/2, normalize_keys/1, normalize_keys/2]).
 -export([force_message/2]).
 %%% Shortcuts and tools:
@@ -160,6 +160,13 @@ resolve(Base, Req, Opts) ->
         }
     ),
     resolve_many([Base | MessagesToExec], Opts).
+
+%% @doc Resolve a full singleton in `raw' mode: the sequence is normalized
+%% and stepped as normal, but each step applies its device function directly,
+%% skipping the cache, validation, persistence, linking, and worker stages.
+%% Equivalent to `resolve/2' with `resolve-mode' set to `raw' in the `Opts'.
+raw(Msg, Opts) ->
+    resolve(Msg, Opts#{ <<"resolve-mode">> => raw }).
 
 %% @doc Invoke only the raw execution of the AO-Core resolution flow, ignoring
 %% normalization, cache, hashpath, worker, and other management components.
@@ -416,6 +423,11 @@ resolve_stage(1, RawBase, RawReq, Opts) ->
     Base = normalize_keys(RawBase, Opts),
     Req = normalize_keys(RawReq, Opts),
     resolve_stage(2, Base, Req, Opts);
+resolve_stage(2, Base, Req, Opts = #{ <<"resolve-mode">> := raw }) ->
+    ?event_debug(debug_ao_core, {stage, 2, raw_execution}, Opts),
+    % Raw mode: apply the device function directly, skipping the cache,
+    % validation, persistence, linking, and worker stages.
+    raw(Base, Req, Opts);
 resolve_stage(2, Base, Req, Opts) ->
     ?event_debug(debug_ao_core, {stage, 2, cache_lookup}, Opts),
     % Lookup request in the cache. If we find a result, return it.

--- a/src/core/test/hb_ao_test_vectors.erl
+++ b/src/core/test/hb_ao_test_vectors.erl
@@ -199,6 +199,21 @@ test_opts() ->
                 paranoid_input_verification,
                 paranoid_result_verification
             ]
+        },
+        #{
+            name => raw,
+            desc => "Raw execution mode",
+            opts => #{
+                <<"resolve-mode">> => raw,
+                <<"store">> => hb_test_utils:test_store()
+            },
+            skip => [
+                % Skip tests that assert behaviors of the management stages
+                % that raw mode explicitly skips.
+                step_hook,
+                paranoid_input_verification,
+                paranoid_result_verification
+            ]
         }
     ].
 


### PR DESCRIPTION
Setting `resolve-mode => raw' in a resolution's `Opts' applies each
step of the sequence with `raw/5' after stage-1 normalization, skipping
the cache, validation, persistence, linking, and worker stages. `raw/2'
wraps `resolve/2' and `resolve_many/2' with the flag set, giving pure
device pipelines a direct execution path whose per-step cost is device
lookup and application alone. The flag travels in `Opts', so
subresolutions and device-internal resolutions of a raw sequence run
raw as well.

The `hb_ao_test_vectors' suite gains a raw opts set, running every
vector under the mode except those that assert the behavior of the
stages raw mode skips (the step hook and the paranoid verification
checks).
