### PR TITLE
feat: `hb_store:list` bounded reads, cursors, and directionality

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -182,11 +182,12 @@
 ]}.
 
 {deps, [
-    %% elmdb pinned to faa7623 on permaweb/elmdb-rs `feat/read-prefix': adds
-    %% `elmdb:read_prefix/2' (packed single-buffer row materialization) used by
-    %% the LMDB composite reads below (edge's 06ccf937 + the read_prefix NIF
-    %% commits). Repin to the default branch once read_prefix lands there.
-    {elmdb, {git, "https://github.com/permaweb/elmdb-rs.git", {ref, "faa762323be6bad2db26abfa1d4243863a877f0f"}}},
+    %% elmdb pinned to acd8c95 on permaweb/elmdb-rs `feat/list-range': adds
+    %% `elmdb:list/3', a children list from a named child, in either direction,
+    %% up to a limit, over faa7623's `read_prefix/2' (packed single-buffer row
+    %% materialization) used by the LMDB composite reads below. Repin to the
+    %% default branch once both land there.
+    {elmdb, {git, "https://github.com/permaweb/elmdb-rs.git", {ref, "acd8c95e9d4466a8bb77082b6eed17d6220835df"}}},
     {b64veryfast, {git, "https://github.com/permaweb/b64veryfast.git", {ref, "20ea7c4b5420501c9a4d5f19d8f043a2e96f3271"}}},
     {base32, "1.0.0"},
     {cowlib, "2.16.0"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -11,7 +11,7 @@
  {<<"ddskerl">>,{pkg,<<"ddskerl">>,<<"0.4.2">>},1},
  {<<"elmdb">>,
   {git,"https://github.com/permaweb/elmdb-rs.git",
-       {ref,"faa762323be6bad2db26abfa1d4243863a877f0f"}},
+       {ref,"acd8c95e9d4466a8bb77082b6eed17d6220835df"}},
   0},
  {<<"eqwalizer_support">>,
   {git_subdir,"https://github.com/whatsapp/eqwalizer.git",

--- a/src/core/store/hb_store.erl
+++ b/src/core/store/hb_store.erl
@@ -30,7 +30,13 @@
 %%%                   term, using a request map of the form `#{ <<"read">> => Path }`.
 %%%     write/3:      Write a request map of the form `#{ Path => Value }`.
 %%%     list/3:       For `composite' type keys, return child keys using a
-%%%                   request map of the form `#{ <<"list">> => Path }`.
+%%%                   request map of the form `#{ <<"list">> => Path }`:
+%%%                   every child, in the store's own order. A request may
+%%%                   instead bound the list: `from' is the child it should
+%%%                   start at, inclusive, in its `direction' (`asc' or
+%%%                   `desc'), and `limit' the most children returned.
+%%%                   `limit' can also be `batch' for every child the store
+%%%                   finds without further work (store determined).
 %%%                   Composite read results may also return children as
 %%%                   `{Key, Value}' pairs when the store can provide a child
 %%%                   value without an additional read.
@@ -536,6 +542,15 @@ to_store(Store, Function, Req, Opts)
     to_pairs(Store, fun to_value/3, Req, Opts);
 to_store(Store, link, Req, Opts) ->
     to_pairs(Store, fun to_key/3, Req, Opts);
+to_store(Store, list, Req = #{ <<"from">> := From }, Opts) ->
+    % The child a list starts from is a key, as the children it answers
+    % with are: it carries no prefix.
+    maybe
+        {ok, NormFrom} ?= execute_normalizer(<<"to-key">>, Store, From, Opts),
+        {ok, NormReq} ?=
+            to_store(Store, list, maps:remove(<<"from">>, Req), Opts),
+        {ok, NormReq#{ <<"from">> => NormFrom }}
+    end;
 to_store(Store, Function, Req, Opts)
         when Function =:= read orelse Function =:= list orelse
             Function =:= type orelse Function =:= group orelse

--- a/src/core/store/hb_store_fs.erl
+++ b/src/core/store/hb_store_fs.erl
@@ -94,9 +94,11 @@ write_path(Opts, PathComponents, Value) ->
     ok.
 
 %% @doc List contents of a directory in the store.
-list(Opts, #{ <<"list">> := Path }, _NodeOpts) ->
+list(Opts, Req = #{ <<"list">> := Path }, _NodeOpts) ->
     case file:list_dir(add_prefix(Opts, hb_path:to_binary(Path))) of
-        {ok, Files} -> {ok, lists:map(fun hb_util:bin/1, Files)};
+        {ok, Files} ->
+            Children = lists:map(fun hb_util:bin/1, Files),
+            {ok, hb_store_utils:apply_list_bounds(Children, Req)};
         {error, _} -> {error, not_found}
     end.
 

--- a/src/core/store/hb_store_lmdb.erl
+++ b/src/core/store/hb_store_lmdb.erl
@@ -459,7 +459,7 @@ scope(_) -> scope().
 %% @param StoreOpts Database configuration map
 %% @param Path Binary prefix to search for
 %% @returns {ok, [Key]} list of matching keys, {error, Reason} on failure
-list(Opts, #{ <<"list">> := Path }, _NodeOpts) ->
+list(Opts, Req = #{ <<"list">> := Path }, _NodeOpts) ->
     EnvOpts = ensure_env(Opts),
     PathBin =
         case is_binary(Path) of
@@ -468,21 +468,31 @@ list(Opts, #{ <<"list">> := Path }, _NodeOpts) ->
         end,
     case read_resolved(EnvOpts, PathBin) of
         {ok, ResolvedPath, <<"group">>} ->
-            list_children(EnvOpts, ResolvedPath);
+            list_children(EnvOpts, ResolvedPath, Req);
         {ok, _ResolvedPath, _Value} ->
             {error, not_found};
         not_found ->
             {error, not_found}
     end.
 
-list_children(Opts, ResolvedPath) ->
-    SearchPath = child_prefix(ResolvedPath),
-    % Use native elmdb:list function
+%% @doc The children of a group through the NIF's cursor: every one, or
+%% those the request names from its `from' in its direction, no more than
+%% its limit -- a batch being every child: LMDB reads a page at a time only
+%% from a key's fixed-size duplicate values, and the database holds none.
+list_children(Opts, ResolvedPath, Req) ->
+    #{
+        <<"from">> := From,
+        <<"limit">> := Limit,
+        <<"direction">> := Direction
+    } = hb_store_utils:list_request_bounds(Req),
     #{ <<"db">> := DBInstance } = find_env(Opts),
-    case elmdb:list(DBInstance, SearchPath) of
+    Options =
+        [ {from, From} || From =/= none ] ++
+        [ {limit, Limit} || Limit =/= all ] ++
+        [ {direction, case Direction of asc -> forward; desc -> backward end} ],
+    case elmdb:list(DBInstance, child_prefix(ResolvedPath), Options) of
         {ok, Children} -> {ok, Children};
-        {error, not_found} -> {ok, []};
-        not_found -> {ok, []}
+        {error, Type, Description} -> {error, {Type, Description}}
     end.
 
 read_prefix_rows(Opts, Path) ->
@@ -816,7 +826,7 @@ test_list(StoreOpts, Path) ->
             not_found ->
                 PathBin
         end,
-    list_children(StoreOpts, ResolvedPath).
+    list_children(StoreOpts, ResolvedPath, #{}).
 
 test_write(StoreOpts, Path, Value) ->
     ok = write(StoreOpts, Path, Value),

--- a/src/core/store/hb_store_utils.erl
+++ b/src/core/store/hb_store_utils.erl
@@ -1,0 +1,115 @@
+%%% @doc Helper tools for `hb_store` implementations, common across
+%%% implementations
+-module(hb_store_utils).
+-export([list_request_bounds/1, apply_list_bounds/2]).
+-include_lib("eunit/include/eunit.hrl").
+
+%% @doc The bounds of a list request as a message: the child it starts
+%% from, or `none'; the most children it returns, `batch', or `all'; and
+%% its direction, `asc' or `desc'. A request naming none of them bounds
+%% nothing: every child, in the store's own order.
+list_request_bounds(Req) ->
+    #{
+        <<"from">> => maps:get(<<"from">>, Req, none),
+        <<"limit">> =>
+            case maps:get(<<"limit">>, Req, all) of
+                all -> all;
+                batch -> batch;
+                Limit -> hb_util:int(Limit)
+            end,
+        <<"direction">> => hb_util:atom(maps:get(<<"direction">>, Req, asc))
+    }.
+
+%% @doc The children a list request names, from every child a store holds:
+%% all of them, in the store's own order, unless the request bounds the
+%% list -- from a child, in a direction, or up to a limit -- when they are
+%% the sorted children within its bounds. A batch is every child.
+apply_list_bounds(Children, Req) ->
+    case list_request_bounds(Req) of
+        #{ <<"from">> := none, <<"limit">> := all, <<"direction">> := asc } ->
+            Children;
+        #{
+            <<"from">> := From,
+            <<"limit">> := Limit,
+            <<"direction">> := Direction
+        } ->
+            Ordered =
+                case Direction of
+                    asc -> lists:sort(Children);
+                    desc -> lists:reverse(lists:sort(Children))
+                end,
+            Ahead =
+                lists:dropwhile(
+                    fun(Child) -> behind(Direction, Child, From) end,
+                    Ordered
+                ),
+            case Limit of
+                Count when is_integer(Count) -> lists:sublist(Ahead, Count);
+                _ -> Ahead
+            end
+    end.
+
+%% @doc Whether a child lies before the start of a bounded list.
+behind(_Direction, _Child, none) -> false;
+behind(asc, Child, From) -> Child < From;
+behind(desc, Child, From) -> Child > From.
+
+%%% Tests
+
+%% @doc A list without bounds is every child, however many; from a named
+%% child it walks the group's sorted children from it, inclusive, in either
+%% direction, up to its limit or as a batch.
+list_request_bounds_test_() ->
+    hb_store:generate_test_suite([{"list bounds", fun list_bounds/1}]).
+
+list_bounds(Store) ->
+    ok = hb_store:group(Store, <<"set">>, #{}),
+    lists:foreach(
+        fun(Name) ->
+            Key = hb_path:to_binary([<<"set">>, Name]),
+            ok = hb_store:write(Store, #{ Key => <<>> }, #{})
+        end,
+        [<<"b">>, <<"d">>, <<"a">>, <<"c">>]
+    ),
+    List =
+        fun(Req) ->
+            hb_store:list(Store, Req#{ <<"list">> => <<"set">> }, #{})
+        end,
+    {ok, All} = List(#{}),
+    ?assertEqual([<<"a">>, <<"b">>, <<"c">>, <<"d">>], lists:sort(All)),
+    ok = hb_store:group(Store, <<"many">>, #{}),
+    ok =
+        hb_store:write(
+            Store,
+            maps:from_list(
+                [
+                    {hb_path:to_binary([<<"many">>, hb_util:bin(N)]), <<>>}
+                ||
+                    N <- lists:seq(1, 1500)
+                ]
+            ),
+            #{}
+        ),
+    {ok, Many} = hb_store:list(Store, <<"many">>, #{}),
+    ?assertEqual(1500, length(Many)),
+    ?assertEqual(
+        {ok, [<<"b">>, <<"c">>]},
+        List(#{ <<"from">> => <<"b">>, <<"limit">> => 2 })
+    ),
+    ?assertEqual(
+        {ok, [<<"c">>, <<"d">>]},
+        List(#{ <<"from">> => <<"bb">>, <<"limit">> => 5 })
+    ),
+    ?assertEqual(
+        {ok, [<<"c">>, <<"b">>, <<"a">>]},
+        List(#{ <<"from">> => <<"c">>, <<"direction">> => <<"desc">> })
+    ),
+    ?assertEqual(
+        {ok, [<<"d">>, <<"c">>]},
+        List(#{ <<"direction">> => desc, <<"limit">> => 2 })
+    ),
+    ?assertEqual(
+        {ok, [<<"c">>, <<"d">>]},
+        List(#{ <<"from">> => <<"c">>, <<"limit">> => batch })
+    ),
+    ?assertEqual({ok, []}, List(#{ <<"from">> => <<"e">> })).

--- a/src/core/store/hb_store_volatile.erl
+++ b/src/core/store/hb_store_volatile.erl
@@ -161,17 +161,18 @@ resolve_path(Opts, CurrPath, [Next | Rest], Depth) ->
     end.
 
 %% @doc List immediate child names under a group path.
-list(Opts, #{ <<"list">> := RawPath }, _NodeOpts) ->
-    list_path(Opts, hb_path:to_binary(RawPath)).
+list(Opts, Req = #{ <<"list">> := RawPath }, _NodeOpts) ->
+    list_path(Opts, hb_path:to_binary(RawPath), Req).
 
-list_path(Opts, <<"">>) ->
-    list_path(Opts, ?ROOT_GROUP);
-list_path(Opts, Path) ->
+list_path(Opts, <<"">>, Req) ->
+    list_path(Opts, ?ROOT_GROUP, Req);
+list_path(Opts, Path, Req) ->
     case lookup_entry(Opts, Path) of
         group ->
-            {ok, immediate_children(Opts, Path)};
+            Children = immediate_children(Opts, Path),
+            {ok, hb_store_utils:apply_list_bounds(Children, Req)};
         {link, Link} ->
-            list_path(Opts, hb_path:to_binary(Link));
+            list_path(Opts, hb_path:to_binary(Link), Req);
         nil when Path =:= ?ROOT_GROUP ->
             %% Empty store at root — no entries here; return `not_found`
             %% rather than `{ok, []}` so a chained store can serve the
@@ -182,7 +183,7 @@ list_path(Opts, Path) ->
             %% links. If resolution yields the same path, it's truly absent.
             case resolve_path(Opts, Path) of
                 Path -> {error, not_found};
-                Resolved -> list_path(Opts, Resolved)
+                Resolved -> list_path(Opts, Resolved, Req)
             end;
         _ ->
             {error, not_found}


### PR DESCRIPTION
This PR is the next in the series (#1108, #1109, #1115) leading to support for efficient GraphQL execution across both locally held stores and Arweave-hosted content. The intention is that at the end of this sequence HyperBEAM nodes should be able to easily offer real-time (including mempool) Arweave-compatible GraphQL services by utilizing ArLMDB snapshots onweave and indexing only the small tip of transactions since the last upload.

In this PR we add support for requesting  partial lists of the sub-keys found at a store prefix, rather than always having to return the entire set.

In the context of the wider arc, this mechanism allows us to load just a small number of the potentially extremely large result set for a hashpath listing. As a result we are able to efficiently return just a single page of GraphQL results rather than pre-computing every known answer before returning only a subset.

The API is as follows:
```
hb_store:list:
    Req/list: The prefix to list the child elements of.
    Req/from: The key (inclusive) that we should start the list operation from, if known in the store.
        Does not include the shared prefix.
    Req/limit: An integer or `batch`. The maximum number of result to return, including the `from` key if present.
        If `limit: batch`, the underlying store should return all of the results that a single 'seek'-equivalent
        operation can provide. Using this option ensures that no matter the underlying store, work is not
        discarded.
    Req/direction: Either `asc`, `desc`, or not provided. In the case that the direction is not supplied the 'natural'
        ordering of the store is used.
```