### PR TITLE
impr: Singleflight mechanism (hb_persistent)

### DIFF
--- a/src/core/resolver/hb_persistent.erl
+++ b/src/core/resolver/hb_persistent.erl
@@ -137,6 +137,7 @@ elect_leader(GroupName, Opts) ->
 %% @doc Unregister as the leader for an execution and notify waiting processes.
 unregister_notify(ungrouped_exec, _Req, _Res, _Opts) -> ok;
 unregister_notify(GroupName, Req, Res, Opts) ->
+    % Close enrollment before draining requests already queued for this leader.
     unregister_groupname(GroupName, Opts),
     notify(GroupName, Req, Res, Opts).
 
@@ -191,16 +192,27 @@ await(Worker, Base, Req, Opts) ->
     % Calculate the compute path that we will wait upon resolution of.
     % Register with the process.
     GroupName = group(Base, Req, Opts),
-    % set monitor to a worker, so we know if it exits
-    _Ref = erlang:monitor(process, Worker),
+    % Monitor before enrolling so that a leader exit cannot be missed.
+    MonitorRef = erlang:monitor(process, Worker),
     Worker ! {resolve, self(), GroupName, Req, Opts},
-    AwaitFun(Worker, GroupName, Base, Req, Opts).
+    % The leader unregisters before draining its enrolled waiters. If it no
+    % longer owns the group, this request may have missed that drain and must
+    % retry election instead of waiting indefinitely.
+    case find_execution(GroupName, Opts) of
+        {ok, Worker} ->
+            try AwaitFun(Worker, GroupName, Base, Req, Opts)
+            after erlang:demonitor(MonitorRef, [flush])
+            end;
+        _ ->
+            erlang:demonitor(MonitorRef, [flush]),
+            {error, leader_died}
+    end.
 
 %% @doc Default await function that waits for a resolution from a worker.
 default_await(Worker, GroupName, Base, Req, Opts) ->
     % Wait for the result.
     receive
-        {resolved, _, GroupName, Req, Res} ->
+        {resolved, Worker, GroupName, Req, Res} ->
             worker_event(GroupName, {resolved_await, Res}, Base, Req, Opts),
             Res;
         {'DOWN', _R, process, Worker, Reason} ->
@@ -486,6 +498,37 @@ atomic_leader_election_test() ->
     lists:foreach(fun(Worker) -> Worker ! stop end, Workers),
     ?assertEqual(length(Workers) - 1, length(Waiters)),
     ?assert(lists:all(fun(Pid) -> Pid =:= Leader end, Waiters)).
+
+%% @doc A waiter retries rather than blocking after enrollment has closed.
+closed_waiter_enrollment_test() ->
+    Base = #{
+        <<"device">> => test_device(),
+        <<"test">> => crypto:strong_rand_bytes(8)
+    },
+    Req = #{ <<"path">> => <<"slow_key">>, <<"wait">> => 1 },
+    Opts = #{ <<"await-inprogress">> => true },
+    Worker = spawn_link(fun() -> receive stop -> ok end end),
+    ?assertEqual({error, leader_died}, await(Worker, Base, Req, Opts)),
+    Worker ! stop,
+    receive
+        {'DOWN', _, process, Worker, _} -> ?assert(false)
+    after 10 -> ok
+    end.
+
+%% @doc A waiter only accepts completion from its elected leader.
+completion_sender_test() ->
+    GroupName = {?MODULE, completion_sender, make_ref()},
+    Req = #{ <<"path">> => <<"test">> },
+    Worker = self(),
+    Other = spawn_link(fun() -> receive stop -> ok end end),
+    self() ! {resolved, Other, GroupName, Req, stale},
+    self() ! {resolved, Worker, GroupName, Req, expected},
+    ?assertEqual(
+        expected,
+        default_await(Worker, GroupName, #{}, Req, #{})
+    ),
+    receive {resolved, Other, GroupName, Req, stale} -> ok end,
+    Other ! stop.
 
 %% @doc The default group uses collision-resistant AO-Core execution identity.
 default_group_identity_test() ->

--- a/src/core/resolver/hb_persistent.erl
+++ b/src/core/resolver/hb_persistent.erl
@@ -112,18 +112,25 @@ find_or_register(ungrouped_exec, _Base, _Req, _Opts) ->
 find_or_register(GroupName, _Base, _Req, Opts) ->
     case hb_opts:get(await_inprogress, false, Opts) of
         false -> {leader, GroupName};
-        _ ->
+        _ -> elect_leader(GroupName, Opts)
+    end.
+
+%% @doc Atomically register as leader or return the process that won election.
+elect_leader(GroupName, Opts) ->
+    case register_groupname(GroupName, Opts) of
+        ok ->
+            ?event({register_resolver, {group, GroupName}}),
+            {leader, GroupName};
+        error ->
             Self = self(),
             case find_execution(GroupName, Opts) of
                 {ok, Leader} when Leader =/= Self ->
                     ?event({found_leader, GroupName, {leader, Leader}}),
                     {wait, Leader};
-                {ok, Leader} when Leader =:= Self ->
+                {ok, Self} ->
                     {infinite_recursion, GroupName};
-                _ ->
-                    ?event({register_resolver, {group, GroupName}}),
-                    register_groupname(GroupName, Opts),
-                    {leader, GroupName}
+                not_found ->
+                    elect_leader(GroupName, Opts)
             end
     end.
 
@@ -445,6 +452,40 @@ spawn_test_client(Base, Req, Opts) ->
 
 wait_for_test_result(Ref) ->
     receive {result, Ref, Res} -> Res end.
+
+%% @doc Concurrent elections produce one leader and direct all losers to it.
+atomic_leader_election_test() ->
+    start(),
+    GroupName = {?MODULE, atomic_election, make_ref()},
+    Opts = #{ <<"await-inprogress">> => true },
+    Parent = self(),
+    Workers =
+        [
+            spawn_link(fun() ->
+                Parent ! {ready, self()},
+                receive start -> ok end,
+                Election =
+                    find_or_register(GroupName, undefined, undefined, Opts),
+                Parent ! {elected, self(), Election},
+                receive stop -> ok end
+            end)
+        || _ <- lists:seq(1, 50)
+        ],
+    [receive {ready, Worker} -> ok end || Worker <- Workers],
+    lists:foreach(fun(Worker) -> Worker ! start end, Workers),
+    Elections =
+        [
+            receive {elected, Worker, Election} -> {Worker, Election} end
+        || Worker <- Workers
+        ],
+    Leaders =
+        [{Worker, Name} || {Worker, {leader, Name}} <- Elections],
+    [{Leader, GroupName}] = Leaders,
+    Waiters = [Pid || {_, {wait, Pid}} <- Elections],
+    hb_name:unregister(GroupName),
+    lists:foreach(fun(Worker) -> Worker ! stop end, Workers),
+    ?assertEqual(length(Workers) - 1, length(Waiters)),
+    ?assert(lists:all(fun(Pid) -> Pid =:= Leader end, Waiters)).
 
 %% @doc The default group uses collision-resistant AO-Core execution identity.
 default_group_identity_test() ->

--- a/src/core/resolver/hb_persistent.erl
+++ b/src/core/resolver/hb_persistent.erl
@@ -175,7 +175,7 @@ unregister(Base, Req, Opts) ->
     unregister_groupname(group(Base, Req, Opts), Opts).
 unregister_groupname(Groupname, _Opts) ->
     ?event({unregister_resolver, {explicit, Groupname}}),
-    hb_name:unregister(Groupname).
+    hb_name:unregister(Groupname, self()).
 
 %% @doc If there was already an Erlang process handling this execution,
 %% we should register with them and wait for them to notify us of
@@ -498,6 +498,16 @@ atomic_leader_election_test() ->
     lists:foreach(fun(Worker) -> Worker ! stop end, Workers),
     ?assertEqual(length(Workers) - 1, length(Waiters)),
     ?assert(lists:all(fun(Pid) -> Pid =:= Leader end, Waiters)).
+
+%% @doc A stale leader cannot unregister the current group owner.
+unregister_respects_owner_test() ->
+    GroupName = {?MODULE, unregister_respects_owner, make_ref()},
+    Owner = spawn_link(fun() -> receive stop -> ok end end),
+    ?assertEqual(ok, hb_name:register(GroupName, Owner)),
+    ?assertEqual(ok, unregister_groupname(GroupName, #{})),
+    ?assertEqual(Owner, hb_name:lookup(GroupName)),
+    hb_name:unregister(GroupName),
+    Owner ! stop.
 
 %% @doc A waiter retries rather than blocking after enrollment has closed.
 closed_waiter_enrollment_test() ->

--- a/src/core/resolver/hb_persistent.erl
+++ b/src/core/resolver/hb_persistent.erl
@@ -462,6 +462,18 @@ spawn_test_client(Base, Req, Opts) ->
     end),
     Ref.
 
+%% @doc Spawn a test resolver that waits for a shared start signal.
+spawn_gated_test_client(Base, Req, Opts, Gate) ->
+    Ref = make_ref(),
+    TestParent = self(),
+    Pid = spawn_link(fun() ->
+        TestParent ! {ready, Ref},
+        receive {go, Gate} -> ok end,
+        Res = hb_ao:resolve(Base, Req, Opts),
+        TestParent ! {result, Ref, Res}
+    end),
+    {Pid, Ref}.
+
 wait_for_test_result(Ref) ->
     receive {result, Ref, Res} -> Res end.
 
@@ -569,22 +581,43 @@ default_worker_group_identity_test() ->
         default_grouper(Base, undefined, Opts)
     ).
 
-%% @doc Test merging and returning a value with a persistent worker.
+%% @doc Concurrent resolutions share one execution, then release the group.
 deduplicated_execution_test() ->
     TestTime = 200,
-    Base = #{ <<"device">> => test_device() },
+    Executions = atomics:new(1, []),
+    SlowKey =
+        fun(_, #{ <<"wait">> := Wait }) ->
+            _ = atomics:add_get(Executions, 1, 1),
+            receive after Wait ->
+                {ok,
+                    #{
+                        waited => Wait,
+                        pid => self(),
+                        random_bytes =>
+                            hb_util:encode(crypto:strong_rand_bytes(4))
+                    }
+                }
+            end
+        end,
+    Device = (test_device())#{ slow_key := SlowKey },
+    Base = #{ <<"device">> => Device },
     Req = #{ <<"path">> => <<"slow_key">>, <<"wait">> => TestTime },
-    T0 = hb:now(),
-    Ref1 = spawn_test_client(Base, Req),
-    receive after 100 -> ok end,
-    Ref2 = spawn_test_client(Base, Req),
-    Res1 = wait_for_test_result(Ref1),
-    Res2 = wait_for_test_result(Ref2),
-    T1 = hb:now(),
-    % Check the result is the same.
-    ?assertEqual(Res1, Res2),
-    % Check the time it took is less than the sum of the two test times.
-    ?assert(T1 - T0 < (2*TestTime)).
+    Opts = #{
+        <<"await-inprogress">> => true,
+        <<"cache-control">> => [<<"no-cache">>, <<"no-store">>]
+    },
+    Gate = make_ref(),
+    Clients =
+        [spawn_gated_test_client(Base, Req, Opts, Gate)
+        || _ <- lists:seq(1, 20)],
+    [receive {ready, Ref} -> ok end || {_, Ref} <- Clients],
+    lists:foreach(fun({Pid, _}) -> Pid ! {go, Gate} end, Clients),
+    [First | Rest] =
+        [wait_for_test_result(Ref) || {_, Ref} <- Clients],
+    ?assert(lists:all(fun(Res) -> Res =:= First end, Rest)),
+    ?assertEqual(1, atomics:get(Executions, 1)),
+    ?assertMatch({ok, _}, hb_ao:resolve(Base, Req, Opts)),
+    ?assertEqual(2, atomics:get(Executions, 1)).
 
 %% @doc Test spawning a default persistent worker.
 persistent_worker_test() ->

--- a/src/core/resolver/hb_persistent.erl
+++ b/src/core/resolver/hb_persistent.erl
@@ -367,30 +367,24 @@ default_worker(GroupName, Base, Opts) ->
         unregister(Base, undefined, Opts)
     end.
 
-%% @doc Create a group name from a Base and Req pair as a tuple.
+%% @doc Create a group name from the AO-Core identity of a Base and Req pair.
 default_grouper(Base, Req, Opts) ->
     %?event({calculating_default_group_name, {base, Base}, {req, Req}}),
-    % Use Erlang's `phash2' to hash the result of the Grouper function.
-    % `phash2' is relatively fast and ensures that the group name is short for
-    % storage in `pg'. In production we should only use a hash with a larger
-    % output range to avoid collisions.
-    ?no_prod("Using a hash for group names is not secure."),
     case hb_opts:get(await_inprogress, true, Opts) of
         true ->
-            erlang:phash2(
-                {
-                    hb_maps:without([<<"priv">>], Base, Opts),
-                    hb_maps:without([<<"priv">>], Req, Opts)
-                }
-            );
+            {?MODULE, execution_id(Base, Req, Opts)};
         _ -> ungrouped_exec
     end.
+
+%% @doc Return the AO-Core identity for an execution or persistent worker.
+execution_id(Base, undefined, Opts) -> hb_path:hashpath(Base, Opts);
+execution_id(Base, Req, Opts) -> hb_path:hashpath(Base, Req, Opts).
 
 %% @doc Log an event with the worker process. If we used the default grouper
 %% function, we should also include the Base and Req in the event. If we did not,
 %% we assume that the group name expresses enough information to identify the
 %% request.
-worker_event(Group, Data, Base, Req, Opts) when is_integer(Group) ->
+worker_event(Group = {?MODULE, _}, Data, Base, Req, Opts) ->
     ?event(worker, {worker_event, Group, Data, {base, Base}, {req, Req}}, Opts);
 worker_event(Group, Data, _, _, Opts) ->
     ?event(worker, {worker_event, Group, Data}, Opts).
@@ -451,6 +445,35 @@ spawn_test_client(Base, Req, Opts) ->
 
 wait_for_test_result(Ref) ->
     receive {result, Ref, Res} -> Res end.
+
+%% @doc The default group uses collision-resistant AO-Core execution identity.
+default_group_identity_test() ->
+    Base = #{ <<"device">> => <<"message@1.0">>, <<"value">> => <<"base">> },
+    Req = #{ <<"path">> => <<"value">> },
+    Opts = #{ <<"await-inprogress">> => true },
+    Group = default_grouper(Base, Req, Opts),
+    ?assertEqual(
+        {?MODULE, hb_path:hashpath(Base, Req, Opts)},
+        Group
+    ),
+    ?assertEqual(Group, default_grouper(Base, Req, Opts)),
+    ?assertNotEqual(
+        Group,
+        default_grouper(Base, Req#{ <<"path">> => <<"device">> }, Opts)
+    ),
+    ?assertEqual(
+        ungrouped_exec,
+        default_grouper(Base, Req, Opts#{ <<"await-inprogress">> => named })
+    ).
+
+%% @doc Persistent workers use the collision-resistant identity of their base.
+default_worker_group_identity_test() ->
+    Base = #{ <<"device">> => <<"message@1.0">>, <<"value">> => <<"base">> },
+    Opts = #{ <<"await-inprogress">> => true },
+    ?assertEqual(
+        {?MODULE, hb_path:hashpath(Base, Opts)},
+        default_grouper(Base, undefined, Opts)
+    ).
 
 %% @doc Test merging and returning a value with a persistent worker.
 deduplicated_execution_test() ->

--- a/src/core/util/hb_name.erl
+++ b/src/core/util/hb_name.erl
@@ -4,7 +4,8 @@
 %%% An important characteristic of these functions is that they are atomic:
 %%% There can only ever be one registrant for a given name at a time.
 -module(hb_name).
--export([start/0, register/1, register/2, unregister/1, lookup/1, all/0]).
+-export([start/0, register/1, register/2]).
+-export([unregister/1, unregister/2, lookup/1, all/0]).
 -export([singleton/2]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -57,6 +58,22 @@ unregister(Name) when is_atom(Name) ->
 unregister(Name) ->
     start(),
     ets:delete(?NAME_TABLE, Name),
+    ok.
+
+%% @doc Unregister a name only when it is owned by the expected process.
+unregister(Name, Pid) when is_atom(Name) ->
+    case whereis(Name) of
+        Pid ->
+            catch erlang:unregister(Name),
+            ok;
+        _ ->
+            start(),
+            ets:delete_object(?NAME_TABLE, {Name, Pid}),
+            ok
+    end;
+unregister(Name, Pid) ->
+    start(),
+    ets:delete_object(?NAME_TABLE, {Name, Pid}),
     ok.
 
 %% @doc Atomic singleton lookup/spawn+register operation.
@@ -117,7 +134,7 @@ ets_lookup(Name) ->
             case is_process_alive(Pid) of
                 true -> Pid;
                 false -> 
-                    ets:delete(?NAME_TABLE, Name),
+                    ets:delete_object(?NAME_TABLE, {Name, Pid}),
                     undefined
             end;
         [] -> undefined
@@ -157,6 +174,21 @@ atom_test() ->
 
 term_test() ->
     basic_test({term, os:timestamp()}).
+
+owner_unregister_test() ->
+    Name = {owner_unregister_test, make_ref()},
+    First = spawn(fun() -> receive stop -> ok end end),
+    Second = spawn(fun() -> receive stop -> ok end end),
+    ?assertEqual(ok, hb_name:register(Name, First)),
+    ?assertEqual(ok, hb_name:unregister(Name, Second)),
+    ?assertEqual(First, hb_name:lookup(Name)),
+    ?assertEqual(ok, hb_name:unregister(Name, First)),
+    ?assertEqual(ok, hb_name:register(Name, Second)),
+    ?assertEqual(ok, hb_name:unregister(Name, First)),
+    ?assertEqual(Second, hb_name:lookup(Name)),
+    hb_name:unregister(Name),
+    First ! stop,
+    Second ! stop.
 
 singleton_returns_spawned_pid_test() ->
     Name = {singleton, os:timestamp()},

--- a/src/preloaded/process/dev_process_worker.erl
+++ b/src/preloaded/process/dev_process_worker.erl
@@ -128,14 +128,14 @@ await(Worker, GroupName, Base, Req, Opts) ->
                 {target_slot, TargetSlot}
             }),
             receive
-                {resolved, _, GroupName, {slot, RecvdSlot}, Res}
+                {resolved, Worker, GroupName, {slot, RecvdSlot}, Res}
                         when RecvdSlot == TargetSlot orelse TargetSlot == any ->
                     ?event(debug_compute, {notified_of_resolution,
                         {target, TargetSlot},
                         {group, GroupName}
                     }),
                     Res;
-                {resolved, _, GroupName, {slot, RecvdSlot}, _Res} ->
+                {resolved, Worker, GroupName, {slot, RecvdSlot}, _Res} ->
                     ?event(debug_compute, {waiting_again,
                         {target, TargetSlot},
                         {recvd, RecvdSlot},


### PR DESCRIPTION
This PR contains 5 comits:

## 1. Collision-resistant execution groups
  - Replaced the small `erlang:phash2/1` group identifier.
  - Derived identities using AO-Core hashpaths:
      - Executions: `hb_path:hashpath(Base, Req, Opts)`
      - Persistent workers: `hb_path:hashpath(Base, Opts)`
  - Namespaced them as: `{hb_persistent, ExecutionID}`.
  - Updated logging and identity tests for the new format.

##  2. Atomic leader election
  - Removed the racy lookup-then-register sequence.
  - Made the atomic result of `hb_name:register/1` decide leadership.
  - Losing callers look up and wait for the winner.
  - Election retries if the winner disappears before lookup.
  - Preserved infinite-recursion detection when the caller already owns the group.
  - Added a 50-contender election test that verifies exactly one leader.

##  3. Hardened waiter enrollment and completion
  - Monitor the elected leader before sending the enrollment message.
  - After enrollment, verify the leader still owns the group.
  - Retry election when enrollment races with completion instead of waiting indefinitely.
  - Always remove and flush the process monitor.
  - Accept completion messages only from the elected leader PID.
  - Applied the sender check to process-worker slot responses as well.
  - Added tests for closed enrollment and unrelated/stale completion senders.

##  4. Ownership-safe unregistering
  - Added: `hb_name:unregister(Name, ExpectedPid)`
  - Persistent leaders now unregister using self() as the expected owner.
  - ETS removal deletes the exact `{Name, Pid}` record instead of deleting solely by name.
  - Dead-process cleanup also removes only the stale ownership record.
  - This prevents a stale leader or cleanup operation from deleting a replacement owner.
  - Added registry-level and persistence-level stale-owner tests.

##  5. Stronger end-to-end concurrent-resolution coverage
  Improved the existing deduplicated_execution_test/0 instead of adding another test:
  - Increased concurrency from 2 staggered callers to 20 gated callers.
  - Sends them through the complete hb_ao:resolve/3 path.
  - Disables cache lookup and storage so caching cannot conceal duplicate work.
  - Counts actual device executions using atomics.
  - Verifies all concurrent callers receive the same result.
  - Verifies the device executes exactly once.
  - Sends a later non-overlapping request and verifies it executes again, proving group cleanup occurred.

  The focused suites passed after each change; the full suite was not run as requested.


## ToDo
- [x] Run multiple reference processes (with `await-inprogress` set to `true`) to check if only one request is done.