### PR TITLE
feat: generalized store normalization and prefixing pipelines

### DIFF
--- a/src/core/store/hb_store.erl
+++ b/src/core/store/hb_store.erl
@@ -526,7 +526,9 @@ preprocess(Store, Function, [Req, Opts])
         {ok, NormReq} ?= preprocess_all(Store, Function, Req, Opts),
         {ok, [NormReq, Opts]}
     end;
-preprocess(Store, Function, [Req, Opts]) ->
+preprocess(Store, Function, [Req, Opts])
+        when Function =:= read orelse Function =:= list orelse
+            Function =:= type orelse Function =:= group ->
     % Process operations where the key to act upon is the 'named' element of
     % the request: `read=KEY`, etc.
     maybe
@@ -537,7 +539,9 @@ preprocess(Store, Function, [Req, Opts]) ->
                 Opts
             ),
         {ok, [Req#{ OpKey => Key }, Opts]}
-    end.
+    end;
+preprocess(_Store, _Function, Args) ->
+    {ok, Args}.
 
 %% @doc Preprocess a single key: admit it against the `prefix' (stripping
 %% the prefix forward unless `prefix-strip' is disabled), then normalize it
@@ -1343,7 +1347,27 @@ prefix_pipeline_test() ->
     ?assertEqual(ok, write([StripOff], write_req(<<"mnt/keep">>, <<"3">>), #{})),
     ?assertEqual({ok, <<"3">>}, read([StripOff], <<"mnt/keep">>, #{})),
     ?assertEqual({ok, <<"3">>}, read([Ungated], <<"mnt/keep">>, #{})),
+    ?assertEqual(ok, reset([Mounted])),
+    ?assertEqual({error, not_found}, read([Ungated], <<"inner">>, #{})),
+    ?assertEqual({ok, <<"2">>}, read([Plain], <<"outer">>, #{})),
     ?event(testing, {unprefixed_skip_and_strip_off_passed}).
+
+%% @doc Test that lifecycle operations bypass path preprocessing for a store
+%% carrying a prefix.
+prefix_pipeline_stop_test() ->
+    Store =
+        (hb_test_utils:test_store(hb_store_volatile, <<"pipeline-stop">>))#{
+            <<"prefix">> => <<"mnt/">>
+        },
+    start(Store),
+    #{ <<"pid">> := Pid } = find(Store),
+    Monitor = erlang:monitor(process, Pid),
+    ?assertEqual(ok, stop(Store)),
+    receive
+        {'DOWN', Monitor, process, Pid, normal} -> ok
+    after 1000 ->
+        ?assert(false)
+    end.
 
 %% @doc Test that `normalize-key' rewrites admitted keys through its path
 %% ahead of the store -- for writes and reads alike -- and that

--- a/src/core/store/hb_store.erl
+++ b/src/core/store/hb_store.erl
@@ -46,6 +46,30 @@
 %%% store is tried. If none of the given store messages are able to execute a
 %%% requested service, the store manager will return the strongest terminal
 %%% result observed, or `{error, not_found}`.
+%%%
+%%% A store message may additionally carry a normalization pipeline, applied
+%%% by the store manager around the module's own functions:
+%%% ```
+%%%     prefix:            Admit only keys with the given prefix, skipping the
+%%%                        store otherwise. The prefix is stripped from the key
+%%%                        ahead of store normalization and invocation, unless
+%%%                        `prefix-strip' is set to `false'.
+%%%     normalize-key:     An AO-Core path, resolved in `raw' mode with the
+%%%                        (post-prefix handling) key as the `Base/body` message.
+%%%                        The result becomes the key the store receives.
+%%%     normalize-result:  An AO-Core path, resolved in `raw' mode with a
+%%%                        successful result as the `Base/body`. A `read' result
+%%%                        is replaced by exactly what the resolution returns;
+%%%                        enumerations -- `list' results and `composite' read
+%%%                        children -- normalize each key independently. A
+%%%                        failing resolution marks the store as errored,
+%%%                        falling through to the next.
+%%% '''
+%%% Every path position of a request is processed through this pipeline: the
+%%% op-named key of `read', `list', `type' and `group' requests, every key of a
+%%% `write', and both sides of a `link'. `resolve' and `match' requests pass to
+%%% the store untouched: resolutions are reused as store paths, and matches
+%%% carry no path at all.
 
 -module(hb_store).
 -export([behavior_info/1]).
@@ -99,6 +123,14 @@ behavior_info(callbacks) ->
     <<"write">> => [write, link, group, reset] ++ ?COMMON_POLICIES,
     <<"admin">> => [reset] ++ ?COMMON_POLICIES
 }).
+
+%% @doc Whether a store message describes a key-normalization pipeline.
+-define(REQUIRES_PREPROCESS(Store),
+    (is_map_key(<<"prefix">>, Store) orelse is_map_key(<<"normalize-key">>, Store))
+).
+
+%% @doc Whether a store's results require postprocessing before return.
+-define(REQUIRES_POSTPROCESS(Store), is_map_key(<<"normalize-result">>, Store)).
 
 %%% Store named terms registry functions.
 
@@ -431,8 +463,8 @@ do_call_function([Store = #{<<"access">> := Access} | Rest], Function, Args, Fai
             do_call_function(Rest, Function, Args, Failure, Error)
     end;
 do_call_function([Store = #{<<"store-module">> := Mod} | Rest], Function, Args, Failure, Error) ->
-    % Attempt to apply the function. If it fails, try the next store.
-    try apply_store_function(Mod, Store, Function, Args) of
+    % Attempt to invoke the function. If it fails, try the next store.
+    try invoke(Mod, Store, Function, Args) of
         ok ->
             ok;
         {ok, _} = Result ->
@@ -462,6 +494,154 @@ do_call_function([Store = #{<<"store-module">> := Mod} | Rest], Function, Args, 
     catch _:_:_ ->
         do_call_function(Rest, Function, Args, Failure, Error)
     end.
+
+%% @doc Invoke a store function, applying the normalization pipeline its
+%% store message describes: requests are preprocessed ahead of the store,
+%% and successful results are normalized on the way back. A request the
+%% store does not admit is `not_found' for that store alone, and a result
+%% that fails its normalization is an error: both move the manager on to
+%% the next store.
+invoke(Mod, Store, Function, Args) ->
+    maybe
+        {ok, NormArgs} ?= preprocess(Store, Function, Args),
+        Result = apply_store_function(Mod, Store, Function, NormArgs),
+        postprocess(Store, Function, Result, NormArgs)
+    end.
+
+%% @doc Preprocess a request ahead of the store: the op-named key of `read',
+%% `list', `type' and `group' requests, every key of a `write' request, and
+%% both sides of a `link' request each pass through the pipeline. Stores
+%% without pipeline keys, and `resolve' and `match' requests, pass through
+%% untouched.
+preprocess(Store, _Function, Args) when not ?REQUIRES_PREPROCESS(Store) ->
+    {ok, Args};
+preprocess(_Store, Function, Args)
+        when Function =:= resolve orelse Function =:= match ->
+    % Resolutions are reused as store paths, which the pipeline cannot map
+    % back to the caller's namespace; matches carry no path at all.
+    {ok, Args};
+preprocess(Store, Function, [Req, Opts])
+        when Function =:= write orelse Function =:= link ->
+    maybe
+        {ok, NormReq} ?= preprocess_all(Store, Function, Req, Opts),
+        {ok, [NormReq, Opts]}
+    end;
+preprocess(Store, Function, [Req, Opts]) ->
+    % Process operations where the key to act upon is the 'named' element of
+    % the request: `read=KEY`, etc.
+    maybe
+        {ok, Key} ?=
+            preprocess_key(
+                Store,
+                maps:get(OpKey = hb_util:bin(Function), Req, <<>>),
+                Opts
+            ),
+        {ok, [Req#{ OpKey => Key }, Opts]}
+    end.
+
+%% @doc Preprocess a single key: admit it against the `prefix' (stripping
+%% the prefix forward unless `prefix-strip' is disabled), then normalize it
+%% through the `normalize-key' path. A key without the prefix is `not_found'
+%% for this store.
+preprocess_key(Store, Key, Opts) ->
+    Prefix = maps:get(<<"prefix">>, Store, <<>>),
+    Size = byte_size(Prefix),
+    case Key of
+        <<Prefix:Size/binary, Rest/binary>> ->
+            Stripped =
+                case strips(Store, Opts) of
+                    true -> Rest;
+                    false -> Key
+                end,
+            case maps:get(<<"normalize-key">>, Store, []) of
+                [] -> {ok, Stripped};
+                NormPath -> normalize(NormPath, Stripped, Opts)
+            end;
+        _ ->
+            {error, not_found}
+    end.
+
+%% @doc Preprocess every path of a write or link request. Write requests
+%% hold `Path => Value' pairs, so only their keys are paths; link requests
+%% hold `New => Existing' pairs, so both sides are.
+preprocess_all(Store, Function, Req, Opts) when is_map(Req) ->
+    preprocess_all(Store, Function, maps:to_list(Req), Opts);
+preprocess_all(_Store, _Function, [], _Opts) ->
+    {ok, #{}};
+preprocess_all(Store, Function, [{Path, Value} | Pairs], Opts) ->
+    maybe
+        {ok, NormPath} ?= preprocess_key(Store, Path, Opts),
+        {ok, NormValue} ?=
+            case Function of
+                link -> preprocess_key(Store, Value, Opts);
+                _ -> {ok, Value}
+            end,
+        {ok, NormPairs} ?= preprocess_all(Store, Function, Pairs, Opts),
+        {ok, NormPairs#{ NormPath => NormValue }}
+    end.
+
+%% @doc Whether a store message's prefix is stripped from admitted keys:
+%% enabled unless `prefix-strip' explicitly disables it.
+strips(Store, _Opts) ->
+    hb_util:bool(maps:get(<<"prefix-strip">>, Store, true)).
+
+%% @doc Normalize a successful store result on its way back to the caller.
+%% A `read' result is replaced by exactly what its `normalize-result'
+%% resolution returns; enumerations -- `list' results and `composite' read
+%% children -- normalize each key independently. All other results pass
+%% through untouched.
+postprocess(Store, _, Result, _) when not ?REQUIRES_POSTPROCESS(Store) ->
+    Result;
+postprocess(#{ <<"normalize-result">> := Path }, read, {ok, Value}, [_, Opts]) ->
+    normalize(Path, Value, Opts);
+postprocess(#{ <<"normalize-result">> := Path }, read, {composite, Keys},
+        [_, Opts]) ->
+    maybe
+        {ok, Normalized} ?= normalize_each(Path, Keys, Opts),
+        {composite, Normalized}
+    end;
+postprocess(#{ <<"normalize-result">> := Path }, list, {ok, Keys}, [_, Opts]) ->
+    normalize_each(Path, Keys, Opts);
+postprocess(_Store, _Function, Result, _Args) ->
+    Result.
+
+%% @doc Normalize each key of an enumeration independently, propagating the
+%% first error encountered. Children given as `{Key, Value}' pairs normalize
+%% the key alone: values are data.
+normalize_each(_Path, [], _Opts) ->
+    {ok, []};
+normalize_each(Path, [{Key, Value} | Keys], Opts) ->
+    maybe
+        {ok, Norm} ?= normalize(Path, Key, Opts),
+        {ok, Rest} ?= normalize_each(Path, Keys, Opts),
+        {ok, [{Norm, Value} | Rest]}
+    end;
+normalize_each(Path, [Key | Keys], Opts) ->
+    maybe
+        {ok, Norm} ?= normalize(Path, Key, Opts),
+        {ok, Rest} ?= normalize_each(Path, Keys, Opts),
+        {ok, [Norm | Rest]}
+    end.
+
+%% @doc Resolve a normalization path over a value in `raw' mode. The value
+%% is scoped to the head of the parsed sequence as its `Base/body': a bare
+%% `body' key would be merged into every stage of the path, clobbering the
+%% values piped between them. The resolution sees only the stores that carry
+%% no pipeline of their own, so any loads it performs -- remote devices
+%% among them -- can never recurse into another normalization.
+normalize(Path, Body, Opts) ->
+    Stores = hb_opts:get(store, [], Opts),
+    Direct =
+        lists:filter(
+            fun(S) ->
+                not (?REQUIRES_PREPROCESS(S) orelse ?REQUIRES_POSTPROCESS(S))
+            end,
+            Stores
+        ),
+    hb_ao:raw(
+        #{ <<"path">> => Path, <<"0.body">> => Body },
+        Opts#{ <<"store">> => Direct }
+    ).
 
 %% @doc Apply a store function, checking if the store returns a retry request or
 %% errors. If it does, attempt to start the store again and retry, up to the
@@ -1130,6 +1310,111 @@ benchmark_message(nested, N, TestDataSize) ->
                 <<"body">> => <<"test", 0:TestDataSize, N:32>>
             }
     }.
+
+%%% Normalization Pipeline Tests
+
+%% @doc Test that a store with a `prefix' only admits keys bearing it --
+%% writes and reads alike -- stripping the prefix ahead of invocation and
+%% falling through to later stores otherwise.
+prefix_pipeline_test() ->
+    Mounted =
+        (hb_test_utils:test_store(hb_store_fs, <<"pipeline-prefix">>))#{
+            <<"prefix">> => <<"mnt/">>
+        },
+    Plain = hb_test_utils:test_store(hb_store_fs, <<"pipeline-plain">>),
+    StoreList = [Mounted, Plain],
+    Ungated = maps:remove(<<"prefix">>, Mounted),
+    start(StoreList),
+    ?event(testing, {prefix_pipeline_test_started}),
+    % A prefixed write is stripped ahead of the store, so the raw key is
+    % visible once the prefix gate is removed from the store message.
+    ?assertEqual(ok, write(StoreList, write_req(<<"mnt/inner">>, <<"1">>), #{})),
+    ?assertEqual({ok, <<"1">>}, read(StoreList, <<"mnt/inner">>, #{})),
+    ?assertEqual({ok, <<"1">>}, read([Ungated], <<"inner">>, #{})),
+    ?assertEqual({error, not_found}, read([Plain], <<"mnt/inner">>, #{})),
+    ?event(testing, {prefixed_write_and_read_passed}),
+    % A key without the prefix skips the mounted store entirely, for writes
+    % and reads alike.
+    ?assertEqual(ok, write(StoreList, write_req(<<"outer">>, <<"2">>), #{})),
+    ?assertEqual({ok, <<"2">>}, read(StoreList, <<"outer">>, #{})),
+    ?assertEqual({error, not_found}, read([Ungated], <<"outer">>, #{})),
+    % Disabling `prefix-strip' admits the key but passes it through whole.
+    StripOff = Mounted#{ <<"prefix-strip">> => <<"false">> },
+    ?assertEqual(ok, write([StripOff], write_req(<<"mnt/keep">>, <<"3">>), #{})),
+    ?assertEqual({ok, <<"3">>}, read([StripOff], <<"mnt/keep">>, #{})),
+    ?assertEqual({ok, <<"3">>}, read([Ungated], <<"mnt/keep">>, #{})),
+    ?event(testing, {unprefixed_skip_and_strip_off_passed}).
+
+%% @doc Test that `normalize-key' rewrites admitted keys through its path
+%% ahead of the store -- for writes and reads alike -- and that
+%% `normalize-result' postprocesses read results, normalizing each key of
+%% list results and composite children independently. A key the
+%% normalization cannot decode, or a result that fails its normalization,
+%% falls through to the next store with the caller's original request.
+normalize_pipeline_test() ->
+    Store =
+        (hb_test_utils:test_store(hb_store_fs, <<"pipeline-normalize">>))#{
+            <<"prefix">> => <<"b64/">>,
+            <<"normalize-key">> => <<"~base64url@1.0/decode/body">>,
+            <<"normalize-result">> => <<"~base64url@1.0/encode/body">>
+        },
+    Fallback = hb_test_utils:test_store(hb_store_fs, <<"pipeline-fallback">>),
+    Raw =
+        maps:without(
+            [<<"prefix">>, <<"normalize-key">>, <<"normalize-result">>],
+            Store
+        ),
+    start([Store, Fallback]),
+    ?event(testing, {normalize_pipeline_test_started}),
+    % A write under the canonical key is decoded ahead of the store: the
+    % decoded key is visible with the pipeline removed from the message.
+    EncodedKey = hb_util:encode(<<"inner">>),
+    ?assertEqual(
+        ok,
+        write([Store], write_req(<<"b64/", EncodedKey/binary>>, <<"val">>), #{})
+    ),
+    ?assertEqual({ok, <<"val">>}, read([Raw], <<"inner">>, #{})),
+    ?assertEqual(
+        {ok, hb_util:encode(<<"val">>)},
+        read([Store], <<"b64/", EncodedKey/binary>>, #{})
+    ),
+    ?event(testing, {normalized_write_and_read_passed}),
+    % Each list item is normalized through the same explicit path.
+    EncodedChild = hb_util:encode(<<"g/a">>),
+    ?assertEqual(
+        ok,
+        write([Store], write_req(<<"b64/", EncodedChild/binary>>, <<"x">>), #{})
+    ),
+    EncodedGroup = hb_util:encode(<<"g">>),
+    ?assertEqual(
+        {ok, [hb_util:encode(<<"a">>)]},
+        list([Store], <<"b64/", EncodedGroup/binary>>, #{})
+    ),
+    % A composite read of the same group normalizes its children alike.
+    ?assertEqual(
+        {composite, [hb_util:encode(<<"a">>)]},
+        read([Store], <<"b64/", EncodedGroup/binary>>, #{})
+    ),
+    % An undecodable key skips the store for writes and reads alike, so the
+    % fallback both receives and serves the original request.
+    ?assertEqual(
+        ok,
+        write([Store, Fallback], write_req(<<"b64/!!!">>, <<"f">>), #{})
+    ),
+    ?assertEqual({ok, <<"f">>}, read([Store, Fallback], <<"b64/!!!">>, #{})),
+    ?event(testing, {undecodable_key_fell_through}),
+    % A result failing its normalization errs the store, falling through to
+    % the next store that carries the key.
+    Bad =
+        (hb_test_utils:test_store(hb_store_fs, <<"pipeline-badresult">>))#{
+            <<"prefix">> => <<"b64/">>,
+            <<"normalize-result">> => <<"~base64url@1.0/decode">>
+        },
+    start([Bad]),
+    ?assertEqual(ok, write([Bad], write_req(<<"b64/x">>, <<"!!!">>), #{})),
+    ?assertEqual(ok, write([Fallback], write_req(<<"b64/x">>, <<"fb">>), #{})),
+    ?assertEqual({ok, <<"fb">>}, read([Bad, Fallback], <<"b64/x">>, #{})),
+    ?event(testing, {failed_result_normalization_fell_through}).
 
 %%% Access Control Tests
 

--- a/src/core/store/hb_store.erl
+++ b/src/core/store/hb_store.erl
@@ -635,12 +635,18 @@ normalize_each(Path, [Key | Keys], Opts) ->
 %% among them -- can never recurse into another normalization.
 normalize(Path, Body, Opts) ->
     Stores = hb_opts:get(store, [], Opts),
+    StoreList =
+        case Stores of
+            List when is_list(List) -> List;
+            Store when is_map(Store) -> [Store];
+            _ -> []
+        end,
     Direct =
         lists:filter(
             fun(S) ->
                 not (?REQUIRES_PREPROCESS(S) orelse ?REQUIRES_POSTPROCESS(S))
             end,
-            Stores
+            StoreList
         ),
     hb_ao:raw(
         #{ <<"path">> => Path, <<"0.body">> => Body },
@@ -1401,6 +1407,17 @@ normalize_pipeline_test() ->
     ?assertEqual(
         {ok, hb_util:encode(<<"val">>)},
         read([Store], <<"b64/", EncodedKey/binary>>, #{})
+    ),
+    % A single store message is also a valid `store' option.
+    SingleKey = hb_util:encode(<<"single">>),
+    SingleOpts = #{ <<"store">> => Store },
+    ?assertEqual(
+        ok,
+        write(write_req(<<"b64/", SingleKey/binary>>, <<"one">>), SingleOpts)
+    ),
+    ?assertEqual(
+        {ok, hb_util:encode(<<"one">>)},
+        read(<<"b64/", SingleKey/binary>>, SingleOpts)
     ),
     ?event(testing, {normalized_write_and_read_passed}),
     % Each list item is normalized through the same explicit path.

--- a/src/core/store/hb_store.erl
+++ b/src/core/store/hb_store.erl
@@ -66,10 +66,12 @@
 %%%                        falling through to the next.
 %%% '''
 %%% Every path position of a request is processed through this pipeline: the
-%%% op-named key of `read', `list', `type' and `group' requests, every key of a
-%%% `write', and both sides of a `link'. `resolve' and `match' requests pass to
-%%% the store untouched: resolutions are reused as store paths, and matches
-%%% carry no path at all.
+%%% op-named key of `read', `list', `type', `group' and `resolve' requests,
+%%% every key of a `write', and both sides of a `link'. For stores without key
+%%% normalization, `resolve' applies only prefix handling and restores a
+%%% stripped prefix on return. Key-normalizing stores cannot map resolved paths
+%%% back into the caller's namespace, so their `resolve' requests pass through
+%%% untouched, as do `match' requests, which carry no path.
 
 -module(hb_store).
 -export([behavior_info/1]).
@@ -509,16 +511,19 @@ invoke(Mod, Store, Function, Args) ->
     end.
 
 %% @doc Preprocess a request ahead of the store: the op-named key of `read',
-%% `list', `type' and `group' requests, every key of a `write' request, and
-%% both sides of a `link' request each pass through the pipeline. Stores
-%% without pipeline keys, and `resolve' and `match' requests, pass through
-%% untouched.
+%% `list', `type', `group' and `resolve' requests, every key of a `write'
+%% request, and both sides of a `link' request each pass through the pipeline.
+%% For stores without key normalization, `resolve' applies only prefix handling
+%% because its results are reused as store paths. Key-normalizing stores cannot
+%% map resolved paths back into the caller's namespace, so their `resolve'
+%% requests pass through untouched, as do `match' and operations with no path.
 preprocess(Store, _Function, Args) when not ?REQUIRES_PREPROCESS(Store) ->
     {ok, Args};
-preprocess(_Store, Function, Args)
-        when Function =:= resolve orelse Function =:= match ->
-    % Resolutions are reused as store paths, which the pipeline cannot map
-    % back to the caller's namespace; matches carry no path at all.
+preprocess(Store, resolve, Args)
+        when is_map_key(<<"normalize-key">>, Store) ->
+    {ok, Args};
+preprocess(_Store, match, Args) ->
+    % Matches carry no path to preprocess.
     {ok, Args};
 preprocess(Store, Function, [Req, Opts])
         when Function =:= write orelse Function =:= link ->
@@ -528,13 +533,15 @@ preprocess(Store, Function, [Req, Opts])
     end;
 preprocess(Store, Function, [Req, Opts])
         when Function =:= read orelse Function =:= list orelse
-            Function =:= type orelse Function =:= group ->
+            Function =:= type orelse Function =:= group orelse
+            Function =:= resolve ->
     % Process operations where the key to act upon is the 'named' element of
     % the request: `read=KEY`, etc.
     maybe
         {ok, Key} ?=
             preprocess_key(
                 Store,
+                Function,
                 maps:get(OpKey = hb_util:bin(Function), Req, <<>>),
                 Opts
             ),
@@ -545,9 +552,10 @@ preprocess(_Store, _Function, Args) ->
 
 %% @doc Preprocess a single key: admit it against the `prefix' (stripping
 %% the prefix forward unless `prefix-strip' is disabled), then normalize it
-%% through the `normalize-key' path. A key without the prefix is `not_found'
-%% for this store.
-preprocess_key(Store, Key, Opts) ->
+%% through the `normalize-key' path. A `resolve' that reaches this function
+%% stops after prefix handling so its result remains a reusable store path.
+%% A key without the prefix is `not_found' for this store.
+preprocess_key(Store, Function, Key, Opts) ->
     Prefix = maps:get(<<"prefix">>, Store, <<>>),
     Size = byte_size(Prefix),
     case Key of
@@ -557,9 +565,10 @@ preprocess_key(Store, Key, Opts) ->
                     true -> Rest;
                     false -> Key
                 end,
-            case maps:get(<<"normalize-key">>, Store, []) of
-                [] -> {ok, Stripped};
-                NormPath -> normalize(NormPath, Stripped, Opts)
+            case {Function, maps:get(<<"normalize-key">>, Store, [])} of
+                {resolve, _} -> {ok, Stripped};
+                {_, []} -> {ok, Stripped};
+                {_, NormPath} -> normalize(NormPath, Stripped, Opts)
             end;
         _ ->
             {error, not_found}
@@ -574,10 +583,10 @@ preprocess_all(_Store, _Function, [], _Opts) ->
     {ok, #{}};
 preprocess_all(Store, Function, [{Path, Value} | Pairs], Opts) ->
     maybe
-        {ok, NormPath} ?= preprocess_key(Store, Path, Opts),
+        {ok, NormPath} ?= preprocess_key(Store, Function, Path, Opts),
         {ok, NormValue} ?=
             case Function of
-                link -> preprocess_key(Store, Value, Opts);
+                link -> preprocess_key(Store, Function, Value, Opts);
                 _ -> {ok, Value}
             end,
         {ok, NormPairs} ?= preprocess_all(Store, Function, Pairs, Opts),
@@ -592,8 +601,18 @@ strips(Store, _Opts) ->
 %% @doc Normalize a successful store result on its way back to the caller.
 %% A `read' result is replaced by exactly what its `normalize-result'
 %% resolution returns; enumerations -- `list' results and `composite' read
-%% children -- normalize each key independently. All other results pass
-%% through untouched.
+%% children -- normalize each key independently. A `resolve' result regains
+%% any prefix stripped before store invocation. All other results pass through
+%% untouched.
+postprocess(Store, resolve, Result, _)
+        when is_map_key(<<"normalize-key">>, Store) ->
+    Result;
+postprocess(Store = #{ <<"prefix">> := Prefix }, resolve, {ok, Res}, [_, Opts])
+        when is_binary(Res) ->
+    case strips(Store, Opts) of
+        true -> {ok, <<Prefix/binary, Res/binary>>};
+        false -> {ok, Res}
+    end;
 postprocess(Store, _, Result, _) when not ?REQUIRES_POSTPROCESS(Store) ->
     Result;
 postprocess(#{ <<"normalize-result">> := Path }, read, {ok, Value}, [_, Opts]) ->
@@ -1357,6 +1376,30 @@ prefix_pipeline_test() ->
     ?assertEqual({error, not_found}, read([Ungated], <<"inner">>, #{})),
     ?assertEqual({ok, <<"2">>}, read([Plain], <<"outer">>, #{})),
     ?event(testing, {unprefixed_skip_and_strip_off_passed}).
+
+%% @doc Demonstrate that cache reads of mounted paths require `resolve' to
+%% cross the external-to-native prefix boundary and restore the external path.
+prefix_pipeline_resolve_test() ->
+    Mounted =
+        (hb_test_utils:test_store(hb_store_fs, <<"pipeline-resolve">>))#{
+            <<"prefix">> => <<"mnt/">>
+        },
+    Native = maps:remove(<<"prefix">>, Mounted),
+    start(Mounted),
+    ?assertEqual(ok, write([Mounted], write_req(<<"mnt/inner">>, <<"1">>), #{})),
+    % The store receives and persists the native path after prefix stripping.
+    ?assertEqual({ok, <<"1">>}, read([Native], <<"inner">>, #{})),
+    ?assertEqual({error, not_found}, resolve([Native], <<"mnt/inner">>, #{})),
+    % `resolve' must translate into the native namespace, then restore the
+    % mounted path because `hb_cache' reuses it for the subsequent read.
+    ?assertEqual({ok, <<"mnt/inner">>}, resolve([Mounted], <<"mnt/inner">>, #{})),
+    ?assertEqual(
+        {ok, <<"1">>},
+        hb_cache:read(
+            <<"mnt/inner">>,
+            #{ <<"store">> => Mounted, <<"cache-read-mode">> => raw }
+        )
+    ).
 
 %% @doc Test that lifecycle operations bypass path preprocessing for a store
 %% carrying a prefix.

--- a/src/core/store/hb_store.erl
+++ b/src/core/store/hb_store.erl
@@ -611,7 +611,7 @@ from_store(Store, resolve, {ok, Path}, Opts) ->
         {ok, Norm} ?= execute_normalizer(<<"from-key">>, Store, Path, Opts),
         {ok,
             case must_strip_prefix(Store) of
-                true -> <<Prefix/binary, Norm/binary>>;
+                true -> <<Prefix/bitstring, Norm/bitstring>>;
                 false -> Norm
             end
         }
@@ -654,20 +654,18 @@ execute_normalizer(Setting, Store, Term, Opts) ->
     case maps:get(Setting, Store, []) of
         [] -> {ok, Term};
         Path ->
+            AllOptsStores = 
+                case hb_opts:get(<<"store">>, [], Opts) of
+                    OptStores when is_list(OptStores) -> OptStores;
+                    OptStore -> [OptStore]
+                end,
             hb_ao:raw(
                 #{ <<"path">> => Path, <<"0.body">> => Term },
                 Opts#{
                     <<"store">> =>
-                        [ S || S <- stores(Opts), not has_processing_pipeline(S) ]
+                        [ S || S <- AllOptsStores, not has_processing_pipeline(S) ]
                 }
             )
-    end.
-
-%% @doc The stores of the node's options as a list.
-stores(Opts) ->
-    case hb_opts:get(<<"store">>, [], Opts) of
-        Stores when is_list(Stores) -> Stores;
-        Store -> [Store]
     end.
 
 %% @doc Apply a store function, checking if the store returns a retry request or

--- a/src/core/store/hb_store.erl
+++ b/src/core/store/hb_store.erl
@@ -19,18 +19,18 @@
 %%%                   `local', `remote', `arweave', etc. Used in order to allow
 %%%                   node operators to prioritize their stores for search.
 %%%     group/3:      Create a new group of keys in the store using a request
-%%%                   map of the form `#{<<"group">> => Path}`.
+%%%                   map of the form `#{ <<"group">> => Path }`.
 %%%     link/3:       Create links using a request map of the form
-%%%                   `#{NewPath => ExistingPath}`.
+%%%                   `#{ NewPath => ExistingPath }`.
 %%%     type/3:       Return whether the value found at the given key is a
 %%%                   `composite' (group) type, or a `simple' direct binary,
-%%%                   using a request map of the form `#{<<"type">> => Path}`.
+%%%                   using a request map of the form `#{ <<"type">> => Path }`.
 %%%     read/3:       Read the data at the given location, returning a binary
 %%%                   if it is a `simple' value, or a message if it is a complex
-%%%                   term, using a request map of the form `#{<<"read">> => Path}`.
-%%%     write/3:      Write a request map of the form `#{Path => Value}`.
+%%%                   term, using a request map of the form `#{ <<"read">> => Path }`.
+%%%     write/3:      Write a request map of the form `#{ Path => Value }`.
 %%%     list/3:       For `composite' type keys, return child keys using a
-%%%                   request map of the form `#{<<"list">> => Path}`.
+%%%                   request map of the form `#{ <<"list">> => Path }`.
 %%%                   Composite read results may also return children as
 %%%                   `{Key, Value}' pairs when the store can provide a child
 %%%                   value without an additional read.
@@ -81,11 +81,6 @@
 %%%     `[to|from]-value`:  An AO-Core path, resolved in `raw' mode with a
 %%%                         successful result as the `Base/body`.
 %%% '''
-%%% Every path position of a request is processed through this pipeline. Every
-%%% `Key` -- whether seen as an input (e.g. to `read`) or an output (as in
-%%% `list`) use the `[to|from]-key` flow, and similarly `[to|from]-value` is
-%%% used upon every value relatively as input or response. A `match` request
-%%% carries no key or value and passes through untouched.
 -module(hb_store).
 -export([behavior_info/1]).
 -export([
@@ -513,7 +508,7 @@ do_call_function([Store = #{<<"store-module">> := Mod} | Rest], Function, Args, 
 %% `not_found' for that store alone, and an answer that fails its
 %% normalization is an error: both move the manager on to the next store.
 invoke(Mod, Store, Function, Args = [Req, Opts]) ->
-    case pipelined(Store) of
+    case has_processing_pipeline(Store) of
         false ->
             apply_store_function(Mod, Store, Function, Args);
         true ->
@@ -529,14 +524,15 @@ invoke(Mod, Store, Function, Args = [Req, Opts]) ->
     end.
 
 %% @doc Whether a store message describes a normalization pipeline.
-pipelined(Store) ->
+has_processing_pipeline(Store) ->
     lists:any(fun(Key) -> is_map_key(Key, Store) end, ?PIPELINE_KEYS).
 
 %% @doc Normalize a request's keys and values to the store: the path a
 %% `read', `list', `type', `group' or `resolve' names, every key and value
-%% of a `write', and both paths of a `link'. Every other request carries no
-%% key or value and passes through.
-to_store(Store, write, Req, Opts) ->
+%% of a `write' or `match', and both paths of a `link'. Every other request
+%% carries no key or value and passes through.
+to_store(Store, Function, Req, Opts)
+        when Function =:= write orelse Function =:= match ->
     to_pairs(Store, fun to_value/3, Req, Opts);
 to_store(Store, link, Req, Opts) ->
     to_pairs(Store, fun to_key/3, Req, Opts);
@@ -558,7 +554,7 @@ to_store(_Store, _Function, Req, _Opts) ->
 to_pairs(Store, Values, Req, Opts) ->
     maybe
         {ok, Pairs} ?=
-            each(
+            maybe_each(
                 fun({Path, Value}) ->
                     maybe
                         {ok, NormPath} ?= to_key(Store, Path, Opts),
@@ -576,32 +572,32 @@ to_pairs(Store, Values, Req, Opts) ->
 %% store's `to-key'. A path without the prefix is `not_found' for the store.
 to_key(Store, Path, Opts) ->
     Prefix = maps:get(<<"prefix">>, Store, <<>>),
-    Size = byte_size(Prefix),
+    PrefixBitSize = bit_size(Prefix),
     case Path of
-        <<Prefix:Size/binary, Rest/binary>> ->
+        <<Prefix:PrefixBitSize/bitstring, Rest/bitstring>> ->
             Admitted =
-                case strips(Store) of
+                case must_strip_prefix(Store) of
                     true -> Rest;
                     false -> Path
                 end,
-            normalize(<<"to-key">>, Store, Admitted, Opts);
+            execute_normalizer(<<"to-key">>, Store, Admitted, Opts);
         _ ->
             {error, not_found}
     end.
 
 %% @doc Normalize a value to the store through its `to-value'.
 to_value(Store, Value, Opts) ->
-    normalize(<<"to-value">>, Store, Value, Opts).
+    execute_normalizer(<<"to-value">>, Store, Value, Opts).
 
 %% @doc Whether the store's prefix is stripped from the paths it admits.
-strips(Store) ->
+must_strip_prefix(Store) ->
     hb_util:bool(maps:get(<<"prefix-strip">>, Store, true)).
 
 %% @doc Normalize a store's answer from it: a read's value, the children a
 %% `list' or a composite read enumerates, and a resolved path, which regains
 %% a stripped prefix. Every other answer passes through.
 from_store(Store, read, {ok, Value}, Opts) ->
-    normalize(<<"from-value">>, Store, Value, Opts);
+    execute_normalizer(<<"from-value">>, Store, Value, Opts);
 from_store(Store, read, {composite, Children}, Opts) ->
     maybe
         {ok, Norm} ?= from_children(Store, Children, Opts),
@@ -612,37 +608,38 @@ from_store(Store, list, {ok, Children}, Opts) ->
 from_store(Store, resolve, {ok, Path}, Opts) ->
     Prefix = maps:get(<<"prefix">>, Store, <<>>),
     maybe
-        {ok, Norm} ?= normalize(<<"from-key">>, Store, Path, Opts),
+        {ok, Norm} ?= execute_normalizer(<<"from-key">>, Store, Path, Opts),
         {ok,
-            case strips(Store) of
+            case must_strip_prefix(Store) of
                 true -> <<Prefix/binary, Norm/binary>>;
                 false -> Norm
-            end}
+            end
+        }
     end;
 from_store(_Store, _Function, Result, _Opts) ->
     Result.
 
 %% @doc Normalize the children a store enumerates from it.
 from_children(Store, Children, Opts) ->
-    each(fun(Child) -> from_child(Store, Child, Opts) end, Children).
+    maybe_each(fun(Child) -> from_child(Store, Child, Opts) end, Children).
 
 %% @doc Normalize a child from the store: its key through `from-key', and
 %% the value of a child given as a pair through `from-value'.
 from_child(Store, {Key, Value}, Opts) ->
     maybe
-        {ok, NormKey} ?= normalize(<<"from-key">>, Store, Key, Opts),
-        {ok, NormValue} ?= normalize(<<"from-value">>, Store, Value, Opts),
+        {ok, NormKey} ?= execute_normalizer(<<"from-key">>, Store, Key, Opts),
+        {ok, NormValue} ?= execute_normalizer(<<"from-value">>, Store, Value, Opts),
         {ok, {NormKey, NormValue}}
     end;
 from_child(Store, Key, Opts) ->
-    normalize(<<"from-key">>, Store, Key, Opts).
+    execute_normalizer(<<"from-key">>, Store, Key, Opts).
 
 %% @doc Normalize each term of a list in order, stopping at the first error.
-each(_Fun, []) -> {ok, []};
-each(Fun, [Term | Rest]) ->
+maybe_each(_Fun, []) -> {ok, []};
+maybe_each(Fun, [Term | Rest]) ->
     maybe
         {ok, Norm} ?= Fun(Term),
-        {ok, Others} ?= each(Fun, Rest),
+        {ok, Others} ?= maybe_each(Fun, Rest),
         {ok, [Norm | Others]}
     end.
 
@@ -653,21 +650,22 @@ each(Fun, [Term | Rest]) ->
 %% the term as it is. The resolution sees only the stores that carry no
 %% pipeline of their own, so any loads it performs -- remote devices among
 %% them -- can never recurse into another normalization.
-normalize(Setting, Store, Term, Opts) ->
+execute_normalizer(Setting, Store, Term, Opts) ->
     case maps:get(Setting, Store, []) of
         [] -> {ok, Term};
         Path ->
             hb_ao:raw(
                 #{ <<"path">> => Path, <<"0.body">> => Term },
                 Opts#{
-                    <<"store">> => [ S || S <- stores(Opts), not pipelined(S) ]
+                    <<"store">> =>
+                        [ S || S <- stores(Opts), not has_processing_pipeline(S) ]
                 }
             )
     end.
 
 %% @doc The stores of the node's options as a list.
 stores(Opts) ->
-    case hb_opts:get(store, [], Opts) of
+    case hb_opts:get(<<"store">>, [], Opts) of
         Stores when is_list(Stores) -> Stores;
         Store -> [Store]
     end.

--- a/src/core/store/hb_store.erl
+++ b/src/core/store/hb_store.erl
@@ -47,32 +47,45 @@
 %%% requested service, the store manager will return the strongest terminal
 %%% result observed, or `{error, not_found}`.
 %%%
-%%% A store message may additionally carry a normalization pipeline, applied
-%%% by the store manager around the module's own functions:
+%%% A store message may additionally specify a normalization pipeline, called
+%%% upon its paths and values during store invocation. These pipelines allow
+%%% node operators to optimize their setups to store their keys with
+%%% particular representations, while AO-Core and its devices remain agnostic
+%%% to their specifics.
+%%%
+%%% Each store invocation progresses through the following pipeline:
+%%%
 %%% ```
-%%%     prefix:            Admit only keys with the given prefix, skipping the
-%%%                        store otherwise. The prefix is stripped from the key
-%%%                        ahead of store normalization and invocation, unless
-%%%                        `prefix-strip' is set to `false'.
-%%%     normalize-key:     An AO-Core path, resolved in `raw' mode with the
-%%%                        (post-prefix handling) key as the `Base/body` message.
-%%%                        The result becomes the key the store receives.
-%%%     normalize-result:  An AO-Core path, resolved in `raw' mode with a
-%%%                        successful result as the `Base/body`. A `read' result
-%%%                        is replaced by exactly what the resolution returns;
-%%%                        enumerations -- `list' results and `composite' read
-%%%                        children -- normalize each key independently. A
-%%%                        failing resolution marks the store as errored,
-%%%                        falling through to the next.
+%%%     Prefix matching/removal ->
+%%%     Pre-normalization ->
+%%%     Store invocation ->
+%%%     Post-normalization ->
+%%%     Re-prefixing (only for `resolve`) ->
+%%%     Return.
 %%% '''
-%%% Every path position of a request is processed through this pipeline: the
-%%% op-named key of `read', `list', `type', `group' and `resolve' requests,
-%%% every key of a `write', and both sides of a `link'. For stores without key
-%%% normalization, `resolve' applies only prefix handling and restores a
-%%% stripped prefix on return. Key-normalizing stores cannot map resolved paths
-%%% back into the caller's namespace, so their `resolve' requests pass through
-%%% untouched, as do `match' requests, which carry no path.
-
+%%%
+%%% `Key`s and `Value`s are normalized individually -- `to` prior to store
+%%% invocation, and `from` upon responses from store. To configure each, a
+%%% store message may specify:
+%%%
+%%% ```
+%%%     `prefix`:           Admit only `Key`s with the given prefix, skipping
+%%%                         the store otherwise. The prefix is stripped from
+%%%                         the `Key` ahead of store normalization and
+%%%                         invocation, unless an additional `prefix-strip'
+%%%                         store message key is explicitly set to `false'.
+%%%     `[to|from]-key`:    An AO-Core path, resolved in `raw' mode with the
+%%%                         (post-prefix handling) key as its `Base/body`
+%%%                         message. The result is utilized as the key the
+%%%                         store sees.
+%%%     `[to|from]-value`:  An AO-Core path, resolved in `raw' mode with a
+%%%                         successful result as the `Base/body`.
+%%% '''
+%%% Every path position of a request is processed through this pipeline. Every
+%%% `Key` -- whether seen as an input (e.g. to `read`) or an output (as in
+%%% `list`) use the `[to|from]-key` flow, and similarly `[to|from]-value` is
+%%% used upon every value relatively as input or response. A `match` request
+%%% carries no key or value and passes through untouched.
 -module(hb_store).
 -export([behavior_info/1]).
 -export([
@@ -126,13 +139,10 @@ behavior_info(callbacks) ->
     <<"admin">> => [reset] ++ ?COMMON_POLICIES
 }).
 
-%% @doc Whether a store message describes a key-normalization pipeline.
--define(REQUIRES_PREPROCESS(Store),
-    (is_map_key(<<"prefix">>, Store) orelse is_map_key(<<"normalize-key">>, Store))
-).
-
-%% @doc Whether a store's results require postprocessing before return.
--define(REQUIRES_POSTPROCESS(Store), is_map_key(<<"normalize-result">>, Store)).
+%% @doc The store message keys that describe a normalization pipeline.
+-define(PIPELINE_KEYS, [
+    <<"prefix">>, <<"to-key">>, <<"from-key">>, <<"to-value">>, <<"from-value">>
+]).
 
 %%% Store named terms registry functions.
 
@@ -497,180 +507,170 @@ do_call_function([Store = #{<<"store-module">> := Mod} | Rest], Function, Args, 
         do_call_function(Rest, Function, Args, Failure, Error)
     end.
 
-%% @doc Invoke a store function, applying the normalization pipeline its
-%% store message describes: requests are preprocessed ahead of the store,
-%% and successful results are normalized on the way back. A request the
-%% store does not admit is `not_found' for that store alone, and a result
-%% that fails its normalization is an error: both move the manager on to
-%% the next store.
-invoke(Mod, Store, Function, Args) ->
-    maybe
-        {ok, NormArgs} ?= preprocess(Store, Function, Args),
-        Result = apply_store_function(Mod, Store, Function, NormArgs),
-        postprocess(Store, Function, Result, NormArgs)
+%% @doc Invoke a store function through the normalization pipeline its store
+%% message describes: the request's keys and values are normalized to the
+%% store, and its answer's from it. A request the store does not admit is
+%% `not_found' for that store alone, and an answer that fails its
+%% normalization is an error: both move the manager on to the next store.
+invoke(Mod, Store, Function, Args = [Req, Opts]) ->
+    case pipelined(Store) of
+        false ->
+            apply_store_function(Mod, Store, Function, Args);
+        true ->
+            maybe
+                {ok, NormReq} ?= to_store(Store, Function, Req, Opts),
+                from_store(
+                    Store,
+                    Function,
+                    apply_store_function(Mod, Store, Function, [NormReq, Opts]),
+                    Opts
+                )
+            end
     end.
 
-%% @doc Preprocess a request ahead of the store: the op-named key of `read',
-%% `list', `type', `group' and `resolve' requests, every key of a `write'
-%% request, and both sides of a `link' request each pass through the pipeline.
-%% For stores without key normalization, `resolve' applies only prefix handling
-%% because its results are reused as store paths. Key-normalizing stores cannot
-%% map resolved paths back into the caller's namespace, so their `resolve'
-%% requests pass through untouched, as do `match' and operations with no path.
-preprocess(Store, _Function, Args) when not ?REQUIRES_PREPROCESS(Store) ->
-    {ok, Args};
-preprocess(Store, resolve, Args)
-        when is_map_key(<<"normalize-key">>, Store) ->
-    {ok, Args};
-preprocess(_Store, match, Args) ->
-    % Matches carry no path to preprocess.
-    {ok, Args};
-preprocess(Store, Function, [Req, Opts])
-        when Function =:= write orelse Function =:= link ->
-    maybe
-        {ok, NormReq} ?= preprocess_all(Store, Function, Req, Opts),
-        {ok, [NormReq, Opts]}
-    end;
-preprocess(Store, Function, [Req, Opts])
+%% @doc Whether a store message describes a normalization pipeline.
+pipelined(Store) ->
+    lists:any(fun(Key) -> is_map_key(Key, Store) end, ?PIPELINE_KEYS).
+
+%% @doc Normalize a request's keys and values to the store: the path a
+%% `read', `list', `type', `group' or `resolve' names, every key and value
+%% of a `write', and both paths of a `link'. Every other request carries no
+%% key or value and passes through.
+to_store(Store, write, Req, Opts) ->
+    to_pairs(Store, fun to_value/3, Req, Opts);
+to_store(Store, link, Req, Opts) ->
+    to_pairs(Store, fun to_key/3, Req, Opts);
+to_store(Store, Function, Req, Opts)
         when Function =:= read orelse Function =:= list orelse
             Function =:= type orelse Function =:= group orelse
             Function =:= resolve ->
-    % Process operations where the key to act upon is the 'named' element of
-    % the request: `read=KEY`, etc.
+    OpKey = hb_util:bin(Function),
     maybe
-        {ok, Key} ?=
-            preprocess_key(
-                Store,
-                Function,
-                maps:get(OpKey = hb_util:bin(Function), Req, <<>>),
-                Opts
-            ),
-        {ok, [Req#{ OpKey => Key }, Opts]}
+        {ok, Path} ?= to_key(Store, maps:get(OpKey, Req), Opts),
+        {ok, Req#{ OpKey => Path }}
     end;
-preprocess(_Store, _Function, Args) ->
-    {ok, Args}.
+to_store(_Store, _Function, Req, _Opts) ->
+    {ok, Req}.
 
-%% @doc Preprocess a single key: admit it against the `prefix' (stripping
-%% the prefix forward unless `prefix-strip' is disabled), then normalize it
-%% through the `normalize-key' path. A `resolve' that reaches this function
-%% stops after prefix handling so its result remains a reusable store path.
-%% A key without the prefix is `not_found' for this store.
-preprocess_key(Store, Function, Key, Opts) ->
+%% @doc Normalize every pair of a request to the store: its keys as paths,
+%% and its values through the given function -- as paths for a `link', as
+%% values for a `write'.
+to_pairs(Store, Values, Req, Opts) ->
+    maybe
+        {ok, Pairs} ?=
+            each(
+                fun({Path, Value}) ->
+                    maybe
+                        {ok, NormPath} ?= to_key(Store, Path, Opts),
+                        {ok, NormValue} ?= Values(Store, Value, Opts),
+                        {ok, {NormPath, NormValue}}
+                    end
+                end,
+                maps:to_list(Req)
+            ),
+        {ok, maps:from_list(Pairs)}
+    end.
+
+%% @doc Normalize a path to the store: admit it by the store's `prefix',
+%% stripped from it unless `prefix-strip' is `false', then through the
+%% store's `to-key'. A path without the prefix is `not_found' for the store.
+to_key(Store, Path, Opts) ->
     Prefix = maps:get(<<"prefix">>, Store, <<>>),
     Size = byte_size(Prefix),
-    case Key of
+    case Path of
         <<Prefix:Size/binary, Rest/binary>> ->
-            Stripped =
-                case strips(Store, Opts) of
+            Admitted =
+                case strips(Store) of
                     true -> Rest;
-                    false -> Key
+                    false -> Path
                 end,
-            case {Function, maps:get(<<"normalize-key">>, Store, [])} of
-                {resolve, _} -> {ok, Stripped};
-                {_, []} -> {ok, Stripped};
-                {_, NormPath} -> normalize(NormPath, Stripped, Opts)
-            end;
+            normalize(<<"to-key">>, Store, Admitted, Opts);
         _ ->
             {error, not_found}
     end.
 
-%% @doc Preprocess every path of a write or link request. Write requests
-%% hold `Path => Value' pairs, so only their keys are paths; link requests
-%% hold `New => Existing' pairs, so both sides are.
-preprocess_all(Store, Function, Req, Opts) when is_map(Req) ->
-    preprocess_all(Store, Function, maps:to_list(Req), Opts);
-preprocess_all(_Store, _Function, [], _Opts) ->
-    {ok, #{}};
-preprocess_all(Store, Function, [{Path, Value} | Pairs], Opts) ->
-    maybe
-        {ok, NormPath} ?= preprocess_key(Store, Function, Path, Opts),
-        {ok, NormValue} ?=
-            case Function of
-                link -> preprocess_key(Store, Function, Value, Opts);
-                _ -> {ok, Value}
-            end,
-        {ok, NormPairs} ?= preprocess_all(Store, Function, Pairs, Opts),
-        {ok, NormPairs#{ NormPath => NormValue }}
-    end.
+%% @doc Normalize a value to the store through its `to-value'.
+to_value(Store, Value, Opts) ->
+    normalize(<<"to-value">>, Store, Value, Opts).
 
-%% @doc Whether a store message's prefix is stripped from admitted keys:
-%% enabled unless `prefix-strip' explicitly disables it.
-strips(Store, _Opts) ->
+%% @doc Whether the store's prefix is stripped from the paths it admits.
+strips(Store) ->
     hb_util:bool(maps:get(<<"prefix-strip">>, Store, true)).
 
-%% @doc Normalize a successful store result on its way back to the caller.
-%% A `read' result is replaced by exactly what its `normalize-result'
-%% resolution returns; enumerations -- `list' results and `composite' read
-%% children -- normalize each key independently. A `resolve' result regains
-%% any prefix stripped before store invocation. All other results pass through
-%% untouched.
-postprocess(Store, resolve, Result, _)
-        when is_map_key(<<"normalize-key">>, Store) ->
-    Result;
-postprocess(Store = #{ <<"prefix">> := Prefix }, resolve, {ok, Res}, [_, Opts])
-        when is_binary(Res) ->
-    case strips(Store, Opts) of
-        true -> {ok, <<Prefix/binary, Res/binary>>};
-        false -> {ok, Res}
-    end;
-postprocess(Store, _, Result, _) when not ?REQUIRES_POSTPROCESS(Store) ->
-    Result;
-postprocess(#{ <<"normalize-result">> := Path }, read, {ok, Value}, [_, Opts]) ->
-    normalize(Path, Value, Opts);
-postprocess(#{ <<"normalize-result">> := Path }, read, {composite, Keys},
-        [_, Opts]) ->
+%% @doc Normalize a store's answer from it: a read's value, the children a
+%% `list' or a composite read enumerates, and a resolved path, which regains
+%% a stripped prefix. Every other answer passes through.
+from_store(Store, read, {ok, Value}, Opts) ->
+    normalize(<<"from-value">>, Store, Value, Opts);
+from_store(Store, read, {composite, Children}, Opts) ->
     maybe
-        {ok, Normalized} ?= normalize_each(Path, Keys, Opts),
-        {composite, Normalized}
+        {ok, Norm} ?= from_children(Store, Children, Opts),
+        {composite, Norm}
     end;
-postprocess(#{ <<"normalize-result">> := Path }, list, {ok, Keys}, [_, Opts]) ->
-    normalize_each(Path, Keys, Opts);
-postprocess(_Store, _Function, Result, _Args) ->
+from_store(Store, list, {ok, Children}, Opts) ->
+    from_children(Store, Children, Opts);
+from_store(Store, resolve, {ok, Path}, Opts) ->
+    Prefix = maps:get(<<"prefix">>, Store, <<>>),
+    maybe
+        {ok, Norm} ?= normalize(<<"from-key">>, Store, Path, Opts),
+        {ok,
+            case strips(Store) of
+                true -> <<Prefix/binary, Norm/binary>>;
+                false -> Norm
+            end}
+    end;
+from_store(_Store, _Function, Result, _Opts) ->
     Result.
 
-%% @doc Normalize each key of an enumeration independently, propagating the
-%% first error encountered. Children given as `{Key, Value}' pairs normalize
-%% the key alone: values are data.
-normalize_each(_Path, [], _Opts) ->
-    {ok, []};
-normalize_each(Path, [{Key, Value} | Keys], Opts) ->
+%% @doc Normalize the children a store enumerates from it.
+from_children(Store, Children, Opts) ->
+    each(fun(Child) -> from_child(Store, Child, Opts) end, Children).
+
+%% @doc Normalize a child from the store: its key through `from-key', and
+%% the value of a child given as a pair through `from-value'.
+from_child(Store, {Key, Value}, Opts) ->
     maybe
-        {ok, Norm} ?= normalize(Path, Key, Opts),
-        {ok, Rest} ?= normalize_each(Path, Keys, Opts),
-        {ok, [{Norm, Value} | Rest]}
+        {ok, NormKey} ?= normalize(<<"from-key">>, Store, Key, Opts),
+        {ok, NormValue} ?= normalize(<<"from-value">>, Store, Value, Opts),
+        {ok, {NormKey, NormValue}}
     end;
-normalize_each(Path, [Key | Keys], Opts) ->
+from_child(Store, Key, Opts) ->
+    normalize(<<"from-key">>, Store, Key, Opts).
+
+%% @doc Normalize each term of a list in order, stopping at the first error.
+each(_Fun, []) -> {ok, []};
+each(Fun, [Term | Rest]) ->
     maybe
-        {ok, Norm} ?= normalize(Path, Key, Opts),
-        {ok, Rest} ?= normalize_each(Path, Keys, Opts),
-        {ok, [Norm | Rest]}
+        {ok, Norm} ?= Fun(Term),
+        {ok, Others} ?= each(Fun, Rest),
+        {ok, [Norm | Others]}
     end.
 
-%% @doc Resolve a normalization path over a value in `raw' mode. The value
-%% is scoped to the head of the parsed sequence as its `Base/body': a bare
-%% `body' key would be merged into every stage of the path, clobbering the
-%% values piped between them. The resolution sees only the stores that carry
-%% no pipeline of their own, so any loads it performs -- remote devices
-%% among them -- can never recurse into another normalization.
-normalize(Path, Body, Opts) ->
-    Stores = hb_opts:get(store, [], Opts),
-    StoreList =
-        case Stores of
-            List when is_list(List) -> List;
-            Store when is_map(Store) -> [Store];
-            _ -> []
-        end,
-    Direct =
-        lists:filter(
-            fun(S) ->
-                not (?REQUIRES_PREPROCESS(S) orelse ?REQUIRES_POSTPROCESS(S))
-            end,
-            StoreList
-        ),
-    hb_ao:raw(
-        #{ <<"path">> => Path, <<"0.body">> => Body },
-        Opts#{ <<"store">> => Direct }
-    ).
+%% @doc Resolve one of the store message's normalization paths over a term
+%% in `raw' mode, with the term as the `body' of the head of the path: a
+%% bare `body' key would be merged into every stage of the path, clobbering
+%% the values piped between them. A store message without the path leaves
+%% the term as it is. The resolution sees only the stores that carry no
+%% pipeline of their own, so any loads it performs -- remote devices among
+%% them -- can never recurse into another normalization.
+normalize(Setting, Store, Term, Opts) ->
+    case maps:get(Setting, Store, []) of
+        [] -> {ok, Term};
+        Path ->
+            hb_ao:raw(
+                #{ <<"path">> => Path, <<"0.body">> => Term },
+                Opts#{
+                    <<"store">> => [ S || S <- stores(Opts), not pipelined(S) ]
+                }
+            )
+    end.
+
+%% @doc The stores of the node's options as a list.
+stores(Opts) ->
+    case hb_opts:get(store, [], Opts) of
+        Stores when is_list(Stores) -> Stores;
+        Store -> [Store]
+    end.
 
 %% @doc Apply a store function, checking if the store returns a retry request or
 %% errors. If it does, attempt to start the store again and retry, up to the
@@ -1344,7 +1344,8 @@ benchmark_message(nested, N, TestDataSize) ->
 
 %% @doc Test that a store with a `prefix' only admits keys bearing it --
 %% writes and reads alike -- stripping the prefix ahead of invocation and
-%% falling through to later stores otherwise.
+%% falling through to later stores otherwise, and that a path resolved
+%% through it regains the prefix, as `hb_cache' reuses the resolution.
 prefix_pipeline_test() ->
     Mounted =
         (hb_test_utils:test_store(hb_store_fs, <<"pipeline-prefix">>))#{
@@ -1361,6 +1362,17 @@ prefix_pipeline_test() ->
     ?assertEqual({ok, <<"1">>}, read(StoreList, <<"mnt/inner">>, #{})),
     ?assertEqual({ok, <<"1">>}, read([Ungated], <<"inner">>, #{})),
     ?assertEqual({error, not_found}, read([Plain], <<"mnt/inner">>, #{})),
+    ?assertEqual(
+        {ok, <<"mnt/inner">>},
+        resolve(StoreList, <<"mnt/inner">>, #{})
+    ),
+    ?assertEqual(
+        {ok, <<"1">>},
+        hb_cache:read(
+            <<"mnt/inner">>,
+            #{ <<"store">> => Mounted, <<"cache-read-mode">> => raw }
+        )
+    ),
     ?event(testing, {prefixed_write_and_read_passed}),
     % A key without the prefix skips the mounted store entirely, for writes
     % and reads alike.
@@ -1376,30 +1388,6 @@ prefix_pipeline_test() ->
     ?assertEqual({error, not_found}, read([Ungated], <<"inner">>, #{})),
     ?assertEqual({ok, <<"2">>}, read([Plain], <<"outer">>, #{})),
     ?event(testing, {unprefixed_skip_and_strip_off_passed}).
-
-%% @doc Demonstrate that cache reads of mounted paths require `resolve' to
-%% cross the external-to-native prefix boundary and restore the external path.
-prefix_pipeline_resolve_test() ->
-    Mounted =
-        (hb_test_utils:test_store(hb_store_fs, <<"pipeline-resolve">>))#{
-            <<"prefix">> => <<"mnt/">>
-        },
-    Native = maps:remove(<<"prefix">>, Mounted),
-    start(Mounted),
-    ?assertEqual(ok, write([Mounted], write_req(<<"mnt/inner">>, <<"1">>), #{})),
-    % The store receives and persists the native path after prefix stripping.
-    ?assertEqual({ok, <<"1">>}, read([Native], <<"inner">>, #{})),
-    ?assertEqual({error, not_found}, resolve([Native], <<"mnt/inner">>, #{})),
-    % `resolve' must translate into the native namespace, then restore the
-    % mounted path because `hb_cache' reuses it for the subsequent read.
-    ?assertEqual({ok, <<"mnt/inner">>}, resolve([Mounted], <<"mnt/inner">>, #{})),
-    ?assertEqual(
-        {ok, <<"1">>},
-        hb_cache:read(
-            <<"mnt/inner">>,
-            #{ <<"store">> => Mounted, <<"cache-read-mode">> => raw }
-        )
-    ).
 
 %% @doc Test that lifecycle operations bypass path preprocessing for a store
 %% carrying a prefix.
@@ -1418,37 +1406,40 @@ prefix_pipeline_stop_test() ->
         ?assert(false)
     end.
 
-%% @doc Test that `normalize-key' rewrites admitted keys through its path
-%% ahead of the store -- for writes and reads alike -- and that
-%% `normalize-result' postprocesses read results, normalizing each key of
-%% list results and composite children independently. A key the
-%% normalization cannot decode, or a result that fails its normalization,
-%% falls through to the next store with the caller's original request.
+%% @doc Test that `to-key' and `to-value' rewrite a request's paths and
+%% values ahead of the store -- for writes and reads alike -- and that
+%% `from-key' and `from-value' normalize its answers: a read's value, each
+%% child a list or a composite read enumerates, and a resolved path, which
+%% regains its prefix. A path the normalization cannot decode, or an answer
+%% that fails its normalization, falls through to the next store with the
+%% caller's original request.
 normalize_pipeline_test() ->
     Store =
         (hb_test_utils:test_store(hb_store_fs, <<"pipeline-normalize">>))#{
             <<"prefix">> => <<"b64/">>,
-            <<"normalize-key">> => <<"~base64url@1.0/decode/body">>,
-            <<"normalize-result">> => <<"~base64url@1.0/encode/body">>
+            <<"to-key">> => <<"~base64url@1.0/decode/body">>,
+            <<"from-key">> => <<"~base64url@1.0/encode/body">>,
+            <<"to-value">> => <<"~base64url@1.0/encode/body">>,
+            <<"from-value">> => <<"~base64url@1.0/decode/body">>
         },
     Fallback = hb_test_utils:test_store(hb_store_fs, <<"pipeline-fallback">>),
-    Raw =
-        maps:without(
-            [<<"prefix">>, <<"normalize-key">>, <<"normalize-result">>],
-            Store
-        ),
+    Raw = maps:without(?PIPELINE_KEYS, Store),
     start([Store, Fallback]),
     ?event(testing, {normalize_pipeline_test_started}),
-    % A write under the canonical key is decoded ahead of the store: the
-    % decoded key is visible with the pipeline removed from the message.
+    % A write under the canonical key is decoded ahead of the store and its
+    % value encoded: both are visible with the pipeline removed from the
+    % message, and the read decodes the value again.
     EncodedKey = hb_util:encode(<<"inner">>),
     ?assertEqual(
         ok,
         write([Store], write_req(<<"b64/", EncodedKey/binary>>, <<"val">>), #{})
     ),
-    ?assertEqual({ok, <<"val">>}, read([Raw], <<"inner">>, #{})),
     ?assertEqual(
         {ok, hb_util:encode(<<"val">>)},
+        read([Raw], <<"inner">>, #{})
+    ),
+    ?assertEqual(
+        {ok, <<"val">>},
         read([Store], <<"b64/", EncodedKey/binary>>, #{})
     ),
     % A single store message is also a valid `store' option.
@@ -1459,11 +1450,12 @@ normalize_pipeline_test() ->
         write(write_req(<<"b64/", SingleKey/binary>>, <<"one">>), SingleOpts)
     ),
     ?assertEqual(
-        {ok, hb_util:encode(<<"one">>)},
+        {ok, <<"one">>},
         read(<<"b64/", SingleKey/binary>>, SingleOpts)
     ),
     ?event(testing, {normalized_write_and_read_passed}),
-    % Each list item is normalized through the same explicit path.
+    % Each child a list or a composite read enumerates is encoded, and a
+    % resolved path is encoded and regains its prefix.
     EncodedChild = hb_util:encode(<<"g/a">>),
     ?assertEqual(
         ok,
@@ -1474,10 +1466,13 @@ normalize_pipeline_test() ->
         {ok, [hb_util:encode(<<"a">>)]},
         list([Store], <<"b64/", EncodedGroup/binary>>, #{})
     ),
-    % A composite read of the same group normalizes its children alike.
     ?assertEqual(
         {composite, [hb_util:encode(<<"a">>)]},
         read([Store], <<"b64/", EncodedGroup/binary>>, #{})
+    ),
+    ?assertEqual(
+        {ok, <<"b64/", EncodedChild/binary>>},
+        resolve([Store], <<"b64/", EncodedChild/binary>>, #{})
     ),
     % An undecodable key skips the store for writes and reads alike, so the
     % fallback both receives and serves the original request.
@@ -1487,12 +1482,12 @@ normalize_pipeline_test() ->
     ),
     ?assertEqual({ok, <<"f">>}, read([Store, Fallback], <<"b64/!!!">>, #{})),
     ?event(testing, {undecodable_key_fell_through}),
-    % A result failing its normalization errs the store, falling through to
+    % An answer failing its normalization errs the store, falling through to
     % the next store that carries the key.
     Bad =
         (hb_test_utils:test_store(hb_store_fs, <<"pipeline-badresult">>))#{
             <<"prefix">> => <<"b64/">>,
-            <<"normalize-result">> => <<"~base64url@1.0/decode">>
+            <<"from-value">> => <<"~base64url@1.0/decode">>
         },
     start([Bad]),
     ?assertEqual(ok, write([Bad], write_req(<<"b64/x">>, <<"!!!">>), #{})),

--- a/src/core/store/hb_store.erl
+++ b/src/core/store/hb_store.erl
@@ -341,7 +341,7 @@ sort(Stores, ScoreMap) ->
 
 %% @doc Read a key from the store.
 read(Path, Opts) ->
-    read(hb_opts:get(store, [], Opts), Path, Opts).
+    read(hb_opts:get(<<"store">>, [], Opts), Path, Opts).
 read(Modules, Req = #{ <<"read">> := _ }, Opts) ->
     call_function(Modules, read, [Req, Opts]);
 read(Modules, Path, Opts) ->
@@ -349,14 +349,14 @@ read(Modules, Path, Opts) ->
 
 %% @doc Write a key with a value to the store.
 write(Req, Opts) ->
-    write(hb_opts:get(store, [], Opts), Req, Opts).
+    write(hb_opts:get(<<"store">>, [], Opts), Req, Opts).
 write(Modules, Req, Opts) ->
     call_function(Modules, write, [Req, Opts]).
 
 %% @doc Make a group in the store. A group can be seen as a namespace or
 %% 'directory' in a filesystem.
 group(Path, Opts) ->
-    group(hb_opts:get(store, [], Opts), Path, Opts).
+    group(hb_opts:get(<<"store">>, [], Opts), Path, Opts).
 group(Modules, Req = #{ <<"group">> := _ }, Opts) ->
     call_function(Modules, group, [Req, Opts]);
 group(Modules, Path, Opts) ->
@@ -364,7 +364,7 @@ group(Modules, Path, Opts) ->
 
 %% @doc Make a link from one path to another in the store.
 link(Req, Opts) ->
-    link(hb_opts:get(store, [], Opts), Req, Opts).
+    link(hb_opts:get(<<"store">>, [], Opts), Req, Opts).
 link(Modules, Req, Opts) ->
     call_function(Modules, link, [Req, Opts]).
 
@@ -383,7 +383,7 @@ reset(Stores, Req, Opts) ->
 %% @doc Get the type of element of a given path in the store. This can be
 %% a performance killer if the store is remote etc. Use only when necessary.
 type(Path, Opts) ->
-    type(hb_opts:get(store, [], Opts), Path, Opts).
+    type(hb_opts:get(<<"store">>, [], Opts), Path, Opts).
 type(Modules, Req = #{ <<"type">> := _ }, Opts) ->
     call_function(Modules, type, [Req, Opts]);
 type(Modules, Path, Opts) ->
@@ -391,7 +391,7 @@ type(Modules, Path, Opts) ->
 
 %% @doc Follow links through the store to resolve a path to its ultimate target.
 resolve(Path, Opts) ->
-    resolve(hb_opts:get(store, [], Opts), Path, Opts).
+    resolve(hb_opts:get(<<"store">>, [], Opts), Path, Opts).
 resolve(Modules, Req = #{ <<"resolve">> := _ }, Opts) ->
     call_function(Modules, resolve, [Req, Opts]);
 resolve(Modules, Path, Opts) ->
@@ -401,7 +401,7 @@ resolve(Modules, Path, Opts) ->
 %% The hyperbeam model assumes that stores are built as efficient hash-based
 %% structures, so this is likely to be very slow for most stores.
 list(Path, Opts) ->
-    list(hb_opts:get(store, [], Opts), Path, Opts).
+    list(hb_opts:get(<<"store">>, [], Opts), Path, Opts).
 list(Modules, Req = #{ <<"list">> := _ }, Opts) ->
     call_function(Modules, list, [Req, Opts]);
 list(Modules, Path, Opts) ->
@@ -412,7 +412,7 @@ list(Modules, Path, Opts) ->
 %% messages in the store that feature all of the given key-value pairs. `Matches'
 %% is given as a list of IDs.
 match(Match, Opts) ->
-    match(hb_opts:get(store, [], Opts), Match, Opts).
+    match(hb_opts:get(<<"store">>, [], Opts), Match, Opts).
 match(Modules, Match, Opts) ->
     call_function(Modules, match, [Match, Opts]).
 

--- a/src/core/store/hb_store.erl
+++ b/src/core/store/hb_store.erl
@@ -316,7 +316,7 @@ get_store_scope(Store) ->
 sort(Stores, PreferenceOrder) when is_list(PreferenceOrder) ->
     sort(
         Stores,
-        hb_maps:from_list(
+        maps:from_list(
             [
                 {Scope, -Index}
             ||
@@ -331,8 +331,8 @@ sort(Stores, PreferenceOrder) when is_list(PreferenceOrder) ->
 sort(Stores, ScoreMap) ->
     lists:sort(
         fun(Store1, Store2) ->
-            hb_maps:get(get_store_scope(Store1), ScoreMap, 0) >
-                hb_maps:get(get_store_scope(Store2), ScoreMap, 0)
+            maps:get(get_store_scope(Store1), ScoreMap, 0) >
+                maps:get(get_store_scope(Store2), ScoreMap, 0)
         end,
         Stores
     ).


### PR DESCRIPTION
Introduces flexible `pre-` and `post-`processing pipeline for `hb_store` invocations. This allows node operators to optimize their setups by storing keys and values with particular representations, while AO-Core and its devices remain agnostic to these specifics.

## Store Prefixes

The simplest transformation in the pipeline is that store configuration messages may now specify that they are only interested in servicing (via read _or_ write) specific prefixes of keys by setting `prefix`. This allows, for example, the node operator to specify that all pseudopaths for a given device (often those with keys starting with `~device@version/`) should be the responsibility of the store, while others should skip it.

By default, if a prefix is specified it is also removed from the key before the store is invoked (and re-added after if the function was `resolve`). This shortens the length of the key. To disable this behavior, `prefix-strip` can be set to false.

## Key and Value Normalization

Each element of the `store` list in a node's configuration message may now specify the transformations that should be performed using four new keys: `to-key`, `to-value`, `from-key`, and `from-value`. In this initial version the values of these keys are expected to be AO-Core paths, invoked to gain the key/value to pass to the store/caller as follows:

```
hb_ao:raw(#{ <<"path">> => PATH, <<"body">> => KeyOrValue }, Opts) -> {ok, Converted}.
```

Under-the-hood, the pipeline processes store invocations through several stages:
*   Prefix matching and removal (configurable via `prefix` and `prefix-strip`).
*   Pre-normalization of request keys and values (`to-key` and `to-value` in most cases).
*   Store invocation.
*   Post-normalization of response keys and values (`from-key` and `from-value` in most cases).
*   Re-prefixing for resolved paths.

A request that does not match a store's prefix or fails during normalization (both `pre-` and `post-`) is treated as if the store had returned a `not_found`/skip result.