### PR TITLE
fix: Start default stores as well

### DIFF
--- a/src/core/http/hb_http_server.erl
+++ b/src/core/http/hb_http_server.erl
@@ -49,6 +49,8 @@ start() ->
             _ -> StoreOpts
         end,
     hb_store:start(UpdatedStoreOpts),
+    % Also start default stores
+    hb_store:start(hb_opts:get(<<"store">>, [], #{})),
     PrivWallet =
         hb:wallet(
             hb_opts:get(


### PR DESCRIPTION
Call `start` to the stores defined in `hb_opts.erl`.

The issue is a Prometheus warning. It cannot report a metric. This happens when it loads from `trusted-devices`, it doesn't use any `<<"store">>` configuration, so it falls back to stores defined in `hb_opts.erl`. Since we never initialized them, an error appears.

# TODO:
- [x] Run full suite.