### PR TITLE
impr: Implement `on/cache-write` hook to enable operator-programmable indexing

### DIFF
--- a/src/core/resolver/hb_cache.erl
+++ b/src/core/resolver/hb_cache.erl
@@ -45,7 +45,6 @@
 -export([test_unsigned/1, test_signed/1]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
--define(MATCH_PREFIX, <<"~match@1.0">>).
 -define(DIRECT_VALUE_LENGTH, 60).
 
 %% @doc Ensure that a value is loaded from the cache if it is an ID or a link.
@@ -271,8 +270,10 @@ write(RawMsg, Opts) when is_map(RawMsg) ->
     TABM = hb_message:convert(Msg, tabm, <<"structured@1.0">>, Opts),
     ?event_debug(debug_cache, {writing_full_message, {msg, TABM}}),
     try
+        % The message's private keys are not written, but the `cache-write'
+        % hook receives them.
         do_write_message(
-            TABM,
+            hb_private:set_priv(TABM, hb_private:from_message(RawMsg)),
             hb_opts:get(store, no_viable_store, Opts),
             Opts
         )
@@ -341,11 +342,6 @@ write_message_ops(Msg, Opts) when is_map(Msg) ->
             [{group, UncommittedID}],
             maps:without([<<"priv">>], Msg)
         ),
-    MatchOps =
-        case match_store(Opts) of
-            [] -> KeyOps;
-            _ -> [{match, AllIDs, Msg} | KeyOps]
-        end,
     Ops =
         lists:foldl(
             fun(AltID, Acc) ->
@@ -357,7 +353,7 @@ write_message_ops(Msg, Opts) when is_map(Msg) ->
                 ),
                 [{link, AltID, UncommittedID} | Acc]
             end,
-            MatchOps,
+            [{index_hook, AllIDs, Msg} | KeyOps],
             AltIDs
         ),
     {ok, UncommittedID, lists:reverse(Ops)}.
@@ -462,9 +458,18 @@ run_write_ops(Store, Ops, Opts) ->
     run_write_ops(Store, Ops, Opts, []).
 run_write_ops(Store, [], Opts, Pending) ->
     flush_write_ops(Store, Pending, Opts);
-run_write_ops(Store, [{match, IDs, Msg} | Rest], Opts, Pending) ->
+run_write_ops(Store, [{index_hook, IDs, Msg} | Rest], Opts, Pending) ->
     flush_write_ops(Store, Pending, Opts),
-    write_match_index(IDs, Msg, Opts),
+    {ok, _} =
+        hb_hook:on(
+            <<"cache-write">>,
+            #{
+                <<"body">> => Msg,
+                <<"ids">> => IDs,
+                <<"priv">> => #{ <<"hook-caller">> => <<"kernel">> }
+            },
+            Opts
+        ),
     run_write_ops(Store, Rest, Opts, []);
 run_write_ops(Store, [Op | Rest], Opts, Pending) ->
     run_write_ops(Store, Rest, Opts, [Op | Pending]).
@@ -505,107 +510,6 @@ apply_write_ops(Store, Ops, Opts) ->
         _ -> hb_store:link(Store, Links, Opts)
     end,
     ok.
-
-%% @doc Write all message keys to the optional match index.
-write_match_index(IDs, Base, Opts) ->
-    case match_store(Opts) of
-        [] -> {skip, <<"No store configured for match index.">>};
-        Store ->
-            IndexBase = hb_message:uncommitted(hb_private:reset(Base)),
-            Ops =
-                hb_maps:fold(
-                fun(RawKey, Value, Acc) ->
-                    Key = hb_ao:normalize_key(RawKey),
-                    ValuePath = match_value_path(Value, Opts),
-                    MatchAddress = match_address(Key, ValuePath),
-                    lists:foldl(
-                        fun(ID, InnerAcc) ->
-                            Address = match_address_id(MatchAddress, ID),
-                            [{write, Address, <<"">>} | InnerAcc]
-                        end,
-                        [{group, MatchAddress} | Acc],
-                        IDs
-                    )
-                end,
-                [],
-                IndexBase
-            ),
-            apply_write_ops(Store, lists:reverse(Ops), Opts)
-    end.
-
-%% @doc Select the store that should receive reverse match-index writes.
-%% A local `match-index' option wins when present. Otherwise, a local
-%% `store' means "write this message and its match index to the same
-%% caller-provided store". If neither is present, use the global node
-%% `match-index' setting. The selected value is interpreted as:
-%% `false' disables index writes, `true' uses the normal configured
-%% store, and a store definition/list writes the index there.
-match_store(Opts) ->
-    LocalMatchIndex = maps:get(<<"match-index">>, Opts, undefined),
-    LocalStore = maps:get(<<"store">>, Opts, undefined),
-    GlobalMatchIndex = hb_opts:get(match_index, false, #{ <<"only">> => global }),
-    MatchIndexStore =
-        case {LocalMatchIndex, LocalStore} of
-            {false, _} ->
-                false;
-            {[], _} ->
-                [];
-            {undefined, undefined} ->
-                GlobalMatchIndex;
-            {undefined, _} ->
-                LocalStore;
-            {Local, Store}
-                    when Store =/= undefined andalso
-                        Local =:= GlobalMatchIndex ->
-                Store;
-            {Local, _} ->
-                Local
-        end,
-    case MatchIndexStore of
-        false -> [];
-        true -> hb_opts:get(store, [], Opts);
-        ResolvedStore when is_list(ResolvedStore) -> ResolvedStore;
-        ResolvedStore -> [ResolvedStore]
-    end.
-
-%% @doc Calculate the address of a key-value pair in the match index.
-match_address(Key, Value) ->
-    KeyBin = match_bin(Key),
-    ValueBin = match_bin(Value),
-    iolist_to_binary([?MATCH_PREFIX, "&", KeyBin, "=", ValueBin]).
-match_address_id(Address, ID) ->
-    IDBin = match_bin(ID),
-    <<Address/binary, "/", IDBin/binary>>.
-
-%% @doc Normalize a match-index path part.
-match_bin(Bin) when is_binary(Bin) -> Bin;
-match_bin(Atom) when is_atom(Atom) -> atom_to_binary(Atom);
-match_bin(Int) when is_integer(Int) -> integer_to_binary(Int);
-match_bin(Float) when is_float(Float) -> float_to_binary(Float, [compact]);
-match_bin(List) when is_list(List) ->
-    try iolist_to_binary(List)
-    catch _:_ -> term_to_binary(List)
-    end;
-match_bin(Other) ->
-    term_to_binary(Other).
-
-%% @doc Return the path representation used by cache key-value links.
-match_value_path(Bin, Opts) when is_binary(Bin) ->
-    generate_binary_path(Bin, Opts);
-match_value_path(Map, Opts) when is_map(Map) ->
-    hb_message:id(Map, none, Opts#{ <<"linkify-mode">> => discard });
-match_value_path(List, Opts) when is_list(List) ->
-    case io_lib:printable_unicode_list(List) of
-        true ->
-            match_value_path(iolist_to_binary(List), Opts);
-        false ->
-            match_value_path(
-                hb_message:convert(List, tabm, <<"structured@1.0">>, Opts),
-                Opts
-            )
-    end;
-match_value_path(Other, Opts) ->
-    match_value_path(hb_path:to_binary(Other), Opts).
 
 %% @doc The `structured@1.0` encoder does not typically encode `commitments`,
 %% subsequently, when we encounter a commitments message we prepare its contents
@@ -1434,11 +1338,37 @@ test_immediate_marker_values(Store) ->
             ok
     end.
 
-match_store_control_test() ->
-    Store = hb_test_utils:test_store(hb_store_volatile, <<"match-control">>),
-    ?assertEqual([Store], match_store(#{ <<"store">> => Store })),
-    ?assertEqual([], match_store(#{ <<"store">> => Store, <<"match-index">> => false })),
-    ?assertEqual([], match_store(#{ <<"store">> => Store, <<"match-index">> => [] })).
+%% @doc The `cache-write' hook receives each message the cache writes with its
+%% private keys, which are not written, under the IDs it is written at.
+test_cache_write_hook(Store) ->
+    hb_store:reset(Store),
+    Self = self(),
+    Opts = #{
+        <<"store">> => Store,
+        <<"priv-wallet">> => ar_wallet:new(),
+        <<"on">> => #{
+            <<"cache-write">> => [
+                #{
+                    <<"device">> => #{
+                        cache_write =>
+                            fun(_, Req, _) -> Self ! Req, {ok, Req} end
+                    }
+                },
+                #{ <<"device">> => <<"match@1.0">>, <<"path">> => <<"index">> }
+            ]
+        }
+    },
+    Committed = hb_message:commit(#{ <<"a">> => <<"b">> }, Opts),
+    Msg = hb_private:set(Committed, <<"offset">>, 1, Opts),
+    {ok, ID} = write(Msg, Opts),
+    Req = receive R = #{ <<"body">> := #{ <<"a">> := _ } } -> R end,
+    #{ <<"body">> := Body, <<"ids">> := IDs } = Req,
+    ?assertEqual(<<"kernel">>, hb_private:get(<<"hook-caller">>, Req, Opts)),
+    ?assertEqual(1, hb_private:get(<<"offset">>, Body, Opts)),
+    ?assertEqual([hb_message:id(Msg, all, Opts)], IDs),
+    ?assertEqual({ok, IDs}, match(#{ <<"a">> => <<"b">> }, Opts)),
+    {ok, Keys} = hb_store:list(Store, ID, Opts),
+    ?assertNot(lists:member(<<"priv">>, Keys)).
 
 cache_suite_test_() ->
     hb_store:generate_test_suite([
@@ -1455,7 +1385,8 @@ cache_suite_test_() ->
         {"match linked message", fun test_match_linked_message/1},
         {"match typed message", fun test_match_typed_message/1},
         {"raw match read", fun test_raw_match_read/1},
-        {"immediate marker values", fun test_immediate_marker_values/1}
+        {"immediate marker values", fun test_immediate_marker_values/1},
+        {"cache-write hook", fun test_cache_write_hook/1}
     ]).
 
 %% @doc Test that message whose device is `#{}' cannot be written. If it were to

--- a/src/core/resolver/hb_hook.erl
+++ b/src/core/resolver/hb_hook.erl
@@ -85,6 +85,9 @@ find(HookName, Opts = #{ <<"on">> := On }) when is_map(On) ->
             % list.
             []
     end;
+find(HookName, Opts) when not is_map_key(<<"on">>, Opts) ->
+    % A message without `on' has the node's hooks.
+    find(HookName, Opts#{ <<"on">> => hb_opts:get(on, #{}, Opts) });
 find(_HookName, _Opts) ->
     [].
 find(_Base, Req, Opts) ->

--- a/src/core/resolver/hb_opts.erl
+++ b/src/core/resolver/hb_opts.erl
@@ -541,6 +541,8 @@ raw_default_message() ->
             <<"routes">> => []
         },
         <<"on">> => #{
+            <<"cache-write">> =>
+                #{ <<"device">> => <<"match@1.0">>, <<"path">> => <<"index">> },
             <<"request">> =>
                 [
                     #{

--- a/src/forge/hb_preload.erl
+++ b/src/forge/hb_preload.erl
@@ -68,10 +68,12 @@ build_dir(Pkgs, Wallet, OutputDir, Opts) ->
     % Reset store before building for deterministic re-builds.
     hb_store:reset(StoreCfg, #{ <<"reset">> => <<"all">> }, Opts),
     hb_store:start(StoreCfg, #{}, Opts),
+    % The device loader reads the store raw, so no `cache-write' hook runs.
     LocalOpts =
         Opts#{
             <<"store">> => [StoreCfg],
-            <<"priv-wallet">> => Wallet
+            <<"priv-wallet">> => Wallet,
+            <<"on">> => #{}
         },
     % Sign and write each spec + each impl message; collect signed IDs.
     {SpecIDs, ImplIDs} =

--- a/src/preloaded/query/dev_match.erl
+++ b/src/preloaded/query/dev_match.erl
@@ -1,6 +1,7 @@
 %%% @doc A reverse index for finding all message IDs with a given key-value pair.
 -module(dev_match).
--export([info/0, all/3]).
+-export([info/0, all/3, index/3]).
+-include_lib("eunit/include/eunit.hrl").
 -include("include/hb.hrl").
 
 -define(CACHE_PREFIX, <<"~match@1.0">>).
@@ -78,6 +79,46 @@ value_path(List, Opts) when is_list(List) ->
 value_path(Other, Opts) ->
     value_path(hb_path:to_binary(Other), Opts).
 
+%% @doc Write the message in the request's `body' to the index: each of its
+%% key-value pairs, but its commitments and private keys, under each of the
+%% IDs the request gives. Only the kernel's `cache-write' hook is served: it
+%% marks its request in a private key, which a request over HTTP cannot carry.
+index(_Base, Req, Opts) ->
+    case hb_private:get(<<"hook-caller">>, Req, Opts) of
+        <<"kernel">> -> index(Req, Opts);
+        _ ->
+            {error,
+                #{
+                    <<"status">> => 401,
+                    <<"body">> => <<"Unauthorized caller.">>
+                }
+            }
+    end.
+index(Req, Opts) ->
+    Store = store(Opts),
+    IDs = hb_maps:get(<<"ids">>, Req, [], Opts),
+    Body = hb_maps:get(<<"body">>, Req, #{}, Opts),
+    Msg = hb_message:uncommitted(hb_private:reset(Body)),
+    Writes =
+        hb_maps:fold(
+            fun(Key, Value, Acc) ->
+                Address =
+                    address(hb_ao:normalize_key(Key), value_path(Value, Opts)),
+                hb_store:group(Store, Address, Opts),
+                maps:merge(
+                    Acc,
+                    maps:from_keys(
+                        [ <<Address/binary, "/", ID/binary>> || ID <- IDs ],
+                        <<>>
+                    )
+                )
+            end,
+            #{},
+            Msg
+        ),
+    hb_store:write(Store, Writes, Opts),
+    {ok, Req}.
+
 %% @doc Match a single key-value pair in the index, returning all message IDs that
 %% contain the key-value pair.
 match(Key, Base, _Req, Opts) -> match(Key, Base, Opts).
@@ -127,3 +168,24 @@ all(Base, _Req, Opts) ->
                     {error, not_found}
             end
     end.
+
+%%% Tests
+
+%% @doc A request over HTTP loses its private keys, so it is not the kernel.
+unauthorized_index_test() ->
+    Node =
+        hb_http_server:start_node(
+            #{ <<"store">> => hb_test_utils:test_store() }
+        ),
+    Res =
+        hb_http:post(
+            Node,
+            #{
+                <<"path">> => <<"/~match@1.0/index">>,
+                <<"body">> => #{ <<"a">> => <<"b">> },
+                <<"ids">> => [<<"id">>],
+                <<"priv">> => #{ <<"hook-caller">> => <<"kernel">> }
+            },
+            #{}
+        ),
+    ?assertMatch({error, #{ <<"status">> := 401 }}, Res).


### PR DESCRIPTION
This PR finishes the implementation of a hook that was first drafted in #1053 by @jfrain99. Setting the `on/cache-write` hook message(s) now allows the node operator to customize which devices should be invoked to index the keys that have been written to a node's stores via `hb_cache:write`. The immediate use for this hook is part of the work stream for improving the `~match@1.0` indexer, ready for real-time GraphQL serving, but later it may also be useful for implementing other forms of indexes -- for example, full-text search etc.